### PR TITLE
Improve stdin/out/err handling for container processes

### DIFF
--- a/createprocess.go
+++ b/createprocess.go
@@ -3,6 +3,8 @@ package hcsshim
 import (
 	"encoding/json"
 	"fmt"
+	"io"
+	"runtime"
 	"syscall"
 	"unsafe"
 
@@ -12,30 +14,71 @@ import (
 // processParameters is use to both the input of CreateProcessInComputeSystem
 // and to convert the parameters to JSON for passing onto the HCS
 type CreateProcessParams struct {
-	ApplicationName                   string
-	CommandLine                       string
-	WorkingDirectory                  string
-	StdInPipe, StdOutPipe, StdErrPipe string
-	Environment                       map[string]string
-	EmulateConsole                    bool
-	ConsoleSize                       [2]int
+	ApplicationName  string
+	CommandLine      string
+	WorkingDirectory string
+	Environment      map[string]string
+	EmulateConsole   bool
+	ConsoleSize      [2]int
+}
+
+// pipe struct used for the stdin/stdout/stderr pipes
+type pipe struct {
+	handle syscall.Handle
+}
+
+func makePipe(h syscall.Handle) *pipe {
+	p := &pipe{h}
+	runtime.SetFinalizer(p, (*pipe).closeHandle)
+	return p
+}
+
+func (p *pipe) closeHandle() {
+	if p.handle != 0 {
+		syscall.CloseHandle(p.handle)
+		p.handle = 0
+	}
+}
+
+func (p *pipe) Close() error {
+	p.closeHandle()
+	runtime.SetFinalizer(p, nil)
+	return nil
+}
+
+func (p *pipe) Read(b []byte) (int, error) {
+	// syscall.Read returns 0, nil on ERROR_BROKEN_PIPE, but for
+	// our purposes this should indicate EOF. This may be a go bug.
+	var read uint32
+	err := syscall.ReadFile(p.handle, b, &read, nil)
+	if err != nil {
+		if err == syscall.ERROR_BROKEN_PIPE {
+			return 0, io.EOF
+		}
+        return 0, err
+	}
+	return int(read), nil
+}
+
+func (p *pipe) Write(b []byte) (int, error) {
+	return syscall.Write(p.handle, b)
 }
 
 // CreateProcessInComputeSystem starts a process in a container. This is invoked, for example,
 // as a result of docker run, docker exec, or RUN in Dockerfile. If successful,
 // it returns the PID of the process.
-func CreateProcessInComputeSystem(id string, params CreateProcessParams) (processid uint32, err error) {
+func CreateProcessInComputeSystem(id string, useStdin bool, useStdout bool, useStderr bool, params CreateProcessParams) (processid uint32, stdin io.WriteCloser, stdout io.ReadCloser, stderr io.ReadCloser, err error) {
 
 	title := "HCSShim::CreateProcessInComputeSystem"
 	logrus.Debugf(title+"id=%s params=%s", id, params)
 
 	// Load the DLL and get a handle to the procedure we need
-	dll, proc, err := loadAndFind(procCreateProcessInComputeSystem)
+	dll, proc, err := loadAndFind(procCreateProcessWithStdHandlesInComputeSystem)
 	if dll != nil {
 		defer dll.Release()
 	}
 	if err != nil {
-		return 0, err
+		return
 	}
 
 	// Convert id to uint16 pointer for calling the procedure
@@ -43,7 +86,7 @@ func CreateProcessInComputeSystem(id string, params CreateProcessParams) (proces
 	if err != nil {
 		err = fmt.Errorf(title+" - Failed conversion of id %s to pointer %s", id, err)
 		logrus.Error(err)
-		return 0, err
+		return
 	}
 
 	// If we are not emulating a console, ignore any console size passed to us
@@ -55,13 +98,13 @@ func CreateProcessInComputeSystem(id string, params CreateProcessParams) (proces
 	paramsJson, err := json.Marshal(params)
 	if err != nil {
 		err = fmt.Errorf(title+" - Failed to marshall params %v %s", params, err)
-		return 0, err
+		return
 	}
 
 	// Convert paramsJson to uint16 pointer for calling the procedure
 	paramsJsonp, err := syscall.UTF16PtrFromString(string(paramsJson))
 	if err != nil {
-		return 0, err
+		return
 	}
 
 	// Get a POINTER to variable to take the pid outparm
@@ -69,11 +112,26 @@ func CreateProcessInComputeSystem(id string, params CreateProcessParams) (proces
 
 	logrus.Debugf(title+" - Calling the procedure itself %s %s", id, paramsJson)
 
+	var stdinHandle, stdoutHandle, stderrHandle syscall.Handle
+	var stdinParam, stdoutParam, stderrParam uintptr
+	if useStdin {
+		stdinParam = uintptr(unsafe.Pointer(&stdinHandle))
+	}
+	if useStdout {
+		stdoutParam = uintptr(unsafe.Pointer(&stdoutHandle))
+	}
+	if useStderr {
+		stderrParam = uintptr(unsafe.Pointer(&stderrHandle))
+	}
+
 	// Call the procedure itself.
 	r1, _, _ := proc.Call(
 		uintptr(unsafe.Pointer(idp)),
 		uintptr(unsafe.Pointer(paramsJsonp)),
-		uintptr(unsafe.Pointer(pid)))
+		uintptr(unsafe.Pointer(pid)),
+		stdinParam,
+		stdoutParam,
+		stderrParam)
 
 	use(unsafe.Pointer(idp))
 	use(unsafe.Pointer(paramsJsonp))
@@ -81,9 +139,19 @@ func CreateProcessInComputeSystem(id string, params CreateProcessParams) (proces
 	if r1 != 0 {
 		err = fmt.Errorf(title+" - Win32 API call returned error r1=%d err=%s id=%s params=%v", r1, syscall.Errno(r1), id, params)
 		logrus.Error(err)
-		return 0, err
+		return
+	}
+
+	if useStdin {
+		stdin = makePipe(stdinHandle)
+	}
+	if useStdout {
+		stdout = makePipe(stdoutHandle)
+	}
+	if useStderr {
+		stderr = makePipe(stderrHandle)
 	}
 
 	logrus.Debugf(title+" - succeeded id=%s params=%s pid=%d", id, paramsJson, *pid)
-	return *pid, nil
+	return *pid, stdin, stdout, stderr, nil
 }

--- a/hcsshim.go
+++ b/hcsshim.go
@@ -16,14 +16,14 @@ const (
 	shimDLLName = "vmcompute.dll"
 
 	// Container related functions in the shim DLL
-	procCreateComputeSystem             = "CreateComputeSystem"
-	procStartComputeSystem              = "StartComputeSystem"
-	procCreateProcessInComputeSystem    = "CreateProcessInComputeSystem"
-	procWaitForProcessInComputeSystem   = "WaitForProcessInComputeSystem"
-	procShutdownComputeSystem           = "ShutdownComputeSystem"
-	procTerminateComputeSystem          = "TerminateComputeSystem"
-	procTerminateProcessInComputeSystem = "TerminateProcessInComputeSystem"
-	procResizeConsoleInComputeSystem    = "ResizeConsoleInComputeSystem"
+	procCreateComputeSystem                        = "CreateComputeSystem"
+	procStartComputeSystem                         = "StartComputeSystem"
+	procCreateProcessWithStdHandlesInComputeSystem = "CreateProcessWithStdHandlesInComputeSystem"
+	procWaitForProcessInComputeSystem              = "WaitForProcessInComputeSystem"
+	procShutdownComputeSystem                      = "ShutdownComputeSystem"
+	procTerminateComputeSystem                     = "TerminateComputeSystem"
+	procTerminateProcessInComputeSystem            = "TerminateProcessInComputeSystem"
+	procResizeConsoleInComputeSystem               = "ResizeConsoleInComputeSystem"
 
 	// Storage related functions in the shim DLL
 	procLayerExists         = "LayerExists"


### PR DESCRIPTION
Use CreateProcessWithStdHandlesInComputeSystem to provide stdin/out/err.
This allows vmcompute.dll to handle creating the named pipes with the
correct paths, security attributes, etc. and provides flexibility for
changing the pipe creation protocol in future builds of Windows.

@jhowardmsft, note that this requires docker changes as part of the re-vendor. See Microsoft/docker@b9cfb089366555749305c2aef7383feaab917ea6 for the necessary changes.

With these changes, the various named pipe bugs seem resolved, and we are set for post-TP3 when we may change how the named pipes are created. There is one last bug in the console that's causing a line of output to sometimes get hidden; I still need to fix this.