### PR TITLE
Ensure HRESULTs are converted to Win32 code early

### DIFF
--- a/createprocess.go
+++ b/createprocess.go
@@ -82,12 +82,12 @@ func CreateProcessInComputeSystem(id string, useStdin bool, useStdout bool, useS
 	err = createProcessWithStdHandlesInComputeSystem(id, string(paramsJson), &pid, stdinParam, stdoutParam, stderrParam)
 	if err != nil {
 		herr := makeErrorf(err, title, "id=%s params=%v", id, params)
-		err = herr
 		// Windows TP4: Hyper-V Containers may return this error with more than one
 		// concurrent exec. Do not log it as an error
-		if herr.Err != WSAEINVAL {
-			logrus.Error(err)
+		if err != WSAEINVAL {
+			logrus.Error(herr)
 		}
+		err = herr
 		return
 	}
 

--- a/mksyscall_windows.go
+++ b/mksyscall_windows.go
@@ -294,6 +294,9 @@ func (r *Rets) SetErrorCode() string {
 	const code = `if r0 != 0 {
 		%s = %sErrno(r0)
 	}`
+	const hrCode = `if int32(r0) < 0 {
+		%s = %sErrno(win32FromHresult(r0))
+	}`
 	if r.Name == "" && !r.ReturnsError {
 		return ""
 	}
@@ -301,7 +304,11 @@ func (r *Rets) SetErrorCode() string {
 		return r.useLongHandleErrorCode("r1")
 	}
 	if r.Type == "error" {
-		return fmt.Sprintf(code, r.Name, syscalldot())
+		if r.Name == "hr" {
+			return fmt.Sprintf(hrCode, r.Name, syscalldot())
+		} else {
+			return fmt.Sprintf(code, r.Name, syscalldot())
+		}
 	}
 	s := ""
 	switch {

--- a/zhcsshim.go
+++ b/zhcsshim.go
@@ -56,8 +56,8 @@ func _activateLayer(info *driverInfo, id *uint16) (hr error) {
 		return
 	}
 	r0, _, _ := syscall.Syscall(procActivateLayer.Addr(), 2, uintptr(unsafe.Pointer(info)), uintptr(unsafe.Pointer(id)), 0)
-	if r0 != 0 {
-		hr = syscall.Errno(r0)
+	if int32(r0) < 0 {
+		hr = syscall.Errno(win32FromHresult(r0))
 	}
 	return
 }
@@ -85,8 +85,8 @@ func _copyLayer(info *driverInfo, srcId *uint16, dstId *uint16, descriptors []WC
 		return
 	}
 	r0, _, _ := syscall.Syscall6(procCopyLayer.Addr(), 5, uintptr(unsafe.Pointer(info)), uintptr(unsafe.Pointer(srcId)), uintptr(unsafe.Pointer(dstId)), uintptr(unsafe.Pointer(_p2)), uintptr(len(descriptors)), 0)
-	if r0 != 0 {
-		hr = syscall.Errno(r0)
+	if int32(r0) < 0 {
+		hr = syscall.Errno(win32FromHresult(r0))
 	}
 	return
 }
@@ -110,8 +110,8 @@ func _createLayer(info *driverInfo, id *uint16, parent *uint16) (hr error) {
 		return
 	}
 	r0, _, _ := syscall.Syscall(procCreateLayer.Addr(), 3, uintptr(unsafe.Pointer(info)), uintptr(unsafe.Pointer(id)), uintptr(unsafe.Pointer(parent)))
-	if r0 != 0 {
-		hr = syscall.Errno(r0)
+	if int32(r0) < 0 {
+		hr = syscall.Errno(win32FromHresult(r0))
 	}
 	return
 }
@@ -139,8 +139,8 @@ func _createSandboxLayer(info *driverInfo, id *uint16, parent *uint16, descripto
 		return
 	}
 	r0, _, _ := syscall.Syscall6(procCreateSandboxLayer.Addr(), 5, uintptr(unsafe.Pointer(info)), uintptr(unsafe.Pointer(id)), uintptr(unsafe.Pointer(parent)), uintptr(unsafe.Pointer(_p2)), uintptr(len(descriptors)), 0)
-	if r0 != 0 {
-		hr = syscall.Errno(r0)
+	if int32(r0) < 0 {
+		hr = syscall.Errno(win32FromHresult(r0))
 	}
 	return
 }
@@ -159,8 +159,8 @@ func _deactivateLayer(info *driverInfo, id *uint16) (hr error) {
 		return
 	}
 	r0, _, _ := syscall.Syscall(procDeactivateLayer.Addr(), 2, uintptr(unsafe.Pointer(info)), uintptr(unsafe.Pointer(id)), 0)
-	if r0 != 0 {
-		hr = syscall.Errno(r0)
+	if int32(r0) < 0 {
+		hr = syscall.Errno(win32FromHresult(r0))
 	}
 	return
 }
@@ -179,8 +179,8 @@ func _destroyLayer(info *driverInfo, id *uint16) (hr error) {
 		return
 	}
 	r0, _, _ := syscall.Syscall(procDestroyLayer.Addr(), 2, uintptr(unsafe.Pointer(info)), uintptr(unsafe.Pointer(id)), 0)
-	if r0 != 0 {
-		hr = syscall.Errno(r0)
+	if int32(r0) < 0 {
+		hr = syscall.Errno(win32FromHresult(r0))
 	}
 	return
 }
@@ -208,8 +208,8 @@ func _exportLayer(info *driverInfo, id *uint16, path *uint16, descriptors []WC_L
 		return
 	}
 	r0, _, _ := syscall.Syscall6(procExportLayer.Addr(), 5, uintptr(unsafe.Pointer(info)), uintptr(unsafe.Pointer(id)), uintptr(unsafe.Pointer(path)), uintptr(unsafe.Pointer(_p2)), uintptr(len(descriptors)), 0)
-	if r0 != 0 {
-		hr = syscall.Errno(r0)
+	if int32(r0) < 0 {
+		hr = syscall.Errno(win32FromHresult(r0))
 	}
 	return
 }
@@ -228,8 +228,8 @@ func _getLayerMountPath(info *driverInfo, id *uint16, length *uintptr, buffer *u
 		return
 	}
 	r0, _, _ := syscall.Syscall6(procGetLayerMountPath.Addr(), 4, uintptr(unsafe.Pointer(info)), uintptr(unsafe.Pointer(id)), uintptr(unsafe.Pointer(length)), uintptr(unsafe.Pointer(buffer)), 0, 0)
-	if r0 != 0 {
-		hr = syscall.Errno(r0)
+	if int32(r0) < 0 {
+		hr = syscall.Errno(win32FromHresult(r0))
 	}
 	return
 }
@@ -239,8 +239,8 @@ func getBaseImages(buffer **uint16) (hr error) {
 		return
 	}
 	r0, _, _ := syscall.Syscall(procGetBaseImages.Addr(), 1, uintptr(unsafe.Pointer(buffer)), 0, 0)
-	if r0 != 0 {
-		hr = syscall.Errno(r0)
+	if int32(r0) < 0 {
+		hr = syscall.Errno(win32FromHresult(r0))
 	}
 	return
 }
@@ -268,8 +268,8 @@ func _importLayer(info *driverInfo, id *uint16, path *uint16, descriptors []WC_L
 		return
 	}
 	r0, _, _ := syscall.Syscall6(procImportLayer.Addr(), 5, uintptr(unsafe.Pointer(info)), uintptr(unsafe.Pointer(id)), uintptr(unsafe.Pointer(path)), uintptr(unsafe.Pointer(_p2)), uintptr(len(descriptors)), 0)
-	if r0 != 0 {
-		hr = syscall.Errno(r0)
+	if int32(r0) < 0 {
+		hr = syscall.Errno(win32FromHresult(r0))
 	}
 	return
 }
@@ -288,8 +288,8 @@ func _layerExists(info *driverInfo, id *uint16, exists *uint32) (hr error) {
 		return
 	}
 	r0, _, _ := syscall.Syscall(procLayerExists.Addr(), 3, uintptr(unsafe.Pointer(info)), uintptr(unsafe.Pointer(id)), uintptr(unsafe.Pointer(exists)))
-	if r0 != 0 {
-		hr = syscall.Errno(r0)
+	if int32(r0) < 0 {
+		hr = syscall.Errno(win32FromHresult(r0))
 	}
 	return
 }
@@ -308,8 +308,8 @@ func _nameToGuid(name *uint16, guid *GUID) (hr error) {
 		return
 	}
 	r0, _, _ := syscall.Syscall(procNameToGuid.Addr(), 2, uintptr(unsafe.Pointer(name)), uintptr(unsafe.Pointer(guid)), 0)
-	if r0 != 0 {
-		hr = syscall.Errno(r0)
+	if int32(r0) < 0 {
+		hr = syscall.Errno(win32FromHresult(r0))
 	}
 	return
 }
@@ -332,8 +332,8 @@ func _prepareLayer(info *driverInfo, id *uint16, descriptors []WC_LAYER_DESCRIPT
 		return
 	}
 	r0, _, _ := syscall.Syscall6(procPrepareLayer.Addr(), 4, uintptr(unsafe.Pointer(info)), uintptr(unsafe.Pointer(id)), uintptr(unsafe.Pointer(_p1)), uintptr(len(descriptors)), 0, 0)
-	if r0 != 0 {
-		hr = syscall.Errno(r0)
+	if int32(r0) < 0 {
+		hr = syscall.Errno(win32FromHresult(r0))
 	}
 	return
 }
@@ -352,8 +352,8 @@ func _unprepareLayer(info *driverInfo, id *uint16) (hr error) {
 		return
 	}
 	r0, _, _ := syscall.Syscall(procUnprepareLayer.Addr(), 2, uintptr(unsafe.Pointer(info)), uintptr(unsafe.Pointer(id)), 0)
-	if r0 != 0 {
-		hr = syscall.Errno(r0)
+	if int32(r0) < 0 {
+		hr = syscall.Errno(win32FromHresult(r0))
 	}
 	return
 }
@@ -377,8 +377,8 @@ func _createComputeSystem(id *uint16, configuration *uint16) (hr error) {
 		return
 	}
 	r0, _, _ := syscall.Syscall(procCreateComputeSystem.Addr(), 2, uintptr(unsafe.Pointer(id)), uintptr(unsafe.Pointer(configuration)), 0)
-	if r0 != 0 {
-		hr = syscall.Errno(r0)
+	if int32(r0) < 0 {
+		hr = syscall.Errno(win32FromHresult(r0))
 	}
 	return
 }
@@ -402,8 +402,8 @@ func _createProcessWithStdHandlesInComputeSystem(id *uint16, paramsJson *uint16,
 		return
 	}
 	r0, _, _ := syscall.Syscall6(procCreateProcessWithStdHandlesInComputeSystem.Addr(), 6, uintptr(unsafe.Pointer(id)), uintptr(unsafe.Pointer(paramsJson)), uintptr(unsafe.Pointer(pid)), uintptr(unsafe.Pointer(stdin)), uintptr(unsafe.Pointer(stdout)), uintptr(unsafe.Pointer(stderr)))
-	if r0 != 0 {
-		hr = syscall.Errno(r0)
+	if int32(r0) < 0 {
+		hr = syscall.Errno(win32FromHresult(r0))
 	}
 	return
 }
@@ -422,8 +422,8 @@ func _resizeConsoleInComputeSystem(id *uint16, pid uint32, height uint16, width 
 		return
 	}
 	r0, _, _ := syscall.Syscall6(procResizeConsoleInComputeSystem.Addr(), 5, uintptr(unsafe.Pointer(id)), uintptr(pid), uintptr(height), uintptr(width), uintptr(flags), 0)
-	if r0 != 0 {
-		hr = syscall.Errno(r0)
+	if int32(r0) < 0 {
+		hr = syscall.Errno(win32FromHresult(r0))
 	}
 	return
 }
@@ -442,8 +442,8 @@ func _shutdownComputeSystem(id *uint16, timeout uint32) (hr error) {
 		return
 	}
 	r0, _, _ := syscall.Syscall(procShutdownComputeSystem.Addr(), 2, uintptr(unsafe.Pointer(id)), uintptr(timeout), 0)
-	if r0 != 0 {
-		hr = syscall.Errno(r0)
+	if int32(r0) < 0 {
+		hr = syscall.Errno(win32FromHresult(r0))
 	}
 	return
 }
@@ -462,8 +462,8 @@ func _startComputeSystem(id *uint16) (hr error) {
 		return
 	}
 	r0, _, _ := syscall.Syscall(procStartComputeSystem.Addr(), 1, uintptr(unsafe.Pointer(id)), 0, 0)
-	if r0 != 0 {
-		hr = syscall.Errno(r0)
+	if int32(r0) < 0 {
+		hr = syscall.Errno(win32FromHresult(r0))
 	}
 	return
 }
@@ -482,8 +482,8 @@ func _terminateComputeSystem(id *uint16) (hr error) {
 		return
 	}
 	r0, _, _ := syscall.Syscall(procTerminateComputeSystem.Addr(), 1, uintptr(unsafe.Pointer(id)), 0, 0)
-	if r0 != 0 {
-		hr = syscall.Errno(r0)
+	if int32(r0) < 0 {
+		hr = syscall.Errno(win32FromHresult(r0))
 	}
 	return
 }
@@ -502,8 +502,8 @@ func _terminateProcessInComputeSystem(id *uint16, pid uint32) (hr error) {
 		return
 	}
 	r0, _, _ := syscall.Syscall(procTerminateProcessInComputeSystem.Addr(), 2, uintptr(unsafe.Pointer(id)), uintptr(pid), 0)
-	if r0 != 0 {
-		hr = syscall.Errno(r0)
+	if int32(r0) < 0 {
+		hr = syscall.Errno(win32FromHresult(r0))
 	}
 	return
 }
@@ -522,8 +522,8 @@ func _waitForProcessInComputeSystem(id *uint16, pid uint32, timeout uint32, exit
 		return
 	}
 	r0, _, _ := syscall.Syscall6(procWaitForProcessInComputeSystem.Addr(), 4, uintptr(unsafe.Pointer(id)), uintptr(pid), uintptr(timeout), uintptr(unsafe.Pointer(exitCode)), 0, 0)
-	if r0 != 0 {
-		hr = syscall.Errno(r0)
+	if int32(r0) < 0 {
+		hr = syscall.Errno(win32FromHresult(r0))
 	}
 	return
 }
@@ -552,8 +552,8 @@ func __hnsCall(method *uint16, path *uint16, object *uint16, response **uint16) 
 		return
 	}
 	r0, _, _ := syscall.Syscall6(procHNSCall.Addr(), 4, uintptr(unsafe.Pointer(method)), uintptr(unsafe.Pointer(path)), uintptr(unsafe.Pointer(object)), uintptr(unsafe.Pointer(response)), 0, 0)
-	if r0 != 0 {
-		hr = syscall.Errno(r0)
+	if int32(r0) < 0 {
+		hr = syscall.Errno(win32FromHresult(r0))
 	}
 	return
 }


### PR DESCRIPTION
This makes it easier to compare return values from vmcompute routines with Win32 error codes. HRESULTs are technically more flexible since they can represent non-S_OK success codes, but this is rarely used in any reasonable interfaces. For Go it seems we're standardizing on Win32.