### PR TITLE
Rely on caller to take privileges when manipulating base layers

### DIFF
--- a/baselayer.go
+++ b/baselayer.go
@@ -62,20 +62,17 @@ func (w *baseLayerWriter) Add(name string, fileInfo *winio.FileBasicInfo) (err e
 		}
 	}()
 
-	err = winio.RunWithPrivileges([]string{winio.SeBackupPrivilege, winio.SeRestorePrivilege}, func() (err error) {
-		createmode := uint32(syscall.CREATE_NEW)
-		if fileInfo.FileAttributes&syscall.FILE_ATTRIBUTE_DIRECTORY != 0 {
-			err := os.Mkdir(path, 0)
-			if err != nil && !os.IsExist(err) {
-				return err
-			}
-			createmode = syscall.OPEN_EXISTING
+	createmode := uint32(syscall.CREATE_NEW)
+	if fileInfo.FileAttributes&syscall.FILE_ATTRIBUTE_DIRECTORY != 0 {
+		err := os.Mkdir(path, 0)
+		if err != nil && !os.IsExist(err) {
+			return err
 		}
+		createmode = syscall.OPEN_EXISTING
+	}
 
-		mode := uint32(syscall.GENERIC_READ | syscall.GENERIC_WRITE | winio.WRITE_DAC | winio.WRITE_OWNER | winio.ACCESS_SYSTEM_SECURITY)
-		f, err = winio.OpenForBackup(path, mode, syscall.FILE_SHARE_READ, createmode)
-		return
-	})
+	mode := uint32(syscall.GENERIC_READ | syscall.GENERIC_WRITE | winio.WRITE_DAC | winio.WRITE_OWNER | winio.ACCESS_SYSTEM_SECURITY)
+	f, err = winio.OpenForBackup(path, mode, syscall.FILE_SHARE_READ, createmode)
 	if err != nil {
 		return err
 	}
@@ -113,9 +110,7 @@ func (w *baseLayerWriter) AddLink(name string, target string) (err error) {
 		return err
 	}
 
-	return winio.RunWithPrivileges([]string{winio.SeBackupPrivilege, winio.SeRestorePrivilege}, func() (err error) {
-		return os.Link(linktarget, linkpath)
-	})
+	return os.Link(linktarget, linkpath)
 }
 
 func (w *baseLayerWriter) Remove(name string) error {
@@ -123,11 +118,7 @@ func (w *baseLayerWriter) Remove(name string) error {
 }
 
 func (w *baseLayerWriter) Write(b []byte) (int, error) {
-	var n int
-	err := winio.RunWithPrivileges([]string{winio.SeBackupPrivilege, winio.SeRestorePrivilege}, func() (err error) {
-		n, err = w.bw.Write(b)
-		return
-	})
+	n, err := w.bw.Write(b)
 	if err != nil {
 		w.err = err
 	}

--- a/exportlayer.go
+++ b/exportlayer.go
@@ -112,7 +112,9 @@ func (r *FilterLayerReader) Close() (err error) {
 }
 
 // NewLayerReader returns a new layer reader for reading the contents of an on-disk layer.
-func NewLayerReader(info DriverInfo, layerId string, parentLayerPaths []string) (LayerReader, error) {
+// The caller must have taken the SeBackupPrivilege privilege
+// to call this and any methods on the resulting LayerReader.
+func NewLayerReader(info DriverInfo, layerID string, parentLayerPaths []string) (LayerReader, error) {
 	if procExportLayerBegin.Find() != nil {
 		// The new layer reader is not available on this Windows build. Fall back to the
 		// legacy export code path.
@@ -120,7 +122,7 @@ func NewLayerReader(info DriverInfo, layerId string, parentLayerPaths []string) 
 		if err != nil {
 			return nil, err
 		}
-		err = ExportLayer(info, layerId, path, parentLayerPaths)
+		err = ExportLayer(info, layerID, path, parentLayerPaths)
 		if err != nil {
 			os.RemoveAll(path)
 			return nil, err
@@ -137,7 +139,7 @@ func NewLayerReader(info DriverInfo, layerId string, parentLayerPaths []string) 
 		return nil, err
 	}
 	r := &FilterLayerReader{}
-	err = exportLayerBegin(&infop, layerId, layers, &r.context)
+	err = exportLayerBegin(&infop, layerID, layers, &r.context)
 	if err != nil {
 		return nil, makeError(err, "ExportLayerBegin", "")
 	}

--- a/importlayer.go
+++ b/importlayer.go
@@ -148,6 +148,8 @@ func (r *legacyLayerWriterWrapper) Close() error {
 }
 
 // NewLayerWriter returns a new layer writer for creating a layer on disk.
+// The caller must have taken the SeBackupPrivilege and SeRestorePrivilege privileges
+// to call this and any methods on the resulting LayerWriter.
 func NewLayerWriter(info DriverInfo, layerID string, parentLayerPaths []string) (LayerWriter, error) {
 	if len(parentLayerPaths) == 0 {
 		// This is a base layer. It gets imported differently.


### PR DESCRIPTION
Don't merge this yet.

With this change, the caller has to ensure that he has taken the appropriate privileges before calling the import/export APIs. This is done because taking these privileges for each small operation can be quite expensive, and the cheapest thing to do is to just set the privileges on the whole process if possible.

This is a breaking change. We should update the version tag appropriately after this. Docker will be able to handle this after docker/docker#22728 is merged.