### PR TITLE
Added dns support

### DIFF
--- a/hcsshim.go
+++ b/hcsshim.go
@@ -14,6 +14,7 @@ import (
 //go:generate go run mksyscall_windows.go -output zhcsshim.go hcsshim.go
 
 //sys coTaskMemFree(buffer unsafe.Pointer) = ole32.CoTaskMemFree
+//sys SetCurrentThreadCompartmentId(compartmentId uint32) (hr error) = iphlpapi.SetCurrentThreadCompartmentId
 
 //sys activateLayer(info *driverInfo, id string) (hr error) = vmcompute.ActivateLayer?
 //sys copyLayer(info *driverInfo, srcId string, dstId string, descriptors []WC_LAYER_DESCRIPTOR) (hr error) = vmcompute.CopyLayer?

--- a/hnsfuncs.go
+++ b/hnsfuncs.go
@@ -33,8 +33,9 @@ type VsidPolicy struct {
 // Subnet is assoicated with a network and represents a list
 // of subnets available to the network
 type Subnet struct {
-	AddressPrefix  string `json:",omitempty"`
-	GatewayAddress string `json:",omitempty"`
+	AddressPrefix  string            `json:",omitempty"`
+	GatewayAddress string            `json:",omitempty"`
+	Policies       []json.RawMessage `json:",omitempty"`
 }
 
 // MacPool is assoicated with a network and represents a list
@@ -46,16 +47,17 @@ type MacPool struct {
 
 // HNSNetwork represents a network in HNS
 type HNSNetwork struct {
-	Id                 string            `json:",omitempty"`
-	Name               string            `json:",omitempty"`
-	Type               string            `json:",omitempty"`
-	NetworkAdapterName string            `json:",omitempty"`
-	SourceMac          string            `json:",omitempty"`
-	Policies           []json.RawMessage `json:",omitempty"`
-	MacPools           []MacPool         `json:",omitempty"`
-	Subnets            []Subnet          `json:",omitempty"`
-	DNSSuffix          string            `json:",omitempty"`
-	DNSServerList      string            `json:",omitempty"`
+	Id                   string            `json:",omitempty"`
+	Name                 string            `json:",omitempty"`
+	Type                 string            `json:",omitempty"`
+	NetworkAdapterName   string            `json:",omitempty"`
+	SourceMac            string            `json:",omitempty"`
+	Policies             []json.RawMessage `json:",omitempty"`
+	MacPools             []MacPool         `json:",omitempty"`
+	Subnets              []Subnet          `json:",omitempty"`
+	DNSSuffix            string            `json:",omitempty"`
+	DNSServerList        string            `json:",omitempty"`
+	DNSServerCompartment uint32            `json:",omitempty"`
 }
 
 // HNSEndpoint represents a network endpoint in HNS
@@ -70,6 +72,7 @@ type HNSEndpoint struct {
 	DNSSuffix          string            `json:",omitempty"`
 	DNSServerList      string            `json:",omitempty"`
 	GatewayAddress     string            `json:",omitempty"`
+	EnableInternalDNS  bool              `json:",omitempty"`
 	PrefixLength       uint8             `json:",omitempty"`
 }
 

--- a/interface.go
+++ b/interface.go
@@ -38,29 +38,30 @@ type HvRuntime struct {
 // ContainerConfig is used as both the input of CreateContainer
 // and to convert the parameters to JSON for passing onto the HCS
 type ContainerConfig struct {
-	SystemType              string      // HCS requires this to be hard-coded to "Container"
-	Name                    string      // Name of the container. We use the docker ID.
-	Owner                   string      // The management platform that created this container
-	IsDummy                 bool        // Used for development purposes.
-	VolumePath              string      // Windows volume path for scratch space
-	IgnoreFlushesDuringBoot bool        // Optimization hint for container startup in Windows
-	LayerFolderPath         string      // Where the layer folders are located
-	Layers                  []Layer     // List of storage layers
-	Credentials             string      `json:",omitempty"` // Credentials information
-	ProcessorCount          uint32      `json:",omitempty"` // Number of processors to assign to the container.
-	ProcessorWeight         uint64      `json:",omitempty"` // CPU Shares 0..10000 on Windows; where 0 will be omitted and HCS will default.
-	ProcessorMaximum        int64       `json:",omitempty"` // CPU maximum usage percent 1..100
-	StorageIOPSMaximum      uint64      `json:",omitempty"` // Maximum Storage IOPS
-	StorageBandwidthMaximum uint64      `json:",omitempty"` // Maximum Storage Bandwidth in bytes per second
-	StorageSandboxSize      uint64      `json:",omitempty"` // Size in bytes that the container system drive should be expanded to if smaller
-	MemoryMaximumInMB       int64       `json:",omitempty"` // Maximum memory available to the container in Megabytes
-	HostName                string      // Hostname
-	MappedDirectories       []MappedDir // List of mapped directories (volumes/mounts)
-	SandboxPath             string      // Location of unmounted sandbox (used for Hyper-V containers)
-	HvPartition             bool        // True if it a Hyper-V Container
-	EndpointList            []string    // List of networking endpoints to be attached to container
-	HvRuntime               *HvRuntime  // Hyper-V container settings
-	Servicing               bool        // True if this container is for servicing
+	SystemType               string      // HCS requires this to be hard-coded to "Container"
+	Name                     string      // Name of the container. We use the docker ID.
+	Owner                    string      // The management platform that created this container
+	IsDummy                  bool        // Used for development purposes.
+	VolumePath               string      // Windows volume path for scratch space
+	IgnoreFlushesDuringBoot  bool        // Optimization hint for container startup in Windows
+	LayerFolderPath          string      // Where the layer folders are located
+	Layers                   []Layer     // List of storage layers
+	Credentials              string      `json:",omitempty"` // Credentials information
+	ProcessorCount           uint32      `json:",omitempty"` // Number of processors to assign to the container.
+	ProcessorWeight          uint64      `json:",omitempty"` // CPU Shares 0..10000 on Windows; where 0 will be omitted and HCS will default.
+	ProcessorMaximum         int64       `json:",omitempty"` // CPU maximum usage percent 1..100
+	StorageIOPSMaximum       uint64      `json:",omitempty"` // Maximum Storage IOPS
+	StorageBandwidthMaximum  uint64      `json:",omitempty"` // Maximum Storage Bandwidth in bytes per second
+	StorageSandboxSize       uint64      `json:",omitempty"` // Size in bytes that the container system drive should be expanded to if smaller
+	MemoryMaximumInMB        int64       `json:",omitempty"` // Maximum memory available to the container in Megabytes
+	HostName                 string      // Hostname
+	MappedDirectories        []MappedDir // List of mapped directories (volumes/mounts)
+	SandboxPath              string      // Location of unmounted sandbox (used for Hyper-V containers)
+	HvPartition              bool        // True if it a Hyper-V Container
+	EndpointList             []string    // List of networking endpoints to be attached to container
+	HvRuntime                *HvRuntime  // Hyper-V container settings
+	Servicing                bool        // True if this container is for servicing
+	AllowUnqualifiedDNSQuery bool        // True to allow unqualified DNS name resolution
 }
 
 // Container represents a created (but not necessarily running) container.

--- a/zhcsshim.go
+++ b/zhcsshim.go
@@ -10,9 +10,11 @@ var _ unsafe.Pointer
 
 var (
 	modole32     = syscall.NewLazyDLL("ole32.dll")
+	modiphlpapi  = syscall.NewLazyDLL("iphlpapi.dll")
 	modvmcompute = syscall.NewLazyDLL("vmcompute.dll")
 
 	procCoTaskMemFree                              = modole32.NewProc("CoTaskMemFree")
+	procSetCurrentThreadCompartmentId              = modiphlpapi.NewProc("SetCurrentThreadCompartmentId")
 	procActivateLayer                              = modvmcompute.NewProc("ActivateLayer")
 	procCopyLayer                                  = modvmcompute.NewProc("CopyLayer")
 	procCreateLayer                                = modvmcompute.NewProc("CreateLayer")
@@ -79,6 +81,14 @@ var (
 
 func coTaskMemFree(buffer unsafe.Pointer) {
 	syscall.Syscall(procCoTaskMemFree.Addr(), 1, uintptr(buffer), 0, 0)
+	return
+}
+
+func SetCurrentThreadCompartmentId(compartmentId uint32) (hr error) {
+	r0, _, _ := syscall.Syscall(procSetCurrentThreadCompartmentId.Addr(), 1, uintptr(compartmentId), 0, 0)
+	if int32(r0) < 0 {
+		hr = syscall.Errno(win32FromHresult(r0))
+	}
 	return
 }
 


### PR DESCRIPTION
Changes required to enable service discovery for containers. DNSServerCompartment in network is required to launch listeners in the correct  compartment for overlay networks once we add support for overlay networks.
Signed-off-by: msabansal <sabansal@microsoft.com>