### PR TITLE
Stop calling post TP5 API in OpenProcess

### DIFF
--- a/container.go
+++ b/container.go
@@ -436,8 +436,10 @@ func (container *container) OpenProcess(pid int) (Process, error) {
 		container: container,
 	}
 
-	if err := process.registerCallback(); err != nil {
-		return nil, makeContainerError(container, operation, "", err)
+	if hcsCallbacksSupported {
+		if err := process.registerCallback(); err != nil {
+			return nil, makeContainerError(container, operation, "", err)
+		}
 	}
 
 	logrus.Debugf(title+" succeeded id=%s processid=%s", container.id, process.processID)


### PR DESCRIPTION
Callbacks were being registered when opening processes regardless of support for callbacks.

Signed-off-by: Darren Stahl <darst@microsoft.com>