### PR TITLE
Added volume QoS settings to MappedDir

### DIFF
--- a/interface.go
+++ b/interface.go
@@ -25,9 +25,11 @@ type Layer struct {
 }
 
 type MappedDir struct {
-	HostPath      string
-	ContainerPath string
-	ReadOnly      bool
+	HostPath         string
+	ContainerPath    string
+	ReadOnly         bool
+	BandwidthMaximum uint64
+	IOPSMaximum      uint64
 }
 
 type HvRuntime struct {


### PR DESCRIPTION
Adds Bandwidth maximum and IOPS maximum settings to MapeedDir

Signed-off-by: Darren Stahl <darst@microsoft.com>

@swernli @jstarks 