### PR TITLE
ConsoleSize --> uint

### DIFF
--- a/interface.go
+++ b/interface.go
@@ -16,7 +16,7 @@ type ProcessConfig struct {
 	CreateStdInPipe  bool
 	CreateStdOutPipe bool
 	CreateStdErrPipe bool
-	ConsoleSize      [2]int
+	ConsoleSize      [2]uint
 }
 
 type Layer struct {


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

Updates ConsoleSize to be a uint. This is part of the feedback from https://github.com/opencontainers/runtime-spec/pull/563#r78852905. It will require a minor tweak to docker once re-vendored.