### PR TITLE
Remove SkipTemplate from HvRuntime

### DIFF
--- a/interface.go
+++ b/interface.go
@@ -33,8 +33,7 @@ type MappedDir struct {
 }
 
 type HvRuntime struct {
-	ImagePath    string `json:",omitempty"`
-	SkipTemplate bool   `json:",omitempty"`
+	ImagePath string `json:",omitempty"`
 }
 
 // ContainerConfig is used as both the input of CreateContainer


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

Following https://github.com/docker/docker/pull/26640, `SkipTemplate` is no longer used by docker. Removing it from the interface. Not sure if should remain though for other callers of HCSShim?

@jstarks 