### PR TITLE
Check errors in LastWaitResult

### DIFF
--- a/process.go
+++ b/process.go
@@ -162,6 +162,10 @@ func (process *process) ExitCode() (int, error) {
 		return 0, makeProcessError(process, operation, "", ErrInvalidProcessState)
 	}
 
+	if properties.LastWaitResult != 0 {
+		return 0, makeProcessError(process, operation, "", syscall.Errno(properties.LastWaitResult))
+	}
+
 	logrus.Debugf(title+" succeeded processid=%d exitCode=%d", process.processID, properties.ExitCode)
 	return int(properties.ExitCode), nil
 }


### PR DESCRIPTION
Ignoring errors returned in LastWaitResult was causing containers that failed to get the exit code to return an incorrect success error code.

/cc @jstarks @jhowardmsft 

Signed-off-by: Darren Stahl <darst@microsoft.com>