### PR TITLE
Add RW Lock to protect the hcs handles

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -16,6 +16,9 @@ var (
 	// ErrHandleClose is an error encountered when the handle generating the notification being waited on has been closed
 	ErrHandleClose = errors.New("hcsshim: the handle generating this notification has been closed")
 
+	// ErrInvalidHandle is an error encountered when using an invalid handle
+	ErrInvalidHandle = errors.New("hcsshim: the handle is invalid")
+
 	// ErrInvalidNotificationType is an error encountered when an invalid notification type is used
 	ErrInvalidNotificationType = errors.New("hcsshim: invalid notification type")
 
@@ -125,7 +128,7 @@ func (e *ProcessError) Error() string {
 	case syscall.Errno:
 		s += fmt.Sprintf(" failed in Win32: %s (0x%x)", e.Err, win32FromError(e.Err))
 	default:
-		s += fmt.Sprintf(" failed: %s", e.Error())
+		s += fmt.Sprintf(" failed: %s", e.Err.Error())
 	}
 
 	return s


### PR DESCRIPTION
This adds a RW lock to the process and container structures, and checks for handle validity on each call to prevent a handle closing during an active request, or calling into HCS with an already closed handle.

/cc @jstarks @jhowardmsft 

Signed-off-by: Darren Stahl <darst@microsoft.com>