### PR TITLE
Don't follow reparse points when cloning the utility VM

### DIFF
--- a/legacy.go
+++ b/legacy.go
@@ -469,6 +469,11 @@ func cloneTree(srcPath, destPath string, mutatedFiles map[string]bool) error {
 			}
 		}
 
+		// Don't recurse on reparse points.
+		if info.IsDir() && isReparsePoint {
+			return filepath.SkipDir
+		}
+
 		return nil
 	})
 	if err != nil {


### PR DESCRIPTION
This works around a Go issue where on Windows filepath.Walk follows
reparse points.