### PR TITLE
Nil the finalizers on Close

### DIFF
--- a/container.go
+++ b/container.go
@@ -514,6 +514,7 @@ func (container *container) Close() error {
 	}
 
 	container.handle = 0
+	runtime.SetFinalizer(container, nil)
 
 	logrus.Debugf(title+" succeeded id=%s", container.id)
 	return nil

--- a/process.go
+++ b/process.go
@@ -3,6 +3,7 @@ package hcsshim
 import (
 	"encoding/json"
 	"io"
+	"runtime"
 	"sync"
 	"syscall"
 	"time"
@@ -321,6 +322,7 @@ func (process *process) Close() error {
 	}
 
 	process.handle = 0
+	runtime.SetFinalizer(process, nil)
 
 	logrus.Debugf(title+" succeeded processid=%d", process.processID)
 	return nil


### PR DESCRIPTION
This stops the extra (harmless) closes being called after already being closed once.

Signed-off-by: Darren Stahl darst@microsoft.com

/cc @jhowardmsft @jstarks 
