### PR TITLE
Change ErrInvalidHandle to ErrAlreadyClosed

### DIFF
--- a/container.go
+++ b/container.go
@@ -175,7 +175,7 @@ func (container *container) Start() error {
 	logrus.Debugf(title+" id=%s", container.id)
 
 	if container.handle == 0 {
-		return makeContainerError(container, operation, "", ErrInvalidHandle)
+		return makeContainerError(container, operation, "", ErrAlreadyClosed)
 	}
 
 	var resultp *uint16
@@ -199,7 +199,7 @@ func (container *container) Shutdown() error {
 	logrus.Debugf(title+" id=%s", container.id)
 
 	if container.handle == 0 {
-		return makeContainerError(container, operation, "", ErrInvalidHandle)
+		return makeContainerError(container, operation, "", ErrAlreadyClosed)
 	}
 
 	var resultp *uint16
@@ -223,7 +223,7 @@ func (container *container) Terminate() error {
 	logrus.Debugf(title+" id=%s", container.id)
 
 	if container.handle == 0 {
-		return makeContainerError(container, operation, "", ErrInvalidHandle)
+		return makeContainerError(container, operation, "", ErrAlreadyClosed)
 	}
 
 	var resultp *uint16
@@ -299,7 +299,7 @@ func (container *container) HasPendingUpdates() (bool, error) {
 	logrus.Debugf(title+" id=%s", container.id)
 
 	if container.handle == 0 {
-		return false, makeContainerError(container, operation, "", ErrInvalidHandle)
+		return false, makeContainerError(container, operation, "", ErrAlreadyClosed)
 	}
 
 	properties, err := container.properties(pendingUpdatesQuery)
@@ -320,7 +320,7 @@ func (container *container) Statistics() (Statistics, error) {
 	logrus.Debugf(title+" id=%s", container.id)
 
 	if container.handle == 0 {
-		return Statistics{}, makeContainerError(container, operation, "", ErrInvalidHandle)
+		return Statistics{}, makeContainerError(container, operation, "", ErrAlreadyClosed)
 	}
 
 	properties, err := container.properties(statisticsQuery)
@@ -341,7 +341,7 @@ func (container *container) ProcessList() ([]ProcessListItem, error) {
 	logrus.Debugf(title+" id=%s", container.id)
 
 	if container.handle == 0 {
-		return nil, makeContainerError(container, operation, "", ErrInvalidHandle)
+		return nil, makeContainerError(container, operation, "", ErrAlreadyClosed)
 	}
 
 	properties, err := container.properties(processListQuery)
@@ -362,7 +362,7 @@ func (container *container) Pause() error {
 	logrus.Debugf(title+" id=%s", container.id)
 
 	if container.handle == 0 {
-		return makeContainerError(container, operation, "", ErrInvalidHandle)
+		return makeContainerError(container, operation, "", ErrAlreadyClosed)
 	}
 
 	var resultp *uint16
@@ -385,7 +385,7 @@ func (container *container) Resume() error {
 	logrus.Debugf(title+" id=%s", container.id)
 
 	if container.handle == 0 {
-		return makeContainerError(container, operation, "", ErrInvalidHandle)
+		return makeContainerError(container, operation, "", ErrAlreadyClosed)
 	}
 
 	var resultp *uint16
@@ -412,7 +412,7 @@ func (container *container) CreateProcess(c *ProcessConfig) (Process, error) {
 	)
 
 	if container.handle == 0 {
-		return nil, makeContainerError(container, operation, "", ErrInvalidHandle)
+		return nil, makeContainerError(container, operation, "", ErrAlreadyClosed)
 	}
 
 	// If we are not emulating a console, ignore any console size passed to us
@@ -468,7 +468,7 @@ func (container *container) OpenProcess(pid int) (Process, error) {
 	)
 
 	if container.handle == 0 {
-		return nil, makeContainerError(container, operation, "", ErrInvalidHandle)
+		return nil, makeContainerError(container, operation, "", ErrAlreadyClosed)
 	}
 
 	err := hcsOpenProcess(container.handle, uint32(pid), &processHandle, &resultp)

--- a/errors.go
+++ b/errors.go
@@ -16,8 +16,8 @@ var (
 	// ErrHandleClose is an error encountered when the handle generating the notification being waited on has been closed
 	ErrHandleClose = errors.New("hcsshim: the handle generating this notification has been closed")
 
-	// ErrInvalidHandle is an error encountered when using an invalid handle
-	ErrInvalidHandle = errors.New("hcsshim: the handle is invalid")
+	// ErrAlreadyClosed is an error encountered when using a handle that has been closed by the Close method
+	ErrAlreadyClosed = errors.New("hcsshim: the handle has already been closed")
 
 	// ErrInvalidNotificationType is an error encountered when an invalid notification type is used
 	ErrInvalidNotificationType = errors.New("hcsshim: invalid notification type")
@@ -157,6 +157,13 @@ func IsNotExist(err error) bool {
 	return err == ErrComputeSystemDoesNotExist ||
 		err == ErrElementNotFound ||
 		err == ErrProcNotFound
+}
+
+// IsAlreadyClosed checks if an error is caused by the Container or Process having been
+// already closed by a call to the Close() method.
+func IsAlreadyClosed(err error) bool {
+	err = getInnerError(err)
+	return err == ErrAlreadyClosed
 }
 
 // IsPending returns a boolean indicating whether the error is that

--- a/process.go
+++ b/process.go
@@ -73,7 +73,7 @@ func (process *process) Kill() error {
 	logrus.Debugf(title+" processid=%d", process.processID)
 
 	if process.handle == 0 {
-		return makeProcessError(process, operation, "", ErrInvalidHandle)
+		return makeProcessError(process, operation, "", ErrAlreadyClosed)
 	}
 
 	var resultp *uint16
@@ -128,7 +128,7 @@ func (process *process) ExitCode() (int, error) {
 	logrus.Debugf(title+" processid=%d", process.processID)
 
 	if process.handle == 0 {
-		return 0, makeProcessError(process, operation, "", ErrInvalidHandle)
+		return 0, makeProcessError(process, operation, "", ErrAlreadyClosed)
 	}
 
 	properties, err := process.properties()
@@ -157,7 +157,7 @@ func (process *process) ResizeConsole(width, height uint16) error {
 	logrus.Debugf(title+" processid=%d", process.processID)
 
 	if process.handle == 0 {
-		return makeProcessError(process, operation, "", ErrInvalidHandle)
+		return makeProcessError(process, operation, "", ErrAlreadyClosed)
 	}
 
 	modifyRequest := processModifyRequest{
@@ -226,7 +226,7 @@ func (process *process) Stdio() (io.WriteCloser, io.ReadCloser, io.ReadCloser, e
 	logrus.Debugf(title+" processid=%d", process.processID)
 
 	if process.handle == 0 {
-		return nil, nil, nil, makeProcessError(process, operation, "", ErrInvalidHandle)
+		return nil, nil, nil, makeProcessError(process, operation, "", ErrAlreadyClosed)
 	}
 
 	var stdIn, stdOut, stdErr syscall.Handle
@@ -270,7 +270,7 @@ func (process *process) CloseStdin() error {
 	logrus.Debugf(title+" processid=%d", process.processID)
 
 	if process.handle == 0 {
-		return makeProcessError(process, operation, "", ErrInvalidHandle)
+		return makeProcessError(process, operation, "", ErrAlreadyClosed)
 	}
 
 	modifyRequest := processModifyRequest{


### PR DESCRIPTION
ErrInvalidHandle is better named ErrAlreadyClosed. 

Signed-off-by: Darren Stahl darst@microsoft.com
