### PR TITLE
Add a callback registration when opening a container

### DIFF
--- a/container.go
+++ b/container.go
@@ -161,6 +161,10 @@ func OpenContainer(id string) (Container, error) {
 
 	container.handle = handle
 
+	if err := container.registerCallback(); err != nil {
+		return nil, makeContainerError(container, operation, "", err)
+	}
+
 	logrus.Debugf(title+" succeeded id=%s handle=%d", id, handle)
 	runtime.SetFinalizer(container, closeContainer)
 	return container, nil


### PR DESCRIPTION
Containers need to register for callbacks when opened so that asynchronous operations can be performed on them. 

Signed-off-by: Darren Stahl <darst@microsoft.com>

/cc @jhowardmsft @jstarks 