### PR TITLE
Add GetContainers function

### DIFF
--- a/interface.go
+++ b/interface.go
@@ -66,6 +66,13 @@ type ContainerConfig struct {
 	AllowUnqualifiedDNSQuery bool        // True to allow unqualified DNS name resolution
 }
 
+type ComputeSystemQuery struct {
+	IDs    []string `json:"Ids,omitempty"`
+	Types  []string `json:",omitempty"`
+	Names  []string `json:",omitempty"`
+	Owners []string `json:",omitempty"`
+}
+
 // Container represents a created (but not necessarily running) container.
 type Container interface {
 	// Start synchronously starts the container.


### PR DESCRIPTION
Add GetContainers to get a list of containers running on the system. This returns all containers including template containers and is needed to fix https://github.com/docker/docker/issues/28087

Signed-off-by: Darren Stahl <darst@microsoft.com>