### PR TITLE
Fix compile error due to containerProperties rename

### DIFF
--- a/container.go
+++ b/container.go
@@ -302,7 +302,7 @@ func (container *container) WaitTimeout(timeout time.Duration) error {
 	return nil
 }
 
-func (container *container) properties(query string) (*containerProperties, error) {
+func (container *container) properties(query string) (*ContainerProperties, error) {
 	var (
 		resultp     *uint16
 		propertiesp *uint16
@@ -317,7 +317,7 @@ func (container *container) properties(query string) (*containerProperties, erro
 		return nil, ErrUnexpectedValue
 	}
 	propertiesRaw := convertAndFreeCoTaskMemBytes(propertiesp)
-	properties := &containerProperties{}
+	properties := &ContainerProperties{}
 	if err := json.Unmarshal(propertiesRaw, properties); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
I missed a change to existing uses of containerProperties in https://github.com/Microsoft/hcsshim/pull/86 due to GO ignoring my gopath and compiling the wrong source. Here's the fix.

@jhowardmsft 

Signed-off-by: Darren Stahl <darst@microsoft.com>