### PR TITLE
bug fix: return errors from hcsEnumerateComputeSystem

### DIFF
--- a/container.go
+++ b/container.go
@@ -192,6 +192,10 @@ func GetContainers(q ComputeSystemQuery) ([]ContainerProperties, error) {
 	)
 	err = hcsEnumerateComputeSystems(query, &computeSystemsp, &resultp)
 	err = processHcsResult(err, resultp)
+	if err != nil {
+		return nil, err
+	}
+
 	if computeSystemsp == nil {
 		return nil, ErrUnexpectedValue
 	}


### PR DESCRIPTION
Errors from GetContainers were being ignored, and instead the returned pointer was unexpectedly null, resulting an (incorrect) invalid data from hcs error.

Signed-off-by: Darren Stahl <darst@microsoft.com>

/cc @jhowardmsft @jstarks 