### PR TITLE
Added option to allow setting DNS search list for containers

### DIFF
--- a/interface.go
+++ b/interface.go
@@ -65,6 +65,7 @@ type ContainerConfig struct {
 	HvRuntime                *HvRuntime  `json:",omitempty"` // Hyper-V container settings. Used by Hyper-V containers only. Format ImagePath=%root%\BaseLayerID\UtilityVM
 	Servicing                bool        // True if this container is for servicing
 	AllowUnqualifiedDNSQuery bool        // True to allow unqualified DNS name resolution
+	DNSSearchList            string      // Comma seperated list of DNS suffixes to use for name resolution
 }
 
 type ComputeSystemQuery struct {


### PR DESCRIPTION
DNSSearchList allows us to set DNS suffixes for containers. This is required to support --dns-search docker option.

Signed-off-by: msabansal <sabansal@microsoft.com>