### PR TITLE
Add 'Access is denied' error

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -50,6 +50,10 @@ var (
 
 	// ErrProcNotFound is an error encountered when the the process cannot be found
 	ErrProcNotFound = syscall.Errno(0x7f)
+
+	// ErrVmcomputeOperationAccessIsDenied is an error which can be encountered when enumerating compute systems in RS1/RS2
+	// builds when the underlying silo might be in the process of terminating. HCS was fixed in RS3.
+	ErrVmcomputeOperationAccessIsDenied = syscall.Errno(0x5)
 )
 
 // ProcessError is an error encountered in HCS during an operation on a Process object


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

@darrenstahlmsft - Adds an error constant as part of fix for docker/docker #30278. Have verified it fixes docker locally - needed for revendoring.