### PR TITLE
Remove finalizers due to go1.8 liveness

### DIFF
--- a/container.go
+++ b/container.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"runtime"
 	"sync"
 	"syscall"
 	"time"
@@ -206,7 +205,6 @@ func createContainerWithJSON(id string, c *ContainerConfig, additionalJSON strin
 	}
 
 	logrus.Debugf(title+" succeeded id=%s handle=%d", id, container.handle)
-	runtime.SetFinalizer(container, closeContainer)
 	return container, nil
 }
 
@@ -264,7 +262,6 @@ func OpenContainer(id string) (Container, error) {
 	}
 
 	logrus.Debugf(title+" succeeded id=%s handle=%d", id, handle)
-	runtime.SetFinalizer(container, closeContainer)
 	return container, nil
 }
 
@@ -589,7 +586,6 @@ func (container *container) CreateProcess(c *ProcessConfig) (Process, error) {
 	}
 
 	logrus.Debugf(title+" succeeded id=%s processid=%s", container.id, process.processID)
-	runtime.SetFinalizer(process, closeProcess)
 	return process, nil
 }
 
@@ -626,7 +622,6 @@ func (container *container) OpenProcess(pid int) (Process, error) {
 	}
 
 	logrus.Debugf(title+" succeeded id=%s processid=%s", container.id, process.processID)
-	runtime.SetFinalizer(process, closeProcess)
 	return process, nil
 }
 
@@ -652,15 +647,9 @@ func (container *container) Close() error {
 	}
 
 	container.handle = 0
-	runtime.SetFinalizer(container, nil)
 
 	logrus.Debugf(title+" succeeded id=%s", container.id)
 	return nil
-}
-
-// closeContainer wraps container.Close for use by a finalizer
-func closeContainer(container *container) {
-	container.Close()
 }
 
 func (container *container) registerCallback() error {

--- a/exportlayer.go
+++ b/exportlayer.go
@@ -4,7 +4,6 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
-	"runtime"
 	"syscall"
 
 	"github.com/Microsoft/go-winio"
@@ -143,7 +142,6 @@ func NewLayerReader(info DriverInfo, layerID string, parentLayerPaths []string) 
 	if err != nil {
 		return nil, makeError(err, "ExportLayerBegin", "")
 	}
-	runtime.SetFinalizer(r, func(r *FilterLayerReader) { r.Close() })
 	return r, err
 }
 

--- a/importlayer.go
+++ b/importlayer.go
@@ -5,7 +5,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"runtime"
 
 	"github.com/Microsoft/go-winio"
 	"github.com/Sirupsen/logrus"
@@ -209,6 +208,5 @@ func NewLayerWriter(info DriverInfo, layerID string, parentLayerPaths []string) 
 	if err != nil {
 		return nil, makeError(err, "ImportLayerStart", "")
 	}
-	runtime.SetFinalizer(w, func(w *FilterLayerWriter) { w.Close() })
 	return w, nil
 }

--- a/process.go
+++ b/process.go
@@ -3,7 +3,6 @@ package hcsshim
 import (
 	"encoding/json"
 	"io"
-	"runtime"
 	"sync"
 	"syscall"
 	"time"
@@ -322,15 +321,9 @@ func (process *process) Close() error {
 	}
 
 	process.handle = 0
-	runtime.SetFinalizer(process, nil)
 
 	logrus.Debugf(title+" succeeded processid=%d", process.processID)
 	return nil
-}
-
-// closeProcess wraps process.Close for use by a finalizer
-func closeProcess(process *process) {
-	process.Close()
 }
 
 func (process *process) registerCallback() error {


### PR DESCRIPTION
The suggested Go conventions seem to prefer to not use finalizers unless absolutely needed. These handles will close when the program closes (if the Close is not called manually, which it should be) anyway, so no need here.

I don't think this affects correctness (I did a quick look, and it seemed that all should remain live) but to avoid potential future issues this should be fixed.

@jstarks @jhowardmsft 

Signed-off-by: Darren Stahl <darst@microsoft.com>