### PR TITLE
update to github.com/sirupsen/logrus v1.0.0

### DIFF
--- a/activatelayer.go
+++ b/activatelayer.go
@@ -1,6 +1,6 @@
 package hcsshim
 
-import "github.com/Sirupsen/logrus"
+import "github.com/sirupsen/logrus"
 
 // ActivateLayer will find the layer with the given id and mount it's filesystem.
 // For a read/write layer, the mounted filesystem will appear as a volume on the

--- a/container.go
+++ b/container.go
@@ -8,7 +8,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 var (

--- a/createlayer.go
+++ b/createlayer.go
@@ -1,6 +1,6 @@
 package hcsshim
 
-import "github.com/Sirupsen/logrus"
+import "github.com/sirupsen/logrus"
 
 // CreateLayer creates a new, empty, read-only layer on the filesystem based on
 // the parent layer provided.

--- a/createsandboxlayer.go
+++ b/createsandboxlayer.go
@@ -1,6 +1,6 @@
 package hcsshim
 
-import "github.com/Sirupsen/logrus"
+import "github.com/sirupsen/logrus"
 
 // CreateSandboxLayer creates and populates new read-write layer for use by a container.
 // This requires both the id of the direct parent layer, as well as the full list

--- a/deactivatelayer.go
+++ b/deactivatelayer.go
@@ -1,6 +1,6 @@
 package hcsshim
 
-import "github.com/Sirupsen/logrus"
+import "github.com/sirupsen/logrus"
 
 // DeactivateLayer will dismount a layer that was mounted via ActivateLayer.
 func DeactivateLayer(info DriverInfo, id string) error {

--- a/destroylayer.go
+++ b/destroylayer.go
@@ -1,6 +1,6 @@
 package hcsshim
 
-import "github.com/Sirupsen/logrus"
+import "github.com/sirupsen/logrus"
 
 // DestroyLayer will remove the on-disk files representing the layer with the given
 // id, including that layer's containing folder, if any.

--- a/expandsandboxsize.go
+++ b/expandsandboxsize.go
@@ -1,6 +1,6 @@
 package hcsshim
 
-import "github.com/Sirupsen/logrus"
+import "github.com/sirupsen/logrus"
 
 // ExpandSandboxSize expands the size of a layer to at least size bytes.
 func ExpandSandboxSize(info DriverInfo, layerId string, size uint64) error {

--- a/exportlayer.go
+++ b/exportlayer.go
@@ -7,7 +7,7 @@ import (
 	"syscall"
 
 	"github.com/Microsoft/go-winio"
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 // ExportLayer will create a folder at exportFolderPath and fill that folder with

--- a/getlayermountpath.go
+++ b/getlayermountpath.go
@@ -3,7 +3,7 @@ package hcsshim
 import (
 	"syscall"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 // GetLayerMountPath will look for a mounted layer with the given id and return

--- a/getsharedbaseimages.go
+++ b/getsharedbaseimages.go
@@ -1,6 +1,6 @@
 package hcsshim
 
-import "github.com/Sirupsen/logrus"
+import "github.com/sirupsen/logrus"
 
 // GetSharedBaseImages will enumerate the images stored in the common central
 // image store and return descriptive info about those images for the purpose

--- a/hcsshim.go
+++ b/hcsshim.go
@@ -8,7 +8,7 @@ import (
 	"syscall"
 	"unsafe"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 //go:generate go run mksyscall_windows.go -output zhcsshim.go hcsshim.go

--- a/hnsfuncs.go
+++ b/hnsfuncs.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"net"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 type NatPolicy struct {

--- a/importlayer.go
+++ b/importlayer.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 
 	"github.com/Microsoft/go-winio"
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 // ImportLayer will take the contents of the folder at importFolderPath and import

--- a/layerexists.go
+++ b/layerexists.go
@@ -1,6 +1,6 @@
 package hcsshim
 
-import "github.com/Sirupsen/logrus"
+import "github.com/sirupsen/logrus"
 
 // LayerExists will return true if a layer with the given id exists and is known
 // to the system.

--- a/layerutils.go
+++ b/layerutils.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"syscall"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 /* To pass into syscall, we need a struct matching the following:

--- a/nametoguid.go
+++ b/nametoguid.go
@@ -1,6 +1,6 @@
 package hcsshim
 
-import "github.com/Sirupsen/logrus"
+import "github.com/sirupsen/logrus"
 
 // NameToGuid converts the given string into a GUID using the algorithm in the
 // Host Compute Service, ensuring GUIDs generated with the same string are common

--- a/preparelayer.go
+++ b/preparelayer.go
@@ -3,7 +3,7 @@ package hcsshim
 import (
 	"sync"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 var prepareLayerLock sync.Mutex

--- a/process.go
+++ b/process.go
@@ -7,7 +7,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 // ContainerError is an error encountered in HCS

--- a/unpreparelayer.go
+++ b/unpreparelayer.go
@@ -1,6 +1,6 @@
 package hcsshim
 
-import "github.com/Sirupsen/logrus"
+import "github.com/sirupsen/logrus"
 
 // UnprepareLayer disables the filesystem filter for the read-write layer with
 // the given id.

--- a/waithelper.go
+++ b/waithelper.go
@@ -3,7 +3,7 @@ package hcsshim
 import (
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 func processAsyncHcsResult(err error, resultp *uint16, callbackNumber uintptr, expectedNotification hcsNotification, timeout *time.Duration) error {


### PR DESCRIPTION
Signed-off-by: Andrew Pennebaker <apennebaker@datapipe.com>

Fix some dependencies by updating logrus to reflect the move from github.com/Sirupsen/logrus to github.com/sirupsen/logrus.

Note: `go test` currently fails with

```console
$ go test
# github.com/Microsoft/hcsshim
./baselayer.go:15: undefined: winio.BackupFileWriter
./baselayer.go:23: undefined: winio.FileBasicInfo
```

on my machine.