### PR TITLE
Dynamic Sandbox Management for LCOW

### DIFF
--- a/container.go
+++ b/container.go
@@ -16,9 +16,10 @@ var (
 )
 
 const (
-	pendingUpdatesQuery = `{ "PropertyTypes" : ["PendingUpdates"]}`
-	statisticsQuery     = `{ "PropertyTypes" : ["Statistics"]}`
-	processListQuery    = `{ "PropertyTypes" : ["ProcessList"]}`
+	pendingUpdatesQuery    = `{ "PropertyTypes" : ["PendingUpdates"]}`
+	statisticsQuery        = `{ "PropertyTypes" : ["Statistics"]}`
+	processListQuery       = `{ "PropertyTypes" : ["ProcessList"]}`
+	mappedVirtualDiskQuery = `{ "PropertyTypes" : ["MappedVirtualDisk"]}`
 )
 
 type container struct {
@@ -30,20 +31,21 @@ type container struct {
 
 // ContainerProperties holds the properties for a container and the processes running in that container
 type ContainerProperties struct {
-	ID                string `json:"Id"`
-	Name              string
-	SystemType        string
-	Owner             string
-	SiloGUID          string            `json:"SiloGuid,omitempty"`
-	RuntimeID         string            `json:"RuntimeId,omitempty"`
-	IsRuntimeTemplate bool              `json:",omitempty"`
-	RuntimeImagePath  string            `json:",omitempty"`
-	Stopped           bool              `json:",omitempty"`
-	ExitType          string            `json:",omitempty"`
-	AreUpdatesPending bool              `json:",omitempty"`
-	ObRoot            string            `json:",omitempty"`
-	Statistics        Statistics        `json:",omitempty"`
-	ProcessList       []ProcessListItem `json:",omitempty"`
+	ID                           string `json:"Id"`
+	Name                         string
+	SystemType                   string
+	Owner                        string
+	SiloGUID                     string                              `json:"SiloGuid,omitempty"`
+	RuntimeID                    string                              `json:"RuntimeId,omitempty"`
+	IsRuntimeTemplate            bool                                `json:",omitempty"`
+	RuntimeImagePath             string                              `json:",omitempty"`
+	Stopped                      bool                                `json:",omitempty"`
+	ExitType                     string                              `json:",omitempty"`
+	AreUpdatesPending            bool                                `json:",omitempty"`
+	ObRoot                       string                              `json:",omitempty"`
+	Statistics                   Statistics                          `json:",omitempty"`
+	ProcessList                  []ProcessListItem                   `json:",omitempty"`
+	MappedVirtualDiskControllers map[int]MappedVirtualDiskController `json:",omitempty"`
 }
 
 // MemoryStats holds the memory statistics for a container
@@ -101,6 +103,11 @@ type ProcessListItem struct {
 	MemoryWorkingSetSharedBytes  uint64    `json:",omitempty"`
 	ProcessId                    uint32    `json:",omitempty"`
 	UserTime100ns                uint64    `json:",omitempty"`
+}
+
+// MappedVirtualDiskController is the structure of an item returned by a MappedVirtualDiskList call on a container
+type MappedVirtualDiskController struct {
+	MappedVirtualDisks map[int]MappedVirtualDisk `json:",omitempty"`
 }
 
 // Type of Request Support in ModifySystem
@@ -485,6 +492,55 @@ func (container *container) ProcessList() ([]ProcessListItem, error) {
 
 	logrus.Debugf(title+" succeeded id=%s", container.id)
 	return properties.ProcessList, nil
+}
+
+// MappedVirtualDisks returns a map of the controllers and the disks mapped
+// to a container.
+//
+// Example of JSON returned by the query.
+//{
+//   "Id":"1126e8d7d279c707a666972a15976371d365eaf622c02cea2c442b84f6f550a3_svm",
+//   "SystemType":"Container",
+//   "RuntimeOsType":"Linux",
+//   "RuntimeId":"00000000-0000-0000-0000-000000000000",
+//   "State":"Running",
+//   "MappedVirtualDiskControllers":{
+//      "0":{
+//         "MappedVirtualDisks":{
+//            "2":{
+//               "HostPath":"C:\\lcow\\lcow\\scratch\\1126e8d7d279c707a666972a15976371d365eaf622c02cea2c442b84f6f550a3.vhdx",
+//               "ContainerPath":"/mnt/gcs/LinuxServiceVM/scratch",
+//               "Lun":2,
+//               "CreateInUtilityVM":true
+//            },
+//            "3":{
+//               "HostPath":"C:\\lcow\\lcow\\1126e8d7d279c707a666972a15976371d365eaf622c02cea2c442b84f6f550a3\\sandbox.vhdx",
+//               "Lun":3,
+//               "CreateInUtilityVM":true,
+//               "AttachOnly":true
+//            }
+//         }
+//      }
+//   }
+//}
+func (container *container) MappedVirtualDisks() (map[int]MappedVirtualDiskController, error) {
+	container.handleLock.RLock()
+	defer container.handleLock.RUnlock()
+	operation := "MappedVirtualDiskList"
+	title := "HCSShim::Container::" + operation
+	logrus.Debugf(title+" id=%s", container.id)
+
+	if container.handle == 0 {
+		return nil, makeContainerError(container, operation, "", ErrAlreadyClosed)
+	}
+
+	properties, err := container.properties(mappedVirtualDiskQuery)
+	if err != nil {
+		return nil, makeContainerError(container, operation, "", err)
+	}
+
+	logrus.Debugf(title+" succeeded id=%s", container.id)
+	return properties.MappedVirtualDiskControllers, nil
 }
 
 // Pause pauses the execution of the container. This feature is not enabled in TP5.

--- a/interface.go
+++ b/interface.go
@@ -38,10 +38,11 @@ type MappedDir struct {
 }
 
 type HvRuntime struct {
-	ImagePath       string `json:",omitempty"`
-	SkipTemplate    bool   `json:",omitempty"`
-	LinuxInitrdFile string `json:",omitempty"` // File under ImagePath on host containing an initrd image for starting a Linux utility VM
-	LinuxKernelFile string `json:",omitempty"` // File under ImagePath on host containing a kernel for starting a Linux utility VM
+	ImagePath           string `json:",omitempty"`
+	SkipTemplate        bool   `json:",omitempty"`
+	LinuxInitrdFile     string `json:",omitempty"` // File under ImagePath on host containing an initrd image for starting a Linux utility VM
+	LinuxKernelFile     string `json:",omitempty"` // File under ImagePath on host containing a kernel for starting a Linux utility VM
+	LinuxBootParameters string `json:",omitempty"` // Additional boot parameters for starting a Linux Utility VM in initrd mode
 }
 
 type MappedVirtualDisk struct {
@@ -50,6 +51,7 @@ type MappedVirtualDisk struct {
 	CreateInUtilityVM bool   `json:",omitempty"`
 	ReadOnly          bool   `json:",omitempty"`
 	Cache             string `json:",omitempty"` // "" (Unspecified); "Disabled"; "Enabled"; "Private"; "PrivateAllowSharing"
+	AttachOnly        bool   `json:",omitempty:`
 }
 
 // ContainerConfig is used as both the input of CreateContainer
@@ -123,6 +125,9 @@ type Container interface {
 
 	// ProcessList returns details for the processes in a container.
 	ProcessList() ([]ProcessListItem, error)
+
+	// MappedVirtualDisks returns virtual disks mapped to a utility VM, indexed by controller
+	MappedVirtualDisks() (map[int]MappedVirtualDiskController, error)
 
 	// CreateProcess launches a new process within the container.
 	CreateProcess(c *ProcessConfig) (Process, error)


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

This PR adds support for querying mapped virtual disks from a utility VM which is necessary to support the dynamic sandbox management for Linux Containers on Windows.

In addition, it extends the schema to support additional Linux kernel boot parameters.

Finally, it extends the schema to support `AttachOnly` mapped virtual disks (also needed for dynamic sandbox management).

(Would like to get this in sooner so I can complete the docker PR before I'm OOF)

@darrenstahlmsft @jstarks PTAL
