### PR TITLE
Add Seek to layer reader

### DIFF
--- a/legacy.go
+++ b/legacy.go
@@ -307,6 +307,16 @@ func (r *legacyLayerReader) Read(b []byte) (int, error) {
 	return r.backupReader.Read(b)
 }
 
+func (r *legacyLayerReader) Seek(offset int64, whence int) (int64, error) {
+	if r.backupReader == nil {
+		if r.currentFile == nil {
+			return 0, errors.New("no current file")
+		}
+		return r.currentFile.Seek(offset, whence)
+	}
+	return 0, errors.New("seek not supported on this stream")
+}
+
 func (r *legacyLayerReader) Close() error {
 	r.proceed <- false
 	<-r.result


### PR DESCRIPTION
This is needed alongside Microsoft/go-winio#64 to be able to reliably get EA information out of container layers. Without this, since the EA chunk in the backup stream comes after the data chunk, go-winio's backuptar code cannot put the EAs in the tar header. With this change, the backuptar code can seek around to read the data in the order it needs.