### PR TITLE
Add CreateInUtilityVM to MappedDir

### DIFF
--- a/interface.go
+++ b/interface.go
@@ -30,11 +30,12 @@ type Layer struct {
 }
 
 type MappedDir struct {
-	HostPath         string
-	ContainerPath    string
-	ReadOnly         bool
-	BandwidthMaximum uint64
-	IOPSMaximum      uint64
+	HostPath          string
+	ContainerPath     string
+	ReadOnly          bool
+	BandwidthMaximum  uint64
+	IOPSMaximum       uint64
+	CreateInUtilityVM bool
 }
 
 type MappedPipe struct {


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

@darrenstahlmsft @jstarks @jterry75 PTAL. Required for support of plan9 bind-mounts for Linux Containers.