### PR TITLE
ApplyACLPolicy needs to allow multiple policies to be provided

### DIFF
--- a/hnsendpoint.go
+++ b/hnsendpoint.go
@@ -192,7 +192,7 @@ func (endpoint *HNSEndpoint) ContainerHotDetach(containerID string) error {
 	return modifyNetworkEndpoint(containerID, endpoint.Id, Remove)
 }
 
-// ApplyPolicy applies a set of ACL Policies on the Endpoint
+// ApplyACLPolicy applies a set of ACL Policies on the Endpoint
 func (endpoint *HNSEndpoint) ApplyACLPolicy(policies ...*ACLPolicy) error {
 	operation := "ApplyACLPolicy"
 	title := "HCSShim::HNSEndpoint::" + operation

--- a/hnsendpoint.go
+++ b/hnsendpoint.go
@@ -192,18 +192,22 @@ func (endpoint *HNSEndpoint) ContainerHotDetach(containerID string) error {
 	return modifyNetworkEndpoint(containerID, endpoint.Id, Remove)
 }
 
-// ApplyACLPolicy applies Acl Policy on the Endpoint
-func (endpoint *HNSEndpoint) ApplyACLPolicy(policy *ACLPolicy) error {
+// ApplyPolicy applies a set of ACL Policies on the Endpoint. This will
+// overwrite any existing policies which were previously applied
+func (endpoint *HNSEndpoint) ApplyACLPolicy(policies []*ACLPolicy) error {
 	operation := "ApplyACLPolicy"
 	title := "HCSShim::HNSEndpoint::" + operation
 	logrus.Debugf(title+" id=%s", endpoint.Id)
 
-	jsonString, err := json.Marshal(policy)
-	if err != nil {
-		return err
+	for _, policy := range policies {
+		jsonString, err := json.Marshal(policy)
+		if err != nil {
+			return err
+		}
+		endpoint.Policies = append(endpoint.Policies, jsonString)
 	}
-	endpoint.Policies[0] = jsonString
-	_, err = endpoint.Update()
+
+	_, err := endpoint.Update()
 	return err
 }
 

--- a/hnsendpoint.go
+++ b/hnsendpoint.go
@@ -192,14 +192,16 @@ func (endpoint *HNSEndpoint) ContainerHotDetach(containerID string) error {
 	return modifyNetworkEndpoint(containerID, endpoint.Id, Remove)
 }
 
-// ApplyPolicy applies a set of ACL Policies on the Endpoint. This will
-// overwrite any existing policies which were previously applied
-func (endpoint *HNSEndpoint) ApplyACLPolicy(policies []*ACLPolicy) error {
+// ApplyPolicy applies a set of ACL Policies on the Endpoint
+func (endpoint *HNSEndpoint) ApplyACLPolicy(policies ...*ACLPolicy) error {
 	operation := "ApplyACLPolicy"
 	title := "HCSShim::HNSEndpoint::" + operation
 	logrus.Debugf(title+" id=%s", endpoint.Id)
 
 	for _, policy := range policies {
+		if policy == nil {
+			continue
+		}
 		jsonString, err := json.Marshal(policy)
 		if err != nil {
 			return err


### PR DESCRIPTION
This change is limited to the hnsendpoint.go ApplyACLPolicy function. For alignment with RS3 HNS behavior, this function should be accepting multiple ACLPolicy to be applied on the endpoint. Without this change, only a single ACLPolicy (i.e. a single rule) can ever be applied to a endpoint, which is very limiting.

We are bringing up some code at the moment which requires this change for RS3. This function is not currently used by docker/k8s/anyone that we are aware of and GitHub wide search did not find any callers.
