### PR TITLE
Correcting ACLPolicy field names to LocalAddresses and RemoteAddresses

### DIFF
--- a/hnspolicy.go
+++ b/hnspolicy.go
@@ -75,19 +75,18 @@ const (
 )
 
 type ACLPolicy struct {
-	Type          PolicyType `json:"Type"`
-	Protocol      uint16
-	InternalPort  uint16
-	Action        ActionType
-	Direction     DirectionType
-	LocalAddress  string
-	RemoteAddress string
-	LocalPort     uint16
-	RemotePort    uint16
-	RuleType      RuleType `json:"RuleType,omitempty"`
-
-	Priority    uint16
-	ServiceName string
+	Type            PolicyType `json:"Type"`
+	Protocol        uint16
+	InternalPort    uint16
+	Action          ActionType
+	Direction       DirectionType
+	LocalAddresses  string
+	RemoteAddresses string
+	LocalPort       uint16
+	RemotePort      uint16
+	RuleType        RuleType `json:"RuleType,omitempty"`
+	Priority        uint16
+	ServiceName     string
 }
 
 type Policy struct {


### PR DESCRIPTION
The ACLPolicy field names LocalAddress and RemoteAddress are incorrect. HNS expects "LocalAddresses" and "RemoteAddresses" for ACLPolicy.