### PR TITLE
Return typed errors when getting endpoints and networks

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -72,6 +72,22 @@ var (
 	ErrPlatformNotSupported = errors.New("unsupported platform request")
 )
 
+type EndpointNotFoundError struct {
+	EndpointName string
+}
+
+func (e EndpointNotFoundError) Error() string {
+	return fmt.Sprintf("Endpoint %s not found", e.EndpointName)
+}
+
+type NetworkNotFoundError struct {
+	NetworkName string
+}
+
+func (e NetworkNotFoundError) Error() string {
+	return fmt.Sprintf("Network %s not found", e.NetworkName)
+}
+
 // ProcessError is an error encountered in HCS during an operation on a Process object
 type ProcessError struct {
 	Process   *process
@@ -174,6 +190,12 @@ func makeProcessError(process *process, operation string, extraInfo string, err 
 // will currently return true when the error is ErrElementNotFound or ErrProcNotFound.
 func IsNotExist(err error) bool {
 	err = getInnerError(err)
+	if _, ok := err.(EndpointNotFoundError); ok {
+		return true
+	}
+	if _, ok := err.(NetworkNotFoundError); ok {
+		return true
+	}
 	return err == ErrComputeSystemDoesNotExist ||
 		err == ErrElementNotFound ||
 		err == ErrProcNotFound

--- a/hnsendpoint.go
+++ b/hnsendpoint.go
@@ -2,7 +2,6 @@ package hcsshim
 
 import (
 	"encoding/json"
-	"fmt"
 	"net"
 
 	"github.com/sirupsen/logrus"
@@ -135,7 +134,7 @@ func GetHNSEndpointByName(endpointName string) (*HNSEndpoint, error) {
 			return &hnsEndpoint, nil
 		}
 	}
-	return nil, fmt.Errorf("Endpoint %v not found", endpointName)
+	return nil, EndpointNotFoundError{EndpointName: endpointName}
 }
 
 // Create Endpoint by sending EndpointRequest to HNS. TODO: Create a separate HNS interface to place all these methods

--- a/hnsnetwork.go
+++ b/hnsnetwork.go
@@ -2,7 +2,6 @@ package hcsshim
 
 import (
 	"encoding/json"
-	"fmt"
 	"net"
 
 	"github.com/sirupsen/logrus"
@@ -90,7 +89,7 @@ func GetHNSNetworkByName(networkName string) (*HNSNetwork, error) {
 			return &hnsnetwork, nil
 		}
 	}
-	return nil, fmt.Errorf("Network %v not found", networkName)
+	return nil, NetworkNotFoundError{NetworkName: networkName}
 }
 
 // Create Network by sending NetworkRequest to HNS.


### PR DESCRIPTION
This makes it easier to determine whether we got an error because a resource does not exist or something else went wrong. For example, we currently have code like this:

```
network, err := hcsshim.GetHNSNetworkByName(networkName)
if err != nil {
	if err.Error() == fmt.Sprintf("Network %s not found", networkName) {
		return nil
	}
	return err
}
```

It is brittle and tightly coupled to your implementation. We could instead write it as:

```
network, err := hcsshim.GetHNSNetworkByName(networkName)
if err != nil {
	if hcsshim.IsNotExist(err) {
		return nil
	}
	return err
}
```