### PR TITLE
Stop skipping directory reparse points in Go1.9

### DIFF
--- a/legacy.go
+++ b/legacy.go
@@ -490,8 +490,9 @@ func cloneTree(srcPath, destPath string, mutatedFiles map[string]bool) error {
 			}
 		}
 
-		// Don't recurse on reparse points.
-		if info.IsDir() && isReparsePoint {
+		// Don't recurse on reparse points in go1.8 and older. Filepath.Walk
+		// handles this in go1.9 and newer.
+		if info.IsDir() && isReparsePoint && shouldSkipDirectoryReparse {
 			return filepath.SkipDir
 		}
 

--- a/legacy18.go
+++ b/legacy18.go
@@ -1,0 +1,7 @@
+// +build !go1.9
+
+package hcsshim
+
+// Due to a bug in go1.8 and before, directory reparse points need to be skipped
+// during filepath.Walk. This is fixed in go1.9
+var shouldSkipDirectoryReparse = true

--- a/legacy19.go
+++ b/legacy19.go
@@ -1,0 +1,7 @@
+// +build go1.9
+
+package hcsshim
+
+// Due to a bug in go1.8 and before, directory reparse points need to be skipped
+// during filepath.Walk. This is fixed in go1.9
+var shouldSkipDirectoryReparse = false


### PR DESCRIPTION
Due to a bug fixed in Golang 1.9, filepath.Walk needs to stop skipping directory reparse points in Go1.9 and newer. This fixes the issues being seen in https://github.com/Microsoft/hcsshim/pull/144 when using the raw file attribute check to determine if the dir should be skipped.

@jstarks 

Signed-off-by: Darren Stahl <darst@microsoft.com>