### PR TITLE
Add FilterDriver const

### DIFF
--- a/layerutils.go
+++ b/layerutils.go
@@ -27,6 +27,9 @@ type DriverInfo struct {
 	HomeDir string
 }
 
+// FilterDriver is the Flavour constant for the Windows Filter Driver
+const FilterDriver = 1
+
 type driverInfo struct {
 	Flavour  int
 	HomeDirp *uint16


### PR DESCRIPTION
Adding FilterDriver const so consumers don't need to all define their own filter driver const.

Signed-off-by: Darren Stahl <darst@microsoft.com>

@jhowardmsft @jstarks 