### PR TITLE
Removes servicing/pending updates

### DIFF
--- a/container.go
+++ b/container.go
@@ -16,7 +16,6 @@ var (
 )
 
 const (
-	pendingUpdatesQuery    = `{ "PropertyTypes" : ["PendingUpdates"]}`
 	statisticsQuery        = `{ "PropertyTypes" : ["Statistics"]}`
 	processListQuery       = `{ "PropertyTypes" : ["ProcessList"]}`
 	mappedVirtualDiskQuery = `{ "PropertyTypes" : ["MappedVirtualDisk"]}`
@@ -41,7 +40,6 @@ type ContainerProperties struct {
 	RuntimeImagePath             string                              `json:",omitempty"`
 	Stopped                      bool                                `json:",omitempty"`
 	ExitType                     string                              `json:",omitempty"`
-	AreUpdatesPending            bool                                `json:",omitempty"`
 	ObRoot                       string                              `json:",omitempty"`
 	Statistics                   Statistics                          `json:",omitempty"`
 	ProcessList                  []ProcessListItem                   `json:",omitempty"`
@@ -435,27 +433,6 @@ func (container *container) properties(query string) (*ContainerProperties, erro
 		return nil, err
 	}
 	return properties, nil
-}
-
-// HasPendingUpdates returns true if the container has updates pending to install
-func (container *container) HasPendingUpdates() (bool, error) {
-	container.handleLock.RLock()
-	defer container.handleLock.RUnlock()
-	operation := "HasPendingUpdates"
-	title := "HCSShim::Container::" + operation
-	logrus.Debugf(title+" id=%s", container.id)
-
-	if container.handle == 0 {
-		return false, makeContainerError(container, operation, "", ErrAlreadyClosed)
-	}
-
-	properties, err := container.properties(pendingUpdatesQuery)
-	if err != nil {
-		return false, makeContainerError(container, operation, "", err)
-	}
-
-	logrus.Debugf(title+" succeeded id=%s", container.id)
-	return properties.AreUpdatesPending, nil
 }
 
 // Statistics returns statistics for the container

--- a/interface.go
+++ b/interface.go
@@ -87,7 +87,6 @@ type ContainerConfig struct {
 	NetworkSharedContainerName  string              `json:",omitempty"` // Name (ID) of the container that we will share the network stack with.
 	EndpointList                []string            `json:",omitempty"` // List of networking endpoints to be attached to container
 	HvRuntime                   *HvRuntime          `json:",omitempty"` // Hyper-V container settings. Used by Hyper-V containers only. Format ImagePath=%root%\BaseLayerID\UtilityVM
-	Servicing                   bool                `json:",omitempty"` // True if this container is for servicing
 	AllowUnqualifiedDNSQuery    bool                `json:",omitempty"` // True to allow unqualified DNS name resolution
 	DNSSearchList               string              `json:",omitempty"` // Comma seperated list of DNS suffixes to use for name resolution
 	ContainerType               string              `json:",omitempty"` // "Linux" for Linux containers on Windows. Omitted otherwise.
@@ -125,9 +124,6 @@ type Container interface {
 
 	// Resume resumes the execution of a container.
 	Resume() error
-
-	// HasPendingUpdates returns true if the container has updates pending to install.
-	HasPendingUpdates() (bool, error)
 
 	// Statistics returns statistics for a container.
 	Statistics() (Statistics, error)


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

@darrenstahlmsft PTAL. Removes support for functionality that didn't work in RS1..RS3 and was removed in RS4 (cupdate no longer exists)

Don't merge until https://github.com/moby/moby/pull/36267 has been merged. Steps are:

1. Wait for https://github.com/moby/moby/pull/36267 to be merged
2. Merge this
3. New HCSShim release
4. Open PR to re-vendor back into moby/moby
