### PR TITLE
Fix oopsie to not cause files to be skipped

### DIFF
--- a/legacy.go
+++ b/legacy.go
@@ -127,7 +127,7 @@ func (r *legacyLayerReader) walkUntilCancelled() error {
 		// UTF16 to UTF8 in files which are left in the recycle bin. Os.Lstat
 		// which is called by filepath.Walk will fail when a filename contains
 		// unicode characters. Skip the recycle bin regardless which is goodness.
-		if strings.HasPrefix(path, filepath.Join(r.root, `Files\$Recycle.Bin`)) {
+		if path == filepath.Join(r.root, `Files\$Recycle.Bin`) && info.IsDir() {
 			return filepath.SkipDir
 		}
 


### PR DESCRIPTION
Signed-off-by: John Howard (VM) <jhoward@ntdev.microsoft.com>

Found via https://github.com/docker/for-win/issues/1947, needs re-vendoring into moby/moby after. It turns out that returning `SkipDir` on a file causes golangs walk to become non-deterministic. With the previous fix for moby/moby 32838, it would return `SkipDir` on `Files\$Recycle.Bin\$wcidirs$` incorrectly. The update checks for an exact filename match, plus verification it is a directory. Have verified locally.

@darrenstahlmsft PTAL.  @johnstep FYI.
