### PR TITLE
wclayer: New package and utility for WCOW layer ops

### DIFF
--- a/cmd/wclayer/create.go
+++ b/cmd/wclayer/create.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"path/filepath"
+
+	"github.com/Microsoft/hcsshim"
+	"github.com/Microsoft/hcsshim/internal/appargs"
+	"github.com/urfave/cli"
+)
+
+var createCommand = cli.Command{
+	Name:  "create",
+	Usage: "creates a new writable container layer",
+	Flags: []cli.Flag{
+		cli.StringSliceFlag{
+			Name:  "layer, l",
+			Usage: "paths to the read-only parent layers",
+		},
+	},
+	ArgsUsage: "<layer path>",
+	Before:    appargs.Validate(appargs.Required),
+	Action: func(context *cli.Context) error {
+		path, err := filepath.Abs(context.Args().First())
+		if err != nil {
+			return err
+		}
+
+		layers, err := normalizeLayers(context.StringSlice("layer"), true)
+		if err != nil {
+			return err
+		}
+
+		di := driverInfo
+		return hcsshim.CreateSandboxLayer(di, path, layers[len(layers)-1], layers)
+	},
+}

--- a/cmd/wclayer/export.go
+++ b/cmd/wclayer/export.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"compress/gzip"
+	"io"
+	"os"
+	"path/filepath"
+
+	winio "github.com/Microsoft/go-winio"
+	"github.com/Microsoft/hcsshim/internal/appargs"
+	"github.com/Microsoft/hcsshim/oci/wclayer"
+	"github.com/urfave/cli"
+)
+
+var exportCommand = cli.Command{
+	Name:  "export",
+	Usage: "exports a layer to a tar file",
+	Flags: []cli.Flag{
+		cli.StringSliceFlag{
+			Name:  "layer, l",
+			Usage: "paths to the read-only parent layers",
+		},
+		cli.StringFlag{
+			Name:  "output, o",
+			Usage: "output layer tar (defaults to stdout)",
+		},
+		cli.BoolFlag{
+			Name:  "gzip, z",
+			Usage: "compress output with gzip compression",
+		},
+	},
+	ArgsUsage: "<layer path>",
+	Before:    appargs.Validate(appargs.Required),
+	Action: func(context *cli.Context) (err error) {
+		path, err := filepath.Abs(context.Args().First())
+		if err != nil {
+			return err
+		}
+
+		layers, err := normalizeLayers(context.StringSlice("layer"), true)
+		if err != nil {
+			return err
+		}
+
+		err = winio.EnableProcessPrivileges([]string{winio.SeBackupPrivilege})
+		if err != nil {
+			return err
+		}
+
+		fp := context.String("output")
+		f := os.Stdout
+		if fp != "" {
+			f, err = os.Create(fp)
+			if err != nil {
+				return err
+			}
+			defer f.Close()
+		}
+		w := io.Writer(f)
+		if context.Bool("gzip") {
+			w = gzip.NewWriter(w)
+		}
+
+		return wclayer.ExportLayer(w, path, layers)
+	},
+}

--- a/cmd/wclayer/import.go
+++ b/cmd/wclayer/import.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"bufio"
+	"compress/gzip"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/Microsoft/go-winio"
+	"github.com/Microsoft/hcsshim/internal/appargs"
+	"github.com/Microsoft/hcsshim/oci/wclayer"
+	"github.com/urfave/cli"
+)
+
+var importCommand = cli.Command{
+	Name:  "import",
+	Usage: "imports a layer from a tar file",
+	Flags: []cli.Flag{
+		cli.StringSliceFlag{
+			Name:  "layer, l",
+			Usage: "paths to the read-only parent layers",
+		},
+		cli.StringFlag{
+			Name:  "input, i",
+			Usage: "input layer tar (defaults to stdin)",
+		},
+	},
+	ArgsUsage: "<layer path>",
+	Before:    appargs.Validate(appargs.Required),
+	Action: func(context *cli.Context) (err error) {
+		path, err := filepath.Abs(context.Args().First())
+		if err != nil {
+			return err
+		}
+
+		layers, err := normalizeLayers(context.StringSlice("layer"), false)
+		if err != nil {
+			return err
+		}
+
+		fp := context.String("input")
+		f := os.Stdin
+		if fp != "" {
+			f, err = os.Open(fp)
+			if err != nil {
+				return err
+			}
+			defer f.Close()
+		}
+		r, err := addDecompressor(f)
+		if err != nil {
+			return err
+		}
+		err = winio.EnableProcessPrivileges([]string{winio.SeBackupPrivilege, winio.SeRestorePrivilege})
+		if err != nil {
+			return err
+		}
+		_, err = wclayer.ImportLayer(r, path, layers)
+		return err
+	},
+}
+
+func addDecompressor(r io.Reader) (io.Reader, error) {
+	b := bufio.NewReader(r)
+	hdr, err := b.Peek(3)
+	if err != nil {
+		return nil, err
+	}
+	if hdr[0] == 0x1f && hdr[1] == 0x8b && hdr[2] == 8 {
+		return gzip.NewReader(b)
+	}
+	return b, nil
+}

--- a/cmd/wclayer/mount.go
+++ b/cmd/wclayer/mount.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/Microsoft/hcsshim"
+	"github.com/Microsoft/hcsshim/internal/appargs"
+	"github.com/urfave/cli"
+)
+
+var mountCommand = cli.Command{
+	Name:      "mount",
+	Usage:     "mounts a sandbox",
+	ArgsUsage: "<sandbox path>",
+	Flags: []cli.Flag{
+		cli.StringSliceFlag{
+			Name:  "layer, l",
+			Usage: "paths to the parent layers for this layer",
+		},
+	},
+	Action: func(context *cli.Context) (err error) {
+		if context.NArg() != 1 {
+			return errors.New("invalid usage")
+		}
+		path, err := filepath.Abs(context.Args().First())
+		if err != nil {
+			return err
+		}
+
+		layers, err := normalizeLayers(context.StringSlice("layer"), true)
+		if err != nil {
+			return err
+		}
+
+		err = hcsshim.ActivateLayer(driverInfo, path)
+		if err != nil {
+			return err
+		}
+		defer func() {
+			if err != nil {
+				hcsshim.DeactivateLayer(driverInfo, path)
+			}
+		}()
+
+		err = hcsshim.PrepareLayer(driverInfo, path, layers)
+		if err != nil {
+			return err
+		}
+		defer func() {
+			if err != nil {
+				hcsshim.UnprepareLayer(driverInfo, path)
+			}
+		}()
+
+		mountPath, err := hcsshim.GetLayerMountPath(driverInfo, path)
+		if err != nil {
+			return err
+		}
+		_, err = fmt.Println(mountPath)
+		return err
+	},
+}
+
+var unmountCommand = cli.Command{
+	Name:      "unmount",
+	Usage:     "unmounts a sandbox",
+	ArgsUsage: "<layer path>",
+	Before:    appargs.Validate(appargs.Required),
+	Action: func(context *cli.Context) (err error) {
+		path, err := filepath.Abs(context.Args().First())
+		if err != nil {
+			return err
+		}
+
+		err = hcsshim.UnprepareLayer(driverInfo, path)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+		}
+		err = hcsshim.DeactivateLayer(driverInfo, path)
+		if err != nil {
+			return err
+		}
+		return nil
+	},
+}

--- a/cmd/wclayer/remove.go
+++ b/cmd/wclayer/remove.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"path/filepath"
+
+	winio "github.com/Microsoft/go-winio"
+	"github.com/Microsoft/hcsshim"
+	"github.com/Microsoft/hcsshim/internal/appargs"
+
+	"github.com/urfave/cli"
+)
+
+var removeCommand = cli.Command{
+	Name:      "remove",
+	Usage:     "permanently removes a layer directory in its entirety",
+	ArgsUsage: "<layer path>",
+	Before:    appargs.Validate(appargs.Required),
+	Action: func(context *cli.Context) (err error) {
+		path, err := filepath.Abs(context.Args().First())
+		if err != nil {
+			return err
+		}
+
+		err = winio.EnableProcessPrivileges([]string{winio.SeBackupPrivilege, winio.SeRestorePrivilege})
+		if err != nil {
+			return err
+		}
+
+		return hcsshim.DestroyLayer(driverInfo, path)
+	},
+}

--- a/cmd/wclayer/wclayer.go
+++ b/cmd/wclayer/wclayer.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/Microsoft/hcsshim"
+	"github.com/urfave/cli"
+)
+
+var usage = `Windows Container layer utility
+
+wclayer is a command line tool for manipulating Windows Container
+storage layers. It can import and export layers from and to OCI format
+layer tar files, create new writable layers, and mount and unmount
+container images.`
+
+var driverInfo = hcsshim.DriverInfo{}
+
+func main() {
+	app := cli.NewApp()
+	app.Name = "wclayer"
+	app.Commands = []cli.Command{
+		createCommand,
+		exportCommand,
+		importCommand,
+		mountCommand,
+		removeCommand,
+		unmountCommand,
+	}
+	app.Usage = usage
+
+	if err := app.Run(os.Args); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func normalizeLayers(il []string, needOne bool) ([]string, error) {
+	if needOne && len(il) == 0 {
+		return nil, errors.New("at least one read-only layer must be specified")
+	}
+	ol := make([]string, len(il))
+	for i := range il {
+		var err error
+		ol[i], err = filepath.Abs(il[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return ol, nil
+}

--- a/internal/appargs/appargs.go
+++ b/internal/appargs/appargs.go
@@ -1,0 +1,67 @@
+// Package appargs provides argument validation routines for use with
+// github.com/urfave/cli.
+package appargs
+
+import (
+	"errors"
+
+	"github.com/urfave/cli"
+)
+
+// Validator is an argument validator function. It returns the number of
+// arguments consumed or -1 on error.
+type Validator = func([]string) int
+
+// Required is a validator for a single required parameter.
+func Required(args []string) int {
+	if len(args) == 0 {
+		return -1
+	}
+	return 1
+}
+
+// Required is a validator for a single required parameter that must not be
+// empty.
+func RequiredNonEmpty(args []string) int {
+	if len(args) == 0 || args[0] == "" {
+		return -1
+	}
+	return 1
+}
+
+// Optional is a validator for an optional parameter.
+func Optional(args []string) int {
+	if len(args) == 0 {
+		return 0
+	}
+	return 1
+}
+
+// Rest is a validator that consumes the rest of the arguments without validation.
+func Rest(args []string) int {
+	return len(args)
+}
+
+// ErrInvalidUsage is returned when there is a validation error.
+var ErrInvalidUsage = errors.New("invalid command usage")
+
+// Validate can be used as a command's Before function to validate the arguments
+// to the command.
+func Validate(vs ...Validator) cli.BeforeFunc {
+	return func(context *cli.Context) error {
+		remaining := context.Args()
+		for _, v := range vs {
+			consumed := v(remaining)
+			if consumed < 0 {
+				return ErrInvalidUsage
+			}
+			remaining = remaining[consumed:]
+		}
+
+		if len(remaining) > 0 {
+			return ErrInvalidUsage
+		}
+
+		return nil
+	}
+}

--- a/oci/wclayer/export.go
+++ b/oci/wclayer/export.go
@@ -1,0 +1,80 @@
+// Package wclayer provides functions for importing and exporting Windows
+// container layers from and to their OCI tar representation.
+package wclayer
+
+import (
+	"io"
+	"path/filepath"
+
+	"github.com/Microsoft/go-winio/archive/tar"
+	"github.com/Microsoft/go-winio/backuptar"
+	"github.com/Microsoft/hcsshim"
+	"github.com/docker/docker/pkg/archive"
+)
+
+var driverInfo = hcsshim.DriverInfo{}
+
+// ExportLayer writes an OCI layer tar stream from the provided on-disk layer.
+// The caller must specify the parent layers, if any, ordered from lowest to
+// highest layer.
+//
+// The layer will be mounted for this process, so the caller should ensure that
+// it is not currently mounted.
+func ExportLayer(w io.Writer, path string, parentLayerPaths []string) error {
+	err := hcsshim.ActivateLayer(driverInfo, path)
+	if err != nil {
+		return err
+	}
+	defer hcsshim.DeactivateLayer(driverInfo, path)
+
+	// Prepare and unprepare the layer to ensure that it has been initialized.
+	err = hcsshim.PrepareLayer(driverInfo, path, parentLayerPaths)
+	if err != nil {
+		return err
+	}
+	err = hcsshim.UnprepareLayer(driverInfo, path)
+	if err != nil {
+		return err
+	}
+
+	r, err := hcsshim.NewLayerReader(driverInfo, path, parentLayerPaths)
+	if err != nil {
+		return err
+	}
+
+	err = writeTarFromLayer(r, w)
+	cerr := r.Close()
+	if err != nil {
+		return err
+	}
+	return cerr
+}
+
+func writeTarFromLayer(r hcsshim.LayerReader, w io.Writer) error {
+	t := tar.NewWriter(w)
+	for {
+		name, size, fileInfo, err := r.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return err
+		}
+		if fileInfo == nil {
+			// Write a whiteout file.
+			hdr := &tar.Header{
+				Name: filepath.ToSlash(filepath.Join(filepath.Dir(name), archive.WhiteoutPrefix+filepath.Base(name))),
+			}
+			err := t.WriteHeader(hdr)
+			if err != nil {
+				return err
+			}
+		} else {
+			err = backuptar.WriteTarFileFromBackupStream(t, r, name, size, fileInfo)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return t.Close()
+}

--- a/oci/wclayer/import.go
+++ b/oci/wclayer/import.go
@@ -1,0 +1,140 @@
+package wclayer
+
+import (
+	"bufio"
+	"io"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
+	winio "github.com/Microsoft/go-winio"
+	"github.com/Microsoft/go-winio/archive/tar"
+	"github.com/Microsoft/go-winio/backuptar"
+	"github.com/Microsoft/hcsshim"
+	"github.com/docker/docker/pkg/archive"
+)
+
+var (
+	// mutatedFiles is a list of files that are mutated by the import process
+	// and must be backed up and restored.
+	mutatedFiles = map[string]string{
+		"UtilityVM/Files/EFI/Microsoft/Boot/BCD":      "bcd.bak",
+		"UtilityVM/Files/EFI/Microsoft/Boot/BCD.LOG":  "bcd.log.bak",
+		"UtilityVM/Files/EFI/Microsoft/Boot/BCD.LOG1": "bcd.log1.bak",
+		"UtilityVM/Files/EFI/Microsoft/Boot/BCD.LOG2": "bcd.log2.bak",
+	}
+)
+
+// ImportLayer reads a layer from an OCI layer tar stream and extracts it to the
+// specified path. The caller must specify the parent layers, if any, ordered
+// from lowest to highest layer.
+//
+// The caller must ensure that the thread or process has acquired backup and
+// restore privileges.
+//
+// This function returns the total size of the layer's files, in bytes.
+func ImportLayer(r io.Reader, path string, parentLayerPaths []string) (int64, error) {
+	err := os.MkdirAll(path, 0)
+	if err != nil {
+		return 0, err
+	}
+	w, err := hcsshim.NewLayerWriter(hcsshim.DriverInfo{}, path, parentLayerPaths)
+	if err != nil {
+		return 0, err
+	}
+	n, err := writeLayerFromTar(r, w, path)
+	cerr := w.Close()
+	if err != nil {
+		return 0, err
+	}
+	if cerr != nil {
+		return 0, cerr
+	}
+	return n, nil
+}
+
+func writeLayerFromTar(r io.Reader, w hcsshim.LayerWriter, root string) (int64, error) {
+	t := tar.NewReader(r)
+	hdr, err := t.Next()
+	totalSize := int64(0)
+	buf := bufio.NewWriter(nil)
+	for err == nil {
+		base := path.Base(hdr.Name)
+		if strings.HasPrefix(base, archive.WhiteoutPrefix) {
+			name := path.Join(path.Dir(hdr.Name), base[len(archive.WhiteoutPrefix):])
+			err = w.Remove(filepath.FromSlash(name))
+			if err != nil {
+				return 0, err
+			}
+			hdr, err = t.Next()
+		} else if hdr.Typeflag == tar.TypeLink {
+			err = w.AddLink(filepath.FromSlash(hdr.Name), filepath.FromSlash(hdr.Linkname))
+			if err != nil {
+				return 0, err
+			}
+			hdr, err = t.Next()
+		} else {
+			var (
+				name     string
+				size     int64
+				fileInfo *winio.FileBasicInfo
+			)
+			name, size, fileInfo, err = backuptar.FileInfoFromHeader(hdr)
+			if err != nil {
+				return 0, err
+			}
+			err = w.Add(filepath.FromSlash(name), fileInfo)
+			if err != nil {
+				return 0, err
+			}
+			hdr, err = writeBackupStreamFromTarAndSaveMutatedFiles(buf, w, t, hdr, root)
+			totalSize += size
+		}
+	}
+	if err != io.EOF {
+		return 0, err
+	}
+	return totalSize, nil
+}
+
+// writeBackupStreamFromTarAndSaveMutatedFiles reads data from a tar stream and
+// writes it to a backup stream, and also saves any files that will be mutated
+// by the import layer process to a backup location.
+func writeBackupStreamFromTarAndSaveMutatedFiles(buf *bufio.Writer, w io.Writer, t *tar.Reader, hdr *tar.Header, root string) (nextHdr *tar.Header, err error) {
+	var bcdBackup *os.File
+	var bcdBackupWriter *winio.BackupFileWriter
+	if backupPath, ok := mutatedFiles[hdr.Name]; ok {
+		bcdBackup, err = os.Create(filepath.Join(root, backupPath))
+		if err != nil {
+			return nil, err
+		}
+		defer func() {
+			cerr := bcdBackup.Close()
+			if err == nil {
+				err = cerr
+			}
+		}()
+
+		bcdBackupWriter = winio.NewBackupFileWriter(bcdBackup, false)
+		defer func() {
+			cerr := bcdBackupWriter.Close()
+			if err == nil {
+				err = cerr
+			}
+		}()
+
+		buf.Reset(io.MultiWriter(w, bcdBackupWriter))
+	} else {
+		buf.Reset(w)
+	}
+
+	defer func() {
+		ferr := buf.Flush()
+		if err == nil {
+			err = ferr
+		}
+	}()
+
+	return backuptar.WriteBackupStreamFromTarFile(buf, t, hdr)
+}


### PR DESCRIPTION
This adds new packages oci/wclayer and cmd/wclayer that can be used to
manipulate Windows container layers. The former is concerned only with
importing and exporting layers from and to their OCI tar formats. The
latter is a command line tool with myriad uses.