### PR TITLE
Move oci/wclayer to internal for now

### DIFF
--- a/cmd/wclayer/export.go
+++ b/cmd/wclayer/export.go
@@ -8,7 +8,7 @@ import (
 
 	winio "github.com/Microsoft/go-winio"
 	"github.com/Microsoft/hcsshim/internal/appargs"
-	"github.com/Microsoft/hcsshim/oci/wclayer"
+	"github.com/Microsoft/hcsshim/internal/ociwclayer"
 	"github.com/urfave/cli"
 )
 
@@ -61,6 +61,6 @@ var exportCommand = cli.Command{
 			w = gzip.NewWriter(w)
 		}
 
-		return wclayer.ExportLayer(w, path, layers)
+		return ociwclayer.ExportLayer(w, path, layers)
 	},
 }

--- a/cmd/wclayer/import.go
+++ b/cmd/wclayer/import.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/Microsoft/go-winio"
 	"github.com/Microsoft/hcsshim/internal/appargs"
-	"github.com/Microsoft/hcsshim/oci/wclayer"
+	"github.com/Microsoft/hcsshim/internal/ociwclayer"
 	"github.com/urfave/cli"
 )
 
@@ -56,7 +56,7 @@ var importCommand = cli.Command{
 		if err != nil {
 			return err
 		}
-		_, err = wclayer.ImportLayer(r, path, layers)
+		_, err = ociwclayer.ImportLayer(r, path, layers)
 		return err
 	},
 }

--- a/internal/ociwclayer/export.go
+++ b/internal/ociwclayer/export.go
@@ -1,6 +1,6 @@
-// Package wclayer provides functions for importing and exporting Windows
+// Package ociwclayer provides functions for importing and exporting Windows
 // container layers from and to their OCI tar representation.
-package wclayer
+package ociwclayer
 
 import (
 	"io"

--- a/internal/ociwclayer/import.go
+++ b/internal/ociwclayer/import.go
@@ -1,4 +1,4 @@
-package wclayer
+package ociwclayer
 
 import (
 	"bufio"


### PR DESCRIPTION
We may want to iterate on this interface a bit before we support it
outside of hcsshim.