### PR TITLE
runhcs: Open shim logs on stderr

### DIFF
--- a/cmd/runhcs/shim.go
+++ b/cmd/runhcs/shim.go
@@ -15,6 +15,7 @@ import (
 	"github.com/Microsoft/hcsshim/internal/hcs"
 	"github.com/Microsoft/hcsshim/internal/schema1"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 	"golang.org/x/sys/windows"
 )
@@ -43,8 +44,8 @@ var shimCommand = cli.Command{
 	},
 	Before: appargs.Validate(argID),
 	Action: func(context *cli.Context) error {
-		// Stdout is not used.
-		os.Stdout.Close()
+		logrus.SetOutput(os.Stderr)
+		fatalWriter.Writer = os.Stdout
 
 		id := context.Args().First()
 		c, err := getContainer(id, true)
@@ -66,7 +67,7 @@ var shimCommand = cli.Command{
 		exec := context.Bool("exec")
 		terminateOnFailure := false
 
-		errorOut := io.WriteCloser(os.Stderr)
+		errorOut := io.WriteCloser(os.Stdout)
 
 		var spec *specs.Process
 

--- a/cmd/runhcs/utils.go
+++ b/cmd/runhcs/utils.go
@@ -44,7 +44,7 @@ func createPidFile(path string, pid int) error {
 func safePipePath(name string) string {
 	// Use a pipe in the Administrators protected prefixed to prevent malicious
 	// squatting.
-	return fmt.Sprintf(`\\.\pipe\ProtectedPrefix\Administrators\runhcs-vmshim-%s`, url.PathEscape(name))
+	return `\\.\pipe\ProtectedPrefix\Administrators\` + url.PathEscape(name)
 }
 
 func closeWritePipe(pipe net.Conn) error {

--- a/cmd/runhcs/vm.go
+++ b/cmd/runhcs/vm.go
@@ -34,8 +34,8 @@ var vmshimCommand = cli.Command{
 	Flags:  []cli.Flag{},
 	Before: appargs.Validate(argID),
 	Action: func(context *cli.Context) error {
-		// Stdout is not used.
-		os.Stdout.Close()
+		logrus.SetOutput(os.Stderr)
+		fatalWriter.Writer = os.Stdout
 
 		id := context.Args().First()
 
@@ -72,8 +72,8 @@ var vmshimCommand = cli.Command{
 
 		// Alert the parent process that initialization has completed
 		// successfully.
-		os.Stderr.Write(shimSuccess)
-		os.Stderr.Close()
+		os.Stdout.Write(shimSuccess)
+		os.Stdout.Close()
 		fatalWriter.Writer = ioutil.Discard
 
 		pipeCh := make(chan net.Conn)


### PR DESCRIPTION
This change opens the shim log files onto the shim processes' standard
error so that Go panics for those processes are written to the log.