### PR TITLE
runhcs: Use random pipe names when communicating

### DIFF
--- a/cmd/runhcs/shim.go
+++ b/cmd/runhcs/shim.go
@@ -91,8 +91,7 @@ var shimCommand = cli.Command{
 			os.Stdin.Close()
 
 			// Listen on the named pipe associated with this container.
-			pipePath := containerPipePath(id)
-			l, err := winio.ListenPipe(pipePath, nil)
+			l, err := winio.ListenPipe(c.ShimPipePath(), nil)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
When a container ID is reused, it's possible to get runhcs into a state
where it will try to connect to the wrong VM (e.g. when cleaning up
resources for a container whose host has been deleted and recreated).

Resolve this comprehensively by using a new random ID to generate the
pipe names for each container.