### PR TITLE
hcsoci: Simplify VSMB

### DIFF
--- a/internal/wclayer/layerid.go
+++ b/internal/wclayer/layerid.go
@@ -1,0 +1,13 @@
+package wclayer
+
+import (
+	"path/filepath"
+
+	"github.com/Microsoft/hcsshim/internal/guid"
+)
+
+// LayerID returns the layer ID of a layer on disk.
+func LayerID(path string) (guid.GUID, error) {
+	_, file := filepath.Split(path)
+	return NameToGuid(file)
+}

--- a/internal/wclayer/layerutils.go
+++ b/internal/wclayer/layerutils.go
@@ -4,7 +4,6 @@ package wclayer
 // functionality.
 
 import (
-	"path/filepath"
 	"syscall"
 
 	"github.com/Microsoft/hcsshim/internal/guid"
@@ -74,10 +73,7 @@ func layerPathsToDescriptors(parentLayerPaths []string) ([]WC_LAYER_DESCRIPTOR, 
 	var layers []WC_LAYER_DESCRIPTOR
 
 	for i := 0; i < len(parentLayerPaths); i++ {
-		// Create a layer descriptor, using the folder name
-		// as the source for a GUID LayerId
-		_, folderName := filepath.Split(parentLayerPaths[i])
-		g, err := NameToGuid(folderName)
+		g, err := LayerID(parentLayerPaths[i])
 		if err != nil {
 			logrus.Debugf("Failed to convert name to guid %s", err)
 			return nil, err

--- a/uvm/types.go
+++ b/uvm/types.go
@@ -17,10 +17,10 @@ import (
 // Read-Only Layer    | VSMB | VPMEM
 // Mapped Directory   | VSMB | PLAN9
 
-// vsmbInfo is an internal structure used for ref-counting VSMB shares mapped to a Windows utility VM.
-type vsmbInfo struct {
+// vsmbShare is an internal structure used for ref-counting VSMB shares mapped to a Windows utility VM.
+type vsmbShare struct {
 	refCount uint32
-	guid     string // effectively a hash of the host path to use as a name and in the resource URI to uniquely identify it
+	name     string
 	uvmPath  string
 }
 
@@ -66,7 +66,8 @@ type UtilityVM struct {
 
 	// VSMB shares that are mapped into a Windows UVM. These are used for read-only
 	// layers and mapped directories
-	vsmbShares map[string]vsmbInfo
+	vsmbShares  map[string]*vsmbShare
+	vsmbCounter uint64 // Counter to generate a unique share name for each VSMB share.
 
 	// VPMEM devices that are mapped into a Linux UVM. These are used for read-only layers.
 	vpmemDevices [maxVPMEM]vpmemInfo // Limited by ACPI size.

--- a/uvm/vsmb_test.go
+++ b/uvm/vsmb_test.go
@@ -6,19 +6,18 @@ package uvm
 
 import (
 	"os"
-	"strings"
 	"testing"
 
 	"github.com/Microsoft/hcsshim/internal/schema2"
 )
 
-// TestVSMBRO tests adding/removing VSMB Read-Only layers from a v2 Windows utility VM
-func TestVSMBRO(t *testing.T) {
+// TestVSMB tests adding/removing VSMB layers from a v2 Windows utility VM
+func TestVSMB(t *testing.T) {
 	uvm, uvmScratchDir := createWCOWUVM(t, layersNanoserver, "", nil)
 	defer os.RemoveAll(uvmScratchDir)
 	defer uvm.Terminate()
 
-	dir := strings.ToUpper(createTempDir(t)) // Force upper-case
+	dir := createTempDir(t)
 	defer os.RemoveAll(dir)
 	var iterations uint32 = 64
 	for i := 0; i < int(iterations); i++ {
@@ -29,23 +28,8 @@ func TestVSMBRO(t *testing.T) {
 	if len(uvm.vsmbShares) != 1 {
 		t.Fatalf("Should only be one VSMB entry")
 	}
-	if _, ok := uvm.vsmbShares[dir]; ok {
-		t.Fatalf("should not found as upper case")
-	}
-	if _, ok := uvm.vsmbShares[strings.ToLower(dir)]; !ok {
-		t.Fatalf("not found!")
-	}
-	if uvm.vsmbShares[strings.ToLower(dir)].refCount != iterations {
-		t.Fatalf("iteration mismatch: %d %d", iterations, uvm.vsmbShares[strings.ToLower(dir)].refCount)
-	}
-
-	// Verify the GUID matches the internal data-structure
-	g, err := uvm.GetVSMBGUID(dir)
-	if err != nil {
-		t.Fatalf("failed to find guid")
-	}
-	if uvm.vsmbShares[strings.ToLower(dir)].guid != g {
-		t.Fatalf("guid from GetVSMBShareGUID doesn't match")
+	if uvm.vsmbShares[dir].refCount != iterations {
+		t.Fatalf("iteration mismatch: %d %d %+v", iterations, uvm.vsmbShares[dir].refCount, uvm.vsmbShares[dir])
 	}
 
 	// Remove them all
@@ -57,7 +41,6 @@ func TestVSMBRO(t *testing.T) {
 	if len(uvm.vsmbShares) != 0 {
 		t.Fatalf("Should not be any vsmb entries remaining")
 	}
-
 }
 
 // TODO: VSMB for mapped directories


### PR DESCRIPTION
This restore's jhoward's previous change to separate the layer ID from
the VSMB share name, but fixes it to still pass the layer ID correctly
for the container and combined layers calls.