### PR TITLE
Rename sandbox to scratch, part 1.

### DIFF
--- a/cmd/wclayer/create.go
+++ b/cmd/wclayer/create.go
@@ -31,6 +31,6 @@ var createCommand = cli.Command{
 		}
 
 		di := driverInfo
-		return hcsshim.CreateSandboxLayer(di, path, layers[len(layers)-1], layers)
+		return hcsshim.CreateScratchLayer(di, path, layers[len(layers)-1], layers)
 	},
 }

--- a/cmd/wclayer/mount.go
+++ b/cmd/wclayer/mount.go
@@ -13,8 +13,8 @@ import (
 
 var mountCommand = cli.Command{
 	Name:      "mount",
-	Usage:     "mounts a sandbox",
-	ArgsUsage: "<sandbox path>",
+	Usage:     "mounts a scratch",
+	ArgsUsage: "<scratch path>",
 	Flags: []cli.Flag{
 		cli.StringSliceFlag{
 			Name:  "layer, l",
@@ -66,7 +66,7 @@ var mountCommand = cli.Command{
 
 var unmountCommand = cli.Command{
 	Name:      "unmount",
-	Usage:     "unmounts a sandbox",
+	Usage:     "unmounts a scratch",
 	ArgsUsage: "<layer path>",
 	Before:    appargs.Validate(appargs.NonEmptyString),
 	Action: func(context *cli.Context) (err error) {

--- a/functional/utilities/scratch.go
+++ b/functional/utilities/scratch.go
@@ -14,7 +14,7 @@ const lcowGlobalSVMID = "test.lcowglobalsvm"
 
 var (
 	lcowGlobalSVM        *uvm.UtilityVM
-	lcowCacheSandboxFile string
+	lcowCacheScratchFile string
 )
 
 func init() {
@@ -35,8 +35,8 @@ func CreateWCOWBlankRWLayer(t *testing.T, imageLayers []string) string {
 	//	}
 
 	tempDir := CreateTempDir(t)
-	if err := wclayer.CreateSandboxLayer(tempDir, imageLayers); err != nil {
-		t.Fatalf("Failed CreateSandboxLayer: %s", err)
+	if err := wclayer.CreateScratchLayer(tempDir, imageLayers); err != nil {
+		t.Fatalf("Failed CreateScratchLayer: %s", err)
 	}
 	// TODO Will need to rename sandbox.vhdx to rwlayer.vhdx or whatever we end up with. scratch.vhdx?
 	return tempDir
@@ -49,11 +49,11 @@ func CreateWCOWBlankRWLayer(t *testing.T, imageLayers []string) string {
 func CreateLCOWBlankRWLayer(t *testing.T, vmID string) string {
 	if lcowGlobalSVM == nil {
 		lcowGlobalSVM = CreateLCOWUVM(t, lcowGlobalSVMID)
-		lcowCacheSandboxFile = filepath.Join(CreateTempDir(t), "sandbox.vhdx") // TODO Global rename of this to rwlayer.vhdx
+		lcowCacheScratchFile = filepath.Join(CreateTempDir(t), "sandbox.vhdx") // TODO Global rename of this to rwlayer.vhdx
 	}
 	tempDir := CreateTempDir(t)
 
-	if err := lcow.CreateScratch(lcowGlobalSVM, filepath.Join(tempDir, "sandbox.vhdx"), uvm.DefaultLCOWScratchSizeGB, lcowCacheSandboxFile, vmID); err != nil {
+	if err := lcow.CreateScratch(lcowGlobalSVM, filepath.Join(tempDir, "sandbox.vhdx"), uvm.DefaultLCOWScratchSizeGB, lcowCacheScratchFile, vmID); err != nil {
 		t.Fatalf("failed to create EXT4 scratch for LCOW test cases: %s", err)
 	}
 	return tempDir

--- a/internal/hcsoci/containerex.go
+++ b/internal/hcsoci/containerex.go
@@ -27,20 +27,11 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-const (
-// HCSOPTION_ constants are string values which can be added in the RuntimeOptions of a call to CreateContainer.
-//HCSOPTION_WCOW_V2_UVM_MEMORY_OVERHEAD = "hcs.wcow.v2.uvm.additional.memory" // WCOW: v2 schema MB of memory to add to WCOW UVM when calculating resources. Defaults to 256MB
-//HCSOPTION_LCOW_GLOBALMODE     = "lcow.globalmode"     // LCOW: Utility VM lifetime. Presence of this causes global mode which is insecure, but more efficient. Default is non-global
-//HCSOPTION_LCOW_SANDBOXSIZE_GB = "lcow.sandboxsize.gb" // LCOW: Size of sandbox in GB
-//HCSOPTION_LCOW_TIMEOUT = "lcow.timeout" // LCOW: Timeout (seconds) waiting for utility VM operations to complete.
-
-)
-
 // CreateOptions are the set of fields used to call CreateContainer().
 // Note: In the spec, the LayerFolders must be arranged in the same way in which
-// moby configures them: layern, layern-1,...,layer2,layer1,sandbox
+// moby configures them: layern, layern-1,...,layer2,layer1,scratch
 // where layer1 is the base read-only layer, layern is the top-most read-only
-// layer, and sandbox is the RW layer. This is for historical reasons only.
+// layer, and scratch is the RW layer. This is for historical reasons only.
 type CreateOptions struct {
 
 	// Common parameters
@@ -324,7 +315,7 @@ func createWindowsContainerDocument(coi *createOptionsInternal) (interface{}, er
 		IgnoreFlushesDuringBoot: coi.Spec.Windows.IgnoreFlushesDuringBoot,
 	}
 
-	// IgnoreFlushesDuringBoot is a property of the SCSI attachment for the sandbox. Set when it's hot-added to the utility VM
+	// IgnoreFlushesDuringBoot is a property of the SCSI attachment for the scratch. Set when it's hot-added to the utility VM
 	// ID is a property on the create call in V2 rather than part of the schema.
 	v2 := &hcsschemav2.ComputeSystemV2{
 		Owner:                             coi.actualOwner,

--- a/internal/hcsoci/resources_wcow.go
+++ b/internal/hcsoci/resources_wcow.go
@@ -16,21 +16,22 @@ import (
 )
 
 func allocateWindowsResources(coi *createOptionsInternal, resources *Resources) error {
-	sandboxFolder := coi.Spec.Windows.LayerFolders[len(coi.Spec.Windows.LayerFolders)-1]
-	logrus.Debugf("hcsshim::allocateWindowsResources Sandbox folder: %s", sandboxFolder)
+	scratchFolder := coi.Spec.Windows.LayerFolders[len(coi.Spec.Windows.LayerFolders)-1]
+	logrus.Debugf("hcsshim::allocateWindowsResources scratch folder: %s", scratchFolder)
 
-	// Create the directory for the RW sandbox layer if it doesn't exist
-	if _, err := os.Stat(sandboxFolder); os.IsNotExist(err) {
-		logrus.Debugf("hcsshim::allocateWindowsResources container sandbox folder does not exist so creating: %s ", sandboxFolder)
-		if err := os.MkdirAll(sandboxFolder, 0777); err != nil {
-			return fmt.Errorf("failed to auto-create container sandbox folder %s: %s", sandboxFolder, err)
+	// Create the directory for the RW scratch layer if it doesn't exist
+	if _, err := os.Stat(scratchFolder); os.IsNotExist(err) {
+		logrus.Debugf("hcsshim::allocateWindowsResources container scratch folder does not exist so creating: %s ", scratchFolder)
+		if err := os.MkdirAll(scratchFolder, 0777); err != nil {
+			return fmt.Errorf("failed to auto-create container scratch folder %s: %s", scratchFolder, err)
 		}
 	}
 
-	// Create sandbox.vhdx if it doesn't exist in the sandbox folder
-	if _, err := os.Stat(filepath.Join(sandboxFolder, "sandbox.vhdx")); os.IsNotExist(err) {
-		logrus.Debugf("hcsshim::allocateWindowsResources container sandbox.vhdx does not exist so creating in %s ", sandboxFolder)
-		if err := wclayer.CreateSandboxLayer(sandboxFolder, coi.Spec.Windows.LayerFolders[:len(coi.Spec.Windows.LayerFolders)-1]); err != nil {
+	// Create sandbox.vhdx if it doesn't exist in the scratch folder. It's called sandbox.vhdx
+	// rather than scratch.vhdx as in the v1 schema, it's hard-coded in HCS.
+	if _, err := os.Stat(filepath.Join(scratchFolder, "sandbox.vhdx")); os.IsNotExist(err) {
+		logrus.Debugf("hcsshim::allocateWindowsResources container sandbox.vhdx does not exist so creating in %s ", scratchFolder)
+		if err := wclayer.CreateScratchLayer(scratchFolder, coi.Spec.Windows.LayerFolders[:len(coi.Spec.Windows.LayerFolders)-1]); err != nil {
 			return fmt.Errorf("failed to CreateSandboxLayer %s", err)
 		}
 	}

--- a/internal/uvm/types.go
+++ b/internal/uvm/types.go
@@ -11,7 +11,7 @@ import (
 )
 
 //                    | WCOW | LCOW
-// Container sandbox  | SCSI | SCSI
+// Container scratch  | SCSI | SCSI
 // Scratch space      | ---- | SCSI   // For file system utilities. /tmp/scratch
 // Read-Only Layer    | VSMB | VPMEM
 // Mapped Directory   | VSMB | PLAN9

--- a/internal/wclayer/createscratchlayer.go
+++ b/internal/wclayer/createscratchlayer.go
@@ -5,12 +5,12 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// CreateSandboxLayer creates and populates new read-write layer for use by a container.
+// CreateScratchLayer creates and populates new read-write layer for use by a container.
 // This requires both the id of the direct parent layer, as well as the full list
 // of paths to all parent layers up to the base (and including the direct parent
 // whose id was provided).
-func CreateSandboxLayer(path string, parentLayerPaths []string) error {
-	title := "hcsshim::CreateSandboxLayer "
+func CreateScratchLayer(path string, parentLayerPaths []string) error {
+	title := "hcsshim::CreateScratchLayer "
 	logrus.Debugf(title+"path %s", path)
 
 	// Generate layer descriptors

--- a/internal/wclayer/expandscratchsize.go
+++ b/internal/wclayer/expandscratchsize.go
@@ -5,9 +5,9 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// ExpandSandboxSize expands the size of a layer to at least size bytes.
-func ExpandSandboxSize(path string, size uint64) error {
-	title := "hcsshim::ExpandSandboxSize "
+// ExpandScratchSize expands the size of a layer to at least size bytes.
+func ExpandScratchSize(path string, size uint64) error {
+	title := "hcsshim::ExpandScratchSize "
 	logrus.Debugf(title+"path=%s size=%d", path, size)
 
 	err := expandSandboxSize(&stdDriverInfo, path, size)

--- a/layer.go
+++ b/layer.go
@@ -19,8 +19,12 @@ func ActivateLayer(info DriverInfo, id string) error {
 func CreateLayer(info DriverInfo, id, parent string) error {
 	return wclayer.CreateLayer(layerPath(&info, id), parent)
 }
+// New clients should use CreateScratchLayer instead. Kept in to preserve API compatibility.
 func CreateSandboxLayer(info DriverInfo, layerId, parentId string, parentLayerPaths []string) error {
-	return wclayer.CreateSandboxLayer(layerPath(&info, layerId), parentLayerPaths)
+	return wclayer.CreateScratchLayer(layerPath(&info, layerId), parentLayerPaths)
+}
+func CreateScratchLayer(info DriverInfo, layerId, parentId string, parentLayerPaths []string) error {
+	return wclayer.CreateScratchLayer(layerPath(&info, layerId), parentLayerPaths)
 }
 func DeactivateLayer(info DriverInfo, id string) error {
 	return wclayer.DeactivateLayer(layerPath(&info, id))
@@ -28,8 +32,12 @@ func DeactivateLayer(info DriverInfo, id string) error {
 func DestroyLayer(info DriverInfo, id string) error {
 	return wclayer.DestroyLayer(layerPath(&info, id))
 }
+// New clients should use ExpandScratchSize instead. Kept in to preserve API compatibility.
 func ExpandSandboxSize(info DriverInfo, layerId string, size uint64) error {
-	return wclayer.ExpandSandboxSize(layerPath(&info, layerId), size)
+	return wclayer.ExpandScratchSize(layerPath(&info, layerId), size)
+}
+func ExpandScratchSize(info DriverInfo, layerId string, size uint64) error {
+	return wclayer.ExpandScratchSize(layerPath(&info, layerId), size)
 }
 func ExportLayer(info DriverInfo, layerId string, exportFolderPath string, parentLayerPaths []string) error {
 	return wclayer.ExportLayer(layerPath(&info, layerId), exportFolderPath, parentLayerPaths)


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>


Part 1.... Unfortunately we have to call it `sandbox.vhdx` for v1 WCOW as it's hard-coded in HCS. But this renames a lot of places. It does introduce two new top-level APIs CreateScratchLayer and ExpandScratchSize which are mirrors of CreateSandboxLayer and ExpandSandboxSize for use by new clients. Obviously, I can't change the names of the actual functions which are exported in VMCompute though.
