### PR TITLE
Fix SCSI eject

### DIFF
--- a/internal/cmd/rootfs2vhd/rootfs2vhd.go
+++ b/internal/cmd/rootfs2vhd/rootfs2vhd.go
@@ -152,7 +152,6 @@ func rootfs2vhd(c *cli.Context) {
 	fmt.Println("- Extract complete!")
 	fmt.Printf("\n%s\n", uvmCommand(lcowUVM, []string{"df", "/target"}))
 	possiblePause()
-	uvmCommand(lcowUVM, []string{"sync", "-f"})
 	uvmCommand(lcowUVM, []string{"umount", device})
 
 	fmt.Println("- Removing SCSI disk...")


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

@jterry75 As discussed this morning. Seems to work from testing rootfs2vhd without the sync command.