### PR TITLE
abbreviate logging; fix test

### DIFF
--- a/functional/lcow_test.go
+++ b/functional/lcow_test.go
@@ -30,7 +30,7 @@ func TestLCOWUVMNoSCSINoVPMemInitrd(t *testing.T) {
 		VPMemDeviceCount:    &vpmemCount,
 		SCSIControllerCount: &scsiCount,
 	}
-	testLCOWUVMNoSCSISingleVPMem(t, opts, `Command line: initrd=\initrd.img`)
+	testLCOWUVMNoSCSISingleVPMem(t, opts, `Command line: initrd=/initrd.img`)
 }
 
 // TestLCOWUVMNoSCSISingleVPMemVHD starts an LCOW utility VM without a SCSI controller and

--- a/internal/uvm/start.go
+++ b/internal/uvm/start.go
@@ -42,6 +42,7 @@ func forwardGcsLogs(l net.Listener) {
 		lvl := e.Data["level"]
 		delete(e.Data, "level")
 		e.Data["vm.time"] = e.Data["time"]
+		delete(e.Data, "time")
 		switch lvl {
 		case "debug":
 			e.Debug(msg)


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

@jterry75 PTAL

- Fixes a test after the recent change to uvm create and the logging stuff
- Removes time= from the GCS logging Finally make the GCS logs somewhat sane. Example below


```
time="2018-06-15T12:02:46-07:00" level=info msg="bridge: read message '{\"ContainerId\":\"00000000-0000-0000-0000-000000000000\",\"ActivityId\":\"00000000-0000-0000-0000-000000000000\",\"ProcessId\":111,\"TimeoutInMs\":4294967295}'" vm.time="2018-06-15T12:02:43Z"
```

