### PR TITLE
Fix vpmem add/remove

### DIFF
--- a/internal/uvm/vpmem.go
+++ b/internal/uvm/vpmem.go
@@ -77,7 +77,7 @@ func (uvm *UtilityVM) AddVPMEM(hostPath string, expose bool) (uint32, string, er
 		modification := &hcsschema.ModifySettingRequest{
 			RequestType:  requesttype.Add,
 			Settings:     controller,
-			ResourcePath: fmt.Sprintf("VirtualMachine/Devices/VirtualPMem/%d", deviceNumber),
+			ResourcePath: fmt.Sprintf("VirtualMachine/Devices/VirtualPMem"),
 		}
 
 		if expose {
@@ -143,15 +143,14 @@ func (uvm *UtilityVM) removeVPMEM(hostPath string, uvmPath string, deviceNumber 
 	if uvm.vpmemDevices[deviceNumber].refCount == 1 {
 		modification := &hcsschema.ModifySettingRequest{
 			RequestType:  requesttype.Remove,
-			ResourcePath: fmt.Sprintf("VirtualMachine/Devices/VirtualPMem/%d", deviceNumber),
-		}
-
-		modification.GuestRequest = guestrequest.GuestRequest{
-			ResourceType: guestrequest.ResourceTypeVPMemDevice,
-			RequestType:  requesttype.Remove,
-			Settings: guestrequest.LCOWMappedVPMemDevice{
-				DeviceNumber: deviceNumber,
-				MountPath:    uvmPath,
+			ResourcePath: fmt.Sprintf("VirtualMachine/Devices/VirtualPMem"),
+			GuestRequest: guestrequest.GuestRequest{
+				ResourceType: guestrequest.ResourceTypeVPMemDevice,
+				RequestType:  requesttype.Remove,
+				Settings: guestrequest.LCOWMappedVPMemDevice{
+					DeviceNumber: deviceNumber,
+					MountPath:    uvmPath,
+				},
 			},
 		}
 


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

Fixes the resource path for VPMem to match the breaking change. Validated TestVPMEM passes on rs5_release_base_dev 17718 180716-1700 with this fix. @jterry75 PTAL