### PR TITLE
Remove two noisy non-required fmt.Println in test code

### DIFF
--- a/functional/wcow_test.go
+++ b/functional/wcow_test.go
@@ -387,8 +387,6 @@ func TestWCOWArgonShim(t *testing.T) {
 
 	argonShimScratchDir := testutilities.CreateTempDir(t)
 	defer os.RemoveAll(argonShimScratchDir)
-	fmt.Println("Calling CreateSCratchLayer:", argonShimScratchDir)
-	fmt.Println("imageLayers:", imageLayers)
 	if err := wclayer.CreateScratchLayer(argonShimScratchDir, imageLayers); err != nil {
 		t.Fatalf("failed to create argon scratch layer: %s", err)
 	}


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

I put these in for debugging a long while back. Not required.