### PR TITLE
TestWCOWXenonOciV1 was using wrong image

### DIFF
--- a/functional/wcow_test.go
+++ b/functional/wcow_test.go
@@ -557,7 +557,7 @@ func TestWCOWArgonOciV1(t *testing.T) {
 
 // Xenon through HCSOCI interface (v1)
 func TestWCOWXenonOciV1(t *testing.T) {
-	imageLayers := testutilities.LayerFolders(t, "busybox")
+	imageLayers := testutilities.LayerFolders(t, imageName)
 	xenonOci1Mounted := false
 
 	xenonOci1ScratchDir := testutilities.CreateTempDir(t)


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

Updated to be in line with the rest of the WCOW tests. Now passes except that read-only platform bug which is in flight to the dev branch. @jterry75 PTAL