### PR TITLE
Fixups to latest vmcompute as of 7/23/18

### DIFF
--- a/functional/wcow_test.go
+++ b/functional/wcow_test.go
@@ -4,7 +4,6 @@ package functional
 
 import (
 	"bytes"
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"

--- a/internal/hcsoci/hcsdoc_wcow.go
+++ b/internal/hcsoci/hcsdoc_wcow.go
@@ -89,7 +89,7 @@ func createWindowsContainerDocument(coi *createOptionsInternal) (interface{}, er
 		if coi.Spec.Windows.Resources.Memory != nil {
 			if coi.Spec.Windows.Resources.Memory.Limit != nil {
 				v1.MemoryMaximumInMB = int64(*coi.Spec.Windows.Resources.Memory.Limit) / 1024 / 1024
-				v2Container.Memory = &hcsschema.Memory{MaximumInMB: int32(v1.MemoryMaximumInMB)}
+				v2Container.Memory = &hcsschema.Memory{SizeInMB: int32(v1.MemoryMaximumInMB)}
 
 			}
 		}

--- a/internal/schema2/memory.go
+++ b/internal/schema2/memory.go
@@ -11,5 +11,5 @@ package hcsschema
 
 type Memory struct {
 
-	MaximumInMB int32 `json:"MaximumInMB,omitempty"`
+	SizeInMB int32 `json:"SizeInMB,omitempty"`
 }

--- a/internal/schema2/memory_2.go
+++ b/internal/schema2/memory_2.go
@@ -19,7 +19,5 @@ type Memory2 struct {
 
 	EnableColdHint bool `json:"EnableColdHint,omitempty"`
 
-	DirectFileMappingMB int64 `json:"DirectFileMappingMB,omitempty"`
-
 	EnableEpf bool `json:"EnableEpf,omitempty"`
 }

--- a/internal/schema2/network_adapter.go
+++ b/internal/schema2/network_adapter.go
@@ -14,6 +14,4 @@ type NetworkAdapter struct {
 	EndpointId string `json:"EndpointId,omitempty"`
 
 	MacAddress string `json:"MacAddress,omitempty"`
-
-	ChannelInstanceGuid string `json:"ChannelInstanceGuid,omitempty"`
 }

--- a/internal/schema2/properties.go
+++ b/internal/schema2/properties.go
@@ -21,8 +21,6 @@ type Properties struct {
 
 	Owner string `json:"Owner,omitempty"`
 
-	ObRoot string `json:"ObRoot,omitempty"`
-
 	RuntimeId string `json:"RuntimeId,omitempty"`
 
 	RuntimeTemplateId string `json:"RuntimeTemplateId,omitempty"`
@@ -35,29 +33,15 @@ type Properties struct {
 
 	Memory *MemoryInformationForVm `json:"Memory,omitempty"`
 
-	ContainerReportedMemory *ContainerMemoryInformation `json:"ContainerReportedMemory,omitempty"`
-
-	CpuGroupId string `json:"CpuGroupId,omitempty"`
-
 	Statistics *Statistics `json:"Statistics,omitempty"`
 
 	ProcessList []ProcessDetails `json:"ProcessList,omitempty"`
 
 	TerminateOnLastHandleClosed bool `json:"TerminateOnLastHandleClosed,omitempty"`
 
-	SystemGUID string `json:"SystemGUID,omitempty"`
-
 	HostingSystemId string `json:"HostingSystemId,omitempty"`
 
 	SharedMemoryRegionInfo []SharedMemoryRegionInfo `json:"SharedMemoryRegionInfo,omitempty"`
 
 	GuestConnectionInfo *GuestConnectionInfo `json:"GuestConnectionInfo,omitempty"`
-
-	Silo *SiloProperties `json:"Silo,omitempty"`
-
-	CosIndex int32 `json:"CosIndex,omitempty"`
-
-	Rmid int32 `json:"Rmid,omitempty"`
-
-	CacheStats *CacheQueryStatsResponse `json:"CacheStats,omitempty"`
 }

--- a/internal/schema2/property_query.go
+++ b/internal/schema2/property_query.go
@@ -9,7 +9,7 @@
 
 package hcsschema
 
-//   By default the basic properties will be returned. This query provides a way to  request for the special properties. 
+//   By default the basic properties will be returned. This query provides a way to  request specific properties. 
 type PropertyQuery struct {
 
 	PropertyTypes []string `json:"PropertyTypes,omitempty"`

--- a/internal/schema2/scsi.go
+++ b/internal/schema2/scsi.go
@@ -13,6 +13,4 @@ type Scsi struct {
 
 	//  Map of attachments, where the key is the integer LUN number on the controller.
 	Attachments map[string]Attachment `json:"Attachments,omitempty"`
-
-	ChannelInstanceGuid string `json:"ChannelInstanceGuid,omitempty"`
 }

--- a/internal/schema2/virtual_smb.go
+++ b/internal/schema2/virtual_smb.go
@@ -12,4 +12,6 @@ package hcsschema
 type VirtualSmb struct {
 
 	Shares []VirtualSmbShare `json:"Shares,omitempty"`
+
+	DirectFileMappingInMB int64 `json:"DirectFileMappingInMB,omitempty"`
 }

--- a/internal/uvm/create.go
+++ b/internal/uvm/create.go
@@ -262,9 +262,8 @@ func Create(opts *UVMOptions) (_ *UtilityVM, err error) {
 			DevicePath: `\EFI\Microsoft\Boot\bootmgfw.efi`,
 			DeviceType: "VmbFs",
 		}
-		vm.ComputeTopology.Memory.DirectFileMappingMB = 1024 // Sensible default, but could be a tuning parameter somewhere
-
 		vm.Devices.VirtualSmb = &hcsschema.VirtualSmb{
+			DirectFileMappingInMB: 1024, // Sensible default, but could be a tuning parameter somewhere
 			Shares: []hcsschema.VirtualSmbShare{
 				{
 					Name: "os",

--- a/internal/uvm/scsi.go
+++ b/internal/uvm/scsi.go
@@ -29,8 +29,7 @@ func (uvm *UtilityVM) allocateSCSI(hostPath string, uvmPath string) (int, int32,
 				uvm.scsiLocations[controller][lun].hostPath = hostPath
 				uvm.scsiLocations[controller][lun].uvmPath = uvmPath
 				logrus.Debugf("uvm::allocateSCSI %d:%d %q %q", controller, lun, hostPath, uvmPath)
-				// TODO: Remove `+ 1` on next line when VSO #18313454 is fixed. @jhowardmsft. Temporary workaround only.
-				return controller, int32(lun + 1), nil
+				return controller, int32(lun), nil
 
 			}
 		}
@@ -167,7 +166,6 @@ func (uvm *UtilityVM) RemoveSCSI(hostPath string) error {
 // MUST be held when calling this function.
 func (uvm *UtilityVM) removeSCSI(hostPath string, uvmPath string, controller int, lun int32) error {
 	logrus.Debugf("uvm::RemoveSCSI id:%s hostPath:%s", uvm.id, hostPath)
-	lun++ // TODO: Remove when VSO #18313454 is fixed. @jhowardmsft. Temporary workaround only.
 	scsiModification := &hcsschema.ModifySettingRequest{
 		RequestType:  requesttype.Remove,
 		ResourcePath: fmt.Sprintf("VirtualMachine/Devices/Scsi/%d/Attachments/%d", controller, lun),

--- a/internal/uvm/vpmem.go
+++ b/internal/uvm/vpmem.go
@@ -2,7 +2,6 @@ package uvm
 
 import (
 	"fmt"
-	"strconv"
 
 	"github.com/Microsoft/hcsshim/internal/guestrequest"
 	"github.com/Microsoft/hcsshim/internal/requesttype"
@@ -66,18 +65,15 @@ func (uvm *UtilityVM) AddVPMEM(hostPath string, expose bool) (uint32, string, er
 		if err != nil {
 			return 0, "", err
 		}
-		controller := hcsschema.VirtualPMemController{}
-		controller.Devices = make(map[string]hcsschema.VirtualPMemDevice)
-		controller.Devices[strconv.Itoa(int(deviceNumber))] = hcsschema.VirtualPMemDevice{
-			HostPath:    hostPath,
-			ReadOnly:    true,
-			ImageFormat: "Vhd1",
-		}
 
 		modification := &hcsschema.ModifySettingRequest{
-			RequestType:  requesttype.Add,
-			Settings:     controller,
-			ResourcePath: fmt.Sprintf("VirtualMachine/Devices/VirtualPMem"),
+			RequestType: requesttype.Add,
+			Settings: hcsschema.VirtualPMemDevice{
+				HostPath:    hostPath,
+				ReadOnly:    true,
+				ImageFormat: "Vhd1",
+			},
+			ResourcePath: fmt.Sprintf("VirtualMachine/Devices/VirtualPMem/Devices/%d", deviceNumber),
 		}
 
 		if expose {
@@ -143,7 +139,7 @@ func (uvm *UtilityVM) removeVPMEM(hostPath string, uvmPath string, deviceNumber 
 	if uvm.vpmemDevices[deviceNumber].refCount == 1 {
 		modification := &hcsschema.ModifySettingRequest{
 			RequestType:  requesttype.Remove,
-			ResourcePath: fmt.Sprintf("VirtualMachine/Devices/VirtualPMem"),
+			ResourcePath: fmt.Sprintf("VirtualMachine/Devices/VirtualPMem/Devices/%d", deviceNumber),
 			GuestRequest: guestrequest.GuestRequest{
 				ResourceType: guestrequest.ResourceTypeVPMemDevice,
 				RequestType:  requesttype.Remove,


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

A bunch of small fixups to HCSShim.

- Refresh swagger
- Compile fixups to match
- Removes SCSI workaround
- Fixes VPMem with new schema

@jterry75 Note there isn't an RS5_RELEASE_.... build to validate these on, so I haven't bumped the RS5 build number in this PR. Have validated against 18203 HYP 180722-0859 instead.