### PR TITLE
Fix FileAttributes size to work across all platforms

### DIFF
--- a/internal/wclayer/legacy.go
+++ b/internal/wclayer/legacy.go
@@ -269,7 +269,7 @@ func (r *legacyLayerReader) Next() (path string, size int64, fileInfo *winio.Fil
 		if err != nil {
 			return
 		}
-		fileInfo.FileAttributes = uint64(attr)
+		fileInfo.FileAttributes = attr
 		beginning := int64(4)
 
 		// Find the accurate file size.

--- a/internal/wclayer/legacy.go
+++ b/internal/wclayer/legacy.go
@@ -269,7 +269,7 @@ func (r *legacyLayerReader) Next() (path string, size int64, fileInfo *winio.Fil
 		if err != nil {
 			return
 		}
-		fileInfo.FileAttributes = uintptr(attr)
+		fileInfo.FileAttributes = uint64(attr)
 		beginning := int64(4)
 
 		// Find the accurate file size.


### PR DESCRIPTION
This is a corresponding change to the following PR: https://github.com/Microsoft/go-winio/pull/88