### PR TITLE
Fix ConvertAndFreeCoTaskMemString for 32 bit platforms

### DIFF
--- a/internal/interop/interop.go
+++ b/internal/interop/interop.go
@@ -10,7 +10,7 @@ import (
 //sys coTaskMemFree(buffer unsafe.Pointer) = ole32.CoTaskMemFree
 
 func ConvertAndFreeCoTaskMemString(buffer *uint16) string {
-	str := syscall.UTF16ToString((*[1 << 30]uint16)(unsafe.Pointer(buffer))[:])
+	str := syscall.UTF16ToString((*[1 << 29]uint16)(unsafe.Pointer(buffer))[:])
 	coTaskMemFree(unsafe.Pointer(buffer))
 	return str
 }


### PR DESCRIPTION
This is submitted on behalf of askariv.

Based on align.go line 367:
       if Widthptr == 4 && w != int64(int32(w)) {
              yyerror("type %v too large”, t)
       }
The idea in this case is to convert to a slice of a large array of uint16s so it can be used with practically any size of a string, since ‘func UTF16ToString(s []uint16) string’.
The original code had [1<<30] of uint16 elemets which make the width 1 << 31 or 2147483648 (0x80000000) meaning  -2147483648 in 32bit!
This is why [1<<29] works, and it is large enough for any real purpose, after all it is a string.

Please let us know if you have a better idea on how to do the type cast.