### PR TITLE
Adds LinuxMetadata back (omitted in master)

### DIFF
--- a/internal/schema1/schema1.go
+++ b/internal/schema1/schema1.go
@@ -59,6 +59,8 @@ type MappedVirtualDisk struct {
 	ReadOnly          bool   `json:",omitempty"`
 	Cache             string `json:",omitempty"` // "" (Unspecified); "Disabled"; "Enabled"; "Private"; "PrivateAllowSharing"
 	AttachOnly        bool   `json:",omitempty:`
+	// LinuxMetadata - Support added in 1803/RS4+.
+	LinuxMetadata bool `json:",omitempty"`
 }
 
 // AssignedDevice represents a device that has been directly assigned to a container


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

@jterry75 This was added to the v0.6.x tree, but omitted from schema1 in master. Adding it here too.