### PR TITLE
Erfrimod/hcn fixes tests

### DIFF
--- a/hcn/hcnendpoint.go
+++ b/hcn/hcnendpoint.go
@@ -2,6 +2,7 @@ package hcn
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/Microsoft/hcsshim/internal/guid"
 	"github.com/Microsoft/hcsshim/internal/interop"
@@ -270,7 +271,7 @@ func GetEndpointByID(endpointId string) (*HostComputeEndpoint, error) {
 		return nil, err
 	}
 	if len(endpoints) == 0 {
-		return nil, nil
+		return nil, fmt.Errorf("Endpoint %s not found", endpointId)
 	}
 	return &endpoints[0], err
 }
@@ -290,7 +291,7 @@ func GetEndpointByName(endpointName string) (*HostComputeEndpoint, error) {
 		return nil, err
 	}
 	if len(endpoints) == 0 {
-		return nil, nil
+		return nil, fmt.Errorf("Endpoint %s not found", endpointName)
 	}
 	return &endpoints[0], err
 }

--- a/hcn/hcnloadbalancer.go
+++ b/hcn/hcnloadbalancer.go
@@ -2,6 +2,7 @@ package hcn
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/Microsoft/hcsshim/internal/guid"
 	"github.com/Microsoft/hcsshim/internal/interop"
@@ -210,7 +211,7 @@ func GetLoadBalancerByID(loadBalancerId string) (*HostComputeLoadBalancer, error
 		return nil, err
 	}
 	if len(loadBalancers) == 0 {
-		return nil, nil
+		return nil, fmt.Errorf("LoadBalancer %s not found", loadBalancerId)
 	}
 	return &loadBalancers[0], err
 }

--- a/hcn/hcnnamespace.go
+++ b/hcn/hcnnamespace.go
@@ -2,6 +2,7 @@ package hcn
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/Microsoft/hcsshim/internal/guid"
 	"github.com/Microsoft/hcsshim/internal/interop"
@@ -249,7 +250,7 @@ func GetNamespaceByID(namespaceId string) (*HostComputeNamespace, error) {
 		return nil, err
 	}
 	if len(namespaces) == 0 {
-		return nil, nil
+		return nil, fmt.Errorf("Namespace %s not found", namespaceId)
 	}
 	return &namespaces[0], err
 }

--- a/hcn/hcnnetwork.go
+++ b/hcn/hcnnetwork.go
@@ -2,6 +2,7 @@ package hcn
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/Microsoft/hcsshim/internal/guid"
 	"github.com/Microsoft/hcsshim/internal/interop"
@@ -245,7 +246,7 @@ func GetNetworkByID(networkID string) (*HostComputeNetwork, error) {
 		return nil, err
 	}
 	if len(networks) == 0 {
-		return nil, nil
+		return nil, fmt.Errorf("Network %s not found", networkID)
 	}
 	return &networks[0], err
 }
@@ -265,7 +266,7 @@ func GetNetworkByName(networkName string) (*HostComputeNetwork, error) {
 		return nil, err
 	}
 	if len(networks) == 0 {
-		return nil, nil
+		return nil, fmt.Errorf("Network %s not found", networkName)
 	}
 	return &networks[0], err
 }

--- a/hcn/hcnv1schema_test.go
+++ b/hcn/hcnv1schema_test.go
@@ -1,0 +1,102 @@
+// +build integration
+
+package hcn
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/Microsoft/hcsshim"
+)
+
+func TestV1Network(t *testing.T) {
+	cleanup()
+
+	v1network := hcsshim.HNSNetwork{
+		Type: "NAT",
+		Name: NatTestNetworkName,
+		MacPools: []hcsshim.MacPool{
+			hcsshim.MacPool{
+				StartMacAddress: "00-15-5D-52-C0-00",
+				EndMacAddress:   "00-15-5D-52-CF-FF",
+			},
+		},
+		Subnets: []hcsshim.Subnet{
+			hcsshim.Subnet{
+				AddressPrefix:  "192.168.100.0/24",
+				GatewayAddress: "192.168.100.1",
+			},
+		},
+	}
+
+	jsonString, err := json.Marshal(v1network)
+	if err != nil {
+		t.Error(err)
+	}
+
+	network, err := createNetwork(string(jsonString))
+	if err != nil {
+		t.Error(err)
+	}
+
+	_, err = network.Delete()
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func TestV1Endpoint(t *testing.T) {
+	cleanup()
+
+	v1network := hcsshim.HNSNetwork{
+		Type: "NAT",
+		Name: NatTestNetworkName,
+		MacPools: []hcsshim.MacPool{
+			hcsshim.MacPool{
+				StartMacAddress: "00-15-5D-52-C0-00",
+				EndMacAddress:   "00-15-5D-52-CF-FF",
+			},
+		},
+		Subnets: []hcsshim.Subnet{
+			hcsshim.Subnet{
+				AddressPrefix:  "192.168.100.0/24",
+				GatewayAddress: "192.168.100.1",
+			},
+		},
+	}
+
+	jsonString, err := json.Marshal(v1network)
+	if err != nil {
+		t.Error(err)
+	}
+
+	network, err := createNetwork(string(jsonString))
+	if err != nil {
+		t.Error(err)
+	}
+
+	v1endpoint := hcsshim.HNSEndpoint{
+		Name:           NatTestEndpointName,
+		VirtualNetwork: network.Id,
+	}
+
+	jsonString, err = json.Marshal(v1endpoint)
+	if err != nil {
+		t.Error(err)
+	}
+
+	endpoint, err := createEndpoint(network.Id, string(jsonString))
+	if err != nil {
+		t.Error(err)
+	}
+
+	_, err = endpoint.Delete()
+	if err != nil {
+		t.Error(err)
+	}
+
+	_, err = network.Delete()
+	if err != nil {
+		t.Error(err)
+	}
+}


### PR DESCRIPTION
* Making sure that the Get<Resource> methods obey golang conventions and return an error if no elements are found so that callers don't have to check for empty arrays.
* Adding a test to verify V1 object schema can be passed using the RPC calls.