### PR TITLE
Adding Namespace to HNS exports.

### DIFF
--- a/hnsendpoint.go
+++ b/hnsendpoint.go
@@ -6,6 +6,8 @@ import (
 
 // HNSEndpoint represents a network endpoint in HNS
 type HNSEndpoint = hns.HNSEndpoint
+// Namespace represents a Compartment.
+type Namespace = hns.Namespace
 
 //SystemType represents the type of the system on which actions are done
 type SystemType string


### PR DESCRIPTION
CNI needs to use the V1 Schema until customers can get the updated HNS code in RS6. This means that the Hcsshim needs to export the Namespace object that is a part of HNSEndpoint.