### PR TITLE
Nil check in allocateWindowsResources

### DIFF
--- a/internal/hcsoci/resources_wcow.go
+++ b/internal/hcsoci/resources_wcow.go
@@ -19,6 +19,10 @@ import (
 )
 
 func allocateWindowsResources(coi *createOptionsInternal, resources *Resources) error {
+	if coi.Spec == nil || coi.Spec.Windows == nil || coi.Spec.Windows.LayerFolders == nil {
+		return fmt.Errorf("field 'Spec.Windows.Layerfolders' is not populated")
+	}
+
 	scratchFolder := coi.Spec.Windows.LayerFolders[len(coi.Spec.Windows.LayerFolders)-1]
 	logrus.Debugf("hcsshim::allocateWindowsResources scratch folder: %s", scratchFolder)
 


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

Avoids a panic doing `runhcs create -b . test` which malformed config.json