### PR TITLE
Remove redundant no-op IsTP4()

### DIFF
--- a/version.go
+++ b/version.go
@@ -1,6 +1,0 @@
-package hcsshim
-
-// IsTP4 returns whether the currently running Windows build is at least TP4.
-func IsTP4() bool {
-	return false
-}


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

This is never called. 