### PR TITLE
ext4:Init Xattrs in Stat()

### DIFF
--- a/ext4/internal/compactext4/compact.go
+++ b/ext4/internal/compactext4/compact.go
@@ -591,8 +591,8 @@ func (w *Writer) Stat(name string) (*File, error) {
 		Devmajor: node.Devmajor,
 		Devminor: node.Devminor,
 	}
+	f.Xattrs = make(map[string][]byte)
 	if node.XattrBlock != 0 || len(node.XattrInline) != 0 {
-		f.Xattrs = make(map[string][]byte)
 		if node.XattrBlock != 0 {
 			orig := w.block()
 			w.seekBlock(node.XattrBlock)


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

@jstarks PTAL. Have verified the fix.

Make sure Xattrs are always initialized to avoid a panic such as below:

```
re-exec error: exit status 2: stderr: panic: assignment to entry in nil map

goroutine 1 [running]:
github.com/docker/docker/vendor/github.com/Microsoft/hcsshim/ext4/tar2ext4.Convert(0x20167c0, 0xc0000b2000, 0x20343e0, 0xc0001342b8, 0xc00063be30, 0x2, 0x2, 0x1ffe75c, 0x0)
        e:/go/src/github.com/docker/docker/vendor/github.com/Microsoft/hcsshim/ext4/tar2ext4/tar2ext4.go:74 +0xa00
github.com/docker/docker/daemon/graphdriver/lcow.tar2ext4Actual(0xc000074060, 0x5a, 0x20167c0, 0xc0000b2000, 0x0, 0x0, 0x0)
        e:/go/src/github.com/docker/docker/daemon/graphdriver/lcow/lcow.go:911 +0x104
github.com/docker/docker/daemon/graphdriver/lcow.tar2ext4Reexec()
        e:/go/src/github.com/docker/docker/daemon/graphdriver/lcow/lcow.go:895 +0x6b
github.com/docker/docker/pkg/reexec.Init(0xc0007e6300)
        e:/go/src/github.com/docker/docker/pkg/reexec/reexec.go:26 +0x7d
main.main()
        e:/go/src/github.com/docker/docker/cmd/dockerd/docker.go:53 +0x3b
```