### PR TITLE
tar2ext4: Make disk size limit configurable

### DIFF
--- a/ext4/internal/compactext4/compact_test.go
+++ b/ext4/internal/compactext4/compact_test.go
@@ -348,3 +348,10 @@ func TestDirLinkLimit(t *testing.T) {
 	testFiles[len(testFiles)-1].ExpectError = true
 	runTestsOnFiles(t, testFiles)
 }
+
+func TestLargeDisk(t *testing.T) {
+	testFiles := []testFile{
+		{Path: "file", File: &File{}},
+	}
+	runTestsOnFiles(t, testFiles, MaximumDiskSize(maxMaxDiskSize))
+}

--- a/ext4/tar2ext4/tar2ext4.go
+++ b/ext4/tar2ext4/tar2ext4.go
@@ -39,6 +39,15 @@ func InlineData(p *params) {
 	p.ext4opts = append(p.ext4opts, compactext4.InlineData)
 }
 
+// MaximumDiskSize instructs the writer to limit the disk size to the specified
+// value. This also reserves enough metadata space for the specified disk size.
+// If not provided, then 16GB is the default.
+func MaximumDiskSize(size int64) Option {
+	return func(p *params) {
+		p.ext4opts = append(p.ext4opts, compactext4.MaximumDiskSize(size))
+	}
+}
+
 const (
 	whiteoutPrefix = ".wh."
 	opaqueWhiteout = ".wh..wh..opq"


### PR DESCRIPTION
The limit is necessary to reduce the group descriptor block size
overhead. It may be unnecessary in the future if metabg support is
implemented.