### PR TITLE
Add GuestConnection query

### DIFF
--- a/functional/uvm_properties_test.go
+++ b/functional/uvm_properties_test.go
@@ -1,0 +1,54 @@
+// +build functional uvmproperties
+
+package functional
+
+import (
+	"os"
+	"testing"
+
+	"github.com/Microsoft/hcsshim/functional/utilities"
+	"github.com/Microsoft/hcsshim/internal/schema1"
+	"github.com/Microsoft/hcsshim/osversion"
+)
+
+func TestPropertiesGuestConnection_LCOW(t *testing.T) {
+	testutilities.RequiresBuild(t, osversion.RS5)
+	tempDir := testutilities.CreateTempDir(t)
+	defer os.RemoveAll(tempDir)
+
+	uvm := testutilities.CreateLCOWUVM(t, "TestCreateLCOWScratch")
+	defer uvm.Terminate()
+
+	_, err := uvm.ComputeSystem().Properties(schema1.PropertyTypeGuestConnection)
+	if err != nil {
+		t.Fatalf("Failed to query properties: %s", err)
+	}
+
+	// TODO: opengcs doesn't currently return NamespaceAddRequestSupported and SignalProcessSupported
+	// @jterry75 - just uncomment this when it's returned.
+	//	if !p.GuestConnectionInfo.GuestDefinedCapabilities.NamespaceAddRequestSupported ||
+	//		!p.GuestConnectionInfo.GuestDefinedCapabilities.SignalProcessSupported ||
+	//		p.GuestConnectionInfo.ProtocolVersion < 4 {
+	//		t.Fatalf("unexpected values: %+v", p.GuestConnectionInfo)
+	//	}
+}
+
+func TestPropertiesGuestConnection_WCOW(t *testing.T) {
+	testutilities.RequiresBuild(t, osversion.RS5)
+	imageName := "microsoft/nanoserver"
+	layers := testutilities.LayerFolders(t, imageName)
+	uvm, uvmScratchDir := testutilities.CreateWCOWUVM(t, layers, "", nil)
+	defer os.RemoveAll(uvmScratchDir)
+	defer uvm.Terminate()
+
+	p, err := uvm.ComputeSystem().Properties(schema1.PropertyTypeGuestConnection)
+	if err != nil {
+		t.Fatalf("Failed to query properties: %s", err)
+	}
+
+	if !p.GuestConnectionInfo.GuestDefinedCapabilities.NamespaceAddRequestSupported ||
+		!p.GuestConnectionInfo.GuestDefinedCapabilities.SignalProcessSupported ||
+		p.GuestConnectionInfo.ProtocolVersion < 4 {
+		t.Fatalf("unexpected values: %+v", p.GuestConnectionInfo)
+	}
+}

--- a/internal/schema1/schema1.go
+++ b/internal/schema1/schema1.go
@@ -3,6 +3,8 @@ package schema1
 import (
 	"encoding/json"
 	"time"
+
+	"github.com/Microsoft/hcsshim/internal/schema2"
 )
 
 // ProcessConfig is used as both the input of Container.CreateProcess
@@ -115,9 +117,10 @@ type ComputeSystemQuery struct {
 type PropertyType string
 
 const (
-	PropertyTypeStatistics        PropertyType = "Statistics"
-	PropertyTypeProcessList                    = "ProcessList"
-	PropertyTypeMappedVirtualDisk              = "MappedVirtualDisk"
+	PropertyTypeStatistics        PropertyType = "Statistics"        // V1 and V2
+	PropertyTypeProcessList                    = "ProcessList"       // V1 and V2
+	PropertyTypeMappedVirtualDisk              = "MappedVirtualDisk" // Not supported in V2 schema call
+	PropertyTypeGuestConnection                = "GuestConnection"   // V1 and V2. Nil return from HCS before RS5
 )
 
 type PropertyQuery struct {
@@ -142,6 +145,7 @@ type ContainerProperties struct {
 	Statistics                   Statistics                          `json:",omitempty"`
 	ProcessList                  []ProcessListItem                   `json:",omitempty"`
 	MappedVirtualDiskControllers map[int]MappedVirtualDiskController `json:",omitempty"`
+	GuestConnectionInfo          GuestConnectionInfo                 `json:",omitempty"`
 }
 
 // MemoryStats holds the memory statistics for a container
@@ -204,6 +208,19 @@ type ProcessListItem struct {
 // MappedVirtualDiskController is the structure of an item returned by a MappedVirtualDiskList call on a container
 type MappedVirtualDiskController struct {
 	MappedVirtualDisks map[int]MappedVirtualDisk `json:",omitempty"`
+}
+
+// GuestDefinedCapabilities is part of the GuestConnectionInfo returned by a GuestConnection call on a utility VM
+type GuestDefinedCapabilities struct {
+	NamespaceAddRequestSupported bool `json:",omitempty"`
+	SignalProcessSupported       bool `json:",omitempty"`
+}
+
+// GuestConnectionInfo is the structure of an iterm return by a GuestConnection call on a utility VM
+type GuestConnectionInfo struct {
+	SupportedSchemaVersions  []hcsschema.Version      `json:",omitempty"`
+	ProtocolVersion          uint32                   `json:",omitempty"`
+	GuestDefinedCapabilities GuestDefinedCapabilities `json:",omitempty"`
 }
 
 // Type of Request Support in ModifySystem


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

@jterry75 

Adds the properties query for guestconnection as per internal email. I don't like that everything is in the schema1 go files, but that can be resolved later - it already has a few issues about what should be where. I'm coming to the conclusion we could use a schemacommon package too. But for another day.


@madhanrm FYI