### PR TITLE
Debug prints out the json provided to HNS on CreateX calls.

### DIFF
--- a/hcn/hcnendpoint.go
+++ b/hcn/hcnendpoint.go
@@ -304,6 +304,7 @@ func (endpoint *HostComputeEndpoint) Create() (*HostComputeEndpoint, error) {
 		return nil, err
 	}
 
+	logrus.Debugf("hcn::HostComputeEndpoint::Create JSON: %s", jsonString)
 	endpoint, hcnErr := createEndpoint(endpoint.HostComputeNetwork, string(jsonString))
 	if hcnErr != nil {
 		return nil, hcnErr

--- a/hcn/hcnloadbalancer.go
+++ b/hcn/hcnloadbalancer.go
@@ -224,6 +224,7 @@ func (loadBalancer *HostComputeLoadBalancer) Create() (*HostComputeLoadBalancer,
 		return nil, err
 	}
 
+	logrus.Debugf("hcn::HostComputeLoadBalancer::Create JSON: %s", jsonString)
 	loadBalancer, hcnErr := createLoadBalancer(string(jsonString))
 	if hcnErr != nil {
 		return nil, hcnErr

--- a/hcn/hcnnamespace.go
+++ b/hcn/hcnnamespace.go
@@ -299,6 +299,7 @@ func (namespace *HostComputeNamespace) Create() (*HostComputeNamespace, error) {
 		return nil, err
 	}
 
+	logrus.Debugf("hcn::HostComputeNamespace::Create JSON: %s", jsonString)
 	namespace, hcnErr := createNamespace(string(jsonString))
 	if hcnErr != nil {
 		return nil, hcnErr

--- a/hcn/hcnnetwork.go
+++ b/hcn/hcnnetwork.go
@@ -293,6 +293,7 @@ func (network *HostComputeNetwork) Create() (*HostComputeNetwork, error) {
 		return nil, err
 	}
 
+	logrus.Debugf("hcn::HostComputeNetwork::Create JSON: %s", jsonString)
 	network, hcnErr := createNetwork(string(jsonString))
 	if hcnErr != nil {
 		return nil, hcnErr


### PR DESCRIPTION
To aid debugging, printing out the Json on all Create calls for HNS objects.