### PR TITLE
LCOW: Use SCSI for layers over 512MB rather than PMEM

### DIFF
--- a/internal/hcsoci/layers.go
+++ b/internal/hcsoci/layers.go
@@ -4,6 +4,7 @@ package hcsoci
 
 import (
 	"fmt"
+	"os"
 	"path"
 	"path/filepath"
 
@@ -17,12 +18,19 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-type vpMemEntry struct {
+type lcowLayerEntry struct {
 	hostPath string
 	uvmPath  string
+	scsi     bool
 }
 
-const scratchPath = "scratch"
+const (
+	scratchPath = "scratch"
+
+	// In LCOW, we can't map to PMEM if a layer VHD is over this size, and
+	// we use SCSI instead.
+	maxPMEMSize = 512 * 1024 * 1024 // 512MB
+)
 
 // mountContainerLayers is a helper for clients to hide all the complexity of layer mounting
 // Layer folder are in order: base, [rolayer1..rolayern,] scratch
@@ -71,11 +79,12 @@ func MountContainerLayers(layerFolders []string, guestRoot string, uvm *uvm.Util
 	logrus.Debugf("hcsshim::mountContainerLayers Is a %s V2 UVM", uvm.OS())
 
 	// 	Add each read-only layers. For Windows, this is a VSMB share with the ResourceUri ending in
-	// a GUID based on the folder path. For Linux, this is a VPMEM device.
+	// a GUID based on the folder path. For Linux, this is a VPMEM device, except where is over the
+	// max size supported, where we put it on SCSI instead.
 	//
 	//  Each layer is ref-counted so that multiple containers in the same utility VM can share them.
-	var vsmbAdded []string
-	var vpmemAdded []vpMemEntry
+	var wcowLayersAdded []string
+	var lcowlayersAdded []lcowLayerEntry
 	attachedSCSIHostPath := ""
 
 	for _, layerPath := range layerFolders[:len(layerFolders)-1] {
@@ -90,21 +99,45 @@ func MountContainerLayers(layerFolders []string, guestRoot string, uvm *uvm.Util
 			}
 			err = uvm.AddVSMB(layerPath, "", options)
 			if err == nil {
-				vsmbAdded = append(vsmbAdded, layerPath)
+				wcowLayersAdded = append(wcowLayersAdded, layerPath)
 			}
 		} else {
 			uvmPath := ""
-			_, uvmPath, err = uvm.AddVPMEM(filepath.Join(layerPath, "layer.vhd"), true) // UVM path is calculated. Will be /tmp/vN/
-			if err == nil {
-				vpmemAdded = append(vpmemAdded,
-					vpMemEntry{
-						hostPath: filepath.Join(layerPath, "layer.vhd"),
-						uvmPath:  uvmPath,
-					})
+			hostPath := filepath.Join(layerPath, "layer.vhd")
+
+			var fi os.FileInfo
+			fi, err = os.Stat(hostPath)
+			if err == nil && fi.Size() > maxPMEMSize {
+				// Too big for PMEM. Add on SCSI instead (at /tmp/S<C>/<L>).
+				// As SCSI, we have to grant access first.
+				if err = wclayer.GrantVmAccess(uvm.ID(), hostPath); err == nil {
+					var (
+						controller int
+						lun        int32
+					)
+					controller, lun, err = uvm.AddSCSILayer(hostPath)
+					if err == nil {
+						lcowlayersAdded = append(lcowlayersAdded,
+							lcowLayerEntry{
+								hostPath: hostPath,
+								uvmPath:  fmt.Sprintf("/tmp/S%d/%d", controller, lun),
+								scsi:     true,
+							})
+					}
+				}
+			} else {
+				_, uvmPath, err = uvm.AddVPMEM(hostPath, true) // UVM path is calculated. Will be /tmp/vN/
+				if err == nil {
+					lcowlayersAdded = append(lcowlayersAdded,
+						lcowLayerEntry{
+							hostPath: hostPath,
+							uvmPath:  uvmPath,
+						})
+				}
 			}
 		}
 		if err != nil {
-			cleanupOnMountFailure(uvm, vsmbAdded, vpmemAdded, attachedSCSIHostPath)
+			cleanupOnMountFailure(uvm, wcowLayersAdded, lcowlayersAdded, attachedSCSIHostPath)
 			return nil, err
 		}
 	}
@@ -116,7 +149,7 @@ func MountContainerLayers(layerFolders []string, guestRoot string, uvm *uvm.Util
 	// On Linux, we need to grant access to the scratch
 	if uvm.OS() == "linux" {
 		if err := wclayer.GrantVmAccess(uvm.ID(), hostPath); err != nil {
-			cleanupOnMountFailure(uvm, vsmbAdded, vpmemAdded, attachedSCSIHostPath)
+			cleanupOnMountFailure(uvm, wcowLayersAdded, lcowlayersAdded, attachedSCSIHostPath)
 			return nil, err
 		}
 	}
@@ -125,7 +158,7 @@ func MountContainerLayers(layerFolders []string, guestRoot string, uvm *uvm.Util
 	containerScratchPathInUVM := ospath.Join(uvm.OS(), guestRoot, scratchPath)
 	_, _, err := uvm.AddSCSI(hostPath, containerScratchPathInUVM)
 	if err != nil {
-		cleanupOnMountFailure(uvm, vsmbAdded, vpmemAdded, attachedSCSIHostPath)
+		cleanupOnMountFailure(uvm, wcowLayersAdded, lcowlayersAdded, attachedSCSIHostPath)
 		return nil, err
 	}
 	attachedSCSIHostPath = hostPath
@@ -133,9 +166,9 @@ func MountContainerLayers(layerFolders []string, guestRoot string, uvm *uvm.Util
 	if uvm.OS() == "windows" {
 		// 	Load the filter at the C:\s<ID> location calculated above. We pass into this request each of the
 		// 	read-only layer folders.
-		layers, err := computeV2Layers(uvm, vsmbAdded)
+		layers, err := computeV2Layers(uvm, wcowLayersAdded)
 		if err != nil {
-			cleanupOnMountFailure(uvm, vsmbAdded, vpmemAdded, attachedSCSIHostPath)
+			cleanupOnMountFailure(uvm, wcowLayersAdded, lcowlayersAdded, attachedSCSIHostPath)
 			return nil, err
 		}
 		guestRequest := guestrequest.CombinedLayers{
@@ -150,7 +183,7 @@ func MountContainerLayers(layerFolders []string, guestRoot string, uvm *uvm.Util
 			},
 		}
 		if err := uvm.Modify(combinedLayersModification); err != nil {
-			cleanupOnMountFailure(uvm, vsmbAdded, vpmemAdded, attachedSCSIHostPath)
+			cleanupOnMountFailure(uvm, wcowLayersAdded, lcowlayersAdded, attachedSCSIHostPath)
 			return nil, err
 		}
 		logrus.Debugln("hcsshim::mountContainerLayers Succeeded")
@@ -175,8 +208,8 @@ func MountContainerLayers(layerFolders []string, guestRoot string, uvm *uvm.Util
 	//       /dev/sd(b...) are scratch spaces for each container
 
 	layers := []hcsschema.Layer{}
-	for _, vpmem := range vpmemAdded {
-		layers = append(layers, hcsschema.Layer{Path: vpmem.uvmPath})
+	for _, l := range lcowlayersAdded {
+		layers = append(layers, hcsschema.Layer{Path: l.uvmPath})
 	}
 	guestRequest := guestrequest.CombinedLayers{
 		ContainerRootPath: path.Join(guestRoot, rootfsPath),
@@ -191,7 +224,7 @@ func MountContainerLayers(layerFolders []string, guestRoot string, uvm *uvm.Util
 		},
 	}
 	if err := uvm.Modify(combinedLayersModification); err != nil {
-		cleanupOnMountFailure(uvm, vsmbAdded, vpmemAdded, attachedSCSIHostPath)
+		cleanupOnMountFailure(uvm, wcowLayersAdded, lcowlayersAdded, attachedSCSIHostPath)
 		return nil, err
 	}
 	logrus.Debugln("hcsshim::mountContainerLayers Succeeded")
@@ -289,17 +322,26 @@ func UnmountContainerLayers(layerFolders []string, guestRoot string, uvm *uvm.Ut
 		}
 	}
 
-	// Remove each of the read-only layers from VPMEM. These's are ref-counted and
-	// only removed once the count drops to zero. This allows multiple containers
-	// to share layers.
+	// Remove each of the read-only layers from VPMEM (or SCSI). These's are ref-counted
+	// and only removed once the count drops to zero. This allows multiple containers to
+	// share layers. Note that SCSI is used on large layers.
 	if uvm.OS() == "linux" && len(layerFolders) > 1 && (op&UnmountOperationVPMEM) == UnmountOperationVPMEM {
 		for _, layerPath := range layerFolders[:len(layerFolders)-1] {
-			if e := uvm.RemoveVPMEM(filepath.Join(layerPath, "layer.vhd")); e != nil {
-				logrus.Debugln(e)
-				if retError == nil {
-					retError = e
+			hostPath := filepath.Join(layerPath, "layer.vhd")
+			if fi, err := os.Stat(hostPath); err != nil {
+				var e error
+				if fi.Size() > maxPMEMSize {
+					e = uvm.RemoveSCSI(hostPath)
 				} else {
-					retError = errors.Wrapf(retError, e.Error())
+					e = uvm.RemoveVPMEM(hostPath)
+				}
+				if e != nil {
+					logrus.Debugln(e)
+					if retError == nil {
+						retError = e
+					} else {
+						retError = errors.Wrapf(retError, e.Error())
+					}
 				}
 			}
 		}
@@ -310,19 +352,23 @@ func UnmountContainerLayers(layerFolders []string, guestRoot string, uvm *uvm.Ut
 	return retError
 }
 
-func cleanupOnMountFailure(uvm *uvm.UtilityVM, vsmbShares []string, vpmemDevices []vpMemEntry, scsiHostPath string) {
-	for _, vsmbShare := range vsmbShares {
-		if err := uvm.RemoveVSMB(vsmbShare); err != nil {
+func cleanupOnMountFailure(uvm *uvm.UtilityVM, wcowLayers []string, lcowLayers []lcowLayerEntry, scratchHostPath string) {
+	for _, wl := range wcowLayers {
+		if err := uvm.RemoveVSMB(wl); err != nil {
 			logrus.Warnf("Possibly leaked vsmbshare on error removal path: %s", err)
 		}
 	}
-	for _, vpmemDevice := range vpmemDevices {
-		if err := uvm.RemoveVPMEM(vpmemDevice.hostPath); err != nil {
+	for _, ll := range lcowLayers {
+		if ll.scsi {
+			if err := uvm.RemoveSCSI(ll.hostPath); err != nil {
+				logrus.Warnf("Possibly leaked SCSI on error removal path: %s", err)
+			}
+		} else if err := uvm.RemoveVPMEM(ll.hostPath); err != nil {
 			logrus.Warnf("Possibly leaked vpmemdevice on error removal path: %s", err)
 		}
 	}
-	if scsiHostPath != "" {
-		if err := uvm.RemoveSCSI(scsiHostPath); err != nil {
+	if scratchHostPath != "" {
+		if err := uvm.RemoveSCSI(scratchHostPath); err != nil {
 			logrus.Warnf("Possibly leaked SCSI disk on error removal path: %s", err)
 		}
 	}

--- a/internal/uvm/scsi.go
+++ b/internal/uvm/scsi.go
@@ -10,24 +10,27 @@ import (
 )
 
 var (
-	ErrNoAvailableLocation = fmt.Errorf("no available location")
-	ErrNotAttached         = fmt.Errorf("not attached")
-	ErrAlreadyAttached     = fmt.Errorf("already attached")
-	ErrNoSCSIControllers   = fmt.Errorf("no SCSI controllers configured for this utility VM")
-	ErrNoUvmParameter      = fmt.Errorf("invalid parameters - uvm parameter missing")
-	ErrTooManyAttachments  = fmt.Errorf("too many SCSI attachments")
+	ErrNoAvailableLocation      = fmt.Errorf("no available location")
+	ErrNotAttached              = fmt.Errorf("not attached")
+	ErrAlreadyAttached          = fmt.Errorf("already attached")
+	ErrNoSCSIControllers        = fmt.Errorf("no SCSI controllers configured for this utility VM")
+	ErrTooManyAttachments       = fmt.Errorf("too many SCSI attachments")
+	ErrSCSILayerWCOWUnsupported = fmt.Errorf("SCSI attached layers are not supported for WCOW")
 )
 
 // allocateSCSI finds the next available slot on the
 // SCSI controllers associated with a utility VM to use.
-func (uvm *UtilityVM) allocateSCSI(hostPath string, uvmPath string) (int, int32, error) {
-	uvm.m.Lock()
-	defer uvm.m.Unlock()
+// Lock must be held when calling this function
+func (uvm *UtilityVM) allocateSCSI(hostPath string, uvmPath string, isLayer bool) (int, int32, error) {
 	for controller, luns := range uvm.scsiLocations {
 		for lun, si := range luns {
 			if si.hostPath == "" {
 				uvm.scsiLocations[controller][lun].hostPath = hostPath
 				uvm.scsiLocations[controller][lun].uvmPath = uvmPath
+				uvm.scsiLocations[controller][lun].isLayer = isLayer
+				if isLayer {
+					uvm.scsiLocations[controller][lun].refCount = 1
+				}
 				logrus.Debugf("uvm::allocateSCSI %d:%d %q %q", controller, lun, hostPath, uvmPath)
 				return controller, int32(lun), nil
 
@@ -42,11 +45,10 @@ func (uvm *UtilityVM) deallocateSCSI(controller int, lun int32) error {
 	defer uvm.m.Unlock()
 	logrus.Debugf("uvm::deallocateSCSI %d:%d %+v", controller, lun, uvm.scsiLocations[controller][lun])
 	uvm.scsiLocations[controller][lun] = scsiInfo{}
-
 	return nil
 }
 
-// Lock must be held when calling this function
+// Lock must be held when calling this function.
 func (uvm *UtilityVM) findSCSIAttachment(findThisHostPath string) (int, int32, string, error) {
 	for controller, luns := range uvm.scsiLocations {
 		for lun, si := range luns {
@@ -60,38 +62,90 @@ func (uvm *UtilityVM) findSCSIAttachment(findThisHostPath string) (int, int32, s
 }
 
 // AddSCSI adds a SCSI disk to a utility VM at the next available location.
+// This function should be called for a RW/scratch layer. For read-only layers
+// on LCOW as an alternate to PMEM for large layers, use AddSCSILayer instead.
+//
+// hostPath is required
+// uvmPath is optional.
+func (uvm *UtilityVM) AddSCSI(hostPath string, uvmPath string) (int, int32, error) {
+	return uvm.addSCSIActual(hostPath, uvmPath, false)
+}
+
+// AddSCSILayer adds a read-only layer disk to a utility VM at the next available
+// location. This function is used by LCOW as an alternate to PMEM for large layers.
+// The UVMPath will always be /tmp/S<controller>/<lun>.
+func (uvm *UtilityVM) AddSCSILayer(hostPath string) (int, int32, error) {
+	return uvm.addSCSIActual(hostPath, "", true)
+}
+
+// addSCSIActual is the implementation behind the external functions AddSCSI and
+// AddSCSILayer.
 //
 // We are in control of everything ourselves. Hence we have ref-
 // counting and so-on tracking what SCSI locations are available or used.
 //
 // hostPath is required
-// uvmPath is optional.
+//
+// uvmPath is optional, and should be empty for layers.
+//   If non-layer, empty just means it won't be mounted in the guest
+//   For layer, it must be empty. Layer isn't supported for WCOW. Layer for
+//   LCOW will be calculated based on /tmp/S<controller>/<lun>
+//
+// isLayer indicates that this is a read-only (LCOW) layer VHD too big to fit on VPMEM,
+// or if there are no remaining VPMEM slots available and we are spilling over to SCSI.
+// Must be false for Windows utility VMs.
 //
 // Returns the controller ID (0..3) and LUN (0..63) where the disk is attached.
-func (uvm *UtilityVM) AddSCSI(hostPath string, uvmPath string) (int, int32, error) {
-	if uvm == nil {
-		return -1, -1, ErrNoUvmParameter
+func (uvm *UtilityVM) addSCSIActual(hostPath string, uvmPath string, isLayer bool) (int, int32, error) {
+	if uvm.operatingSystem == "windows" && isLayer {
+		return -1, -1, ErrSCSILayerWCOWUnsupported
 	}
+
 	logrus.Debugf("uvm::AddSCSI id:%s hostPath:%s uvmPath:%s", uvm.id, hostPath, uvmPath)
 
 	if uvm.scsiControllerCount == 0 {
 		return -1, -1, ErrNoSCSIControllers
 	}
 
+	// We must hold the lock throughout the lookup (findSCSIAttachment) until
+	// after the possible allocation (allocateSCSI) has been completed to ensure
+	// there isn't a race condition for it being attached by another thread between
+	// these two operations. All failure paths between these two must release
+	// the lock.
 	uvm.m.Lock()
-	if _, _, _, err := uvm.findSCSIAttachment(hostPath); err == nil {
-		uvm.m.Unlock()
-		return -1, -1, ErrAlreadyAttached
+	if controller, lun, _, err := uvm.findSCSIAttachment(hostPath); err == nil {
+		// So is attached
+		if isLayer {
+			// Increment the refcount
+			uvm.scsiLocations[controller][lun].refCount++
+			logrus.Debugf("uvm::AddSCSI id:%s hostPath:%s uvmPath:%s refCount now %d", uvm.id, hostPath, uvmPath, uvm.scsiLocations[controller][lun].refCount)
+			uvm.m.Unlock()
+			return controller, int32(lun), nil
+		} else {
+			uvm.m.Unlock()
+			return -1, -1, ErrAlreadyAttached
+		}
 	}
-	uvm.m.Unlock()
 
-	controller, lun, err := uvm.allocateSCSI(hostPath, uvmPath)
+	// At this point, we know it's not attached, regardless of whether it's a
+	// ref-counted layer VHD, or not.
+	controller, lun, err := uvm.allocateSCSI(hostPath, uvmPath, isLayer)
 	if err != nil {
+		uvm.m.Unlock()
 		return -1, -1, err
 	}
 
+	// Auto-generate the UVM path for LCOW layers
+	if isLayer {
+		uvmPath = fmt.Sprintf("/tmp/S%d/%d", controller, lun)
+	}
+
+	// See comment higher up. Now safe to release the lock.
+	uvm.m.Unlock()
+
 	// Note: Can remove this check post-RS5 if multiple controllers are supported
 	if controller > 0 {
+		uvm.deallocateSCSI(controller, lun)
 		return -1, -1, ErrTooManyAttachments
 	}
 
@@ -122,7 +176,7 @@ func (uvm *UtilityVM) AddSCSI(hostPath string, uvmPath string) (int, int32, erro
 					MountPath:  uvmPath,
 					Lun:        uint8(lun),
 					Controller: uint8(controller),
-					ReadOnly:   false,
+					ReadOnly:   isLayer,
 				},
 			}
 		}
@@ -151,6 +205,14 @@ func (uvm *UtilityVM) RemoveSCSI(hostPath string) error {
 	controller, lun, uvmPath, err := uvm.findSCSIAttachment(hostPath)
 	if err != nil {
 		return err
+	}
+
+	if uvm.scsiLocations[controller][lun].isLayer {
+		uvm.scsiLocations[controller][lun].refCount--
+		if uvm.scsiLocations[controller][lun].refCount > 0 {
+			logrus.Debugf("uvm::RemoveSCSI: refCount now %d: %s %s %d:%d", uvm.scsiLocations[controller][lun].refCount, hostPath, uvm.id, controller, lun)
+			return nil
+		}
 	}
 
 	if err := uvm.removeSCSI(hostPath, uvmPath, controller, lun); err != nil {

--- a/internal/uvm/types.go
+++ b/internal/uvm/types.go
@@ -29,6 +29,12 @@ type vsmbShare struct {
 type scsiInfo struct {
 	hostPath string
 	uvmPath  string
+
+	// While most VHDs attached to SCSI are scratch spaces, in the case of LCOW
+	// when the size is over the size possible to attach to PMEM, we use SCSI for
+	// read-only layers. As RO layers are shared, we perform ref-counting.
+	isLayer  bool
+	refCount uint32
 }
 
 // vpmemInfo is an internal structure used for determining VPMem devices mapped to


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

@jterry75 As talked about offline.

Verified this now works end to end with containerd, and the combined layers being constructed correctly, using your example below.

```
ctr images pull --snapshotter windows-lcow docker.io/microsoft/dotnet:2.1.403-sdk-stretch
ctr run --rm --runtime io.containerd.runhcs.v1 --snapshotter windows-lcow docker.io/microsoft/dotnet:2.1.403-sdk-stretch lc1 sh -c "echo hello"
```


eg the following from the containerd debug spew when using an updated runhcs.exe from this branch:

```level=info msg="bridge: read message '{"ContainerId":"00000000-0000-0000-0000-000000000000","ActivityId":"00000000-0000-0000-a483-c500f77f0000","Request":{"RequestType":"Add","ResourceType":"CombinedLayers","Settings":{"ContainerRootPath":"/run/gcs/c/1/rootfs","Layers":[{"Path":"/tmp/p0"},{"Path":"/tmp/p1"},{"Path":"/tmp/p2"},{"Path":"/tmp/p3"},{"Path":"/tmp/p4"},{"Path":"/tmp/p5"},{"Path":"/tmp/S0/0"}],"ScratchPath":"/run/gcs/c/1/scratch"}},"v2Request":null}'" log-source=runhcs--vm-shim runtime=io.containerd.runhcs.v1 task-id=lc1 vm.time="2018-10-24T15:45:55Z"```