### PR TITLE
Move GrantVmAccess calls

### DIFF
--- a/functional/uvm_vpmem_test.go
+++ b/functional/uvm_vpmem_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/Microsoft/hcsshim/functional/utilities"
 	"github.com/Microsoft/hcsshim/internal/copyfile"
 	"github.com/Microsoft/hcsshim/internal/uvm"
-	"github.com/Microsoft/hcsshim/internal/wclayer"
 	"github.com/Microsoft/hcsshim/osversion"
 	"github.com/sirupsen/logrus"
 )
@@ -32,9 +31,6 @@ func TestVPMEM(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer os.RemoveAll(tempDir)
-	if err := wclayer.GrantVmAccess(id, filepath.Join(tempDir, "layer.vhd")); err != nil {
-		t.Fatal(err)
-	}
 
 	for i := 0; i < int(iterations); i++ {
 		deviceNumber, uvmPath, err := u.AddVPMEM(filepath.Join(tempDir, "layer.vhd"), true)

--- a/internal/lcow/scratch.go
+++ b/internal/lcow/scratch.go
@@ -12,7 +12,6 @@ import (
 	"github.com/Microsoft/hcsshim/internal/copyfile"
 	"github.com/Microsoft/hcsshim/internal/timeout"
 	"github.com/Microsoft/hcsshim/internal/uvm"
-	"github.com/Microsoft/hcsshim/internal/wclayer"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/sirupsen/logrus"
 )
@@ -46,14 +45,6 @@ func CreateScratch(lcowUVM *uvm.UtilityVM, destFile string, sizeGB uint32, cache
 				return fmt.Errorf("failed to copy cached file '%s' to '%s': %s", cacheFile, destFile, err)
 			}
 			logrus.Debugf("hcsshim::CreateLCOWScratch: %s fulfilled from cache (%s)", destFile, cacheFile)
-
-			if vmID != "" {
-				if err := wclayer.GrantVmAccess(vmID, destFile); err != nil {
-					os.Remove(destFile)
-					return err
-				}
-			}
-
 			return nil
 		}
 	}
@@ -61,12 +52,6 @@ func CreateScratch(lcowUVM *uvm.UtilityVM, destFile string, sizeGB uint32, cache
 	// Create the VHDX
 	if err := vhd.CreateVhdx(destFile, sizeGB, defaultVhdxBlockSizeMB); err != nil {
 		return fmt.Errorf("failed to create VHDx %s: %s", destFile, err)
-	}
-
-	//	uvmc.DebugLCOWGCS()
-	// Grant access
-	if err := wclayer.GrantVmAccess(lcowUVM.ID(), destFile); err != nil {
-		return err
 	}
 
 	controller, lun, err := lcowUVM.AddSCSI(destFile, "") // No destination as not formatted
@@ -176,13 +161,6 @@ func CreateScratch(lcowUVM *uvm.UtilityVM, destFile string, sizeGB uint32, cache
 	if cacheFile != "" && (sizeGB == DefaultScratchSizeGB) {
 		if err := copyfile.CopyFile(destFile, cacheFile, true); err != nil {
 			return fmt.Errorf("failed to seed cache '%s' from '%s': %s", destFile, cacheFile, err)
-		}
-	}
-
-	if vmID != "" {
-		if err := wclayer.GrantVmAccess(vmID, destFile); err != nil {
-			os.Remove(destFile)
-			return err
 		}
 	}
 

--- a/internal/uvm/scsi.go
+++ b/internal/uvm/scsi.go
@@ -6,6 +6,7 @@ import (
 	"github.com/Microsoft/hcsshim/internal/guestrequest"
 	"github.com/Microsoft/hcsshim/internal/requesttype"
 	"github.com/Microsoft/hcsshim/internal/schema2"
+	"github.com/Microsoft/hcsshim/internal/wclayer"
 	"github.com/sirupsen/logrus"
 )
 
@@ -105,6 +106,11 @@ func (uvm *UtilityVM) addSCSIActual(hostPath string, uvmPath string, isLayer boo
 
 	if uvm.scsiControllerCount == 0 {
 		return -1, -1, ErrNoSCSIControllers
+	}
+
+	// Ensure the utility VM has access
+	if err := wclayer.GrantVmAccess(uvm.ID(), hostPath); err != nil {
+		return -1, -1, err
 	}
 
 	// We must hold the lock throughout the lookup (findSCSIAttachment) until

--- a/internal/uvm/vpmem.go
+++ b/internal/uvm/vpmem.go
@@ -6,6 +6,7 @@ import (
 	"github.com/Microsoft/hcsshim/internal/guestrequest"
 	"github.com/Microsoft/hcsshim/internal/requesttype"
 	"github.com/Microsoft/hcsshim/internal/schema2"
+	"github.com/Microsoft/hcsshim/internal/wclayer"
 	"github.com/sirupsen/logrus"
 )
 
@@ -60,6 +61,11 @@ func (uvm *UtilityVM) AddVPMEM(hostPath string, expose bool) (uint32, string, er
 
 	deviceNumber, uvmPath, err = uvm.findVPMEMDevice(hostPath)
 	if err != nil {
+		// Ensure the utility VM has access
+		if err := wclayer.GrantVmAccess(uvm.ID(), hostPath); err != nil {
+			return 0, "", err
+		}
+
 		// It doesn't exist, so we're going to allocate and hot-add it
 		deviceNumber, err = uvm.allocateVPMEM(hostPath)
 		if err != nil {


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

Follow-up from https://github.com/Microsoft/hcsshim/pull/359#discussion_r228579031. This moves the `GrantVmAccess` calls rather than being the responsibility of callers, to the AddSCSI and AddVPMem functions.