### PR TITLE
Use Scratch in TestMemBackingTypeWCOW

### DIFF
--- a/functional/uvm_mem_backingtype_test.go
+++ b/functional/uvm_mem_backingtype_test.go
@@ -44,7 +44,7 @@ func runMemStartWCOWTest(t *testing.T, opts *uvm.UVMOptions) {
 	scratchDir := testutilities.CreateTempDir(t)
 	defer os.RemoveAll(scratchDir)
 
-	opts.LayerFolders = layers
+	opts.LayerFolders = append(layers, scratchDir)
 	runMemStartTest(t, opts)
 }
 


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

@jterry75 TestMemBackingTypeWCOW was failing on my test machine, probably because I'm using a nanoserver base image direct from the build share which only has one layer, rather than pulling one which probably has both the base and the patch. Fix was simple - you'd omitted to pass the scratch to the layer folders.