### PR TITLE
AllowOvercommit has replaced Backing and should be used instead.

### DIFF
--- a/internal/schema2/memory_2.go
+++ b/internal/schema2/memory_2.go
@@ -12,9 +12,6 @@ package hcsschema
 type Memory2 struct {
 	SizeInMB int32 `json:"SizeInMB,omitempty"`
 
-	// Backing { Physical, Virtual } is private in the schema. If regenerated need to add back.
-	Backing string `json:"Backing,omitempty"`
-
 	AllowOvercommit bool `json:"AllowOvercommit,omitempty"`
 
 	EnableHotHint bool `json:"EnableHotHint,omitempty"`

--- a/internal/uvm/create.go
+++ b/internal/uvm/create.go
@@ -242,15 +242,14 @@ func Create(opts *UVMOptions) (_ *UtilityVM, err error) {
 		}
 	}
 
-	var backing string
+	allowOvercommit := true
 	enableDeferredCommit := false
 	if opts.MemoryBackingType != nil {
-		backing = "Virtual"
 		switch *opts.MemoryBackingType {
 		case MemoryBackingTypeVirtualDeferred:
 			enableDeferredCommit = true
 		case MemoryBackingTypePhysical:
-			backing = "Physical"
+			allowOvercommit = false
 		}
 	}
 
@@ -262,8 +261,7 @@ func Create(opts *UVMOptions) (_ *UtilityVM, err error) {
 		ComputeTopology: &hcsschema.Topology{
 			Memory: &hcsschema.Memory2{
 				SizeInMB:             memory,
-				Backing:              backing,
-				AllowOvercommit:      true,
+				AllowOvercommit:      allowOvercommit,
 				EnableHotHint:        uvm.operatingSystem == "windows",
 				EnableDeferredCommit: enableDeferredCommit,
 			},


### PR DESCRIPTION
Signed-off-by: Justin Terry (VM) <juterry@microsoft.com>