### PR TITLE
Update annotation fields

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,9 +18,11 @@ build_script:
   - go test -c ./pkg/go-runhcs/ -tags runhcs_test
   - go build ./cmd/tar2ext4
   - go test -v ./... -tags admin
+  - go test -c ./functional/ -tags functional
 
 artifacts:
   - path: 'wclayer.exe'
   - path: 'runhcs.exe'
   - path: 'go-runhcs.test.exe'
   - path: 'tar2ext4.exe'
+  - path: 'functional.test.exe'

--- a/functional/lcow_test.go
+++ b/functional/lcow_test.go
@@ -23,7 +23,7 @@ import (
 // no VPMem device. Uses initrd.
 func TestLCOWUVMNoSCSINoVPMemInitrd(t *testing.T) {
 	scsiCount := 0
-	var vpmemCount int32 = 0
+	var vpmemCount uint32 = 0
 	opts := &uvm.UVMOptions{
 		OperatingSystem:     "linux",
 		ID:                  "uvm",
@@ -37,7 +37,7 @@ func TestLCOWUVMNoSCSINoVPMemInitrd(t *testing.T) {
 // only a single VPMem device. Uses VPMEM VHD
 func TestLCOWUVMNoSCSISingleVPMemVHD(t *testing.T) {
 	scsiCount := 0
-	var vpmemCount int32 = 1
+	var vpmemCount uint32 = 1
 	var prfst uvm.PreferredRootFSType = uvm.PreferredRootFSTypeVHD
 	opts := &uvm.UVMOptions{
 		OperatingSystem:     "linux",
@@ -83,7 +83,7 @@ func TestLCOWTimeUVMStartInitRD(t *testing.T) {
 
 func testLCOWTimeUVMStart(t *testing.T, rfsType uvm.PreferredRootFSType) {
 	testutilities.RequiresBuild(t, osversion.RS5)
-	var vpmemCount int32 = 32
+	var vpmemCount uint32 = 32
 	for i := 0; i < 3; i++ {
 		opts := &uvm.UVMOptions{
 			OperatingSystem:     "linux",

--- a/functional/uvm_mem_backingtype_test.go
+++ b/functional/uvm_mem_backingtype_test.go
@@ -45,10 +45,10 @@ func runMemTests(t *testing.T, os string) {
 	no := false
 
 	testCases := []testCase{
-		testCase{nil, nil}, // Implicit default - Virtual
-		testCase{allowOvercommit: &yes, enableDeferredCommit: &no},  // Explicit default - Virtual
-		testCase{allowOvercommit: &yes, enableDeferredCommit: &yes}, // Virtual Deferred
-		testCase{allowOvercommit: &no, enableDeferredCommit: &no},   // Physical
+		{nil, nil}, // Implicit default - Virtual
+		{allowOvercommit: &yes, enableDeferredCommit: &no},  // Explicit default - Virtual
+		{allowOvercommit: &yes, enableDeferredCommit: &yes}, // Virtual Deferred
+		{allowOvercommit: &no, enableDeferredCommit: &no},   // Physical
 	}
 
 	for _, bt := range testCases {

--- a/functional/uvm_mem_backingtype_test.go
+++ b/functional/uvm_mem_backingtype_test.go
@@ -3,7 +3,6 @@
 package functional
 
 import (
-	"fmt"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -13,19 +12,6 @@ import (
 	"github.com/Microsoft/hcsshim/osversion"
 	"github.com/sirupsen/logrus"
 )
-
-func memoryBackingTypeToString(bt uvm.MemoryBackingType) string {
-	switch bt {
-	case uvm.MemoryBackingTypeVirtual:
-		return "Virtual"
-	case uvm.MemoryBackingTypeVirtualDeferred:
-		return "VirtualDeferred"
-	case uvm.MemoryBackingTypePhysical:
-		return "Physical"
-	default:
-		panic(fmt.Sprintf("unknown memory type: %v", bt))
-	}
-}
 
 func runMemStartTest(t *testing.T, opts *uvm.UVMOptions) {
 	u, err := uvm.Create(opts)
@@ -49,17 +35,27 @@ func runMemStartWCOWTest(t *testing.T, opts *uvm.UVMOptions) {
 }
 
 func runMemTests(t *testing.T, os string) {
-	types := [3]uvm.MemoryBackingType{
-		uvm.MemoryBackingTypeVirtual,
-		uvm.MemoryBackingTypeVirtualDeferred,
-		uvm.MemoryBackingTypePhysical,
+
+	type testCase struct {
+		allowOvercommit      *bool
+		enableDeferredCommit *bool
 	}
 
-	for _, bt := range types {
+	yes := true
+	no := false
+
+	testCases := []testCase{
+		testCase{nil, nil}, // Implicit default - Virtual
+		testCase{allowOvercommit: &yes, enableDeferredCommit: &no},  // Explicit default - Virtual
+		testCase{allowOvercommit: &yes, enableDeferredCommit: &yes}, // Virtual Deferred
+		testCase{allowOvercommit: &no, enableDeferredCommit: &no},   // Physical
+	}
+
+	for _, bt := range testCases {
 		opts := &uvm.UVMOptions{
-			ID:                fmt.Sprintf("%s-%s", t.Name(), memoryBackingTypeToString(bt)),
-			OperatingSystem:   os,
-			MemoryBackingType: &bt,
+			OperatingSystem:      os,
+			AllowOvercommit:      bt.allowOvercommit,
+			EnableDeferredCommit: bt.enableDeferredCommit,
 		}
 
 		if os == "windows" {
@@ -91,12 +87,12 @@ func runBenchMemStartTest(b *testing.B, opts *uvm.UVMOptions) {
 	}
 }
 
-func runBenchMemStartLcowTest(b *testing.B, bt uvm.MemoryBackingType) {
+func runBenchMemStartLcowTest(b *testing.B, allowOverCommit bool, enableDeferredCommit bool) {
 	for i := 0; i < b.N; i++ {
 		opts := &uvm.UVMOptions{
-			ID:                fmt.Sprintf("%s-%s-%d", b.Name(), memoryBackingTypeToString(bt), i),
-			OperatingSystem:   "linux",
-			MemoryBackingType: &bt,
+			OperatingSystem:      "linux",
+			AllowOvercommit:      &allowOverCommit,
+			EnableDeferredCommit: &enableDeferredCommit,
 		}
 		runBenchMemStartTest(b, opts)
 	}
@@ -106,19 +102,19 @@ func BenchmarkMemBackingTypeVirtualLCOW(b *testing.B) {
 	//testutilities.RequiresBuild(t, osversion.RS5)
 	logrus.SetOutput(ioutil.Discard)
 
-	runBenchMemStartLcowTest(b, uvm.MemoryBackingTypeVirtual)
+	runBenchMemStartLcowTest(b, true, false)
 }
 
 func BenchmarkMemBackingTypeVirtualDeferredLCOW(b *testing.B) {
 	//testutilities.RequiresBuild(t, osversion.RS5)
 	logrus.SetOutput(ioutil.Discard)
 
-	runBenchMemStartLcowTest(b, uvm.MemoryBackingTypeVirtualDeferred)
+	runBenchMemStartLcowTest(b, true, true)
 }
 
 func BenchmarkMemBackingTypePhyscialLCOW(b *testing.B) {
 	//testutilities.RequiresBuild(t, osversion.RS5)
 	logrus.SetOutput(ioutil.Discard)
 
-	runBenchMemStartLcowTest(b, uvm.MemoryBackingTypePhysical)
+	runBenchMemStartLcowTest(b, false, false)
 }

--- a/functional/uvm_vpmem_test.go
+++ b/functional/uvm_vpmem_test.go
@@ -23,7 +23,7 @@ func TestVPMEM(t *testing.T) {
 	u := testutilities.CreateLCOWUVM(t, id)
 	defer u.Terminate()
 
-	var iterations uint32 = uvm.MaxVPMEM
+	var iterations uint32 = uvm.MaxVPMEMCount
 
 	// Use layer.vhd from the alpine image as something to add
 	tempDir := testutilities.CreateTempDir(t)

--- a/internal/schema2/virtual_p_mem_controller.go
+++ b/internal/schema2/virtual_p_mem_controller.go
@@ -10,12 +10,11 @@
 package hcsschema
 
 type VirtualPMemController struct {
-
 	Devices map[string]VirtualPMemDevice `json:"Devices,omitempty"`
 
-	MaximumCount int32 `json:"MaximumCount,omitempty"`
+	MaximumCount uint32 `json:"MaximumCount,omitempty"`
 
-	MaximumSizeBytes int32 `json:"MaximumSizeBytes,omitempty"`
+	MaximumSizeBytes uint64 `json:"MaximumSizeBytes,omitempty"`
 
 	Backing string `json:"Backing,omitempty"`
 }

--- a/internal/uvm/constants.go
+++ b/internal/uvm/constants.go
@@ -3,13 +3,17 @@ package uvm
 import "fmt"
 
 const (
-	// MaxVPMEM is the maximum number of VPMem devices that may be added to an LCOW
+	// MaxVPMEMCount is the maximum number of VPMem devices that may be added to an LCOW
 	// utility VM
-	MaxVPMEM = 128
+	MaxVPMEMCount = 128
 
-	// DefaultVPMEM is the default number of VPMem devices that may be added to an LCOW
+	// DefaultVPMEMCount is the default number of VPMem devices that may be added to an LCOW
 	// utility VM if the create request doesn't specify how many.
-	DefaultVPMEM = 64
+	DefaultVPMEMCount = 64
+
+	// DefaultVPMemSizeBytes is the default size of a VPMem device if the create request
+	// doesn't specify.
+	DefaultVPMemSizeBytes = 4 * 1024 * 1024 * 1024 // 4GB
 )
 
 var errNotSupported = fmt.Errorf("not supported")

--- a/internal/uvm/create.go
+++ b/internal/uvm/create.go
@@ -243,12 +243,8 @@ func Create(opts *UVMOptions) (_ *UtilityVM, err error) {
 	// +-------------------+------------------+------------------------+
 	allowOvercommit := true
 	enableDeferredCommit := false
-	enableHotHint := uvm.operatingSystem == "windows"
 	if opts.AllowOvercommit != nil {
 		allowOvercommit = *opts.AllowOvercommit
-		if !allowOvercommit {
-			enableHotHint = false // Hot hint is not compatible with physical/don't allow overcommit
-		}
 	}
 	if opts.EnableDeferredCommit != nil {
 		enableDeferredCommit = *opts.EnableDeferredCommit
@@ -261,9 +257,10 @@ func Create(opts *UVMOptions) (_ *UtilityVM, err error) {
 
 		ComputeTopology: &hcsschema.Topology{
 			Memory: &hcsschema.Memory2{
-				SizeInMB:             memory,
-				AllowOvercommit:      allowOvercommit,
-				EnableHotHint:        enableHotHint,
+				SizeInMB:        memory,
+				AllowOvercommit: allowOvercommit,
+				// Hot hint is not compatible with physical. Only virtual, and only Windows.
+				EnableHotHint:        allowOvercommit && uvm.operatingSystem == "windows",
 				EnableDeferredCommit: enableDeferredCommit,
 			},
 			Processor: &hcsschema.Processor2{

--- a/internal/uvm/types.go
+++ b/internal/uvm/types.go
@@ -77,8 +77,9 @@ type UtilityVM struct {
 
 	// VPMEM devices that are mapped into a Linux UVM. These are used for read-only layers, or for
 	// booting from VHD.
-	vpmemDevices [MaxVPMEM]vpmemInfo // Limited by ACPI size.
-	vpmemMax     int32               // Actual number of VPMem devices
+	vpmemDevices      [MaxVPMEMCount]vpmemInfo // Limited by ACPI size.
+	vpmemMaxCount     uint32                   // Actual number of VPMem devices
+	vpmemMaxSizeBytes uint64                   // Actual size of VPMem devices
 
 	// SCSI devices that are mapped into a Windows or Linux utility VM
 	scsiLocations       [4][64]scsiInfo // Hyper-V supports 4 controllers, 64 slots per controller. Limited to 1 controller for now though.


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

@jterry75 This reworks the memory backing type into individual annotations. In addition, it adds two further options for VPMem - the device count, and the maximum size (which defaults to 4GB for consistency with v1 callers).
