### PR TITLE
Refactor uvm.Create into CreateWCOW and CreateLCOW

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,10 +12,10 @@ build_script:
   - go get -u github.com/alecthomas/gometalinter
   - gometalinter.exe --install
   - gometalinter.exe --config .gometalinter.json ./...
-  - go get -v -d -t -tags "runhcs_test functional integration admin" ./...
+  - go get -v -d -t -tags "functional integration admin" ./...
   - go build ./cmd/wclayer
   - go build ./cmd/runhcs
-  - go test -c ./pkg/go-runhcs/ -tags runhcs_test
+  - go test -c ./pkg/go-runhcs/ -tags integration
   - go build ./cmd/tar2ext4
   - go test -v ./... -tags admin
   - go test -c ./functional/ -tags functional

--- a/cmd/runhcs/create-scratch.go
+++ b/cmd/runhcs/create-scratch.go
@@ -51,11 +51,13 @@ var createScratchCommand = cli.Command{
 				return errors.Wrapf(err, "failed to create ext4vhdx for '%s'", cfg.Name)
 			}
 		} else {
-			opts := uvm.UVMOptions{
-				ID:              "createscratch-uvm",
-				OperatingSystem: "linux",
+			opts := uvm.OptionsLCOW{
+				Options: &uvm.Options{
+					ID:    "createscratch-uvm",
+					Owner: context.GlobalString("owner"),
+				},
 			}
-			convertUVM, err := uvm.Create(&opts)
+			convertUVM, err := uvm.CreateLCOW(&opts)
 			if err != nil {
 				return errors.Wrapf(err, "failed to create '%s'", opts.ID)
 			}

--- a/cmd/runhcs/create.go
+++ b/cmd/runhcs/create.go
@@ -95,5 +95,6 @@ func containerConfigFromContext(context *cli.Context) (*containerConfig, error) 
 		VMConsolePipe: context.String("vm-console"),
 		Spec:          spec,
 		HostID:        context.String("host"),
+		Owner:         context.GlobalString("owner"),
 	}, nil
 }

--- a/ext4/internal/compactext4/verify_linux_test.go
+++ b/ext4/internal/compactext4/verify_linux_test.go
@@ -219,13 +219,15 @@ func mountImage(t *testing.T, image string, mountPath string) bool {
 
 	err = os.MkdirAll(mountPath, 0777)
 	if err != nil {
-		t.Fatal(err)
+		t.Error(err)
+		return false
 	}
 
 	out, err := exec.Command("mount", "-o", "loop,ro", "-t", "ext4", image, mountPath).CombinedOutput()
 	t.Logf("%s", out)
 	if err != nil {
-		t.Fatal(err)
+		t.Error(err)
+		return false
 	}
 	return true
 }
@@ -243,6 +245,6 @@ func fsck(t *testing.T, image string) {
 	out, err := cmd.CombinedOutput()
 	t.Logf("%s", out)
 	if err != nil {
-		t.Fatal(err)
+		t.Error(err)
 	}
 }

--- a/functional/lcow_test.go
+++ b/functional/lcow_test.go
@@ -22,11 +22,12 @@ import (
 // TestLCOWUVMNoSCSINoVPMemInitrd starts an LCOW utility VM without a SCSI controller and
 // no VPMem device. Uses initrd.
 func TestLCOWUVMNoSCSINoVPMemInitrd(t *testing.T) {
-	scsiCount := 0
+	var scsiCount uint = 0
 	var vpmemCount uint32 = 0
-	opts := &uvm.UVMOptions{
-		OperatingSystem:     "linux",
-		ID:                  "uvm",
+	opts := &uvm.OptionsLCOW{
+		Options: &uvm.Options{
+			ID: t.Name(),
+		},
 		VPMemDeviceCount:    &vpmemCount,
 		SCSIControllerCount: &scsiCount,
 	}
@@ -36,23 +37,23 @@ func TestLCOWUVMNoSCSINoVPMemInitrd(t *testing.T) {
 // TestLCOWUVMNoSCSISingleVPMemVHD starts an LCOW utility VM without a SCSI controller and
 // only a single VPMem device. Uses VPMEM VHD
 func TestLCOWUVMNoSCSISingleVPMemVHD(t *testing.T) {
-	scsiCount := 0
+	var scsiCount uint = 0
 	var vpmemCount uint32 = 1
-	var prfst uvm.PreferredRootFSType = uvm.PreferredRootFSTypeVHD
-	opts := &uvm.UVMOptions{
-		OperatingSystem:     "linux",
-		ID:                  "uvm",
+	opts := &uvm.OptionsLCOW{
+		Options: &uvm.Options{
+			ID: t.Name(),
+		},
 		VPMemDeviceCount:    &vpmemCount,
 		SCSIControllerCount: &scsiCount,
-		PreferredRootFSType: &prfst,
+		PreferredRootFSType: uvm.PreferredRootFSTypeVHD,
 		//ConsolePipe:         `\\.\pipe\vmpipe`,
 	}
 	testLCOWUVMNoSCSISingleVPMem(t, opts, `Command line: root=/dev/pmem0 init=/init`)
 }
 
-func testLCOWUVMNoSCSISingleVPMem(t *testing.T, opts *uvm.UVMOptions, expected string) {
+func testLCOWUVMNoSCSISingleVPMem(t *testing.T, opts *uvm.OptionsLCOW, expected string) {
 	testutilities.RequiresBuild(t, osversion.RS5)
-	lcowUVM, err := uvm.Create(opts)
+	lcowUVM, err := uvm.CreateLCOW(opts)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -85,13 +86,14 @@ func testLCOWTimeUVMStart(t *testing.T, rfsType uvm.PreferredRootFSType) {
 	testutilities.RequiresBuild(t, osversion.RS5)
 	var vpmemCount uint32 = 32
 	for i := 0; i < 3; i++ {
-		opts := &uvm.UVMOptions{
-			OperatingSystem:     "linux",
-			ID:                  "uvm",
+		opts := &uvm.OptionsLCOW{
+			Options: &uvm.Options{
+				ID: t.Name(),
+			},
 			VPMemDeviceCount:    &vpmemCount,
-			PreferredRootFSType: &rfsType,
+			PreferredRootFSType: rfsType,
 		}
-		lcowUVM, err := uvm.Create(opts)
+		lcowUVM, err := uvm.CreateLCOW(opts)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -126,11 +128,12 @@ func TestLCOWSimplePodScenario(t *testing.T) {
 	defer os.RemoveAll(c2ScratchDir)
 	c2ScratchFile := filepath.Join(c2ScratchDir, "sandbox.vhdx")
 
-	opts := &uvm.UVMOptions{
-		OperatingSystem: "linux",
-		ID:              "uvm",
+	opts := &uvm.OptionsLCOW{
+		Options: &uvm.Options{
+			ID: t.Name(),
+		},
 	}
-	lcowUVM, err := uvm.Create(opts)
+	lcowUVM, err := uvm.CreateLCOW(opts)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/functional/utilities/createuvm.go
+++ b/functional/utilities/createuvm.go
@@ -11,15 +11,16 @@ import (
 func CreateWCOWUVM(t *testing.T, uvmLayers []string, id string, resources *specs.WindowsResources) (*uvm.UtilityVM, string) {
 	scratchDir := CreateTempDir(t)
 
-	opts := &uvm.UVMOptions{
-		OperatingSystem: "windows",
-		LayerFolders:    append(uvmLayers, scratchDir),
-		Resources:       resources,
+	opts := &uvm.OptionsWCOW{
+		Options: &uvm.Options{
+			Resources: resources,
+		},
+		LayerFolders: append(uvmLayers, scratchDir),
 	}
 	if id != "" {
 		opts.ID = id
 	}
-	uvm, err := uvm.Create(opts)
+	uvm, err := uvm.CreateWCOW(opts)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -32,11 +33,11 @@ func CreateWCOWUVM(t *testing.T, uvmLayers []string, id string, resources *specs
 
 // CreateLCOWUVM creates an LCOW utility VM.
 func CreateLCOWUVM(t *testing.T, id string) *uvm.UtilityVM {
-	opts := &uvm.UVMOptions{OperatingSystem: "linux"}
+	opts := &uvm.OptionsLCOW{}
 	if id != "" {
 		opts.ID = id
 	}
-	uvm, err := uvm.Create(opts)
+	uvm, err := uvm.CreateLCOW(opts)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/functional/wcow_test.go
+++ b/functional/wcow_test.go
@@ -692,11 +692,12 @@ func TestWCOWXenonOciV2(t *testing.T) {
 		t.Fatalf("failed to create scratch: %s", err)
 	}
 
-	xenonOci2UVM, err = uvm.Create(
-		&uvm.UVMOptions{
-			ID:              xenonOci2UVMId,
-			OperatingSystem: "windows",
-			LayerFolders:    append(imageLayers, xenonOci2UVMScratchDir),
+	xenonOci2UVM, err = uvm.CreateWCOW(
+		&uvm.OptionsWCOW{
+			Options: &uvm.Options{
+				ID: xenonOci2UVMId,
+			},
+			LayerFolders: append(imageLayers, xenonOci2UVMScratchDir),
 		})
 	if err != nil {
 		t.Fatalf("Failed create UVM: %s", err)

--- a/internal/cmd/createuvm/createuvm.go
+++ b/internal/cmd/createuvm/createuvm.go
@@ -14,7 +14,7 @@ import (
 func main() {
 
 	fmt.Println("Creating...")
-	lcowUVM, err := uvm.Create(&uvm.UVMOptions{OperatingSystem: "linux", ID: "uvm"})
+	lcowUVM, err := uvm.CreateLCOW(&uvm.OptionsLCOW{Options: &uvm.Options{ID: "uvm"}})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to create utility VM: %s", err)
 		os.Exit(-1)

--- a/internal/cmd/rootfs2vhd/rootfs2vhd.go
+++ b/internal/cmd/rootfs2vhd/rootfs2vhd.go
@@ -98,7 +98,7 @@ func rootfs2vhd(c *cli.Context) {
 	}
 
 	fmt.Println("- Creating an LCOW utility VM...")
-	lcowUVM, err := uvm.Create(&uvm.UVMOptions{OperatingSystem: "linux", ID: "rootfs2vhd"})
+	lcowUVM, err := uvm.CreateLCOW(&uvm.OptionsLCOW{Options: &uvm.Options{ID: "rootfs2vhd"}})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to create utility VM: %s", err)
 		os.Exit(-1)

--- a/internal/schemaversion/schemaversion_test.go
+++ b/internal/schemaversion/schemaversion_test.go
@@ -12,8 +12,8 @@ func TestDetermineSchemaVersion(t *testing.T) {
 	osv := osversion.Get()
 
 	if osv.Build >= osversion.RS5 {
-		if sv := DetermineSchemaVersion(nil); !IsV10(sv) { // TODO: Toggle this at some point so default is 2.0
-			t.Fatalf("expected v1")
+		if sv := DetermineSchemaVersion(nil); !IsV21(sv) {
+			t.Fatalf("expected v2")
 		}
 		if sv := DetermineSchemaVersion(SchemaV21()); !IsV21(sv) {
 			t.Fatalf("expected requested v2")
@@ -21,8 +21,8 @@ func TestDetermineSchemaVersion(t *testing.T) {
 		if sv := DetermineSchemaVersion(SchemaV10()); !IsV10(sv) {
 			t.Fatalf("expected requested v1")
 		}
-		if sv := DetermineSchemaVersion(&hcsschema.Version{}); !IsV10(sv) { // Logs a warning that 0.0 is ignored // TODO: Toggle this too
-			t.Fatalf("expected requested v1")
+		if sv := DetermineSchemaVersion(&hcsschema.Version{}); !IsV21(sv) { // Logs a warning that 0.0 is ignored // TODO: Toggle this too
+			t.Fatalf("expected requested v2")
 		}
 
 		if err := IsSupported(SchemaV21()); err != nil {

--- a/internal/uvm/create.go
+++ b/internal/uvm/create.go
@@ -1,468 +1,21 @@
 package uvm
 
 import (
-	"encoding/binary"
-	"fmt"
-	"net"
-	"os"
-	"path/filepath"
 	"runtime"
-	"strings"
 
-	"github.com/Microsoft/hcsshim/internal/guid"
-	"github.com/Microsoft/hcsshim/internal/hcs"
-	"github.com/Microsoft/hcsshim/internal/mergemaps"
-	"github.com/Microsoft/hcsshim/internal/schema2"
-	"github.com/Microsoft/hcsshim/internal/schemaversion"
-	"github.com/Microsoft/hcsshim/internal/uvmfolder"
-	"github.com/Microsoft/hcsshim/internal/wclayer"
-	"github.com/Microsoft/hcsshim/internal/wcow"
-	"github.com/linuxkit/virtsock/pkg/hvsock"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/sirupsen/logrus"
 )
 
-type PreferredRootFSType int
-
-const (
-	PreferredRootFSTypeInitRd = 0
-	PreferredRootFSTypeVHD    = 1
-
-	initrdFile = "initrd.img"
-	vhdFile    = "rootfs.vhd"
-)
-
-// UVMOptions are the set of options passed to Create() to create a utility vm.
-type UVMOptions struct {
+// Options are the set of options passed to Create() to create a utility vm.
+type Options struct {
 	ID                      string                  // Identifier for the uvm. Defaults to generated GUID.
 	Owner                   string                  // Specifies the owner. Defaults to executable name.
-	OperatingSystem         string                  // "windows" or "linux".
 	Resources               *specs.WindowsResources // Optional resources for the utility VM. Supports Memory.limit and CPU.Count only currently. // TODO consider extending?
 	AdditionHCSDocumentJSON string                  // Optional additional JSON to merge into the HCS document prior
 
-	// WCOW specific parameters
-	LayerFolders []string // Set of folders for base layers and scratch. Ordered from top most read-only through base read-only layer, followed by scratch
-
-	// LCOW specific parameters
-	BootFilesPath         string               // Folder in which kernel and root file system reside. Defaults to \Program Files\Linux Containers
-	KernelFile            string               // Filename under BootFilesPath for the kernel. Defaults to `kernel`
-	RootFSFile            string               // Filename under BootFilesPath for the UVMs root file system. Defaults are `initrd.img` or `rootfs.vhd`.
-	PreferredRootFSType   *PreferredRootFSType // Controls searching for the RootFSFile.
-	KernelBootOptions     string               // Additional boot options for the kernel
-	EnableGraphicsConsole bool                 // If true, enable a graphics console for the utility VM
-	ConsolePipe           string               // The named pipe path to use for the serial console.  eg \\.\pipe\vmpipe
-	SCSIControllerCount   *int                 // The number of SCSI controllers. Defaults to 1 if omitted. Currently we only support 0 or 1.
-
 	// Fields that can be configured via OCI annotations in runhcs.
-	AllowOvercommit      *bool   // Memory for UVM. Defaults to true. For physical backed memory, set to false. io.microsoft.virtualmachine.computetopology.memory.allowovercommit=true|false
-	EnableDeferredCommit *bool   // Memory for UVM. Defaults to false. For virtual memory with deferred commit, set to true. io.microsoft.virtualmachine.computetopology.memory.enabledeferredcommit=true|false
-	VPMemDeviceCount     *uint32 // Number of VPMem devices. Limit at 128. If booting UVM from VHD, device 0 is taken. LCOW Only. io.microsoft.virtualmachine.devices.virtualpmem.maximumcount
-	VPMemSizeBytes       *uint64 // Size of the VPMem devices. LCOW Only. Defaults to 4GB. io.microsoft.virtualmachine.devices.virtualpmem.maximumsizebytes
-}
-
-const linuxLogVsockPort = 109
-
-// Create creates an HCS compute system representing a utility VM.
-//
-// WCOW Notes:
-//   - If the scratch folder does not exist, it will be created
-//   - If the scratch folder does not contain `sandbox.vhdx` it will be created based on the system template located in the layer folders.
-//   - The scratch is always attached to SCSI 0:0
-//
-func Create(opts *UVMOptions) (_ *UtilityVM, err error) {
-	logrus.Debugf("uvm::Create %+v", opts)
-
-	if opts == nil {
-		return nil, fmt.Errorf("no options supplied to create")
-	}
-
-	uvm := &UtilityVM{
-		id:              opts.ID,
-		owner:           opts.Owner,
-		operatingSystem: opts.OperatingSystem,
-	}
-
-	uvmFolder := "" // Windows
-
-	if opts.OperatingSystem != "linux" && opts.OperatingSystem != "windows" {
-		logrus.Debugf("uvm::Create Unsupported OS")
-		return nil, fmt.Errorf("unsupported operating system %q", opts.OperatingSystem)
-	}
-
-	// Defaults if omitted by caller.
-	// TODO: Change this. Don't auto generate ID if omitted. Avoids the chicken-and-egg problem
-	if uvm.id == "" {
-		uvm.id = guid.New().String()
-	}
-	if uvm.owner == "" {
-		uvm.owner = filepath.Base(os.Args[0])
-	}
-
-	attachments := make(map[string]hcsschema.Attachment)
-	scsi := make(map[string]hcsschema.Scsi)
-	uvm.scsiControllerCount = 1
-	var actualRootFSType PreferredRootFSType = PreferredRootFSTypeInitRd // TODO Should we switch to VPMem/VHD as default?
-
-	if uvm.operatingSystem == "windows" {
-		if len(opts.LayerFolders) < 2 {
-			return nil, fmt.Errorf("at least 2 LayerFolders must be supplied")
-		}
-		if opts.VPMemDeviceCount != nil {
-			return nil, fmt.Errorf("cannot specify VPMemDeviceCount for Windows utility VMs")
-		}
-		if opts.VPMemSizeBytes != nil {
-			return nil, fmt.Errorf("cannot specify VPMemSizeBytes for Windows utility VMs")
-		}
-		var err error
-		uvmFolder, err = uvmfolder.LocateUVMFolder(opts.LayerFolders)
-		if err != nil {
-			return nil, fmt.Errorf("failed to locate utility VM folder from layer folders: %s", err)
-		}
-
-		// TODO: BUGBUG Remove this. @jhowardmsft
-		//       It should be the responsiblity of the caller to do the creation and population.
-		//       - Update runhcs too (vm.go).
-		//       - Remove comment in function header
-		//       - Update tests that rely on this current behaviour.
-		// Create the RW scratch in the top-most layer folder, creating the folder if it doesn't already exist.
-		scratchFolder := opts.LayerFolders[len(opts.LayerFolders)-1]
-		logrus.Debugf("uvm::createWCOW scratch folder: %s", scratchFolder)
-
-		// Create the directory if it doesn't exist
-		if _, err := os.Stat(scratchFolder); os.IsNotExist(err) {
-			logrus.Debugf("uvm::createWCOW Creating folder: %s ", scratchFolder)
-			if err := os.MkdirAll(scratchFolder, 0777); err != nil {
-				return nil, fmt.Errorf("failed to create utility VM scratch folder: %s", err)
-			}
-		}
-
-		// Create sandbox.vhdx in the scratch folder based on the template, granting the correct permissions to it
-		if _, err := os.Stat(filepath.Join(scratchFolder, `sandbox.vhdx`)); os.IsNotExist(err) {
-			if err := wcow.CreateUVMScratch(uvmFolder, scratchFolder, uvm.id); err != nil {
-				return nil, fmt.Errorf("failed to create scratch: %s", err)
-			}
-		}
-
-		// We attach the scratch to SCSI 0:0
-		attachments["0"] = hcsschema.Attachment{
-			Path:  filepath.Join(scratchFolder, "sandbox.vhdx"),
-			Type_: "VirtualDisk",
-		}
-		scsi["0"] = hcsschema.Scsi{Attachments: attachments}
-		uvm.scsiLocations[0][0].hostPath = attachments["0"].Path
-	} else {
-		uvm.vpmemMaxCount = DefaultVPMEMCount
-		if opts.VPMemDeviceCount != nil {
-			if *opts.VPMemDeviceCount > MaxVPMEMCount {
-				return nil, fmt.Errorf("vpmem device count cannot be greater than %d", MaxVPMEMCount)
-			}
-			uvm.vpmemMaxCount = *opts.VPMemDeviceCount
-			logrus.Debugln("uvm::Create:: uvm.vpmemMax=", uvm.vpmemMaxCount)
-		}
-		if uvm.vpmemMaxCount > 0 {
-			uvm.vpmemMaxSizeBytes = DefaultVPMemSizeBytes
-			if opts.VPMemSizeBytes != nil {
-				if *opts.VPMemSizeBytes%4096 != 0 {
-					return nil, fmt.Errorf("VPMemSizeBytes must be a multiple of 4096")
-				}
-				uvm.vpmemMaxSizeBytes = *opts.VPMemSizeBytes
-			}
-		}
-
-		scsi["0"] = hcsschema.Scsi{Attachments: attachments}
-		uvm.scsiControllerCount = 1
-		if opts.SCSIControllerCount != nil {
-			if *opts.SCSIControllerCount < 0 || *opts.SCSIControllerCount > 1 {
-				return nil, fmt.Errorf("SCSI controller count must be 0 or 1") // Future extension here for up to 4
-			}
-			uvm.scsiControllerCount = *opts.SCSIControllerCount
-			if uvm.scsiControllerCount == 0 {
-				scsi = nil
-			}
-			logrus.Debugln("uvm::Create:: uvm.scsiControllerCount=", uvm.scsiControllerCount)
-		}
-		if opts.BootFilesPath == "" {
-			opts.BootFilesPath = filepath.Join(os.Getenv("ProgramFiles"), "Linux Containers")
-		}
-		if opts.KernelFile == "" {
-			opts.KernelFile = "kernel"
-		}
-		if _, err := os.Stat(filepath.Join(opts.BootFilesPath, opts.KernelFile)); os.IsNotExist(err) {
-			return nil, fmt.Errorf("kernel '%s' not found", filepath.Join(opts.BootFilesPath, opts.KernelFile))
-		}
-
-		if opts.RootFSFile == "" {
-			if opts.PreferredRootFSType != nil {
-				actualRootFSType = *opts.PreferredRootFSType
-				if actualRootFSType != PreferredRootFSTypeInitRd && actualRootFSType != PreferredRootFSTypeVHD {
-					return nil, fmt.Errorf("invalid PreferredRootFSType")
-				}
-			}
-
-			switch actualRootFSType {
-			case PreferredRootFSTypeInitRd:
-				if _, err := os.Stat(filepath.Join(opts.BootFilesPath, initrdFile)); os.IsNotExist(err) {
-					return nil, fmt.Errorf("initrd not found")
-				}
-				opts.RootFSFile = initrdFile
-			case PreferredRootFSTypeVHD:
-				if _, err := os.Stat(filepath.Join(opts.BootFilesPath, vhdFile)); os.IsNotExist(err) {
-					return nil, fmt.Errorf("rootfs.vhd not found")
-				}
-				opts.RootFSFile = vhdFile
-			}
-		} else {
-			// Determine the root FS type by the extension of the explicitly supplied RootFSFile
-			if _, err := os.Stat(filepath.Join(opts.BootFilesPath, opts.RootFSFile)); os.IsNotExist(err) {
-				return nil, fmt.Errorf("%s not found under %s", opts.RootFSFile, opts.BootFilesPath)
-			}
-			switch strings.ToLower(filepath.Ext(opts.RootFSFile)) {
-			case "vhd", "vhdx":
-				actualRootFSType = PreferredRootFSTypeVHD
-			case "img":
-				actualRootFSType = PreferredRootFSTypeInitRd
-			default:
-				return nil, fmt.Errorf("unsupported filename extension for RootFSFile")
-			}
-		}
-	}
-
-	memory := int32(1024)
-	processors := int32(2)
-	if runtime.NumCPU() == 1 {
-		processors = 1
-	}
-	if opts.Resources != nil {
-		if opts.Resources.Memory != nil && opts.Resources.Memory.Limit != nil {
-			memory = int32(*opts.Resources.Memory.Limit / 1024 / 1024) // OCI spec is in bytes. HCS takes MB
-		}
-		if opts.Resources.CPU != nil && opts.Resources.CPU.Count != nil {
-			processors = int32(*opts.Resources.CPU.Count)
-		}
-	}
-
-	//                     +------------------+------------------------+
-	//                     | Allow OverCommit | Enable Deferred Commit |
-	// +-------------------+------------------+------------------------+
-	// | Virtual (Default) |       YES        |        NO              |
-	// +-------------------+------------------+------------------------+
-	// | Virtual Deferred  |       YES        |        YES             |
-	// +-------------------+------------------+------------------------+
-	// | Physical          |       NO         |        NO              |
-	// +-------------------+------------------+------------------------+
-	allowOvercommit := true
-	enableDeferredCommit := false
-	if opts.AllowOvercommit != nil {
-		allowOvercommit = *opts.AllowOvercommit
-	}
-	if opts.EnableDeferredCommit != nil {
-		enableDeferredCommit = *opts.EnableDeferredCommit
-	}
-
-	vm := &hcsschema.VirtualMachine{
-		Chipset: &hcsschema.Chipset{
-			Uefi: &hcsschema.Uefi{},
-		},
-
-		ComputeTopology: &hcsschema.Topology{
-			Memory: &hcsschema.Memory2{
-				SizeInMB:        memory,
-				AllowOvercommit: allowOvercommit,
-				// Hot hint is not compatible with physical. Only virtual, and only Windows.
-				EnableHotHint:        allowOvercommit && uvm.operatingSystem == "windows",
-				EnableDeferredCommit: enableDeferredCommit,
-			},
-			Processor: &hcsschema.Processor2{
-				Count: processors,
-			},
-		},
-
-		GuestConnection: &hcsschema.GuestConnection{},
-
-		Devices: &hcsschema.Devices{
-			Scsi: scsi,
-			HvSocket: &hcsschema.HvSocket2{
-				HvSocketConfig: &hcsschema.HvSocketSystemConfig{
-					// Allow administrators and SYSTEM to bind to vsock sockets
-					// so that we can create a GCS log socket.
-					DefaultBindSecurityDescriptor: "D:P(A;;FA;;;SY)(A;;FA;;;BA)",
-				},
-			},
-		},
-	}
-
-	hcsDocument := &hcsschema.ComputeSystem{
-		Owner:          uvm.owner,
-		SchemaVersion:  schemaversion.SchemaV21(),
-		VirtualMachine: vm,
-	}
-
-	if uvm.operatingSystem == "windows" {
-		vm.Chipset.Uefi.BootThis = &hcsschema.UefiBootEntry{
-			DevicePath: `\EFI\Microsoft\Boot\bootmgfw.efi`,
-			DeviceType: "VmbFs",
-		}
-		vm.Devices.VirtualSmb = &hcsschema.VirtualSmb{
-			DirectFileMappingInMB: 1024, // Sensible default, but could be a tuning parameter somewhere
-			Shares: []hcsschema.VirtualSmbShare{
-				{
-					Name: "os",
-					Path: filepath.Join(uvmFolder, `UtilityVM\Files`),
-					Options: &hcsschema.VirtualSmbShareOptions{
-						ReadOnly:            true,
-						PseudoOplocks:       true,
-						TakeBackupPrivilege: true,
-						CacheIo:             true,
-						ShareRead:           true,
-					},
-				},
-			},
-		}
-	} else {
-		vmDebugging := false
-		vm.GuestConnection.UseVsock = true
-		vm.GuestConnection.UseConnectedSuspend = true
-		vm.Devices.VirtualSmb = &hcsschema.VirtualSmb{
-			Shares: []hcsschema.VirtualSmbShare{
-				{
-					Name: "os",
-					Path: opts.BootFilesPath,
-					Options: &hcsschema.VirtualSmbShareOptions{
-						ReadOnly:            true,
-						TakeBackupPrivilege: true,
-						CacheIo:             true,
-						ShareRead:           true,
-					},
-				},
-			},
-		}
-
-		if uvm.vpmemMaxCount > 0 {
-			vm.Devices.VirtualPMem = &hcsschema.VirtualPMemController{
-				MaximumCount:     uvm.vpmemMaxCount,
-				MaximumSizeBytes: uvm.vpmemMaxSizeBytes,
-			}
-		}
-
-		kernelArgs := "initrd=/" + opts.RootFSFile
-		if actualRootFSType == PreferredRootFSTypeVHD {
-			kernelArgs = "root=/dev/pmem0 init=/init"
-		}
-
-		// Support for VPMem VHD(X) booting rather than initrd..
-		if actualRootFSType == PreferredRootFSTypeVHD {
-			if uvm.vpmemMaxCount == 0 {
-				return nil, fmt.Errorf("PreferredRootFSTypeVHD requess at least one VPMem device")
-			}
-			imageFormat := "Vhd1"
-			if strings.ToLower(filepath.Ext(opts.RootFSFile)) == "vhdx" {
-				imageFormat = "Vhdx"
-			}
-			vm.Devices.VirtualPMem.Devices = map[string]hcsschema.VirtualPMemDevice{
-				"0": {
-					HostPath:    filepath.Join(opts.BootFilesPath, opts.RootFSFile),
-					ReadOnly:    true,
-					ImageFormat: imageFormat,
-				},
-			}
-			if err := wclayer.GrantVmAccess(uvm.id, filepath.Join(opts.BootFilesPath, opts.RootFSFile)); err != nil {
-				return nil, fmt.Errorf("faied to grantvmaccess to %s: %s", filepath.Join(opts.BootFilesPath, opts.RootFSFile), err)
-			}
-			// Add to our internal structure
-			uvm.vpmemDevices[0] = vpmemInfo{
-				hostPath: opts.RootFSFile,
-				uvmPath:  "/",
-				refCount: 1,
-			}
-		}
-
-		if opts.ConsolePipe != "" {
-			vmDebugging = true
-			kernelArgs += " console=ttyS0,115200"
-			vm.Devices.ComPorts = map[string]hcsschema.ComPort{
-				"0": { // Which is actually COM1
-					NamedPipe: opts.ConsolePipe,
-				},
-			}
-		}
-
-		if opts.EnableGraphicsConsole {
-			vmDebugging = true
-			kernelArgs += " console=tty"
-			vm.Devices.Keyboard = &hcsschema.Keyboard{}
-			vm.Devices.EnhancedModeVideo = &hcsschema.EnhancedModeVideo{}
-			vm.Devices.VideoMonitor = &hcsschema.VideoMonitor{}
-		}
-
-		if !vmDebugging {
-			// Terminate the VM if there is a kernel panic.
-			kernelArgs += " panic=-1"
-		}
-
-		if opts.KernelBootOptions != "" {
-			kernelArgs += " " + opts.KernelBootOptions
-		}
-
-		// Start GCS with stderr pointing to the vsock port created below in
-		// order to forward guest logs to logrus.
-		initArgs := fmt.Sprintf("/bin/vsockexec -e %d /bin/gcs -log-format json -loglevel %s",
-			linuxLogVsockPort,
-			logrus.StandardLogger().Level.String())
-
-		if vmDebugging {
-			// Launch a shell on the console.
-			initArgs = `sh -c "` + initArgs + ` & exec sh"`
-		}
-
-		kernelArgs += ` -- ` + initArgs
-		vm.Chipset.Uefi.BootThis = &hcsschema.UefiBootEntry{
-			DevicePath:   `\` + opts.KernelFile,
-			DeviceType:   "VmbFs",
-			OptionalData: kernelArgs,
-		}
-	}
-
-	fullDoc, err := mergemaps.MergeJSON(hcsDocument, ([]byte)(opts.AdditionHCSDocumentJSON))
-	if err != nil {
-		return nil, fmt.Errorf("failed to merge additional JSON '%s': %s", opts.AdditionHCSDocumentJSON, err)
-	}
-
-	hcsSystem, err := hcs.CreateComputeSystem(uvm.id, fullDoc)
-	if err != nil {
-		logrus.Debugln("failed to create UVM: ", err)
-		return nil, err
-	}
-
-	uvm.hcsSystem = hcsSystem
-	defer func() {
-		if err != nil {
-			uvm.Close()
-		}
-	}()
-
-	if uvm.operatingSystem == "linux" {
-		// Create a socket that the GCS can send logrus log data to.
-		uvm.gcslog, err = uvm.listenVsock(linuxLogVsockPort)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	return uvm, nil
-}
-
-func (uvm *UtilityVM) listenVsock(port uint32) (net.Listener, error) {
-	properties, err := uvm.hcsSystem.Properties()
-	if err != nil {
-		return nil, err
-	}
-	vmID, err := hvsock.GUIDFromString(properties.RuntimeID)
-	if err != nil {
-		return nil, err
-	}
-	serviceID, _ := hvsock.GUIDFromString("00000000-facb-11e6-bd58-64006a7986d3")
-	binary.LittleEndian.PutUint32(serviceID[0:4], port)
-	return hvsock.Listen(hvsock.Addr{VMID: vmID, ServiceID: serviceID})
+	AllowOvercommit      *bool // Memory for UVM. Defaults to true. For physical backed memory, set to false. io.microsoft.virtualmachine.computetopology.memory.allowovercommit=true|false
+	EnableDeferredCommit *bool // Memory for UVM. Defaults to false. For virtual memory with deferred commit, set to true. io.microsoft.virtualmachine.computetopology.memory.enabledeferredcommit=true|false
 }
 
 // ID returns the ID of the VM's compute system.
@@ -475,11 +28,6 @@ func (uvm *UtilityVM) OS() string {
 	return uvm.operatingSystem
 }
 
-// PMemMaxSizeBytes returns the maximum size of a PMEM layer (LCOW)
-func (uvm *UtilityVM) PMemMaxSizeBytes() uint64 {
-	return uvm.vpmemMaxSizeBytes
-}
-
 // Close terminates and releases resources associated with the utility VM.
 func (uvm *UtilityVM) Close() error {
 	uvm.Terminate()
@@ -490,4 +38,22 @@ func (uvm *UtilityVM) Close() error {
 	err := uvm.hcsSystem.Close()
 	uvm.hcsSystem = nil
 	return err
+}
+
+func getMemory(r *specs.WindowsResources) int32 {
+	if r == nil || r.Memory == nil || r.Memory.Limit == nil {
+		return 1024 // 1GB By Default.
+	}
+	return int32(*r.Memory.Limit / 1024 / 1024) // OCI spec is in bytes. HCS takes MB
+}
+
+func getProcessors(r *specs.WindowsResources) int32 {
+	if r == nil || r.CPU == nil || r.CPU.Count == nil {
+		processors := int32(2)
+		if runtime.NumCPU() == 1 {
+			processors = 1
+		}
+		return processors
+	}
+	return int32(*r.CPU.Count)
 }

--- a/internal/uvm/create_lcow.go
+++ b/internal/uvm/create_lcow.go
@@ -1,0 +1,309 @@
+package uvm
+
+import (
+	"encoding/binary"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/Microsoft/hcsshim/internal/guid"
+	"github.com/Microsoft/hcsshim/internal/hcs"
+	"github.com/Microsoft/hcsshim/internal/mergemaps"
+	"github.com/Microsoft/hcsshim/internal/schema2"
+	"github.com/Microsoft/hcsshim/internal/schemaversion"
+	"github.com/Microsoft/hcsshim/internal/wclayer"
+	"github.com/linuxkit/virtsock/pkg/hvsock"
+	"github.com/sirupsen/logrus"
+)
+
+type PreferredRootFSType int
+
+const (
+	PreferredRootFSTypeInitRd = 0
+	PreferredRootFSTypeVHD    = 1
+
+	initrdFile = "initrd.img"
+	vhdFile    = "rootfs.vhd"
+)
+
+// OptionsLCOW are the set of options passed to CreateLCOW() to create a utility vm.
+type OptionsLCOW struct {
+	*Options
+
+	BootFilesPath string // Folder in which kernel and root file system reside. Defaults to \Program Files\Linux Containers
+	KernelFile    string // Filename under BootFilesPath for the kernel. Defaults to `kernel`
+	RootFSFile    string // Filename under BootFilesPath for the UVMs root file system. Defaults are `initrd.img` or `rootfs.vhd` based on `PreferredRootFSType`.
+	// PreferredRootFSType controls searching for the RootFSFile. If left default will use `initrd.img`
+	PreferredRootFSType   PreferredRootFSType
+	KernelBootOptions     string // Additional boot options for the kernel
+	EnableGraphicsConsole bool   // If true, enable a graphics console for the utility VM
+	ConsolePipe           string // The named pipe path to use for the serial console.  eg \\.\pipe\vmpipe
+	SCSIControllerCount   *uint  // The number of SCSI controllers. Defaults to 1 if omitted. Currently we only support 0 or 1.
+
+	// Fields that can be configured via OCI annotations in runhcs.
+	VPMemDeviceCount *uint32 // Number of VPMem devices. Limit at 128. If booting UVM from VHD, device 0 is taken. LCOW Only. io.microsoft.virtualmachine.devices.virtualpmem.maximumcount
+	VPMemSizeBytes   *uint64 // Size of the VPMem devices. LCOW Only. Defaults to 4GB. io.microsoft.virtualmachine.devices.virtualpmem.maximumsizebytes
+}
+
+const linuxLogVsockPort = 109
+
+// CreateLCOW creates an HCS compute system representing a utility VM.
+func CreateLCOW(opts *OptionsLCOW) (_ *UtilityVM, err error) {
+	logrus.Debugf("uvm::CreateLCOW %+v", opts)
+
+	if opts.Options == nil {
+		opts.Options = &Options{}
+	}
+
+	uvm := &UtilityVM{
+		id:                  opts.ID,
+		owner:               opts.Owner,
+		operatingSystem:     "linux",
+		scsiControllerCount: 1,
+		vpmemMaxCount:       DefaultVPMEMCount,
+		vpmemMaxSizeBytes:   DefaultVPMemSizeBytes,
+	}
+
+	// Defaults if omitted by caller.
+	// TODO: Change this. Don't auto generate ID if omitted. Avoids the chicken-and-egg problem
+	if uvm.id == "" {
+		uvm.id = guid.New().String()
+	}
+	if uvm.owner == "" {
+		uvm.owner = filepath.Base(os.Args[0])
+	}
+
+	if opts.BootFilesPath == "" {
+		opts.BootFilesPath = filepath.Join(os.Getenv("ProgramFiles"), "Linux Containers")
+	}
+	if opts.KernelFile == "" {
+		opts.KernelFile = "kernel"
+	}
+	if _, err := os.Stat(filepath.Join(opts.BootFilesPath, opts.KernelFile)); os.IsNotExist(err) {
+		return nil, fmt.Errorf("kernel '%s' not found", filepath.Join(opts.BootFilesPath, opts.KernelFile))
+	}
+
+	if opts.RootFSFile == "" {
+		switch opts.PreferredRootFSType {
+		case PreferredRootFSTypeInitRd:
+			opts.RootFSFile = initrdFile
+		case PreferredRootFSTypeVHD:
+			opts.RootFSFile = "rootfs.vhd"
+		}
+	}
+
+	if _, err := os.Stat(filepath.Join(opts.BootFilesPath, opts.RootFSFile)); os.IsNotExist(err) {
+		return nil, fmt.Errorf("%s not found under %s", opts.RootFSFile, opts.BootFilesPath)
+	}
+
+	if opts.SCSIControllerCount != nil {
+		if *opts.SCSIControllerCount > 1 {
+			return nil, fmt.Errorf("SCSI controller count must be 0 or 1") // Future extension here for up to 4
+		}
+		uvm.scsiControllerCount = *opts.SCSIControllerCount
+	}
+	if opts.VPMemDeviceCount != nil {
+		if *opts.VPMemDeviceCount > MaxVPMEMCount {
+			return nil, fmt.Errorf("vpmem device count cannot be greater than %d", MaxVPMEMCount)
+		}
+		uvm.vpmemMaxCount = *opts.VPMemDeviceCount
+	}
+	if uvm.vpmemMaxCount > 0 {
+		if opts.VPMemSizeBytes != nil {
+			if *opts.VPMemSizeBytes%4096 != 0 {
+				return nil, fmt.Errorf("opts.VPMemSizeBytes must be a multiple of 4096")
+			}
+			uvm.vpmemMaxSizeBytes = *opts.VPMemSizeBytes
+		}
+	} else {
+		if opts.PreferredRootFSType == PreferredRootFSTypeVHD {
+			return nil, fmt.Errorf("PreferredRootFSTypeVHD requires at least one VPMem device")
+		}
+	}
+
+	doc := &hcsschema.ComputeSystem{
+		Owner:         uvm.owner,
+		SchemaVersion: schemaversion.SchemaV21(),
+		VirtualMachine: &hcsschema.VirtualMachine{
+			Chipset: &hcsschema.Chipset{
+				Uefi: &hcsschema.Uefi{
+					BootThis: &hcsschema.UefiBootEntry{
+						DevicePath: `\` + opts.KernelFile,
+						DeviceType: "VmbFs",
+					},
+				},
+			},
+			ComputeTopology: &hcsschema.Topology{
+				Memory: &hcsschema.Memory2{
+					SizeInMB: getMemory(opts.Resources),
+					// AllowOvercommit `true` by default if not passed.
+					AllowOvercommit: opts.AllowOvercommit == nil || *opts.AllowOvercommit,
+					// EnableDeferredCommit `false` by default if not passed.
+					EnableDeferredCommit: opts.EnableDeferredCommit != nil && *opts.EnableDeferredCommit,
+				},
+				Processor: &hcsschema.Processor2{
+					Count: getProcessors(opts.Resources),
+				},
+			},
+			GuestConnection: &hcsschema.GuestConnection{
+				UseVsock:            true,
+				UseConnectedSuspend: true,
+			},
+			Devices: &hcsschema.Devices{
+				HvSocket: &hcsschema.HvSocket2{
+					HvSocketConfig: &hcsschema.HvSocketSystemConfig{
+						// Allow administrators and SYSTEM to bind to vsock sockets
+						// so that we can create a GCS log socket.
+						DefaultBindSecurityDescriptor: "D:P(A;;FA;;;SY)(A;;FA;;;BA)",
+					},
+				},
+				VirtualSmb: &hcsschema.VirtualSmb{
+					Shares: []hcsschema.VirtualSmbShare{
+						{
+							Name: "os",
+							Path: opts.BootFilesPath,
+							Options: &hcsschema.VirtualSmbShareOptions{
+								ReadOnly:            true,
+								TakeBackupPrivilege: true,
+								CacheIo:             true,
+								ShareRead:           true,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	if uvm.scsiControllerCount > 0 {
+		doc.VirtualMachine.Devices.Scsi = map[string]hcsschema.Scsi{
+			"0": {
+				Attachments: make(map[string]hcsschema.Attachment),
+			},
+		}
+	}
+	if uvm.vpmemMaxCount > 0 {
+		doc.VirtualMachine.Devices.VirtualPMem = &hcsschema.VirtualPMemController{
+			MaximumCount:     uvm.vpmemMaxCount,
+			MaximumSizeBytes: uvm.vpmemMaxSizeBytes,
+		}
+	}
+
+	var kernelArgs string
+	switch opts.PreferredRootFSType {
+	case PreferredRootFSTypeInitRd:
+		kernelArgs = "initrd=/" + opts.RootFSFile
+	case PreferredRootFSTypeVHD:
+		// Support for VPMem VHD(X) booting rather than initrd..
+		kernelArgs = "root=/dev/pmem0 init=/init"
+		imageFormat := "Vhd1"
+		if strings.ToLower(filepath.Ext(opts.RootFSFile)) == "vhdx" {
+			imageFormat = "Vhdx"
+		}
+		doc.VirtualMachine.Devices.VirtualPMem.Devices = map[string]hcsschema.VirtualPMemDevice{
+			"0": {
+				HostPath:    filepath.Join(opts.BootFilesPath, opts.RootFSFile),
+				ReadOnly:    true,
+				ImageFormat: imageFormat,
+			},
+		}
+		if err := wclayer.GrantVmAccess(uvm.id, filepath.Join(opts.BootFilesPath, opts.RootFSFile)); err != nil {
+			return nil, fmt.Errorf("faied to grantvmaccess to %s: %s", filepath.Join(opts.BootFilesPath, opts.RootFSFile), err)
+		}
+		// Add to our internal structure
+		uvm.vpmemDevices[0] = vpmemInfo{
+			hostPath: opts.RootFSFile,
+			uvmPath:  "/",
+			refCount: 1,
+		}
+	}
+
+	vmDebugging := false
+	if opts.ConsolePipe != "" {
+		vmDebugging = true
+		kernelArgs += " console=ttyS0,115200"
+		doc.VirtualMachine.Devices.ComPorts = map[string]hcsschema.ComPort{
+			"0": { // Which is actually COM1
+				NamedPipe: opts.ConsolePipe,
+			},
+		}
+	}
+
+	if opts.EnableGraphicsConsole {
+		vmDebugging = true
+		kernelArgs += " console=tty"
+		doc.VirtualMachine.Devices.Keyboard = &hcsschema.Keyboard{}
+		doc.VirtualMachine.Devices.EnhancedModeVideo = &hcsschema.EnhancedModeVideo{}
+		doc.VirtualMachine.Devices.VideoMonitor = &hcsschema.VideoMonitor{}
+	}
+
+	if !vmDebugging {
+		// Terminate the VM if there is a kernel panic.
+		kernelArgs += " panic=-1"
+	}
+
+	if opts.KernelBootOptions != "" {
+		kernelArgs += " " + opts.KernelBootOptions
+	}
+
+	// Start GCS with stderr pointing to the vsock port created below in
+	// order to forward guest logs to logrus.
+	initArgs := fmt.Sprintf("/bin/vsockexec -e %d /bin/gcs -log-format json -loglevel %s",
+		linuxLogVsockPort,
+		logrus.StandardLogger().Level.String())
+
+	if vmDebugging {
+		// Launch a shell on the console.
+		initArgs = `sh -c "` + initArgs + ` & exec sh"`
+	}
+
+	kernelArgs += ` -- ` + initArgs
+	doc.VirtualMachine.Chipset.Uefi.BootThis.OptionalData = kernelArgs
+
+	fullDoc, err := mergemaps.MergeJSON(doc, ([]byte)(opts.AdditionHCSDocumentJSON))
+	if err != nil {
+		return nil, fmt.Errorf("failed to merge additional JSON '%s': %s", opts.AdditionHCSDocumentJSON, err)
+	}
+
+	hcsSystem, err := hcs.CreateComputeSystem(uvm.id, fullDoc)
+	if err != nil {
+		logrus.Debugln("failed to create UVM: ", err)
+		return nil, err
+	}
+
+	uvm.hcsSystem = hcsSystem
+	defer func() {
+		if err != nil {
+			uvm.Close()
+		}
+	}()
+
+	// Create a socket that the GCS can send logrus log data to.
+	uvm.gcslog, err = uvm.listenVsock(linuxLogVsockPort)
+	if err != nil {
+		return nil, err
+	}
+
+	return uvm, nil
+}
+
+func (uvm *UtilityVM) listenVsock(port uint32) (net.Listener, error) {
+	properties, err := uvm.hcsSystem.Properties()
+	if err != nil {
+		return nil, err
+	}
+	vmID, err := hvsock.GUIDFromString(properties.RuntimeID)
+	if err != nil {
+		return nil, err
+	}
+	serviceID, _ := hvsock.GUIDFromString("00000000-facb-11e6-bd58-64006a7986d3")
+	binary.LittleEndian.PutUint32(serviceID[0:4], port)
+	return hvsock.Listen(hvsock.Addr{VMID: vmID, ServiceID: serviceID})
+}
+
+// PMemMaxSizeBytes returns the maximum size of a PMEM layer (LCOW)
+func (uvm *UtilityVM) PMemMaxSizeBytes() uint64 {
+	return uvm.vpmemMaxSizeBytes
+}

--- a/internal/uvm/create_test.go
+++ b/internal/uvm/create_test.go
@@ -6,32 +6,19 @@ import (
 
 // Unit tests for negative testing of input to uvm.Create()
 
-func TestCreateBadOS(t *testing.T) {
-	opts := &UVMOptions{
-		OperatingSystem: "foobar",
-	}
-	_, err := Create(opts)
-	if err == nil || (err != nil && err.Error() != `unsupported operating system "foobar"`) {
-		t.Fatal(err)
-	}
-}
-
 func TestCreateBadBootFilesPath(t *testing.T) {
-	opts := &UVMOptions{
-		OperatingSystem: "linux",
-		BootFilesPath:   `c:\does\not\exist\I\hope`,
+	opts := &OptionsLCOW{
+		BootFilesPath: `c:\does\not\exist\I\hope`,
 	}
-	_, err := Create(opts)
+	_, err := CreateLCOW(opts)
 	if err == nil || (err != nil && err.Error() != `kernel 'c:\does\not\exist\I\hope\kernel' not found`) {
 		t.Fatal(err)
 	}
 }
 
 func TestCreateWCOWBadLayerFolders(t *testing.T) {
-	opts := &UVMOptions{
-		OperatingSystem: "windows",
-	}
-	_, err := Create(opts)
+	opts := &OptionsWCOW{}
+	_, err := CreateWCOW(opts)
 	if err == nil || (err != nil && err.Error() != `at least 2 LayerFolders must be supplied`) {
 		t.Fatal(err)
 	}

--- a/internal/uvm/create_wcow.go
+++ b/internal/uvm/create_wcow.go
@@ -1,0 +1,144 @@
+package uvm
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/Microsoft/hcsshim/internal/guid"
+	"github.com/Microsoft/hcsshim/internal/hcs"
+	"github.com/Microsoft/hcsshim/internal/mergemaps"
+	"github.com/Microsoft/hcsshim/internal/schema2"
+	"github.com/Microsoft/hcsshim/internal/schemaversion"
+	"github.com/Microsoft/hcsshim/internal/uvmfolder"
+	"github.com/sirupsen/logrus"
+)
+
+// OptionsWCOW are the set of options passed to CreateWCOW() to create a utility vm.
+type OptionsWCOW struct {
+	*Options
+
+	LayerFolders []string // Set of folders for base layers and scratch. Ordered from top most read-only through base read-only layer, followed by scratch
+}
+
+// CreateWCOW creates an HCS compute system representing a utility VM.
+//
+// WCOW Notes:
+//   - The scratch is always attached to SCSI 0:0
+//
+func CreateWCOW(opts *OptionsWCOW) (_ *UtilityVM, err error) {
+	logrus.Debugf("uvm::CreateWCOW %+v", opts)
+
+	if opts.Options == nil {
+		opts.Options = &Options{}
+	}
+
+	uvm := &UtilityVM{
+		id:                  opts.ID,
+		owner:               opts.Owner,
+		operatingSystem:     "windows",
+		scsiControllerCount: 1,
+	}
+
+	// Defaults if omitted by caller.
+	// TODO: Change this. Don't auto generate ID if omitted. Avoids the chicken-and-egg problem
+	if uvm.id == "" {
+		uvm.id = guid.New().String()
+	}
+	if uvm.owner == "" {
+		uvm.owner = filepath.Base(os.Args[0])
+	}
+
+	if len(opts.LayerFolders) < 2 {
+		return nil, fmt.Errorf("at least 2 LayerFolders must be supplied")
+	}
+	uvmFolder, err := uvmfolder.LocateUVMFolder(opts.LayerFolders)
+	if err != nil {
+		return nil, fmt.Errorf("failed to locate utility VM folder from layer folders: %s", err)
+	}
+
+	scratchPath := filepath.Join(opts.LayerFolders[len(opts.LayerFolders)-1], `sandbox.vhdx`)
+	if _, err := os.Stat(scratchPath); err != nil {
+		return nil, fmt.Errorf("sandbox.vhdx not found: %v", err)
+	}
+
+	doc := &hcsschema.ComputeSystem{
+		Owner:         uvm.owner,
+		SchemaVersion: schemaversion.SchemaV21(),
+		VirtualMachine: &hcsschema.VirtualMachine{
+			Chipset: &hcsschema.Chipset{
+				Uefi: &hcsschema.Uefi{
+					BootThis: &hcsschema.UefiBootEntry{
+						DevicePath: `\EFI\Microsoft\Boot\bootmgfw.efi`,
+						DeviceType: "VmbFs",
+					},
+				},
+			},
+			ComputeTopology: &hcsschema.Topology{
+				Memory: &hcsschema.Memory2{
+					SizeInMB: getMemory(opts.Resources),
+					// AllowOvercommit `true` by default if not passed.
+					AllowOvercommit: opts.AllowOvercommit == nil || *opts.AllowOvercommit,
+					// EnableHotHint is not compatible with physical. Only virtual, and only Windows.
+					EnableHotHint: opts.AllowOvercommit == nil || *opts.AllowOvercommit,
+					// EnableDeferredCommit `false` by default if not passed.
+					EnableDeferredCommit: opts.EnableDeferredCommit != nil && *opts.EnableDeferredCommit,
+				},
+				Processor: &hcsschema.Processor2{
+					Count: getProcessors(opts.Resources),
+				},
+			},
+			GuestConnection: &hcsschema.GuestConnection{},
+			Devices: &hcsschema.Devices{
+				Scsi: map[string]hcsschema.Scsi{
+					"0": {
+						Attachments: map[string]hcsschema.Attachment{
+							"0": {
+								Path:  scratchPath,
+								Type_: "VirtualDisk",
+							},
+						},
+					},
+				},
+				HvSocket: &hcsschema.HvSocket2{
+					HvSocketConfig: &hcsschema.HvSocketSystemConfig{
+						// Allow administrators and SYSTEM to bind to vsock sockets
+						// so that we can create a GCS log socket.
+						DefaultBindSecurityDescriptor: "D:P(A;;FA;;;SY)(A;;FA;;;BA)",
+					},
+				},
+				VirtualSmb: &hcsschema.VirtualSmb{
+					DirectFileMappingInMB: 1024, // Sensible default, but could be a tuning parameter somewhere
+					Shares: []hcsschema.VirtualSmbShare{
+						{
+							Name: "os",
+							Path: filepath.Join(uvmFolder, `UtilityVM\Files`),
+							Options: &hcsschema.VirtualSmbShareOptions{
+								ReadOnly:            true,
+								PseudoOplocks:       true,
+								TakeBackupPrivilege: true,
+								CacheIo:             true,
+								ShareRead:           true,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	uvm.scsiLocations[0][0].hostPath = doc.VirtualMachine.Devices.Scsi["0"].Attachments["0"].Path
+
+	fullDoc, err := mergemaps.MergeJSON(doc, ([]byte)(opts.AdditionHCSDocumentJSON))
+	if err != nil {
+		return nil, fmt.Errorf("failed to merge additional JSON '%s': %s", opts.AdditionHCSDocumentJSON, err)
+	}
+
+	hcsSystem, err := hcs.CreateComputeSystem(uvm.id, fullDoc)
+	if err != nil {
+		logrus.Debugln("failed to create UVM: ", err)
+		return nil, err
+	}
+	uvm.hcsSystem = hcsSystem
+	return uvm, nil
+}

--- a/internal/uvm/types.go
+++ b/internal/uvm/types.go
@@ -83,7 +83,7 @@ type UtilityVM struct {
 
 	// SCSI devices that are mapped into a Windows or Linux utility VM
 	scsiLocations       [4][64]scsiInfo // Hyper-V supports 4 controllers, 64 slots per controller. Limited to 1 controller for now though.
-	scsiControllerCount int             // Number of SCSI controllers in the utility VM
+	scsiControllerCount uint            // Number of SCSI controllers in the utility VM
 
 	// Plan9 are directories mapped into a Linux utility VM
 	plan9Shares  map[string]*plan9Info

--- a/internal/wcow/scratch.go
+++ b/internal/wcow/scratch.go
@@ -10,7 +10,7 @@ import (
 )
 
 // CreateUVMScratch is a helper to create a scratch for a Windows utility VM
-// with permissions to the specified VM ID in a specified directory
+// with permissions to the specified VM ID in a specified directory.
 func CreateUVMScratch(imagePath, destDirectory, vmID string) error {
 	sourceScratch := filepath.Join(imagePath, `UtilityVM\SystemTemplate.vhdx`)
 	targetScratch := filepath.Join(destDirectory, "sandbox.vhdx")

--- a/pkg/go-runhcs/runhcs_test.go
+++ b/pkg/go-runhcs/runhcs_test.go
@@ -1,4 +1,4 @@
-// +build runhcs_test
+// +build integration
 
 package runhcs
 


### PR DESCRIPTION
Moves uvm.Create into uvm.CreateWCOW and uvm.CreateLCOW and splits
uvm.UVMOptions into the set of Common/WCOW/LCOW specific options to simplify
validation and customization logic.

Fixes a few tests.

Signed-off-by: Justin Terry (VM) <juterry@microsoft.com>