### PR TITLE
Update uvm_mem tests to use 512MB by default

### DIFF
--- a/functional/uvm_mem_backingtype_test.go
+++ b/functional/uvm_mem_backingtype_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Microsoft/hcsshim/functional/utilities"
 	"github.com/Microsoft/hcsshim/internal/uvm"
 	"github.com/Microsoft/hcsshim/osversion"
+	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/sirupsen/logrus"
 )
 
@@ -51,9 +52,15 @@ func runMemTests(t *testing.T, os string) {
 		{allowOvercommit: &no, enableDeferredCommit: &no},   // Physical
 	}
 
+	mem := uint64(512 * 1024 * 1024) // 512 MB (OCI in Bytes)
 	for _, bt := range testCases {
 		opts := &uvm.UVMOptions{
-			OperatingSystem:      os,
+			OperatingSystem: os,
+			Resources: &specs.WindowsResources{
+				Memory: &specs.WindowsMemoryResources{
+					Limit: &mem,
+				},
+			},
 			AllowOvercommit:      bt.allowOvercommit,
 			EnableDeferredCommit: bt.enableDeferredCommit,
 		}
@@ -88,9 +95,15 @@ func runBenchMemStartTest(b *testing.B, opts *uvm.UVMOptions) {
 }
 
 func runBenchMemStartLcowTest(b *testing.B, allowOverCommit bool, enableDeferredCommit bool) {
+	mem := uint64(512 * 1024 * 1024) // 512 MB (OCI in Bytes)
 	for i := 0; i < b.N; i++ {
 		opts := &uvm.UVMOptions{
-			OperatingSystem:      "linux",
+			OperatingSystem: "linux",
+			Resources: &specs.WindowsResources{
+				Memory: &specs.WindowsMemoryResources{
+					Limit: &mem,
+				},
+			},
 			AllowOvercommit:      &allowOverCommit,
 			EnableDeferredCommit: &enableDeferredCommit,
 		}


### PR DESCRIPTION
Signed-off-by: Justin Terry (VM) <juterry@microsoft.com>