### PR TITLE
Revert breaking change to AddLoadBalancer

### DIFF
--- a/hnspolicylist.go
+++ b/hnspolicylist.go
@@ -37,8 +37,8 @@ func GetPolicyListByID(policyListID string) (*PolicyList, error) {
 }
 
 // AddLoadBalancer policy list for the specified endpoints
-func AddLoadBalancer(endpoints []HNSEndpoint, isILB bool, isDSR bool, sourceVIP, vip string, protocol uint16, internalPort uint16, externalPort uint16) (*PolicyList, error) {
-	return hns.AddLoadBalancer(endpoints, isILB, isDSR, sourceVIP, vip, protocol, internalPort, externalPort)
+func AddLoadBalancer(endpoints []HNSEndpoint, isILB bool, sourceVIP, vip string, protocol uint16, internalPort uint16, externalPort uint16) (*PolicyList, error) {
+	return hns.AddLoadBalancer(endpoints, isILB, sourceVIP, vip, protocol, internalPort, externalPort)
 }
 
 // AddRoute adds route policy list for the specified endpoints

--- a/internal/hns/hnspolicylist.go
+++ b/internal/hns/hnspolicylist.go
@@ -140,7 +140,7 @@ func (policylist *PolicyList) RemoveEndpoint(endpoint *HNSEndpoint) (*PolicyList
 }
 
 // AddLoadBalancer policy list for the specified endpoints
-func AddLoadBalancer(endpoints []HNSEndpoint, isILB bool, isDSR bool, sourceVIP, vip string, protocol uint16, internalPort uint16, externalPort uint16) (*PolicyList, error) {
+func AddLoadBalancer(endpoints []HNSEndpoint, isILB bool, sourceVIP, vip string, protocol uint16, internalPort uint16, externalPort uint16) (*PolicyList, error) {
 	operation := "AddLoadBalancer"
 	title := "hcsshim::PolicyList::" + operation
 	logrus.Debugf(title+" endpointId=%v, isILB=%v, sourceVIP=%s, vip=%s, protocol=%v, internalPort=%v, externalPort=%v", endpoints, isILB, sourceVIP, vip, protocol, internalPort, externalPort)
@@ -150,7 +150,6 @@ func AddLoadBalancer(endpoints []HNSEndpoint, isILB bool, isDSR bool, sourceVIP,
 	elbPolicy := &ELBPolicy{
 		SourceVIP: sourceVIP,
 		ILB:       isILB,
-		DSR:       isDSR,
 	}
 
 	if len(vip) > 0 {


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

Reverting the breaking API change introduced in https://github.com/Microsoft/hcsshim/pull/356. We cannot do this. @madhanrm @jterry75 