### PR TITLE
Don't attempt to write to callback channels that we don't support

### DIFF
--- a/internal/hcs/callback.go
+++ b/internal/hcs/callback.go
@@ -5,6 +5,7 @@ import (
 	"syscall"
 
 	"github.com/Microsoft/hcsshim/internal/interop"
+	"github.com/sirupsen/logrus"
 )
 
 var (
@@ -75,7 +76,13 @@ func notificationWatcher(notificationType hcsNotification, callbackNumber uintpt
 		return 0
 	}
 
-	context.channels[notificationType] <- result
+	if channel, ok := context.channels[notificationType]; ok {
+		channel <- result
+	} else {
+		logrus.WithFields(logrus.Fields{
+			"notification-type": notificationType,
+		}).Warn("Received a callback of an unsupported type")
+	}
 
 	return 0
 }


### PR DESCRIPTION
Previously, if we received an HCS callback of a type that we don't support, we wouldn't have a channel prepared for it. This causes a send to a nil channel, which hangs forever.

Now, we will only send to a channel if the channel has been prepared, and will otherwise log a warning.