### PR TITLE
uvm: Mark pmem0 root fs readonly

### DIFF
--- a/internal/uvm/create.go
+++ b/internal/uvm/create.go
@@ -369,7 +369,7 @@ func Create(opts *UVMOptions) (_ *UtilityVM, err error) {
 				kernelArgs = "initrd=/" + opts.RootFSFile
 			}
 		case PreferredRootFSTypeVHD:
-			kernelArgs = "root=/dev/pmem0 init=/init"
+			kernelArgs = "root=/dev/pmem0 ro init=/init"
 		}
 
 		// Support for VPMem VHD(X) booting rather than initrd..


### PR DESCRIPTION
Not doing this causes spurious machine checks during boot in some cases.