### PR TITLE
Add computestorage syscalls so we can base RS5 wclayer on it.

### DIFF
--- a/internal/computestorage/computestorage.go
+++ b/internal/computestorage/computestorage.go
@@ -1,0 +1,18 @@
+// Windows Syscall layer for computestorage.dll introduced in Windows RS5 1809 for
+// managing containers storage via the HCS (Host Compute Service)
+
+package computestorage
+
+//go:generate go run ../../mksyscall_windows.go -output zsyscall_windows.go computestorage.go
+
+//sys hcsImportLayer(layerPath string, sourceFolderPath string, layerData string) (hr error) = computestorage.HcsImportLayer?
+//sys hcsExportLayer(layerPath string, exportFolderPath string, layerData string, options string) (hr error) = computestorage.HcsExportLayer?
+//sys hcsExportLegacyWritableLayer(writableLayerMountPath string, writableLayerFolderPath string, exportFolderPath string, layerData string) (hr error) = computestorage.hcsExportLegacyWritableLayer?
+//sys hcsDestroyLayer(layerPath string) (hr error) = computestorage.hcsDestroyLayer?
+//sys hcsSetupBaseOSLayer(layerPath string, vhdHandle syscall.Handle, options string) (hr error) = computestorage.hcsSetupBaseOSLayer?
+//sys hcsInitializeWritableLayer(writableLayerPath string, layerData string, options string) (hr error) = computestorage.hcsInitializeWritableLayer?
+//sys hcsInitializeLegacyWritableLayer(writableLayerMountPath string, writableLayerFolderPath string, layerData string, options string) (hr error) = computestorage.hcsInitializeLegacyWritableLayer?
+//sys hcsAttachLayerStorageFilter(layerPath string, layerData string) (hr error) = computestorage.hcsAttachLayerStorageFilter?
+//sys hcsDetachLayerStorageFilter(layerPath string) (hr error) = computestorage.hcsDetachLayerStorageFilter?
+//sys hcsFormatWritableLayerVhd(vhdHandle syscall.Handle) (hr error) = computestorage.hcsFormatWritableLayerVhd?
+//sys hcsGetLayerVhdMountPath(vhdHandle syscall.Handle, mountPath **uint16) (hr error) = computestorage.hcsGetLayerVhdMountPath?

--- a/internal/computestorage/computestorage.go
+++ b/internal/computestorage/computestorage.go
@@ -3,6 +3,14 @@
 
 package computestorage
 
+import (
+	"encoding/json"
+	"syscall"
+
+	"github.com/Microsoft/hcsshim/internal/interop"
+	hcsschema "github.com/Microsoft/hcsshim/internal/schema2"
+)
+
 //go:generate go run ../../mksyscall_windows.go -output zsyscall_windows.go computestorage.go
 
 //sys hcsImportLayer(layerPath string, sourceFolderPath string, layerData string) (hr error) = computestorage.HcsImportLayer?
@@ -16,3 +24,157 @@ package computestorage
 //sys hcsDetachLayerStorageFilter(layerPath string) (hr error) = computestorage.hcsDetachLayerStorageFilter?
 //sys hcsFormatWritableLayerVhd(vhdHandle syscall.Handle) (hr error) = computestorage.hcsFormatWritableLayerVhd?
 //sys hcsGetLayerVhdMountPath(vhdHandle syscall.Handle, mountPath **uint16) (hr error) = computestorage.hcsGetLayerVhdMountPath?
+
+// LayerData is the data used to describe parent layer information.
+type LayerData struct {
+	SchemaVersion hcsschema.Version `json:"SchemaVersion,omitempty"`
+
+	Layers []hcsschema.Layer `json:"Layers,omitempty"`
+}
+
+// ExportLayerOptions are the set of options that are used with the `computestorage.HcsExportLayer` syscall.
+type ExportLayerOptions struct {
+	IsWritableLayer bool `json:"IsWritableLayer,omitempty"`
+}
+
+// OsLayerType is the type of layer being operated on.
+type OsLayerType string
+
+const (
+	// OsLayerTypeContainer is a container layer.
+	OsLayerTypeContainer OsLayerType = "Container"
+	// OsLayerTypeVM is a virtual machine layer.
+	OsLayerTypeVM OsLayerType = "Vm"
+)
+
+// OsLayerOptions are the set of options that are used with the `computestorage.HcsSetupBaseOSLayer` syscall.
+type OsLayerOptions struct {
+	Type                       OsLayerType `json:"Type,omitempty"`
+	DisableCiCacheOptimization bool        `json:"DisableCiCacheOptimization,omitempty"`
+}
+
+// HcsImportLayer imports a container layer.
+//
+// `layerPath` is a path to a directory to import the layer to. If the directory
+// does not exist it will be automatically created.
+//
+// `sourceFolderpath` is a pre-existing folder that contains the layer to
+// import.
+//
+// `layerData` is the parent layer data.
+func HcsImportLayer(layerPath, sourceFolderPath string, layerData LayerData) error {
+	bytes, err := json.Marshal(layerData)
+	if err != nil {
+		return err
+	}
+
+	return hcsImportLayer(layerPath, sourceFolderPath, string(bytes))
+}
+
+// HcsExportLayer exports a container layer.
+//
+// `layerPath` is a path to a directory containing the layer to export.
+//
+// `exportFolderPath` is a pre-existing folder to export the layer to.
+//
+// `layerData` is the parent layer data.
+//
+// `options` are the export options applied to the exported layer.
+func HcsExportLayer(layerPath, exportFolderPath string, layerData LayerData, options ExportLayerOptions) error {
+	ldbytes, err := json.Marshal(layerData)
+	if err != nil {
+		return err
+	}
+
+	obytes, err := json.Marshal(options)
+	if err != nil {
+		return err
+	}
+
+	return hcsExportLayer(layerPath, exportFolderPath, string(ldbytes), string(obytes))
+}
+
+// HcsDestroyLayer deletes a container layer.
+//
+// `layerPath` is a path to a directory containing the layer to delete.
+func HcsDestroyLayer(layerPath string) error {
+	return hcsDestroyLayer(layerPath)
+}
+
+// HcsSetupBaseOSLayer sets up a layer that contains a base OS for a container.
+//
+// `layerPath` is a path to a directory containing the layer.
+//
+// `vhdHandle` is an empty file handle of `options.Type == OsLayerTypeContainer`
+// or else it is a file handle to the 'SystemTemplateBase.vhdx' if `options.Type
+// == OsLayerTypeVm`.
+//
+// `options` are the options applied while processing the layer.
+func HcsSetupBaseOSLayer(layerPath string, vhdHandle syscall.Handle, options OsLayerOptions) error {
+	bytes, err := json.Marshal(options)
+	if err != nil {
+		return err
+	}
+
+	return hcsSetupBaseOSLayer(layerPath, vhdHandle, string(bytes))
+}
+
+// HcsInitializeWritableLayer initializes a writable layer for a container.
+//
+// `writableLayerPath` is a path to a directory the layer is mounted. If the
+// path does not end in a `\` the platform will append it automatically.
+//
+// `layerData` is the parent read-only layer data.
+func HcsInitializeWritableLayer(writableLayerPath string, layerData LayerData) error {
+	bytes, err := json.Marshal(layerData)
+	if err != nil {
+		return err
+	}
+
+	// options are not used in the platform as of RS5
+	return hcsInitializeWritableLayer(writableLayerPath, string(bytes), "")
+}
+
+// HcsAttachLayerStorageFilter sets up the layer storage filter on a writable
+// container layer.
+//
+// `layerPath` is a path to a directory the writable layer is mounted. If the
+// path does not end in a `\` the platform will append it automatically.
+//
+// `layerData` is the parent read-only layer data.
+func HcsAttachLayerStorageFilter(layerPath string, layerData LayerData) error {
+	bytes, err := json.Marshal(layerData)
+	if err != nil {
+		return err
+	}
+
+	return hcsAttachLayerStorageFilter(layerPath, string(bytes))
+}
+
+// HcsDetachLayerStorageFilter detaches the layer storage filter from a writable
+// container layer.
+//
+// `layerPath` is the path to a directory the writable layer is mounted. If the
+// path does not end in a `\` the platform will append it automatically.
+func HcsDetachLayerStorageFilter(layerPath string) error {
+	return hcsDetachLayerStorageFilter(layerPath)
+}
+
+// HcsFormatWritableLayerVhd formats a virtual disk for the use as a writable container layer.
+//
+// `vhdHandle` is the handle to a writable layer vhd.
+func HcsFormatWritableLayerVhd(vhdHandle syscall.Handle) error {
+	return hcsFormatWritableLayerVhd(vhdHandle)
+}
+
+// HcsGetLayerVhdMountPath returns the volume path for a virtual disk of a writable container layer.
+//
+// `vhdHandle` is the handle to a writable layer vhd.
+func HcsGetLayerVhdMountPath(vhdHandle syscall.Handle) (string, error) {
+	var mountPath *uint16
+	err := hcsGetLayerVhdMountPath(vhdHandle, &mountPath)
+	if err != nil {
+		return "", err
+	}
+	return interop.ConvertAndFreeCoTaskMemString(mountPath), nil
+}

--- a/internal/computestorage/zsyscall_windows.go
+++ b/internal/computestorage/zsyscall_windows.go
@@ -1,0 +1,331 @@
+// Code generated mksyscall_windows.exe DO NOT EDIT
+
+package computestorage
+
+import (
+	"syscall"
+	"unsafe"
+
+	"github.com/Microsoft/hcsshim/internal/interop"
+	"golang.org/x/sys/windows"
+)
+
+var _ unsafe.Pointer
+
+// Do the interface allocations only once for common
+// Errno values.
+const (
+	errnoERROR_IO_PENDING = 997
+)
+
+var (
+	errERROR_IO_PENDING error = syscall.Errno(errnoERROR_IO_PENDING)
+)
+
+// errnoErr returns common boxed Errno values, to prevent
+// allocations at runtime.
+func errnoErr(e syscall.Errno) error {
+	switch e {
+	case 0:
+		return nil
+	case errnoERROR_IO_PENDING:
+		return errERROR_IO_PENDING
+	}
+	// TODO: add more here, after collecting data on the common
+	// error values see on Windows. (perhaps when running
+	// all.bat?)
+	return e
+}
+
+var (
+	modcomputestorage = windows.NewLazySystemDLL("computestorage.dll")
+
+	procHcsImportLayer                   = modcomputestorage.NewProc("HcsImportLayer")
+	procHcsExportLayer                   = modcomputestorage.NewProc("HcsExportLayer")
+	prochcsExportLegacyWritableLayer     = modcomputestorage.NewProc("hcsExportLegacyWritableLayer")
+	prochcsDestroyLayer                  = modcomputestorage.NewProc("hcsDestroyLayer")
+	prochcsSetupBaseOSLayer              = modcomputestorage.NewProc("hcsSetupBaseOSLayer")
+	prochcsInitializeWritableLayer       = modcomputestorage.NewProc("hcsInitializeWritableLayer")
+	prochcsInitializeLegacyWritableLayer = modcomputestorage.NewProc("hcsInitializeLegacyWritableLayer")
+	prochcsAttachLayerStorageFilter      = modcomputestorage.NewProc("hcsAttachLayerStorageFilter")
+	prochcsDetachLayerStorageFilter      = modcomputestorage.NewProc("hcsDetachLayerStorageFilter")
+	prochcsFormatWritableLayerVhd        = modcomputestorage.NewProc("hcsFormatWritableLayerVhd")
+	prochcsGetLayerVhdMountPath          = modcomputestorage.NewProc("hcsGetLayerVhdMountPath")
+)
+
+func hcsImportLayer(layerPath string, sourceFolderPath string, layerData string) (hr error) {
+	var _p0 *uint16
+	_p0, hr = syscall.UTF16PtrFromString(layerPath)
+	if hr != nil {
+		return
+	}
+	var _p1 *uint16
+	_p1, hr = syscall.UTF16PtrFromString(sourceFolderPath)
+	if hr != nil {
+		return
+	}
+	var _p2 *uint16
+	_p2, hr = syscall.UTF16PtrFromString(layerData)
+	if hr != nil {
+		return
+	}
+	return _hcsImportLayer(_p0, _p1, _p2)
+}
+
+func _hcsImportLayer(layerPath *uint16, sourceFolderPath *uint16, layerData *uint16) (hr error) {
+	if hr = procHcsImportLayer.Find(); hr != nil {
+		return
+	}
+	r0, _, _ := syscall.Syscall(procHcsImportLayer.Addr(), 3, uintptr(unsafe.Pointer(layerPath)), uintptr(unsafe.Pointer(sourceFolderPath)), uintptr(unsafe.Pointer(layerData)))
+	if int32(r0) < 0 {
+		hr = interop.Win32FromHresult(r0)
+	}
+	return
+}
+
+func hcsExportLayer(layerPath string, exportFolderPath string, layerData string, options string) (hr error) {
+	var _p0 *uint16
+	_p0, hr = syscall.UTF16PtrFromString(layerPath)
+	if hr != nil {
+		return
+	}
+	var _p1 *uint16
+	_p1, hr = syscall.UTF16PtrFromString(exportFolderPath)
+	if hr != nil {
+		return
+	}
+	var _p2 *uint16
+	_p2, hr = syscall.UTF16PtrFromString(layerData)
+	if hr != nil {
+		return
+	}
+	var _p3 *uint16
+	_p3, hr = syscall.UTF16PtrFromString(options)
+	if hr != nil {
+		return
+	}
+	return _hcsExportLayer(_p0, _p1, _p2, _p3)
+}
+
+func _hcsExportLayer(layerPath *uint16, exportFolderPath *uint16, layerData *uint16, options *uint16) (hr error) {
+	if hr = procHcsExportLayer.Find(); hr != nil {
+		return
+	}
+	r0, _, _ := syscall.Syscall6(procHcsExportLayer.Addr(), 4, uintptr(unsafe.Pointer(layerPath)), uintptr(unsafe.Pointer(exportFolderPath)), uintptr(unsafe.Pointer(layerData)), uintptr(unsafe.Pointer(options)), 0, 0)
+	if int32(r0) < 0 {
+		hr = interop.Win32FromHresult(r0)
+	}
+	return
+}
+
+func hcsExportLegacyWritableLayer(writableLayerMountPath string, writableLayerFolderPath string, exportFolderPath string, layerData string) (hr error) {
+	var _p0 *uint16
+	_p0, hr = syscall.UTF16PtrFromString(writableLayerMountPath)
+	if hr != nil {
+		return
+	}
+	var _p1 *uint16
+	_p1, hr = syscall.UTF16PtrFromString(writableLayerFolderPath)
+	if hr != nil {
+		return
+	}
+	var _p2 *uint16
+	_p2, hr = syscall.UTF16PtrFromString(exportFolderPath)
+	if hr != nil {
+		return
+	}
+	var _p3 *uint16
+	_p3, hr = syscall.UTF16PtrFromString(layerData)
+	if hr != nil {
+		return
+	}
+	return _hcsExportLegacyWritableLayer(_p0, _p1, _p2, _p3)
+}
+
+func _hcsExportLegacyWritableLayer(writableLayerMountPath *uint16, writableLayerFolderPath *uint16, exportFolderPath *uint16, layerData *uint16) (hr error) {
+	if hr = prochcsExportLegacyWritableLayer.Find(); hr != nil {
+		return
+	}
+	r0, _, _ := syscall.Syscall6(prochcsExportLegacyWritableLayer.Addr(), 4, uintptr(unsafe.Pointer(writableLayerMountPath)), uintptr(unsafe.Pointer(writableLayerFolderPath)), uintptr(unsafe.Pointer(exportFolderPath)), uintptr(unsafe.Pointer(layerData)), 0, 0)
+	if int32(r0) < 0 {
+		hr = interop.Win32FromHresult(r0)
+	}
+	return
+}
+
+func hcsDestroyLayer(layerPath string) (hr error) {
+	var _p0 *uint16
+	_p0, hr = syscall.UTF16PtrFromString(layerPath)
+	if hr != nil {
+		return
+	}
+	return _hcsDestroyLayer(_p0)
+}
+
+func _hcsDestroyLayer(layerPath *uint16) (hr error) {
+	if hr = prochcsDestroyLayer.Find(); hr != nil {
+		return
+	}
+	r0, _, _ := syscall.Syscall(prochcsDestroyLayer.Addr(), 1, uintptr(unsafe.Pointer(layerPath)), 0, 0)
+	if int32(r0) < 0 {
+		hr = interop.Win32FromHresult(r0)
+	}
+	return
+}
+
+func hcsSetupBaseOSLayer(layerPath string, vhdHandle syscall.Handle, options string) (hr error) {
+	var _p0 *uint16
+	_p0, hr = syscall.UTF16PtrFromString(layerPath)
+	if hr != nil {
+		return
+	}
+	var _p1 *uint16
+	_p1, hr = syscall.UTF16PtrFromString(options)
+	if hr != nil {
+		return
+	}
+	return _hcsSetupBaseOSLayer(_p0, vhdHandle, _p1)
+}
+
+func _hcsSetupBaseOSLayer(layerPath *uint16, vhdHandle syscall.Handle, options *uint16) (hr error) {
+	if hr = prochcsSetupBaseOSLayer.Find(); hr != nil {
+		return
+	}
+	r0, _, _ := syscall.Syscall(prochcsSetupBaseOSLayer.Addr(), 3, uintptr(unsafe.Pointer(layerPath)), uintptr(vhdHandle), uintptr(unsafe.Pointer(options)))
+	if int32(r0) < 0 {
+		hr = interop.Win32FromHresult(r0)
+	}
+	return
+}
+
+func hcsInitializeWritableLayer(writableLayerPath string, layerData string, options string) (hr error) {
+	var _p0 *uint16
+	_p0, hr = syscall.UTF16PtrFromString(writableLayerPath)
+	if hr != nil {
+		return
+	}
+	var _p1 *uint16
+	_p1, hr = syscall.UTF16PtrFromString(layerData)
+	if hr != nil {
+		return
+	}
+	var _p2 *uint16
+	_p2, hr = syscall.UTF16PtrFromString(options)
+	if hr != nil {
+		return
+	}
+	return _hcsInitializeWritableLayer(_p0, _p1, _p2)
+}
+
+func _hcsInitializeWritableLayer(writableLayerPath *uint16, layerData *uint16, options *uint16) (hr error) {
+	if hr = prochcsInitializeWritableLayer.Find(); hr != nil {
+		return
+	}
+	r0, _, _ := syscall.Syscall(prochcsInitializeWritableLayer.Addr(), 3, uintptr(unsafe.Pointer(writableLayerPath)), uintptr(unsafe.Pointer(layerData)), uintptr(unsafe.Pointer(options)))
+	if int32(r0) < 0 {
+		hr = interop.Win32FromHresult(r0)
+	}
+	return
+}
+
+func hcsInitializeLegacyWritableLayer(writableLayerMountPath string, writableLayerFolderPath string, layerData string, options string) (hr error) {
+	var _p0 *uint16
+	_p0, hr = syscall.UTF16PtrFromString(writableLayerMountPath)
+	if hr != nil {
+		return
+	}
+	var _p1 *uint16
+	_p1, hr = syscall.UTF16PtrFromString(writableLayerFolderPath)
+	if hr != nil {
+		return
+	}
+	var _p2 *uint16
+	_p2, hr = syscall.UTF16PtrFromString(layerData)
+	if hr != nil {
+		return
+	}
+	var _p3 *uint16
+	_p3, hr = syscall.UTF16PtrFromString(options)
+	if hr != nil {
+		return
+	}
+	return _hcsInitializeLegacyWritableLayer(_p0, _p1, _p2, _p3)
+}
+
+func _hcsInitializeLegacyWritableLayer(writableLayerMountPath *uint16, writableLayerFolderPath *uint16, layerData *uint16, options *uint16) (hr error) {
+	if hr = prochcsInitializeLegacyWritableLayer.Find(); hr != nil {
+		return
+	}
+	r0, _, _ := syscall.Syscall6(prochcsInitializeLegacyWritableLayer.Addr(), 4, uintptr(unsafe.Pointer(writableLayerMountPath)), uintptr(unsafe.Pointer(writableLayerFolderPath)), uintptr(unsafe.Pointer(layerData)), uintptr(unsafe.Pointer(options)), 0, 0)
+	if int32(r0) < 0 {
+		hr = interop.Win32FromHresult(r0)
+	}
+	return
+}
+
+func hcsAttachLayerStorageFilter(layerPath string, layerData string) (hr error) {
+	var _p0 *uint16
+	_p0, hr = syscall.UTF16PtrFromString(layerPath)
+	if hr != nil {
+		return
+	}
+	var _p1 *uint16
+	_p1, hr = syscall.UTF16PtrFromString(layerData)
+	if hr != nil {
+		return
+	}
+	return _hcsAttachLayerStorageFilter(_p0, _p1)
+}
+
+func _hcsAttachLayerStorageFilter(layerPath *uint16, layerData *uint16) (hr error) {
+	if hr = prochcsAttachLayerStorageFilter.Find(); hr != nil {
+		return
+	}
+	r0, _, _ := syscall.Syscall(prochcsAttachLayerStorageFilter.Addr(), 2, uintptr(unsafe.Pointer(layerPath)), uintptr(unsafe.Pointer(layerData)), 0)
+	if int32(r0) < 0 {
+		hr = interop.Win32FromHresult(r0)
+	}
+	return
+}
+
+func hcsDetachLayerStorageFilter(layerPath string) (hr error) {
+	var _p0 *uint16
+	_p0, hr = syscall.UTF16PtrFromString(layerPath)
+	if hr != nil {
+		return
+	}
+	return _hcsDetachLayerStorageFilter(_p0)
+}
+
+func _hcsDetachLayerStorageFilter(layerPath *uint16) (hr error) {
+	if hr = prochcsDetachLayerStorageFilter.Find(); hr != nil {
+		return
+	}
+	r0, _, _ := syscall.Syscall(prochcsDetachLayerStorageFilter.Addr(), 1, uintptr(unsafe.Pointer(layerPath)), 0, 0)
+	if int32(r0) < 0 {
+		hr = interop.Win32FromHresult(r0)
+	}
+	return
+}
+
+func hcsFormatWritableLayerVhd(vhdHandle syscall.Handle) (hr error) {
+	if hr = prochcsFormatWritableLayerVhd.Find(); hr != nil {
+		return
+	}
+	r0, _, _ := syscall.Syscall(prochcsFormatWritableLayerVhd.Addr(), 1, uintptr(vhdHandle), 0, 0)
+	if int32(r0) < 0 {
+		hr = interop.Win32FromHresult(r0)
+	}
+	return
+}
+
+func hcsGetLayerVhdMountPath(vhdHandle syscall.Handle, mountPath **uint16) (hr error) {
+	if hr = prochcsGetLayerVhdMountPath.Find(); hr != nil {
+		return
+	}
+	r0, _, _ := syscall.Syscall(prochcsGetLayerVhdMountPath.Addr(), 2, uintptr(vhdHandle), uintptr(unsafe.Pointer(mountPath)), 0)
+	if int32(r0) < 0 {
+		hr = interop.Win32FromHresult(r0)
+	}
+	return
+}


### PR DESCRIPTION
- Adds the computestorage.dll exports package.
- Implements the `internal/computestorage` exports that are callable by internal packages.