### PR TITLE
Split UVM create into WCOW/LCOW

### DIFF
--- a/cmd/runhcs/create-scratch.go
+++ b/cmd/runhcs/create-scratch.go
@@ -51,19 +51,20 @@ var createScratchCommand = cli.Command{
 				return errors.Wrapf(err, "failed to create ext4vhdx for '%s'", cfg.Name)
 			}
 		} else {
-			opts := uvm.UVMOptions{
-				ID:              "createscratch-uvm",
-				Owner:           context.GlobalString("owner"),
-				OperatingSystem: "linux",
+			opts := uvm.OptionsLCOW{
+				Options: &uvm.Options{
+					ID:    "createscratch-uvm",
+					Owner: context.GlobalString("owner"),
+				},
 			}
-			convertUVM, err := uvm.Create(&opts)
+			convertUVM, err := uvm.CreateLCOW(&opts)
 			if err != nil {
 				return errors.Wrapf(err, "failed to create '%s'", opts.ID)
 			}
+			defer convertUVM.Close()
 			if err := convertUVM.Start(); err != nil {
 				return errors.Wrapf(err, "failed to start '%s'", opts.ID)
 			}
-			defer convertUVM.Terminate()
 
 			if err := lcow.CreateScratch(convertUVM, dest, lcow.DefaultScratchSizeGB, "", ""); err != nil {
 				return errors.Wrapf(err, "failed to create ext4vhdx for '%s'", opts.ID)

--- a/functional/lcow_test.go
+++ b/functional/lcow_test.go
@@ -24,9 +24,10 @@ import (
 func TestLCOWUVMNoSCSINoVPMemInitrd(t *testing.T) {
 	var scsiCount uint32 = 0
 	var vpmemCount uint32 = 0
-	opts := &uvm.UVMOptions{
-		OperatingSystem:     "linux",
-		ID:                  "uvm",
+	opts := &uvm.OptionsLCOW{
+		Options: &uvm.Options{
+			ID: "uvm",
+		},
 		VPMemDeviceCount:    &vpmemCount,
 		SCSIControllerCount: &scsiCount,
 	}
@@ -39,9 +40,10 @@ func TestLCOWUVMNoSCSISingleVPMemVHD(t *testing.T) {
 	var scsiCount uint32 = 0
 	var vpmemCount uint32 = 1
 	var prfst uvm.PreferredRootFSType = uvm.PreferredRootFSTypeVHD
-	opts := &uvm.UVMOptions{
-		OperatingSystem:     "linux",
-		ID:                  "uvm",
+	opts := &uvm.OptionsLCOW{
+		Options: &uvm.Options{
+			ID: "uvm",
+		},
 		VPMemDeviceCount:    &vpmemCount,
 		SCSIControllerCount: &scsiCount,
 		PreferredRootFSType: &prfst,
@@ -50,7 +52,7 @@ func TestLCOWUVMNoSCSISingleVPMemVHD(t *testing.T) {
 	testLCOWUVMNoSCSISingleVPMem(t, opts, `Command line: root=/dev/pmem0 init=/init`)
 }
 
-func testLCOWUVMNoSCSISingleVPMem(t *testing.T, opts *uvm.UVMOptions, expected string) {
+func testLCOWUVMNoSCSISingleVPMem(t *testing.T, opts *uvm.OptionsLCOW, expected string) {
 	testutilities.RequiresBuild(t, osversion.RS5)
 	lcowUVM := testutilities.CreateLCOWUVMFromOpts(t, opts)
 	defer lcowUVM.Close()
@@ -100,9 +102,10 @@ func TestLCOWUVMStart_KernelDirect_InitRd(t *testing.T) {
 func testLCOWTimeUVMStart(t *testing.T, kernelDirect bool, rfsType uvm.PreferredRootFSType) {
 	var vpmemCount uint32 = 32
 	for i := 0; i < 3; i++ {
-		opts := &uvm.UVMOptions{
-			OperatingSystem:     "linux",
-			ID:                  "uvm",
+		opts := &uvm.OptionsLCOW{
+			Options: &uvm.Options{
+				ID: t.Name(),
+			},
 			VPMemDeviceCount:    &vpmemCount,
 			PreferredRootFSType: &rfsType,
 			KernelDirect:        kernelDirect,

--- a/functional/utilities/createuvm.go
+++ b/functional/utilities/createuvm.go
@@ -11,11 +11,12 @@ import (
 // CreateWCOWUVM creates a WCOW utility VM with all default options. Returns the
 // UtilityVM object; folder used as its scratch
 func CreateWCOWUVM(t *testing.T, id, image string) (*uvm.UtilityVM, []string, string) {
-	return CreateWCOWUVMFromOptsWithImage(t, &uvm.UVMOptions{ID: id, OperatingSystem: "windows"}, image)
+	return CreateWCOWUVMFromOptsWithImage(t, &uvm.OptionsWCOW{Options: &uvm.Options{ID: id}}, image)
+
 }
 
 // CreateWCOWUVMFromOpts creates a WCOW utility VM with the passed opts.
-func CreateWCOWUVMFromOpts(t *testing.T, opts *uvm.UVMOptions) *uvm.UtilityVM {
+func CreateWCOWUVMFromOpts(t *testing.T, opts *uvm.OptionsWCOW) *uvm.UtilityVM {
 	if opts == nil || len(opts.LayerFolders) < 2 {
 		t.Fatalf("opts must bet set with LayerFolders")
 	}
@@ -23,7 +24,7 @@ func CreateWCOWUVMFromOpts(t *testing.T, opts *uvm.UVMOptions) *uvm.UtilityVM {
 		opts.ID = guid.New().String()
 	}
 
-	uvm, err := uvm.Create(opts)
+	uvm, err := uvm.CreateWCOW(opts)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -37,7 +38,7 @@ func CreateWCOWUVMFromOpts(t *testing.T, opts *uvm.UVMOptions) *uvm.UtilityVM {
 // CreateWCOWUVMFromOptsWithImage creates a WCOW utility VM with the passed opts
 // builds the LayerFolders based on `image`. Returns the UtilityVM object;
 // folder used as its scratch
-func CreateWCOWUVMFromOptsWithImage(t *testing.T, opts *uvm.UVMOptions, image string) (*uvm.UtilityVM, []string, string) {
+func CreateWCOWUVMFromOptsWithImage(t *testing.T, opts *uvm.OptionsWCOW, image string) (*uvm.UtilityVM, []string, string) {
 	if opts == nil {
 		t.Fatal("opts must be set")
 	}
@@ -58,19 +59,21 @@ func CreateWCOWUVMFromOptsWithImage(t *testing.T, opts *uvm.UVMOptions, image st
 
 // CreateLCOWUVM with all default options.
 func CreateLCOWUVM(t *testing.T, id string) *uvm.UtilityVM {
-	return CreateLCOWUVMFromOpts(t, &uvm.UVMOptions{ID: id, OperatingSystem: "linux"})
+	return CreateLCOWUVMFromOpts(t, &uvm.OptionsLCOW{Options: &uvm.Options{ID: id}})
 }
 
 // CreateLCOWUVMFromOpts creates an LCOW utility VM with the specified options.
-func CreateLCOWUVMFromOpts(t *testing.T, opts *uvm.UVMOptions) *uvm.UtilityVM {
+func CreateLCOWUVMFromOpts(t *testing.T, opts *uvm.OptionsLCOW) *uvm.UtilityVM {
 	if opts == nil {
-		opts = &uvm.UVMOptions{}
+		opts = &uvm.OptionsLCOW{
+			Options: &uvm.Options{},
+		}
 	}
 	if opts.ID == "" {
 		opts.ID = guid.New().String()
 	}
 
-	uvm, err := uvm.Create(opts)
+	uvm, err := uvm.CreateLCOW(opts)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/functional/uvm_mem_backingtype_test.go
+++ b/functional/uvm_mem_backingtype_test.go
@@ -14,13 +14,13 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-func runMemStartLCOWTest(t *testing.T, opts *uvm.UVMOptions) {
-	u := testutilities.CreateLCOWUVMFromOpts(t, opts)
+func runMemStartLCOWTest(t *testing.T, opts *uvm.Options) {
+	u := testutilities.CreateLCOWUVMFromOpts(t, &uvm.OptionsLCOW{Options: opts})
 	u.Close()
 }
 
-func runMemStartWCOWTest(t *testing.T, opts *uvm.UVMOptions) {
-	u, _, scratchDir := testutilities.CreateWCOWUVMFromOptsWithImage(t, opts, "microsoft/nanoserver")
+func runMemStartWCOWTest(t *testing.T, opts *uvm.Options) {
+	u, _, scratchDir := testutilities.CreateWCOWUVMFromOptsWithImage(t, &uvm.OptionsWCOW{Options: opts}, "microsoft/nanoserver")
 	defer os.RemoveAll(scratchDir)
 	u.Close()
 }
@@ -43,9 +43,8 @@ func runMemTests(t *testing.T, os string) {
 
 	mem := uint64(512 * 1024 * 1024) // 512 MB (OCI in Bytes)
 	for _, bt := range testCases {
-		opts := &uvm.UVMOptions{
-			ID:              t.Name(),
-			OperatingSystem: os,
+		opts := &uvm.Options{
+			ID: t.Name(),
 			Resources: &specs.WindowsResources{
 				Memory: &specs.WindowsMemoryResources{
 					Limit: &mem,
@@ -73,8 +72,9 @@ func TestMemBackingTypeLCOW(t *testing.T) {
 	runMemTests(t, "linux")
 }
 
-func runBenchMemStartTest(b *testing.B, opts *uvm.UVMOptions) {
-	u, err := uvm.Create(opts)
+func runBenchMemStartTest(b *testing.B, opts *uvm.Options) {
+	// Cant use testutilities here because its `testing.B` not `testing.T`
+	u, err := uvm.CreateLCOW(&uvm.OptionsLCOW{Options: opts})
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -87,9 +87,8 @@ func runBenchMemStartTest(b *testing.B, opts *uvm.UVMOptions) {
 func runBenchMemStartLcowTest(b *testing.B, allowOverCommit bool, enableDeferredCommit bool) {
 	mem := uint64(512 * 1024 * 1024) // 512 MB (OCI in Bytes)
 	for i := 0; i < b.N; i++ {
-		opts := &uvm.UVMOptions{
-			ID:              b.Name(),
-			OperatingSystem: "linux",
+		opts := &uvm.Options{
+			ID: b.Name(),
 			Resources: &specs.WindowsResources{
 				Memory: &specs.WindowsMemoryResources{
 					Limit: &mem,

--- a/functional/wcow_test.go
+++ b/functional/wcow_test.go
@@ -692,11 +692,12 @@ func TestWCOWXenonOciV2(t *testing.T) {
 		t.Fatalf("failed to create scratch: %s", err)
 	}
 
-	xenonOci2UVM, err = uvm.Create(
-		&uvm.UVMOptions{
-			ID:              xenonOci2UVMId,
-			OperatingSystem: "windows",
-			LayerFolders:    append(imageLayers, xenonOci2UVMScratchDir),
+	xenonOci2UVM, err = uvm.CreateWCOW(
+		&uvm.OptionsWCOW{
+			Options: &uvm.Options{
+				ID: xenonOci2UVMId,
+			},
+			LayerFolders: append(imageLayers, xenonOci2UVMScratchDir),
 		})
 	if err != nil {
 		t.Fatalf("Failed create UVM: %s", err)

--- a/internal/cmd/rootfs2vhd/rootfs2vhd.go
+++ b/internal/cmd/rootfs2vhd/rootfs2vhd.go
@@ -98,7 +98,7 @@ func rootfs2vhd(c *cli.Context) {
 	}
 
 	fmt.Println("- Creating an LCOW utility VM...")
-	lcowUVM, err := uvm.Create(&uvm.UVMOptions{OperatingSystem: "linux", ID: "rootfs2vhd"})
+	lcowUVM, err := uvm.CreateLCOW(&uvm.OptionsLCOW{Options: &uvm.Options{ID: "rootfs2vhd"}})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to create utility VM: %s", err)
 		os.Exit(-1)

--- a/internal/uvm/create.go
+++ b/internal/uvm/create.go
@@ -1,58 +1,17 @@
 package uvm
 
 import (
-	"encoding/binary"
-	"fmt"
-	"net"
-	"os"
-	"path/filepath"
 	"runtime"
-	"strings"
 
-	"github.com/Microsoft/hcsshim/internal/guid"
-	"github.com/Microsoft/hcsshim/internal/hcs"
-	"github.com/Microsoft/hcsshim/internal/mergemaps"
-	"github.com/Microsoft/hcsshim/internal/schema2"
-	"github.com/Microsoft/hcsshim/internal/schemaversion"
-	"github.com/Microsoft/hcsshim/internal/uvmfolder"
-	"github.com/Microsoft/hcsshim/internal/wclayer"
-	"github.com/Microsoft/hcsshim/internal/wcow"
-	"github.com/Microsoft/hcsshim/osversion"
-	"github.com/linuxkit/virtsock/pkg/hvsock"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/sirupsen/logrus"
 )
 
-type PreferredRootFSType int
-
-const (
-	PreferredRootFSTypeInitRd = 0
-	PreferredRootFSTypeVHD    = 1
-
-	initrdFile = "initrd.img"
-	vhdFile    = "rootfs.vhd"
-)
-
-// UVMOptions are the set of options passed to Create() to create a utility vm.
-type UVMOptions struct {
+// Options are the set of options passed to Create() to create a utility vm.
+type Options struct {
 	ID                      string                  // Identifier for the uvm. Defaults to generated GUID.
 	Owner                   string                  // Specifies the owner. Defaults to executable name.
-	OperatingSystem         string                  // "windows" or "linux".
 	Resources               *specs.WindowsResources // Optional resources for the utility VM. Supports Memory.limit and CPU.Count only currently. // TODO consider extending?
 	AdditionHCSDocumentJSON string                  // Optional additional JSON to merge into the HCS document prior
-
-	// WCOW specific parameters
-	LayerFolders []string // Set of folders for base layers and scratch. Ordered from top most read-only through base read-only layer, followed by scratch
-
-	// LCOW specific parameters
-	BootFilesPath         string  // Folder in which kernel and root file system reside. Defaults to \Program Files\Linux Containers
-	KernelFile            string  // Filename under BootFilesPath for the kernel. Defaults to `kernel`
-	KernelDirect          bool    // Skip UEFI and boot directly to `kernel`
-	RootFSFile            string  // Filename under BootFilesPath for the UVMs root file system. Defaults are `initrd.img` or `rootfs.vhd`.
-	KernelBootOptions     string  // Additional boot options for the kernel
-	EnableGraphicsConsole bool    // If true, enable a graphics console for the utility VM
-	ConsolePipe           string  // The named pipe path to use for the serial console.  eg \\.\pipe\vmpipe
-	SCSIControllerCount   *uint32 // The number of SCSI controllers. Defaults to 1 if omitted. Currently we only support 0 or 1.
 
 	// Fields that can be configured via OCI annotations in runhcs.
 
@@ -61,445 +20,6 @@ type UVMOptions struct {
 
 	// Memory for UVM. Defaults to false. For virtual memory with deferred commit, set to true. io.microsoft.virtualmachine.computetopology.memory.enabledeferredcommit=true|false
 	EnableDeferredCommit *bool
-
-	// Number of VPMem devices. Limit at 128. If booting UVM from VHD, device 0 is taken. LCOW Only. io.microsoft.virtualmachine.devices.virtualpmem.maximumcount
-	VPMemDeviceCount *uint32
-
-	// Size of the VPMem devices. LCOW Only. Defaults to 4GB. io.microsoft.virtualmachine.devices.virtualpmem.maximumsizebytes
-	VPMemSizeBytes *uint64
-
-	// Controls searching for the RootFSFile. Defaults to initrd (0). Can be set to VHD (1). io.microsoft.virtualmachine.lcow.preferredrootfstype
-	// Note this uses an arbitrary annotation strict which has no direct mapping to the HCS schema.
-	PreferredRootFSType *PreferredRootFSType
-}
-
-const linuxLogVsockPort = 109
-
-// Create creates an HCS compute system representing a utility VM.
-//
-// WCOW Notes:
-//   - If the scratch folder does not exist, it will be created
-//   - If the scratch folder does not contain `sandbox.vhdx` it will be created based on the system template located in the layer folders.
-//   - The scratch is always attached to SCSI 0:0
-//
-func Create(opts *UVMOptions) (_ *UtilityVM, err error) {
-	logrus.Debugf("uvm::Create %+v", opts)
-
-	if opts == nil {
-		return nil, fmt.Errorf("no options supplied to create")
-	}
-
-	uvm := &UtilityVM{
-		id:              opts.ID,
-		owner:           opts.Owner,
-		operatingSystem: opts.OperatingSystem,
-	}
-
-	uvmFolder := "" // Windows
-
-	if opts.OperatingSystem != "linux" && opts.OperatingSystem != "windows" {
-		logrus.Debugf("uvm::Create Unsupported OS")
-		return nil, fmt.Errorf("unsupported operating system %q", opts.OperatingSystem)
-	}
-
-	// Defaults if omitted by caller.
-	// TODO: Change this. Don't auto generate ID if omitted. Avoids the chicken-and-egg problem
-	if uvm.id == "" {
-		uvm.id = guid.New().String()
-	}
-	if uvm.owner == "" {
-		uvm.owner = filepath.Base(os.Args[0])
-	}
-
-	attachments := make(map[string]hcsschema.Attachment)
-	scsi := make(map[string]hcsschema.Scsi)
-	uvm.scsiControllerCount = 1
-	var actualRootFSType PreferredRootFSType = PreferredRootFSTypeInitRd
-
-	if uvm.operatingSystem == "windows" {
-		if len(opts.LayerFolders) < 2 {
-			return nil, fmt.Errorf("at least 2 LayerFolders must be supplied")
-		}
-		if opts.VPMemDeviceCount != nil {
-			return nil, fmt.Errorf("cannot specify VPMemDeviceCount for Windows utility VMs")
-		}
-		if opts.VPMemSizeBytes != nil {
-			return nil, fmt.Errorf("cannot specify VPMemSizeBytes for Windows utility VMs")
-		}
-		var err error
-		uvmFolder, err = uvmfolder.LocateUVMFolder(opts.LayerFolders)
-		if err != nil {
-			return nil, fmt.Errorf("failed to locate utility VM folder from layer folders: %s", err)
-		}
-
-		// TODO: BUGBUG Remove this. @jhowardmsft
-		//       It should be the responsiblity of the caller to do the creation and population.
-		//       - Update runhcs too (vm.go).
-		//       - Remove comment in function header
-		//       - Update tests that rely on this current behaviour.
-		// Create the RW scratch in the top-most layer folder, creating the folder if it doesn't already exist.
-		scratchFolder := opts.LayerFolders[len(opts.LayerFolders)-1]
-		logrus.Debugf("uvm::createWCOW scratch folder: %s", scratchFolder)
-
-		// Create the directory if it doesn't exist
-		if _, err := os.Stat(scratchFolder); os.IsNotExist(err) {
-			logrus.Debugf("uvm::createWCOW Creating folder: %s ", scratchFolder)
-			if err := os.MkdirAll(scratchFolder, 0777); err != nil {
-				return nil, fmt.Errorf("failed to create utility VM scratch folder: %s", err)
-			}
-		}
-
-		// Create sandbox.vhdx in the scratch folder based on the template, granting the correct permissions to it
-		if _, err := os.Stat(filepath.Join(scratchFolder, `sandbox.vhdx`)); os.IsNotExist(err) {
-			if err := wcow.CreateUVMScratch(uvmFolder, scratchFolder, uvm.id); err != nil {
-				return nil, fmt.Errorf("failed to create scratch: %s", err)
-			}
-		}
-
-		// We attach the scratch to SCSI 0:0
-		attachments["0"] = hcsschema.Attachment{
-			Path:  filepath.Join(scratchFolder, "sandbox.vhdx"),
-			Type_: "VirtualDisk",
-		}
-		scsi["0"] = hcsschema.Scsi{Attachments: attachments}
-		uvm.scsiLocations[0][0].hostPath = attachments["0"].Path
-	} else {
-		uvm.vpmemMaxCount = DefaultVPMEMCount
-		if opts.VPMemDeviceCount != nil {
-			if *opts.VPMemDeviceCount > MaxVPMEMCount {
-				return nil, fmt.Errorf("vpmem device count cannot be greater than %d", MaxVPMEMCount)
-			}
-			uvm.vpmemMaxCount = *opts.VPMemDeviceCount
-			logrus.Debugln("uvm::Create:: uvm.vpmemMax=", uvm.vpmemMaxCount)
-		}
-		if uvm.vpmemMaxCount > 0 {
-			uvm.vpmemMaxSizeBytes = DefaultVPMemSizeBytes
-			if opts.VPMemSizeBytes != nil {
-				if *opts.VPMemSizeBytes%4096 != 0 {
-					return nil, fmt.Errorf("VPMemSizeBytes must be a multiple of 4096")
-				}
-				uvm.vpmemMaxSizeBytes = *opts.VPMemSizeBytes
-			}
-		}
-		if opts.KernelDirect && osversion.Get().Build < 18286 {
-			return nil, fmt.Errorf("KernelDirectBoot is not support on builds older than 18286")
-		}
-
-		scsi["0"] = hcsschema.Scsi{Attachments: attachments}
-		uvm.scsiControllerCount = 1
-		if opts.SCSIControllerCount != nil {
-			if *opts.SCSIControllerCount > 1 {
-				return nil, fmt.Errorf("SCSI controller count must be 0 or 1") // Future extension here for up to 4
-			}
-			uvm.scsiControllerCount = *opts.SCSIControllerCount
-			if uvm.scsiControllerCount == 0 {
-				scsi = nil
-			}
-			logrus.Debugln("uvm::Create:: uvm.scsiControllerCount=", uvm.scsiControllerCount)
-		}
-		if opts.BootFilesPath == "" {
-			opts.BootFilesPath = filepath.Join(os.Getenv("ProgramFiles"), "Linux Containers")
-		}
-		if opts.KernelFile == "" {
-			opts.KernelFile = "kernel"
-		}
-		if _, err := os.Stat(filepath.Join(opts.BootFilesPath, opts.KernelFile)); os.IsNotExist(err) {
-			return nil, fmt.Errorf("kernel '%s' not found", filepath.Join(opts.BootFilesPath, opts.KernelFile))
-		}
-
-		if opts.RootFSFile == "" {
-			if opts.PreferredRootFSType != nil {
-				actualRootFSType = *opts.PreferredRootFSType
-				if actualRootFSType != PreferredRootFSTypeInitRd && actualRootFSType != PreferredRootFSTypeVHD {
-					return nil, fmt.Errorf("invalid PreferredRootFSType")
-				}
-			}
-
-			switch actualRootFSType {
-			case PreferredRootFSTypeInitRd:
-				if _, err := os.Stat(filepath.Join(opts.BootFilesPath, initrdFile)); os.IsNotExist(err) {
-					return nil, fmt.Errorf("initrd not found")
-				}
-				opts.RootFSFile = initrdFile
-			case PreferredRootFSTypeVHD:
-				if _, err := os.Stat(filepath.Join(opts.BootFilesPath, vhdFile)); os.IsNotExist(err) {
-					return nil, fmt.Errorf("rootfs.vhd not found")
-				}
-				opts.RootFSFile = vhdFile
-			}
-		} else {
-			// Determine the root FS type by the extension of the explicitly supplied RootFSFile
-			if _, err := os.Stat(filepath.Join(opts.BootFilesPath, opts.RootFSFile)); os.IsNotExist(err) {
-				return nil, fmt.Errorf("%s not found under %s", opts.RootFSFile, opts.BootFilesPath)
-			}
-			switch strings.ToLower(filepath.Ext(opts.RootFSFile)) {
-			case "vhd", "vhdx":
-				actualRootFSType = PreferredRootFSTypeVHD
-			case "img":
-				actualRootFSType = PreferredRootFSTypeInitRd
-			default:
-				return nil, fmt.Errorf("unsupported filename extension for RootFSFile")
-			}
-		}
-	}
-
-	memory := int32(1024)
-	processors := int32(2)
-	if runtime.NumCPU() == 1 {
-		processors = 1
-	}
-	if opts.Resources != nil {
-		if opts.Resources.Memory != nil && opts.Resources.Memory.Limit != nil {
-			memory = int32(*opts.Resources.Memory.Limit / 1024 / 1024) // OCI spec is in bytes. HCS takes MB
-		}
-		if opts.Resources.CPU != nil && opts.Resources.CPU.Count != nil {
-			processors = int32(*opts.Resources.CPU.Count)
-		}
-	}
-
-	//                     +------------------+------------------------+
-	//                     | Allow OverCommit | Enable Deferred Commit |
-	// +-------------------+------------------+------------------------+
-	// | Virtual (Default) |       YES        |        NO              |
-	// +-------------------+------------------+------------------------+
-	// | Virtual Deferred  |       YES        |        YES             |
-	// +-------------------+------------------+------------------------+
-	// | Physical          |       NO         |        NO              |
-	// +-------------------+------------------+------------------------+
-	allowOvercommit := true
-	enableDeferredCommit := false
-	if opts.AllowOvercommit != nil {
-		allowOvercommit = *opts.AllowOvercommit
-	}
-	if opts.EnableDeferredCommit != nil {
-		enableDeferredCommit = *opts.EnableDeferredCommit
-	}
-
-	vm := &hcsschema.VirtualMachine{
-		Chipset: &hcsschema.Chipset{
-			Uefi: &hcsschema.Uefi{},
-		},
-
-		ComputeTopology: &hcsschema.Topology{
-			Memory: &hcsschema.Memory2{
-				SizeInMB:        memory,
-				AllowOvercommit: allowOvercommit,
-				// Hot hint is not compatible with physical. Only virtual, and only Windows.
-				EnableHotHint:        allowOvercommit && uvm.operatingSystem == "windows",
-				EnableDeferredCommit: enableDeferredCommit,
-			},
-			Processor: &hcsschema.Processor2{
-				Count: processors,
-			},
-		},
-
-		GuestConnection: &hcsschema.GuestConnection{},
-
-		Devices: &hcsschema.Devices{
-			Scsi: scsi,
-			HvSocket: &hcsschema.HvSocket2{
-				HvSocketConfig: &hcsschema.HvSocketSystemConfig{
-					// Allow administrators and SYSTEM to bind to vsock sockets
-					// so that we can create a GCS log socket.
-					DefaultBindSecurityDescriptor: "D:P(A;;FA;;;SY)(A;;FA;;;BA)",
-				},
-			},
-		},
-	}
-
-	hcsDocument := &hcsschema.ComputeSystem{
-		Owner:          uvm.owner,
-		SchemaVersion:  schemaversion.SchemaV21(),
-		VirtualMachine: vm,
-	}
-
-	if uvm.operatingSystem == "windows" {
-		vm.Chipset.Uefi.BootThis = &hcsschema.UefiBootEntry{
-			DevicePath: `\EFI\Microsoft\Boot\bootmgfw.efi`,
-			DeviceType: "VmbFs",
-		}
-		vm.Devices.VirtualSmb = &hcsschema.VirtualSmb{
-			DirectFileMappingInMB: 1024, // Sensible default, but could be a tuning parameter somewhere
-			Shares: []hcsschema.VirtualSmbShare{
-				{
-					Name: "os",
-					Path: filepath.Join(uvmFolder, `UtilityVM\Files`),
-					Options: &hcsschema.VirtualSmbShareOptions{
-						ReadOnly:            true,
-						PseudoOplocks:       true,
-						TakeBackupPrivilege: true,
-						CacheIo:             true,
-						ShareRead:           true,
-					},
-				},
-			},
-		}
-	} else {
-		vmDebugging := false
-		vm.GuestConnection.UseVsock = true
-		vm.GuestConnection.UseConnectedSuspend = true
-		if !opts.KernelDirect {
-			vm.Devices.VirtualSmb = &hcsschema.VirtualSmb{
-				Shares: []hcsschema.VirtualSmbShare{
-					{
-						Name: "os",
-						Path: opts.BootFilesPath,
-						Options: &hcsschema.VirtualSmbShareOptions{
-							ReadOnly:            true,
-							TakeBackupPrivilege: true,
-							CacheIo:             true,
-							ShareRead:           true,
-						},
-					},
-				},
-			}
-		}
-
-		if uvm.vpmemMaxCount > 0 {
-			vm.Devices.VirtualPMem = &hcsschema.VirtualPMemController{
-				MaximumCount:     uvm.vpmemMaxCount,
-				MaximumSizeBytes: uvm.vpmemMaxSizeBytes,
-			}
-		}
-
-		var kernelArgs string
-		switch actualRootFSType {
-		case PreferredRootFSTypeInitRd:
-			if !opts.KernelDirect {
-				kernelArgs = "initrd=/" + opts.RootFSFile
-			}
-		case PreferredRootFSTypeVHD:
-			kernelArgs = "root=/dev/pmem0 ro init=/init"
-		}
-
-		// Support for VPMem VHD(X) booting rather than initrd..
-		if actualRootFSType == PreferredRootFSTypeVHD {
-			if uvm.vpmemMaxCount == 0 {
-				return nil, fmt.Errorf("PreferredRootFSTypeVHD requess at least one VPMem device")
-			}
-			imageFormat := "Vhd1"
-			if strings.ToLower(filepath.Ext(opts.RootFSFile)) == "vhdx" {
-				imageFormat = "Vhdx"
-			}
-			vm.Devices.VirtualPMem.Devices = map[string]hcsschema.VirtualPMemDevice{
-				"0": {
-					HostPath:    filepath.Join(opts.BootFilesPath, opts.RootFSFile),
-					ReadOnly:    true,
-					ImageFormat: imageFormat,
-				},
-			}
-			if err := wclayer.GrantVmAccess(uvm.id, filepath.Join(opts.BootFilesPath, opts.RootFSFile)); err != nil {
-				return nil, fmt.Errorf("faied to grantvmaccess to %s: %s", filepath.Join(opts.BootFilesPath, opts.RootFSFile), err)
-			}
-			// Add to our internal structure
-			uvm.vpmemDevices[0] = vpmemInfo{
-				hostPath: opts.RootFSFile,
-				uvmPath:  "/",
-				refCount: 1,
-			}
-		}
-
-		if opts.ConsolePipe != "" {
-			vmDebugging = true
-			kernelArgs += " 8250_core.nr_uarts=1 8250_core.skip_txen_test=1 console=ttyS0,115200"
-			vm.Devices.ComPorts = map[string]hcsschema.ComPort{
-				"0": { // Which is actually COM1
-					NamedPipe: opts.ConsolePipe,
-				},
-			}
-		} else {
-			kernelArgs += " 8250_core.nr_uarts=0"
-		}
-
-		if opts.EnableGraphicsConsole {
-			vmDebugging = true
-			kernelArgs += " console=tty"
-			vm.Devices.Keyboard = &hcsschema.Keyboard{}
-			vm.Devices.EnhancedModeVideo = &hcsschema.EnhancedModeVideo{}
-			vm.Devices.VideoMonitor = &hcsschema.VideoMonitor{}
-		}
-
-		if !vmDebugging {
-			// Terminate the VM if there is a kernel panic.
-			kernelArgs += " panic=-1 quiet"
-		}
-
-		if opts.KernelBootOptions != "" {
-			kernelArgs += " " + opts.KernelBootOptions
-		}
-
-		// Start GCS with stderr pointing to the vsock port created below in
-		// order to forward guest logs to logrus.
-		initArgs := fmt.Sprintf("/bin/vsockexec -e %d /bin/gcs -log-format json -loglevel %s",
-			linuxLogVsockPort,
-			logrus.StandardLogger().Level.String())
-
-		if vmDebugging {
-			// Launch a shell on the console.
-			initArgs = `sh -c "` + initArgs + ` & exec sh"`
-		}
-
-		kernelArgs += ` pci=off brd.rd_nr=0 pmtmr=0 -- ` + initArgs
-
-		if !opts.KernelDirect {
-			vm.Chipset.Uefi.BootThis = &hcsschema.UefiBootEntry{
-				DevicePath:   `\` + opts.KernelFile,
-				DeviceType:   "VmbFs",
-				OptionalData: kernelArgs,
-			}
-		} else {
-			vm.Chipset.Uefi = nil
-			vm.Chipset.LinuxKernelDirect = &hcsschema.LinuxKernelDirect{
-				KernelFilePath: filepath.Join(opts.BootFilesPath, opts.KernelFile),
-				KernelCmdLine:  kernelArgs,
-			}
-			if actualRootFSType == PreferredRootFSTypeInitRd {
-				vm.Chipset.LinuxKernelDirect.InitRdPath = filepath.Join(opts.BootFilesPath, opts.RootFSFile)
-			}
-		}
-	}
-
-	fullDoc, err := mergemaps.MergeJSON(hcsDocument, ([]byte)(opts.AdditionHCSDocumentJSON))
-	if err != nil {
-		return nil, fmt.Errorf("failed to merge additional JSON '%s': %s", opts.AdditionHCSDocumentJSON, err)
-	}
-
-	hcsSystem, err := hcs.CreateComputeSystem(uvm.id, fullDoc)
-	if err != nil {
-		logrus.Debugln("failed to create UVM: ", err)
-		return nil, err
-	}
-
-	uvm.hcsSystem = hcsSystem
-	defer func() {
-		if err != nil {
-			uvm.Close()
-		}
-	}()
-
-	if uvm.operatingSystem == "linux" {
-		// Create a socket that the GCS can send logrus log data to.
-		uvm.gcslog, err = uvm.listenVsock(linuxLogVsockPort)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	return uvm, nil
-}
-
-func (uvm *UtilityVM) listenVsock(port uint32) (net.Listener, error) {
-	properties, err := uvm.hcsSystem.Properties()
-	if err != nil {
-		return nil, err
-	}
-	vmID, err := hvsock.GUIDFromString(properties.RuntimeID)
-	if err != nil {
-		return nil, err
-	}
-	serviceID, _ := hvsock.GUIDFromString("00000000-facb-11e6-bd58-64006a7986d3")
-	binary.LittleEndian.PutUint32(serviceID[0:4], port)
-	return hvsock.Listen(hvsock.Addr{VMID: vmID, ServiceID: serviceID})
 }
 
 // ID returns the ID of the VM's compute system.
@@ -512,11 +32,6 @@ func (uvm *UtilityVM) OS() string {
 	return uvm.operatingSystem
 }
 
-// PMemMaxSizeBytes returns the maximum size of a PMEM layer (LCOW)
-func (uvm *UtilityVM) PMemMaxSizeBytes() uint64 {
-	return uvm.vpmemMaxSizeBytes
-}
-
 // Close terminates and releases resources associated with the utility VM.
 func (uvm *UtilityVM) Close() error {
 	uvm.Terminate()
@@ -527,4 +42,22 @@ func (uvm *UtilityVM) Close() error {
 	err := uvm.hcsSystem.Close()
 	uvm.hcsSystem = nil
 	return err
+}
+
+func getMemory(r *specs.WindowsResources) int32 {
+	if r == nil || r.Memory == nil || r.Memory.Limit == nil {
+		return 1024 // 1GB By Default.
+	}
+	return int32(*r.Memory.Limit / 1024 / 1024) // OCI spec is in bytes. HCS takes MB
+}
+
+func getProcessors(r *specs.WindowsResources) int32 {
+	if r == nil || r.CPU == nil || r.CPU.Count == nil {
+		processors := int32(2)
+		if runtime.NumCPU() == 1 {
+			processors = 1
+		}
+		return processors
+	}
+	return int32(*r.CPU.Count)
 }

--- a/internal/uvm/create_lcow.go
+++ b/internal/uvm/create_lcow.go
@@ -1,0 +1,339 @@
+package uvm
+
+import (
+	"encoding/binary"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/Microsoft/hcsshim/internal/guid"
+	"github.com/Microsoft/hcsshim/internal/hcs"
+	"github.com/Microsoft/hcsshim/internal/mergemaps"
+	"github.com/Microsoft/hcsshim/internal/schema2"
+	"github.com/Microsoft/hcsshim/internal/schemaversion"
+	"github.com/Microsoft/hcsshim/internal/wclayer"
+	"github.com/Microsoft/hcsshim/osversion"
+	"github.com/linuxkit/virtsock/pkg/hvsock"
+	"github.com/sirupsen/logrus"
+)
+
+type PreferredRootFSType int
+
+const (
+	PreferredRootFSTypeInitRd PreferredRootFSType = 0
+	PreferredRootFSTypeVHD    PreferredRootFSType = 1
+
+	initrdFile = "initrd.img"
+	vhdFile    = "rootfs.vhd"
+)
+
+// OptionsLCOW are the set of options passed to CreateLCOW() to create a utility vm.
+type OptionsLCOW struct {
+	*Options
+
+	BootFilesPath         string  // Folder in which kernel and root file system reside. Defaults to \Program Files\Linux Containers
+	KernelFile            string  // Filename under BootFilesPath for the kernel. Defaults to `kernel`
+	KernelDirect          bool    // Skip UEFI and boot directly to `kernel`
+	RootFSFile            string  // Filename under BootFilesPath for the UVMs root file system. Defaults are `initrd.img` or `rootfs.vhd` based on `PreferredRootFSType`.
+	KernelBootOptions     string  // Additional boot options for the kernel
+	EnableGraphicsConsole bool    // If true, enable a graphics console for the utility VM
+	ConsolePipe           string  // The named pipe path to use for the serial console.  eg \\.\pipe\vmpipe
+	SCSIControllerCount   *uint32 // The number of SCSI controllers. Defaults to 1 if omitted. Currently we only support 0 or 1.
+
+	// Number of VPMem devices. Limit at 128. If booting UVM from VHD, device 0 is taken. LCOW Only. io.microsoft.virtualmachine.devices.virtualpmem.maximumcount
+	VPMemDeviceCount *uint32
+
+	// Size of the VPMem devices. LCOW Only. Defaults to 4GB. io.microsoft.virtualmachine.devices.virtualpmem.maximumsizebytes
+	VPMemSizeBytes *uint64
+
+	// Controls searching for the RootFSFile. Defaults to initrd (0). Can be set to VHD (1). io.microsoft.virtualmachine.lcow.preferredrootfstype
+	// Note this uses an arbitrary annotation strict which has no direct mapping to the HCS schema.
+	PreferredRootFSType *PreferredRootFSType
+}
+
+const linuxLogVsockPort = 109
+
+// CreateLCOW creates an HCS compute system representing a utility VM.
+func CreateLCOW(opts *OptionsLCOW) (_ *UtilityVM, err error) {
+	logrus.Debugf("uvm::CreateLCOW %+v", opts)
+
+	if opts.Options == nil {
+		opts.Options = &Options{}
+	}
+
+	uvm := &UtilityVM{
+		id:                  opts.ID,
+		owner:               opts.Owner,
+		operatingSystem:     "linux",
+		scsiControllerCount: 1,
+		vpmemMaxCount:       DefaultVPMEMCount,
+		vpmemMaxSizeBytes:   DefaultVPMemSizeBytes,
+	}
+
+	// Defaults if omitted by caller.
+	// TODO: Change this. Don't auto generate ID if omitted. Avoids the chicken-and-egg problem
+	if uvm.id == "" {
+		uvm.id = guid.New().String()
+	}
+	if uvm.owner == "" {
+		uvm.owner = filepath.Base(os.Args[0])
+	}
+
+	if opts.BootFilesPath == "" {
+		opts.BootFilesPath = filepath.Join(os.Getenv("ProgramFiles"), "Linux Containers")
+	}
+	if opts.KernelFile == "" {
+		opts.KernelFile = "kernel"
+	}
+	if _, err := os.Stat(filepath.Join(opts.BootFilesPath, opts.KernelFile)); os.IsNotExist(err) {
+		return nil, fmt.Errorf("kernel '%s' not found", filepath.Join(opts.BootFilesPath, opts.KernelFile))
+	}
+	if opts.PreferredRootFSType == nil {
+		v := PreferredRootFSTypeInitRd
+		opts.PreferredRootFSType = &v
+	}
+	if opts.RootFSFile == "" {
+		switch *opts.PreferredRootFSType {
+		case PreferredRootFSTypeInitRd:
+			opts.RootFSFile = initrdFile
+		case PreferredRootFSTypeVHD:
+			opts.RootFSFile = "rootfs.vhd"
+		}
+	}
+
+	if _, err := os.Stat(filepath.Join(opts.BootFilesPath, opts.RootFSFile)); os.IsNotExist(err) {
+		return nil, fmt.Errorf("%s not found under %s", opts.RootFSFile, opts.BootFilesPath)
+	}
+
+	if opts.SCSIControllerCount != nil {
+		if *opts.SCSIControllerCount > 1 {
+			return nil, fmt.Errorf("SCSI controller count must be 0 or 1") // Future extension here for up to 4
+		}
+		uvm.scsiControllerCount = *opts.SCSIControllerCount
+	}
+	if opts.VPMemDeviceCount != nil {
+		if *opts.VPMemDeviceCount > MaxVPMEMCount {
+			return nil, fmt.Errorf("vpmem device count cannot be greater than %d", MaxVPMEMCount)
+		}
+		uvm.vpmemMaxCount = *opts.VPMemDeviceCount
+	}
+	if uvm.vpmemMaxCount > 0 {
+		if opts.VPMemSizeBytes != nil {
+			if *opts.VPMemSizeBytes%4096 != 0 {
+				return nil, fmt.Errorf("opts.VPMemSizeBytes must be a multiple of 4096")
+			}
+			uvm.vpmemMaxSizeBytes = *opts.VPMemSizeBytes
+		}
+	} else {
+		if *opts.PreferredRootFSType == PreferredRootFSTypeVHD {
+			return nil, fmt.Errorf("PreferredRootFSTypeVHD requires at least one VPMem device")
+		}
+	}
+	if opts.KernelDirect && osversion.Get().Build < 18286 {
+		return nil, fmt.Errorf("KernelDirectBoot is not support on builds older than 18286")
+	}
+
+	doc := &hcsschema.ComputeSystem{
+		Owner:         uvm.owner,
+		SchemaVersion: schemaversion.SchemaV21(),
+		VirtualMachine: &hcsschema.VirtualMachine{
+			Chipset: &hcsschema.Chipset{},
+			ComputeTopology: &hcsschema.Topology{
+				Memory: &hcsschema.Memory2{
+					SizeInMB: getMemory(opts.Resources),
+					// AllowOvercommit `true` by default if not passed.
+					AllowOvercommit: opts.AllowOvercommit == nil || *opts.AllowOvercommit,
+					// EnableDeferredCommit `false` by default if not passed.
+					EnableDeferredCommit: opts.EnableDeferredCommit != nil && *opts.EnableDeferredCommit,
+				},
+				Processor: &hcsschema.Processor2{
+					Count: getProcessors(opts.Resources),
+				},
+			},
+			GuestConnection: &hcsschema.GuestConnection{
+				UseVsock:            true,
+				UseConnectedSuspend: true,
+			},
+			Devices: &hcsschema.Devices{
+				HvSocket: &hcsschema.HvSocket2{
+					HvSocketConfig: &hcsschema.HvSocketSystemConfig{
+						// Allow administrators and SYSTEM to bind to vsock sockets
+						// so that we can create a GCS log socket.
+						DefaultBindSecurityDescriptor: "D:P(A;;FA;;;SY)(A;;FA;;;BA)",
+					},
+				},
+			},
+		},
+	}
+
+	if !opts.KernelDirect {
+		doc.VirtualMachine.Devices.VirtualSmb = &hcsschema.VirtualSmb{
+			Shares: []hcsschema.VirtualSmbShare{
+				{
+					Name: "os",
+					Path: opts.BootFilesPath,
+					Options: &hcsschema.VirtualSmbShareOptions{
+						ReadOnly:            true,
+						TakeBackupPrivilege: true,
+						CacheIo:             true,
+						ShareRead:           true,
+					},
+				},
+			},
+		}
+	}
+
+	if uvm.scsiControllerCount > 0 {
+		// TODO: JTERRY75 - this should enumerate scsicount and add an entry per value.
+		doc.VirtualMachine.Devices.Scsi = map[string]hcsschema.Scsi{
+			"0": {
+				Attachments: make(map[string]hcsschema.Attachment),
+			},
+		}
+	}
+	if uvm.vpmemMaxCount > 0 {
+		doc.VirtualMachine.Devices.VirtualPMem = &hcsschema.VirtualPMemController{
+			MaximumCount:     uvm.vpmemMaxCount,
+			MaximumSizeBytes: uvm.vpmemMaxSizeBytes,
+		}
+	}
+
+	var kernelArgs string
+	switch *opts.PreferredRootFSType {
+	case PreferredRootFSTypeInitRd:
+		if !opts.KernelDirect {
+			kernelArgs = "initrd=/" + opts.RootFSFile
+		}
+	case PreferredRootFSTypeVHD:
+		// Support for VPMem VHD(X) booting rather than initrd..
+		kernelArgs = "root=/dev/pmem0 ro init=/init"
+		imageFormat := "Vhd1"
+		if strings.ToLower(filepath.Ext(opts.RootFSFile)) == "vhdx" {
+			imageFormat = "Vhdx"
+		}
+		doc.VirtualMachine.Devices.VirtualPMem.Devices = map[string]hcsschema.VirtualPMemDevice{
+			"0": {
+				HostPath:    filepath.Join(opts.BootFilesPath, opts.RootFSFile),
+				ReadOnly:    true,
+				ImageFormat: imageFormat,
+			},
+		}
+		if err := wclayer.GrantVmAccess(uvm.id, filepath.Join(opts.BootFilesPath, opts.RootFSFile)); err != nil {
+			return nil, fmt.Errorf("failed to grantvmaccess to %s: %s", filepath.Join(opts.BootFilesPath, opts.RootFSFile), err)
+		}
+		// Add to our internal structure
+		uvm.vpmemDevices[0] = vpmemInfo{
+			hostPath: opts.RootFSFile,
+			uvmPath:  "/",
+			refCount: 1,
+		}
+	}
+
+	vmDebugging := false
+	if opts.ConsolePipe != "" {
+		vmDebugging = true
+		kernelArgs += " 8250_core.nr_uarts=1 8250_core.skip_txen_test=1 console=ttyS0,115200"
+		doc.VirtualMachine.Devices.ComPorts = map[string]hcsschema.ComPort{
+			"0": { // Which is actually COM1
+				NamedPipe: opts.ConsolePipe,
+			},
+		}
+	} else {
+		kernelArgs += " 8250_core.nr_uarts=0"
+	}
+
+	if opts.EnableGraphicsConsole {
+		vmDebugging = true
+		kernelArgs += " console=tty"
+		doc.VirtualMachine.Devices.Keyboard = &hcsschema.Keyboard{}
+		doc.VirtualMachine.Devices.EnhancedModeVideo = &hcsschema.EnhancedModeVideo{}
+		doc.VirtualMachine.Devices.VideoMonitor = &hcsschema.VideoMonitor{}
+	}
+
+	if !vmDebugging {
+		// Terminate the VM if there is a kernel panic.
+		kernelArgs += " panic=-1 quiet"
+	}
+
+	if opts.KernelBootOptions != "" {
+		kernelArgs += " " + opts.KernelBootOptions
+	}
+
+	// Start GCS with stderr pointing to the vsock port created below in
+	// order to forward guest logs to logrus.
+	initArgs := fmt.Sprintf("/bin/vsockexec -e %d /bin/gcs -log-format json -loglevel %s",
+		linuxLogVsockPort,
+		logrus.StandardLogger().Level.String())
+
+	if vmDebugging {
+		// Launch a shell on the console.
+		initArgs = `sh -c "` + initArgs + ` & exec sh"`
+	}
+
+	kernelArgs += ` pci=off brd.rd_nr=0 pmtmr=0 -- ` + initArgs
+
+	if !opts.KernelDirect {
+		doc.VirtualMachine.Chipset.Uefi = &hcsschema.Uefi{
+			BootThis: &hcsschema.UefiBootEntry{
+				DevicePath:   `\` + opts.KernelFile,
+				DeviceType:   "VmbFs",
+				OptionalData: kernelArgs,
+			},
+		}
+	} else {
+		doc.VirtualMachine.Chipset.LinuxKernelDirect = &hcsschema.LinuxKernelDirect{
+			KernelFilePath: filepath.Join(opts.BootFilesPath, opts.KernelFile),
+			KernelCmdLine:  kernelArgs,
+		}
+		if *opts.PreferredRootFSType == PreferredRootFSTypeInitRd {
+			doc.VirtualMachine.Chipset.LinuxKernelDirect.InitRdPath = filepath.Join(opts.BootFilesPath, opts.RootFSFile)
+		}
+	}
+
+	fullDoc, err := mergemaps.MergeJSON(doc, ([]byte)(opts.AdditionHCSDocumentJSON))
+	if err != nil {
+		return nil, fmt.Errorf("failed to merge additional JSON '%s': %s", opts.AdditionHCSDocumentJSON, err)
+	}
+
+	hcsSystem, err := hcs.CreateComputeSystem(uvm.id, fullDoc)
+	if err != nil {
+		logrus.Debugln("failed to create UVM: ", err)
+		return nil, err
+	}
+
+	uvm.hcsSystem = hcsSystem
+	defer func() {
+		if err != nil {
+			uvm.Close()
+		}
+	}()
+
+	// Create a socket that the GCS can send logrus log data to.
+	uvm.gcslog, err = uvm.listenVsock(linuxLogVsockPort)
+	if err != nil {
+		return nil, err
+	}
+
+	return uvm, nil
+}
+
+func (uvm *UtilityVM) listenVsock(port uint32) (net.Listener, error) {
+	properties, err := uvm.hcsSystem.Properties()
+	if err != nil {
+		return nil, err
+	}
+	vmID, err := hvsock.GUIDFromString(properties.RuntimeID)
+	if err != nil {
+		return nil, err
+	}
+	serviceID, _ := hvsock.GUIDFromString("00000000-facb-11e6-bd58-64006a7986d3")
+	binary.LittleEndian.PutUint32(serviceID[0:4], port)
+	return hvsock.Listen(hvsock.Addr{VMID: vmID, ServiceID: serviceID})
+}
+
+// PMemMaxSizeBytes returns the maximum size of a PMEM layer (LCOW)
+func (uvm *UtilityVM) PMemMaxSizeBytes() uint64 {
+	return uvm.vpmemMaxSizeBytes
+}

--- a/internal/uvm/create_test.go
+++ b/internal/uvm/create_test.go
@@ -6,32 +6,19 @@ import (
 
 // Unit tests for negative testing of input to uvm.Create()
 
-func TestCreateBadOS(t *testing.T) {
-	opts := &UVMOptions{
-		OperatingSystem: "foobar",
-	}
-	_, err := Create(opts)
-	if err == nil || (err != nil && err.Error() != `unsupported operating system "foobar"`) {
-		t.Fatal(err)
-	}
-}
-
 func TestCreateBadBootFilesPath(t *testing.T) {
-	opts := &UVMOptions{
-		OperatingSystem: "linux",
-		BootFilesPath:   `c:\does\not\exist\I\hope`,
+	opts := &OptionsLCOW{
+		BootFilesPath: `c:\does\not\exist\I\hope`,
 	}
-	_, err := Create(opts)
+	_, err := CreateLCOW(opts)
 	if err == nil || (err != nil && err.Error() != `kernel 'c:\does\not\exist\I\hope\kernel' not found`) {
 		t.Fatal(err)
 	}
 }
 
 func TestCreateWCOWBadLayerFolders(t *testing.T) {
-	opts := &UVMOptions{
-		OperatingSystem: "windows",
-	}
-	_, err := Create(opts)
+	opts := &OptionsWCOW{}
+	_, err := CreateWCOW(opts)
 	if err == nil || (err != nil && err.Error() != `at least 2 LayerFolders must be supplied`) {
 		t.Fatal(err)
 	}

--- a/internal/uvm/create_wcow.go
+++ b/internal/uvm/create_wcow.go
@@ -1,0 +1,165 @@
+package uvm
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/Microsoft/hcsshim/internal/guid"
+	"github.com/Microsoft/hcsshim/internal/hcs"
+	"github.com/Microsoft/hcsshim/internal/mergemaps"
+	"github.com/Microsoft/hcsshim/internal/schema2"
+	"github.com/Microsoft/hcsshim/internal/schemaversion"
+	"github.com/Microsoft/hcsshim/internal/uvmfolder"
+	"github.com/Microsoft/hcsshim/internal/wcow"
+	"github.com/sirupsen/logrus"
+)
+
+// OptionsWCOW are the set of options passed to CreateWCOW() to create a utility vm.
+type OptionsWCOW struct {
+	*Options
+
+	LayerFolders []string // Set of folders for base layers and scratch. Ordered from top most read-only through base read-only layer, followed by scratch
+}
+
+// CreateWCOW creates an HCS compute system representing a utility VM.
+//
+// WCOW Notes:
+//   - The scratch is always attached to SCSI 0:0
+//
+func CreateWCOW(opts *OptionsWCOW) (_ *UtilityVM, err error) {
+	logrus.Debugf("uvm::CreateWCOW %+v", opts)
+
+	if opts.Options == nil {
+		opts.Options = &Options{}
+	}
+
+	uvm := &UtilityVM{
+		id:                  opts.ID,
+		owner:               opts.Owner,
+		operatingSystem:     "windows",
+		scsiControllerCount: 1,
+	}
+
+	// Defaults if omitted by caller.
+	// TODO: Change this. Don't auto generate ID if omitted. Avoids the chicken-and-egg problem
+	if uvm.id == "" {
+		uvm.id = guid.New().String()
+	}
+	if uvm.owner == "" {
+		uvm.owner = filepath.Base(os.Args[0])
+	}
+
+	if len(opts.LayerFolders) < 2 {
+		return nil, fmt.Errorf("at least 2 LayerFolders must be supplied")
+	}
+	uvmFolder, err := uvmfolder.LocateUVMFolder(opts.LayerFolders)
+	if err != nil {
+		return nil, fmt.Errorf("failed to locate utility VM folder from layer folders: %s", err)
+	}
+
+	// TODO: BUGBUG Remove this. @jhowardmsft
+	//       It should be the responsiblity of the caller to do the creation and population.
+	//       - Update runhcs too (vm.go).
+	//       - Remove comment in function header
+	//       - Update tests that rely on this current behaviour.
+	// Create the RW scratch in the top-most layer folder, creating the folder if it doesn't already exist.
+	scratchFolder := opts.LayerFolders[len(opts.LayerFolders)-1]
+	logrus.Debugf("uvm::CreateWCOW scratch folder: %s", scratchFolder)
+
+	// Create the directory if it doesn't exist
+	if _, err := os.Stat(scratchFolder); os.IsNotExist(err) {
+		logrus.Debugf("uvm::CreateWCOW creating folder: %s ", scratchFolder)
+		if err := os.MkdirAll(scratchFolder, 0777); err != nil {
+			return nil, fmt.Errorf("failed to create utility VM scratch folder: %s", err)
+		}
+	}
+
+	// Create sandbox.vhdx in the scratch folder based on the template, granting the correct permissions to it
+	scratchPath := filepath.Join(scratchFolder, "sandbox.vhdx")
+	if _, err := os.Stat(scratchPath); os.IsNotExist(err) {
+		if err := wcow.CreateUVMScratch(uvmFolder, scratchFolder, uvm.id); err != nil {
+			return nil, fmt.Errorf("failed to create scratch: %s", err)
+		}
+	}
+
+	doc := &hcsschema.ComputeSystem{
+		Owner:         uvm.owner,
+		SchemaVersion: schemaversion.SchemaV21(),
+		VirtualMachine: &hcsschema.VirtualMachine{
+			Chipset: &hcsschema.Chipset{
+				Uefi: &hcsschema.Uefi{
+					BootThis: &hcsschema.UefiBootEntry{
+						DevicePath: `\EFI\Microsoft\Boot\bootmgfw.efi`,
+						DeviceType: "VmbFs",
+					},
+				},
+			},
+			ComputeTopology: &hcsschema.Topology{
+				Memory: &hcsschema.Memory2{
+					SizeInMB: getMemory(opts.Resources),
+					// AllowOvercommit `true` by default if not passed.
+					AllowOvercommit: opts.AllowOvercommit == nil || *opts.AllowOvercommit,
+					// EnableHotHint is not compatible with physical. Only virtual, and only Windows.
+					EnableHotHint: opts.AllowOvercommit == nil || *opts.AllowOvercommit,
+					// EnableDeferredCommit `false` by default if not passed.
+					EnableDeferredCommit: opts.EnableDeferredCommit != nil && *opts.EnableDeferredCommit,
+				},
+				Processor: &hcsschema.Processor2{
+					Count: getProcessors(opts.Resources),
+				},
+			},
+			GuestConnection: &hcsschema.GuestConnection{},
+			Devices: &hcsschema.Devices{
+				Scsi: map[string]hcsschema.Scsi{
+					"0": {
+						Attachments: map[string]hcsschema.Attachment{
+							"0": {
+								Path:  scratchPath,
+								Type_: "VirtualDisk",
+							},
+						},
+					},
+				},
+				HvSocket: &hcsschema.HvSocket2{
+					HvSocketConfig: &hcsschema.HvSocketSystemConfig{
+						// Allow administrators and SYSTEM to bind to vsock sockets
+						// so that we can create a GCS log socket.
+						DefaultBindSecurityDescriptor: "D:P(A;;FA;;;SY)(A;;FA;;;BA)",
+					},
+				},
+				VirtualSmb: &hcsschema.VirtualSmb{
+					DirectFileMappingInMB: 1024, // Sensible default, but could be a tuning parameter somewhere
+					Shares: []hcsschema.VirtualSmbShare{
+						{
+							Name: "os",
+							Path: filepath.Join(uvmFolder, `UtilityVM\Files`),
+							Options: &hcsschema.VirtualSmbShareOptions{
+								ReadOnly:            true,
+								PseudoOplocks:       true,
+								TakeBackupPrivilege: true,
+								CacheIo:             true,
+								ShareRead:           true,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	uvm.scsiLocations[0][0].hostPath = doc.VirtualMachine.Devices.Scsi["0"].Attachments["0"].Path
+
+	fullDoc, err := mergemaps.MergeJSON(doc, ([]byte)(opts.AdditionHCSDocumentJSON))
+	if err != nil {
+		return nil, fmt.Errorf("failed to merge additional JSON '%s': %s", opts.AdditionHCSDocumentJSON, err)
+	}
+
+	hcsSystem, err := hcs.CreateComputeSystem(uvm.id, fullDoc)
+	if err != nil {
+		logrus.Debugln("failed to create UVM: ", err)
+		return nil, err
+	}
+	uvm.hcsSystem = hcsSystem
+	return uvm, nil
+}


### PR DESCRIPTION
Splits up the internal uvm.Create into uvm.CreateWCOW and uvm.CreateLCOW which
enables us to have options for each. This makes the code significantly easier
to read and maintain.

Signed-off-by: Justin Terry (VM) <juterry@microsoft.com>