### PR TITLE
Fix operation-end logging

### DIFF
--- a/internal/hcs/process.go
+++ b/internal/hcs/process.go
@@ -116,7 +116,7 @@ func (process *Process) Signal(options guestrequest.SignalProcessOptions) (err e
 
 	operation := "hcsshim::Process::Signal"
 	process.logOperationBegin(operation)
-	defer process.logOperationEnd(err)
+	defer func() { process.logOperationEnd(err) }()
 
 	if process.handle == 0 {
 		return makeProcessError(process, operation, ErrAlreadyClosed, nil)
@@ -149,7 +149,7 @@ func (process *Process) Kill() (err error) {
 
 	operation := "hcsshim::Process::Kill"
 	process.logOperationBegin(operation)
-	defer process.logOperationEnd(err)
+	defer func() { process.logOperationEnd(err) }()
 
 	if process.handle == 0 {
 		return makeProcessError(process, operation, ErrAlreadyClosed, nil)
@@ -172,7 +172,7 @@ func (process *Process) Kill() (err error) {
 func (process *Process) Wait() (err error) {
 	operation := "hcsshim::Process::Wait"
 	process.logOperationBegin(operation)
-	defer process.logOperationEnd(err)
+	defer func() { process.logOperationEnd(err) }()
 
 	err = waitForNotification(process.callbackNumber, hcsNotificationProcessExited, nil)
 	if err != nil {
@@ -187,7 +187,7 @@ func (process *Process) Wait() (err error) {
 func (process *Process) WaitTimeout(timeout time.Duration) (err error) {
 	operation := "hcssshim::Process::WaitTimeout"
 	process.logOperationBegin(operation)
-	defer process.logOperationEnd(err)
+	defer func() { process.logOperationEnd(err) }()
 
 	err = waitForNotification(process.callbackNumber, hcsNotificationProcessExited, &timeout)
 	if err != nil {
@@ -204,7 +204,7 @@ func (process *Process) ResizeConsole(width, height uint16) (err error) {
 
 	operation := "hcsshim::Process::ResizeConsole"
 	process.logOperationBegin(operation)
-	defer process.logOperationEnd(err)
+	defer func() { process.logOperationEnd(err) }()
 
 	if process.handle == 0 {
 		return makeProcessError(process, operation, ErrAlreadyClosed, nil)
@@ -241,7 +241,7 @@ func (process *Process) Properties() (_ *ProcessStatus, err error) {
 
 	operation := "hcsshim::Process::Properties"
 	process.logOperationBegin(operation)
-	defer process.logOperationEnd(err)
+	defer func() { process.logOperationEnd(err) }()
 
 	if process.handle == 0 {
 		return nil, makeProcessError(process, operation, ErrAlreadyClosed, nil)
@@ -278,7 +278,7 @@ func (process *Process) Properties() (_ *ProcessStatus, err error) {
 func (process *Process) ExitCode() (_ int, err error) {
 	operation := "hcsshim::Process::ExitCode"
 	process.logOperationBegin(operation)
-	defer process.logOperationEnd(err)
+	defer func() { process.logOperationEnd(err) }()
 
 	properties, err := process.Properties()
 	if err != nil {
@@ -305,7 +305,7 @@ func (process *Process) Stdio() (_ io.WriteCloser, _ io.ReadCloser, _ io.ReadClo
 
 	operation := "hcsshim::Process::Stdio"
 	process.logOperationBegin(operation)
-	defer process.logOperationEnd(err)
+	defer func() { process.logOperationEnd(err) }()
 
 	if process.handle == 0 {
 		return nil, nil, nil, makeProcessError(process, operation, ErrAlreadyClosed, nil)
@@ -349,7 +349,7 @@ func (process *Process) CloseStdin() (err error) {
 
 	operation := "hcsshim::Process::CloseStdin"
 	process.logOperationBegin(operation)
-	defer process.logOperationEnd(err)
+	defer func() { process.logOperationEnd(err) }()
 
 	if process.handle == 0 {
 		return makeProcessError(process, operation, ErrAlreadyClosed, nil)
@@ -387,7 +387,7 @@ func (process *Process) Close() (err error) {
 
 	operation := "hcsshim::Process::Close"
 	process.logOperationBegin(operation)
-	defer process.logOperationEnd(err)
+	defer func() { process.logOperationEnd(err) }()
 
 	// Don't double free this
 	if process.handle == 0 {

--- a/internal/hcs/system.go
+++ b/internal/hcs/system.go
@@ -83,7 +83,7 @@ func CreateComputeSystem(id string, hcsDocumentInterface interface{}) (_ *System
 
 	computeSystem := newSystem(id)
 	computeSystem.logOperationBegin(operation)
-	defer computeSystem.logOperationEnd(err)
+	defer func() { computeSystem.logOperationEnd(err) }()
 
 	hcsDocumentB, err := json.Marshal(hcsDocumentInterface)
 	if err != nil {
@@ -133,7 +133,7 @@ func OpenComputeSystem(id string) (_ *System, err error) {
 
 	computeSystem := newSystem(id)
 	computeSystem.logOperationBegin(operation)
-	defer computeSystem.logOperationEnd(err)
+	defer func() { computeSystem.logOperationEnd(err) }()
 
 	var (
 		handle  hcsSystem
@@ -221,7 +221,7 @@ func (computeSystem *System) Start() (err error) {
 
 	operation := "hcsshim::ComputeSystem::Start"
 	computeSystem.logOperationBegin(operation)
-	defer computeSystem.logOperationEnd(err)
+	defer func() { computeSystem.logOperationEnd(err) }()
 
 	if computeSystem.handle == 0 {
 		return makeSystemError(computeSystem, "Start", "", ErrAlreadyClosed, nil)
@@ -279,7 +279,7 @@ func (computeSystem *System) Shutdown() (err error) {
 
 	operation := "hcsshim::ComputeSystem::Shutdown"
 	computeSystem.logOperationBegin(operation)
-	defer computeSystem.logOperationEnd(err)
+	defer func() { computeSystem.logOperationEnd(err) }()
 
 	if computeSystem.handle == 0 {
 		return makeSystemError(computeSystem, "Shutdown", "", ErrAlreadyClosed, nil)
@@ -306,7 +306,7 @@ func (computeSystem *System) Terminate() (err error) {
 
 	operation := "hcsshim::ComputeSystem::Terminate"
 	computeSystem.logOperationBegin(operation)
-	defer computeSystem.logOperationEnd(err)
+	defer func() { computeSystem.logOperationEnd(err) }()
 
 	if computeSystem.handle == 0 {
 		return makeSystemError(computeSystem, "Terminate", "", ErrAlreadyClosed, nil)
@@ -329,7 +329,7 @@ func (computeSystem *System) Terminate() (err error) {
 func (computeSystem *System) Wait() (err error) {
 	operation := "hcsshim::ComputeSystem::Wait"
 	computeSystem.logOperationBegin(operation)
-	defer computeSystem.logOperationEnd(err)
+	defer func() { computeSystem.logOperationEnd(err) }()
 
 	err = waitForNotification(computeSystem.callbackNumber, hcsNotificationSystemExited, nil)
 	if err != nil {
@@ -344,7 +344,7 @@ func (computeSystem *System) Wait() (err error) {
 func (computeSystem *System) WaitTimeout(timeout time.Duration) (err error) {
 	operation := "hcsshim::ComputeSystem::WaitTimeout"
 	computeSystem.logOperationBegin(operation)
-	defer computeSystem.logOperationEnd(err)
+	defer func() { computeSystem.logOperationEnd(err) }()
 
 	err = waitForNotification(computeSystem.callbackNumber, hcsNotificationSystemExited, &timeout)
 	if err != nil {
@@ -360,7 +360,7 @@ func (computeSystem *System) Properties(types ...schema1.PropertyType) (_ *schem
 
 	operation := "hcsshim::ComputeSystem::Properties"
 	computeSystem.logOperationBegin(operation)
-	defer computeSystem.logOperationEnd(err)
+	defer func() { computeSystem.logOperationEnd(err) }()
 
 	queryj, err := json.Marshal(schema1.PropertyQuery{types})
 	if err != nil {
@@ -400,7 +400,7 @@ func (computeSystem *System) Pause() (err error) {
 
 	operation := "hcsshim::ComputeSystem::Pause"
 	computeSystem.logOperationBegin(operation)
-	defer computeSystem.logOperationEnd(err)
+	defer func() { computeSystem.logOperationEnd(err) }()
 
 	if computeSystem.handle == 0 {
 		return makeSystemError(computeSystem, "Pause", "", ErrAlreadyClosed, nil)
@@ -426,7 +426,7 @@ func (computeSystem *System) Resume() (err error) {
 
 	operation := "hcsshim::ComputeSystem::Resume"
 	computeSystem.logOperationBegin(operation)
-	defer computeSystem.logOperationEnd(err)
+	defer func() { computeSystem.logOperationEnd(err) }()
 
 	if computeSystem.handle == 0 {
 		return makeSystemError(computeSystem, "Resume", "", ErrAlreadyClosed, nil)
@@ -452,7 +452,7 @@ func (computeSystem *System) CreateProcess(c interface{}) (_ *Process, err error
 
 	operation := "hcsshim::ComputeSystem::CreateProcess"
 	computeSystem.logOperationBegin(operation)
-	defer computeSystem.logOperationEnd(err)
+	defer func() { computeSystem.logOperationEnd(err) }()
 
 	var (
 		processInfo   hcsProcessInformation
@@ -513,7 +513,7 @@ func (computeSystem *System) OpenProcess(pid int) (_ *Process, err error) {
 
 	operation := "hcsshim::ComputeSystem::OpenProcess"
 	computeSystem.logOperationBegin(operation)
-	defer computeSystem.logOperationEnd(err)
+	defer func() { computeSystem.logOperationEnd(err) }()
 
 	var (
 		processHandle hcsProcess
@@ -548,7 +548,7 @@ func (computeSystem *System) Close() (err error) {
 
 	operation := "hcsshim::ComputeSystem::Close"
 	computeSystem.logOperationBegin(operation)
-	defer computeSystem.logOperationEnd(err)
+	defer func() { computeSystem.logOperationEnd(err) }()
 
 	// Don't double free this
 	if computeSystem.handle == 0 {
@@ -636,7 +636,7 @@ func (computeSystem *System) Modify(config interface{}) (err error) {
 
 	operation := "hcsshim::ComputeSystem::Modify"
 	computeSystem.logOperationBegin(operation)
-	defer computeSystem.logOperationEnd(err)
+	defer func() { computeSystem.logOperationEnd(err) }()
 
 	if computeSystem.handle == 0 {
 		return makeSystemError(computeSystem, "Modify", "", ErrAlreadyClosed, nil)


### PR DESCRIPTION
Defer evaluates function arguments at the time of the defer statement, rather than when the function actually exits. Due to this, all of our operation end logging was seeing nil for error, and claiming the operation was a success, even if it failed.