### PR TITLE
Add OCI passthrough mount support for WCOW/LCOW

### DIFF
--- a/functional/lcow_test.go
+++ b/functional/lcow_test.go
@@ -146,7 +146,7 @@ func TestLCOWSimplePodScenario(t *testing.T) {
 	if err := lcow.CreateScratch(lcowUVM, uvmScratchFile, lcow.DefaultScratchSizeGB, cacheFile, ""); err != nil {
 		t.Fatal(err)
 	}
-	if _, _, err := lcowUVM.AddSCSI(uvmScratchFile, `/tmp/scratch`); err != nil {
+	if _, _, err := lcowUVM.AddSCSI(uvmScratchFile, `/tmp/scratch`, false); err != nil {
 		t.Fatal(err)
 	}
 

--- a/functional/uvm_scratch_test.go
+++ b/functional/uvm_scratch_test.go
@@ -43,7 +43,7 @@ func TestScratchCreateLCOW(t *testing.T) {
 	}
 
 	// Make sure it can be added (verifies it has access correctly)
-	c, l, err := targetUVM.AddSCSI(destTwo, "")
+	c, l, err := targetUVM.AddSCSI(destTwo, "", false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/functional/uvm_scsi_test.go
+++ b/functional/uvm_scsi_test.go
@@ -60,7 +60,7 @@ func testSCSIAddRemove(t *testing.T, u *uvm.UtilityVM, pathPrefix string, operat
 	// Add each of the disks to the utility VM. Attach-only, no container path
 	logrus.Debugln("First - adding in attach-only")
 	for i := 0; i < numDisks; i++ {
-		_, _, err := u.AddSCSI(disks[i], "")
+		_, _, err := u.AddSCSI(disks[i], "", false)
 		if err != nil {
 			t.Fatalf("failed to add scsi disk %d %s: %s", i, disks[i], err)
 		}
@@ -69,7 +69,7 @@ func testSCSIAddRemove(t *testing.T, u *uvm.UtilityVM, pathPrefix string, operat
 	// Try to re-add. These should all fail.
 	logrus.Debugln("Next - trying to re-add")
 	for i := 0; i < numDisks; i++ {
-		_, _, err := u.AddSCSI(disks[i], "")
+		_, _, err := u.AddSCSI(disks[i], "", false)
 		if err == nil {
 			t.Fatalf("should not be able to re-add the same SCSI disk!")
 		}
@@ -89,7 +89,7 @@ func testSCSIAddRemove(t *testing.T, u *uvm.UtilityVM, pathPrefix string, operat
 	// Now re-add but providing a container path
 	logrus.Debugln("Next - re-adding with a container path")
 	for i := 0; i < numDisks; i++ {
-		_, _, err := u.AddSCSI(disks[i], fmt.Sprintf(`%s%d`, pathPrefix, i))
+		_, _, err := u.AddSCSI(disks[i], fmt.Sprintf(`%s%d`, pathPrefix, i), false)
 		if err != nil {
 			t.Fatalf("failed to add scsi disk %d %s: %s", i, disks[i], err)
 		}
@@ -98,7 +98,7 @@ func testSCSIAddRemove(t *testing.T, u *uvm.UtilityVM, pathPrefix string, operat
 	// Try to re-add. These should all fail.
 	logrus.Debugln("Next - trying to re-add")
 	for i := 0; i < numDisks; i++ {
-		_, _, err := u.AddSCSI(disks[i], fmt.Sprintf(`%s%d`, pathPrefix, i))
+		_, _, err := u.AddSCSI(disks[i], fmt.Sprintf(`%s%d`, pathPrefix, i), false)
 		if err == nil {
 			t.Fatalf("should not be able to re-add the same SCSI disk!")
 		}

--- a/internal/hcsoci/hcsdoc_wcow.go
+++ b/internal/hcsoci/hcsdoc_wcow.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Microsoft/hcsshim/internal/schema1"
 	"github.com/Microsoft/hcsshim/internal/schema2"
 	"github.com/Microsoft/hcsshim/internal/schemaversion"
+	"github.com/Microsoft/hcsshim/internal/uvm"
 	"github.com/Microsoft/hcsshim/internal/uvmfolder"
 	"github.com/Microsoft/hcsshim/internal/wclayer"
 	"github.com/Microsoft/hcsshim/osversion"
@@ -228,7 +229,15 @@ func createWindowsContainerDocument(coi *createOptionsInternal) (interface{}, er
 			} else {
 				uvmPath, err := coi.HostingSystem.GetVSMBUvmPath(mount.Source)
 				if err != nil {
-					return nil, err
+					if err == uvm.ErrNotAttached {
+						// It could also be a scsi mount.
+						uvmPath, err = coi.HostingSystem.GetScsiUvmPath(mount.Source)
+						if err != nil {
+							return nil, err
+						}
+					} else {
+						return nil, err
+					}
 				}
 				mdv2.HostPath = uvmPath
 			}

--- a/internal/hcsoci/layers.go
+++ b/internal/hcsoci/layers.go
@@ -139,7 +139,7 @@ func MountContainerLayers(layerFolders []string, guestRoot string, uvm *uvm.Util
 
 	// BUGBUG Rename guestRoot better.
 	containerScratchPathInUVM := ospath.Join(uvm.OS(), guestRoot, scratchPath)
-	_, _, err := uvm.AddSCSI(hostPath, containerScratchPathInUVM)
+	_, _, err := uvm.AddSCSI(hostPath, containerScratchPathInUVM, false)
 	if err != nil {
 		cleanupOnMountFailure(uvm, wcowLayersAdded, lcowlayersAdded, attachedSCSIHostPath)
 		return nil, err

--- a/internal/hcsoci/resources.go
+++ b/internal/hcsoci/resources.go
@@ -50,6 +50,10 @@ type Resources struct {
 
 	// addedNetNSToVM indicates if the network namespace has been added to the containers utility VM
 	addedNetNSToVM bool
+
+	// scsiMounts is an array of the host-paths mounted into a utility VM to
+	// support scsi device passthrough.
+	scsiMounts []string
 }
 
 // TODO: Method on the resources?
@@ -109,6 +113,13 @@ func ReleaseResources(r *Resources, vm *uvm.UtilityVM, all bool) error {
 				return err
 			}
 			r.plan9Mounts = r.plan9Mounts[:len(r.plan9Mounts)-1]
+		}
+
+		for _, path := range r.scsiMounts {
+			if err := vm.RemoveSCSI(path); err != nil {
+				return err
+			}
+			r.scsiMounts = nil
 		}
 	}
 

--- a/internal/hcsoci/resources_wcow.go
+++ b/internal/hcsoci/resources_wcow.go
@@ -65,32 +65,61 @@ func allocateWindowsResources(coi *createOptionsInternal, resources *Resources) 
 	// Validate each of the mounts. If this is a V2 Xenon, we have to add them as
 	// VSMB shares to the utility VM. For V1 Xenon and Argons, there's nothing for
 	// us to do as it's done by HCS.
-	for _, mount := range coi.Spec.Mounts {
+	for i, mount := range coi.Spec.Mounts {
 		if mount.Destination == "" || mount.Source == "" {
 			return fmt.Errorf("invalid OCI spec - a mount must have both source and a destination: %+v", mount)
 		}
-		if mount.Type != "" {
-			return fmt.Errorf("invalid OCI spec - Type '%s' must not be set", mount.Type)
+		switch mount.Type {
+		case "":
+		case "physical-disk":
+		case "virtual-disk":
+		default:
+			return fmt.Errorf("invalid OCI spec - Type '%s' not supported", mount.Type)
 		}
 
 		if coi.HostingSystem != nil && schemaversion.IsV21(coi.actualSchemaVersion) {
-			logrus.Debugf("hcsshim::allocateWindowsResources Hot-adding VSMB share for OCI mount %+v", mount)
-			options := &hcsschema.VirtualSmbShareOptions{}
+			uvmPath := fmt.Sprintf("C:\\%s\\%d", coi.actualID, i)
+
+			readOnly := false
 			for _, o := range mount.Options {
 				if strings.ToLower(o) == "ro" {
+					readOnly = true
+					break
+				}
+			}
+			if mount.Type == "physical-disk" {
+				logrus.Debugf("hcsshim::allocateWindowsResources Hot-adding SCSI physical disk for OCI mount %+v", mount)
+				_, _, err := coi.HostingSystem.AddSCSIPhysicalDisk(mount.Source, uvmPath, readOnly)
+				if err != nil {
+					return fmt.Errorf("adding SCSI physical disk mount %+v: %s", mount, err)
+				}
+				coi.Spec.Mounts[i].Type = ""
+				resources.scsiMounts = append(resources.scsiMounts, mount.Source)
+			} else if mount.Type == "virtual-disk" {
+				logrus.Debugf("hcsshim::allocateWindowsResources Hot-adding SCSI virtual disk for OCI mount %+v", mount)
+				_, _, err := coi.HostingSystem.AddSCSI(mount.Source, uvmPath, readOnly)
+				if err != nil {
+					return fmt.Errorf("adding SCSI virtual disk mount %+v: %s", mount, err)
+				}
+				coi.Spec.Mounts[i].Type = ""
+				resources.scsiMounts = append(resources.scsiMounts, mount.Source)
+			} else {
+				logrus.Debugf("hcsshim::allocateWindowsResources Hot-adding VSMB share for OCI mount %+v", mount)
+				options := &hcsschema.VirtualSmbShareOptions{}
+				if readOnly {
 					options.ReadOnly = true
 					options.CacheIo = true
 					options.ShareRead = true
 					options.ForceLevelIIOplocks = true
 					break
 				}
-			}
 
-			err := coi.HostingSystem.AddVSMB(mount.Source, "", options)
-			if err != nil {
-				return fmt.Errorf("failed to add VSMB share to utility VM for mount %+v: %s", mount, err)
+				err := coi.HostingSystem.AddVSMB(mount.Source, "", options)
+				if err != nil {
+					return fmt.Errorf("failed to add VSMB share to utility VM for mount %+v: %s", mount, err)
+				}
+				resources.vsmbMounts = append(resources.vsmbMounts, mount.Source)
 			}
-			resources.vsmbMounts = append(resources.vsmbMounts, mount.Source)
 		}
 	}
 

--- a/internal/lcow/scratch.go
+++ b/internal/lcow/scratch.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"strings"
-
 	"time"
 
 	"github.com/Microsoft/go-winio/vhd"
@@ -54,7 +53,7 @@ func CreateScratch(lcowUVM *uvm.UtilityVM, destFile string, sizeGB uint32, cache
 		return fmt.Errorf("failed to create VHDx %s: %s", destFile, err)
 	}
 
-	controller, lun, err := lcowUVM.AddSCSI(destFile, "") // No destination as not formatted
+	controller, lun, err := lcowUVM.AddSCSI(destFile, "", false) // No destination as not formatted
 	if err != nil {
 		return err
 	}

--- a/internal/uvm/create_wcow.go
+++ b/internal/uvm/create_wcow.go
@@ -39,6 +39,7 @@ func CreateWCOW(opts *OptionsWCOW) (_ *UtilityVM, err error) {
 		owner:               opts.Owner,
 		operatingSystem:     "windows",
 		scsiControllerCount: 1,
+		vsmbShares:          make(map[string]*vsmbShare),
 	}
 
 	// Defaults if omitted by caller.

--- a/internal/uvm/plan9.go
+++ b/internal/uvm/plan9.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/Microsoft/hcsshim/internal/guestrequest"
+	"github.com/Microsoft/hcsshim/internal/logfields"
 	"github.com/Microsoft/hcsshim/internal/requesttype"
 	"github.com/Microsoft/hcsshim/internal/schema2"
 	"github.com/sirupsen/logrus"
@@ -12,6 +13,13 @@ import (
 // AddPlan9 adds a Plan9 share to a utility VM. Each Plan9 share is ref-counted and
 // only added if it isn't already.
 func (uvm *UtilityVM) AddPlan9(hostPath string, uvmPath string, readOnly bool) error {
+	logrus.WithFields(logrus.Fields{
+		logfields.UVMID: uvm.id,
+		"host-path":     hostPath,
+		"uvm-path":      uvmPath,
+		"readOnly":      readOnly,
+	}).Debug("uvm::AddPlan9")
+
 	if uvm.operatingSystem != "linux" {
 		return errNotSupported
 	}
@@ -19,7 +27,6 @@ func (uvm *UtilityVM) AddPlan9(hostPath string, uvmPath string, readOnly bool) e
 		return fmt.Errorf("uvmPath must be passed to AddPlan9")
 	}
 
-	logrus.Debugf("uvm::AddPlan9 %s %s %t id:%s", hostPath, uvmPath, readOnly, uvm.id)
 	uvm.m.Lock()
 	defer uvm.m.Unlock()
 	if uvm.plan9Shares == nil {


### PR DESCRIPTION
This PR adds support for passthrough mounts to the UVM for WCOW/LCOW. This can
be accomplished by passing a mount in the OCI spec as follows:

{
    "type": "passthrough-disk",
    "destination": "<path-in-lcow-or-wcow>",
    "source": "C:\\test.vhd",
    "options": ["rbind", "rw"]
}

Signed-off-by: Justin Terry (VM) <juterry@microsoft.com>