### PR TITLE
Adding efi=noruntime when using KernelDirect

### DIFF
--- a/internal/uvm/create_lcow.go
+++ b/internal/uvm/create_lcow.go
@@ -257,6 +257,10 @@ func CreateLCOW(opts *OptionsLCOW) (_ *UtilityVM, err error) {
 		kernelArgs += " panic=-1 quiet"
 	}
 
+	if opts.KernelDirect {
+		kernelArgs += " efi=noruntime"
+	}
+
 	if opts.KernelBootOptions != "" {
 		kernelArgs += " " + opts.KernelBootOptions
 	}


### PR DESCRIPTION
Signed-off-by: Justin Terry (VM) <juterry@microsoft.com>