### PR TITLE
Removing nil objects from returns of Delete functions.

### DIFF
--- a/hcn/hcnendpoint.go
+++ b/hcn/hcnendpoint.go
@@ -313,13 +313,13 @@ func (endpoint *HostComputeEndpoint) Create() (*HostComputeEndpoint, error) {
 }
 
 // Delete Endpoint.
-func (endpoint *HostComputeEndpoint) Delete() (*HostComputeEndpoint, error) {
+func (endpoint *HostComputeEndpoint) Delete() error {
 	logrus.Debugf("hcn::HostComputeEndpoint::Delete id=%s", endpoint.Id)
 
 	if err := deleteEndpoint(endpoint.Id); err != nil {
-		return nil, err
+		return err
 	}
-	return nil, nil
+	return nil
 }
 
 // ModifyEndpointSettings updates the Port/Policy of an Endpoint.

--- a/hcn/hcnendpoint_test.go
+++ b/hcn/hcnendpoint_test.go
@@ -23,11 +23,11 @@ func TestCreateDeleteEndpoint(t *testing.T) {
 	}
 	fmt.Printf("Endpoint JSON:\n%s \n", jsonString)
 
-	_, err = Endpoint.Delete()
+	err = Endpoint.Delete()
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = network.Delete()
+	err = network.Delete()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -51,11 +51,11 @@ func TestGetEndpointById(t *testing.T) {
 		t.Fatal("No Endpoint found")
 	}
 
-	_, err = foundEndpoint.Delete()
+	err = foundEndpoint.Delete()
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = network.Delete()
+	err = network.Delete()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -79,11 +79,11 @@ func TestGetEndpointByName(t *testing.T) {
 		t.Fatal("No Endpoint found")
 	}
 
-	_, err = foundEndpoint.Delete()
+	err = foundEndpoint.Delete()
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = network.Delete()
+	err = network.Delete()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -107,11 +107,11 @@ func TestListEndpoints(t *testing.T) {
 		t.Fatal("No Endpoint found")
 	}
 
-	_, err = Endpoint.Delete()
+	err = Endpoint.Delete()
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = network.Delete()
+	err = network.Delete()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -135,11 +135,11 @@ func TestListEndpointsOfNetwork(t *testing.T) {
 		t.Fatal("No Endpoint found")
 	}
 
-	_, err = Endpoint.Delete()
+	err = Endpoint.Delete()
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = network.Delete()
+	err = network.Delete()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -168,15 +168,15 @@ func TestEndpointNamespaceAttachDetach(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = namespace.Delete()
+	err = namespace.Delete()
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = endpoint.Delete()
+	err = endpoint.Delete()
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = network.Delete()
+	err = network.Delete()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -199,11 +199,11 @@ func TestCreateEndpointWithNamespace(t *testing.T) {
 		t.Fatal("No Namespace detected.")
 	}
 
-	_, err = Endpoint.Delete()
+	err = Endpoint.Delete()
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = network.Delete()
+	err = network.Delete()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -240,11 +240,11 @@ func TestApplyPolicyOnEndpoint(t *testing.T) {
 		t.Fatal("No Endpoint Policies found")
 	}
 
-	_, err = Endpoint.Delete()
+	err = Endpoint.Delete()
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = network.Delete()
+	err = network.Delete()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -287,11 +287,11 @@ func TestModifyEndpointSettings(t *testing.T) {
 		t.Fatal("No Endpoint Policies found")
 	}
 
-	_, err = endpoint.Delete()
+	err = endpoint.Delete()
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = network.Delete()
+	err = network.Delete()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/hcn/hcnloadbalancer.go
+++ b/hcn/hcnloadbalancer.go
@@ -247,7 +247,7 @@ func (loadBalancer *HostComputeLoadBalancer) Delete() error {
 func (loadBalancer *HostComputeLoadBalancer) AddEndpoint(endpoint *HostComputeEndpoint) (*HostComputeLoadBalancer, error) {
 	logrus.Debugf("hcn::HostComputeLoadBalancer::AddEndpoint loadBalancer=%s endpoint=%s", loadBalancer.Id, endpoint.Id)
 
-	_, err := loadBalancer.Delete()
+	err := loadBalancer.Delete()
 	if err != nil {
 		return nil, err
 	}
@@ -262,7 +262,7 @@ func (loadBalancer *HostComputeLoadBalancer) AddEndpoint(endpoint *HostComputeEn
 func (loadBalancer *HostComputeLoadBalancer) RemoveEndpoint(endpoint *HostComputeEndpoint) (*HostComputeLoadBalancer, error) {
 	logrus.Debugf("hcn::HostComputeLoadBalancer::RemoveEndpoint loadBalancer=%s endpoint=%s", loadBalancer.Id, endpoint.Id)
 
-	_, err := loadBalancer.Delete()
+	err := loadBalancer.Delete()
 	if err != nil {
 		return nil, err
 	}

--- a/hcn/hcnloadbalancer.go
+++ b/hcn/hcnloadbalancer.go
@@ -234,13 +234,13 @@ func (loadBalancer *HostComputeLoadBalancer) Create() (*HostComputeLoadBalancer,
 }
 
 // Delete LoadBalancer.
-func (loadBalancer *HostComputeLoadBalancer) Delete() (*HostComputeLoadBalancer, error) {
+func (loadBalancer *HostComputeLoadBalancer) Delete() error {
 	logrus.Debugf("hcn::HostComputeLoadBalancer::Delete id=%s", loadBalancer.Id)
 
 	if err := deleteLoadBalancer(loadBalancer.Id); err != nil {
-		return nil, err
+		return err
 	}
-	return nil, nil
+	return nil
 }
 
 // AddEndpoint add an endpoint to a LoadBalancer

--- a/hcn/hcnloadbalancer_test.go
+++ b/hcn/hcnloadbalancer_test.go
@@ -27,15 +27,15 @@ func TestCreateDeleteLoadBalancer(t *testing.T) {
 	}
 	fmt.Printf("LoadBalancer JSON:\n%s \n", jsonString)
 
-	_, err = loadBalancer.Delete()
+	err = loadBalancer.Delete()
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = endpoint.Delete()
+	err = endpoint.Delete()
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = network.Delete()
+	err = network.Delete()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -61,15 +61,15 @@ func TestGetLoadBalancerById(t *testing.T) {
 	if foundLB == nil {
 		t.Fatalf("No loadBalancer found")
 	}
-	_, err = loadBalancer.Delete()
+	err = loadBalancer.Delete()
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = endpoint.Delete()
+	err = endpoint.Delete()
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = network.Delete()
+	err = network.Delete()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -116,19 +116,19 @@ func TestLoadBalancerAddRemoveEndpoint(t *testing.T) {
 		t.Fatalf("Endpoint not removed from loadBalancer")
 	}
 
-	_, err = loadBalancer.Delete()
+	err = loadBalancer.Delete()
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = secondEndpoint.Delete()
+	err = secondEndpoint.Delete()
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = endpoint.Delete()
+	err = endpoint.Delete()
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = network.Delete()
+	err = network.Delete()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -156,15 +156,15 @@ func TestAddLoadBalancer(t *testing.T) {
 		t.Fatal(fmt.Errorf("No loadBalancer found"))
 	}
 
-	_, err = loadBalancer.Delete()
+	err = loadBalancer.Delete()
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = endpoint.Delete()
+	err = endpoint.Delete()
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = network.Delete()
+	err = network.Delete()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -192,15 +192,15 @@ func TestAddDSRLoadBalancer(t *testing.T) {
 		t.Fatal(fmt.Errorf("No loadBalancer found"))
 	}
 
-	_, err = loadBalancer.Delete()
+	err = loadBalancer.Delete()
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = endpoint.Delete()
+	err = endpoint.Delete()
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = network.Delete()
+	err = network.Delete()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -228,15 +228,15 @@ func TestAddILBLoadBalancer(t *testing.T) {
 		t.Fatal(fmt.Errorf("No loadBalancer found"))
 	}
 
-	_, err = loadBalancer.Delete()
+	err = loadBalancer.Delete()
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = endpoint.Delete()
+	err = endpoint.Delete()
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = network.Delete()
+	err = network.Delete()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/hcn/hcnnamespace.go
+++ b/hcn/hcnnamespace.go
@@ -308,13 +308,13 @@ func (namespace *HostComputeNamespace) Create() (*HostComputeNamespace, error) {
 }
 
 // Delete Namespace.
-func (namespace *HostComputeNamespace) Delete() (*HostComputeNamespace, error) {
+func (namespace *HostComputeNamespace) Delete() error {
 	logrus.Debugf("hcn::HostComputeNamespace::Delete id=%s", namespace.Id)
 
 	if err := deleteNamespace(namespace.Id); err != nil {
-		return nil, err
+		return err
 	}
-	return nil, nil
+	return nil
 }
 
 // Sync Namespace endpoints with the appropriate sandbox container holding the

--- a/hcn/hcnnamespace_test.go
+++ b/hcn/hcnnamespace_test.go
@@ -30,7 +30,7 @@ func TestCreateDeleteNamespace(t *testing.T) {
 	}
 	fmt.Printf("Namespace JSON:\n%s \n", jsonString)
 
-	_, err = namespace.Delete()
+	err = namespace.Delete()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -50,7 +50,7 @@ func TestCreateDeleteNamespaceGuest(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = hnsNamespace.Delete()
+	err = hnsNamespace.Delete()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -70,7 +70,7 @@ func TestGetNamespaceById(t *testing.T) {
 		t.Fatal("No namespace found")
 	}
 
-	_, err = namespace.Delete()
+	err = namespace.Delete()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -90,7 +90,7 @@ func TestListNamespaces(t *testing.T) {
 		t.Fatal("No Namespaces found")
 	}
 
-	_, err = namespace.Delete()
+	err = namespace.Delete()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -126,15 +126,15 @@ func TestGetNamespaceEndpointIds(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = namespace.Delete()
+	err = namespace.Delete()
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = endpoint.Delete()
+	err = endpoint.Delete()
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = network.Delete()
+	err = network.Delete()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -154,7 +154,7 @@ func TestGetNamespaceContainers(t *testing.T) {
 		t.Fatal("Found containers when none should exist")
 	}
 
-	_, err = namespace.Delete()
+	err = namespace.Delete()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -190,15 +190,15 @@ func TestAddRemoveNamespaceEndpoint(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = namespace.Delete()
+	err = namespace.Delete()
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = endpoint.Delete()
+	err = endpoint.Delete()
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = network.Delete()
+	err = network.Delete()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -245,15 +245,15 @@ func TestModifyNamespaceSettings(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = namespace.Delete()
+	err = namespace.Delete()
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = endpoint.Delete()
+	err = endpoint.Delete()
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = network.Delete()
+	err = network.Delete()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -282,7 +282,7 @@ func TestSyncNamespaceHostDefault(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = hnsNamespace.Delete()
+	err = hnsNamespace.Delete()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -309,7 +309,7 @@ func TestSyncNamespaceHost(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = hnsNamespace.Delete()
+	err = hnsNamespace.Delete()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -336,7 +336,7 @@ func TestSyncNamespaceGuestNoReg(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = hnsNamespace.Delete()
+	err = hnsNamespace.Delete()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -363,7 +363,7 @@ func TestSyncNamespaceGuestDefaultNoReg(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = hnsNamespace.Delete()
+	err = hnsNamespace.Delete()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -404,7 +404,7 @@ func TestSyncNamespaceGuest(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = hnsNamespace.Delete()
+	err = hnsNamespace.Delete()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -444,7 +444,7 @@ func TestSyncNamespaceGuestDefault(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = hnsNamespace.Delete()
+	err = hnsNamespace.Delete()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/hcn/hcnnetwork.go
+++ b/hcn/hcnnetwork.go
@@ -326,13 +326,13 @@ func (network *HostComputeNetwork) Create() (*HostComputeNetwork, error) {
 }
 
 // Delete Network.
-func (network *HostComputeNetwork) Delete() (*HostComputeNetwork, error) {
+func (network *HostComputeNetwork) Delete() error {
 	logrus.Debugf("hcn::HostComputeNetwork::Delete id=%s", network.Id)
 
 	if err := deleteNetwork(network.Id); err != nil {
-		return nil, err
+		return err
 	}
-	return nil, nil
+	return nil
 }
 
 // ModifyNetworkSettings updates the Policy for a network.

--- a/hcn/hcnnetwork_test.go
+++ b/hcn/hcnnetwork_test.go
@@ -18,7 +18,7 @@ func TestCreateDeleteNetwork(t *testing.T) {
 		t.Fatal(err)
 	}
 	fmt.Printf("Network JSON:\n%s \n", jsonString)
-	_, err = network.Delete()
+	err = network.Delete()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -36,7 +36,7 @@ func TestGetNetworkByName(t *testing.T) {
 	if network == nil {
 		t.Fatal("No Network found")
 	}
-	_, err = network.Delete()
+	err = network.Delete()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -54,7 +54,7 @@ func TestGetNetworkById(t *testing.T) {
 	if network == nil {
 		t.Fatal("No Network found")
 	}
-	_, err = network.Delete()
+	err = network.Delete()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -119,7 +119,7 @@ func TestAddRemoveRemoteSubnetRoutePolicy(t *testing.T) {
 		t.Fatalf("Found remote subnet route policy on network when it should have been deleted.")
 	}
 
-	_, err = network.Delete()
+	err = network.Delete()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/hcn/hcnutils_test.go
+++ b/hcn/hcnutils_test.go
@@ -13,7 +13,7 @@ func cleanup(networkName string) {
 		return
 	}
 	if testNetwork != nil {
-		_, err := testNetwork.Delete()
+		err := testNetwork.Delete()
 		if err != nil {
 			return
 		}

--- a/hcn/hcnv1schema_test.go
+++ b/hcn/hcnv1schema_test.go
@@ -41,7 +41,7 @@ func TestV1Network(t *testing.T) {
 		t.Fail()
 	}
 
-	_, err = network.Delete()
+	err = network.Delete()
 	if err != nil {
 		t.Fatal(err)
 		t.Fail()
@@ -97,13 +97,13 @@ func TestV1Endpoint(t *testing.T) {
 		t.Fail()
 	}
 
-	_, err = endpoint.Delete()
+	err = endpoint.Delete()
 	if err != nil {
 		t.Fatal(err)
 		t.Fail()
 	}
 
-	_, err = network.Delete()
+	err = network.Delete()
 	if err != nil {
 		t.Fatal(err)
 		t.Fail()


### PR DESCRIPTION
Delete methods all have object references in the return values, which are always nil.
Changing the method signature so that only the error is returned.