### PR TITLE
Fix race in syscallWatcher

### DIFF
--- a/internal/hcs/process.go
+++ b/internal/hcs/process.go
@@ -130,10 +130,9 @@ func (process *Process) Signal(options guestrequest.SignalProcessOptions) (err e
 	optionsStr := string(optionsb)
 
 	var resultp *uint16
-	completed := false
-	go syscallWatcher(process.logctx, &completed)
-	err = hcsSignalProcess(process.handle, optionsStr, &resultp)
-	completed = true
+	syscallWatcher(process.logctx, func() {
+		err = hcsSignalProcess(process.handle, optionsStr, &resultp)
+	})
 	events := processHcsResult(resultp)
 	if err != nil {
 		return makeProcessError(process, operation, err, events)
@@ -156,10 +155,9 @@ func (process *Process) Kill() (err error) {
 	}
 
 	var resultp *uint16
-	completed := false
-	go syscallWatcher(process.logctx, &completed)
-	err = hcsTerminateProcess(process.handle, &resultp)
-	completed = true
+	syscallWatcher(process.logctx, func() {
+		err = hcsTerminateProcess(process.handle, &resultp)
+	})
 	events := processHcsResult(resultp)
 	if err != nil {
 		return makeProcessError(process, operation, err, events)
@@ -251,10 +249,9 @@ func (process *Process) Properties() (_ *ProcessStatus, err error) {
 		resultp     *uint16
 		propertiesp *uint16
 	)
-	completed := false
-	go syscallWatcher(process.logctx, &completed)
-	err = hcsGetProcessProperties(process.handle, &propertiesp, &resultp)
-	completed = true
+	syscallWatcher(process.logctx, func() {
+		err = hcsGetProcessProperties(process.handle, &propertiesp, &resultp)
+	})
 	events := processHcsResult(resultp)
 	if err != nil {
 		return nil, makeProcessError(process, operation, err, events)

--- a/internal/hcs/watcher.go
+++ b/internal/hcs/watcher.go
@@ -17,7 +17,7 @@ import (
 //
 // Usage is:
 //
-// sysycallWatcher(logContext, func() {
+// syscallWatcher(logContext, func() {
 //    err = <syscall>(args...)
 // })
 //

--- a/internal/hcs/watcher.go
+++ b/internal/hcs/watcher.go
@@ -1,7 +1,7 @@
 package hcs
 
 import (
-	"time"
+	"context"
 
 	"github.com/Microsoft/hcsshim/internal/logfields"
 	"github.com/Microsoft/hcsshim/internal/timeout"
@@ -17,17 +17,25 @@ import (
 //
 // Usage is:
 //
-// completed := false
-// go syscallWatcher(context, &completed)
-// <syscall>
-// completed = true
+// sysycallWatcher(logContext, func() {
+//    err = <syscall>(args...)
+// })
 //
-func syscallWatcher(context logrus.Fields, syscallCompleted *bool) {
-	time.Sleep(timeout.SyscallWatcher)
-	if *syscallCompleted {
-		return
+
+func syscallWatcher(logContext logrus.Fields, syscallLambda func()) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout.SyscallWatcher)
+	defer cancel()
+	go watchFunc(ctx, logContext)
+	syscallLambda()
+}
+
+func watchFunc(ctx context.Context, logContext logrus.Fields) {
+	select {
+	case <-ctx.Done():
+		if ctx.Err() != context.Canceled {
+			logrus.WithFields(logContext).
+				WithField(logfields.Timeout, timeout.SyscallWatcher).
+				Warning("Syscall did not complete within operation timeout. This may indicate a platform issue. If it appears to be making no forward progress, obtain the stacks and see if there is a syscall stuck in the platform API for a significant length of time.")
+		}
 	}
-	logrus.WithFields(context).
-		WithField(logfields.Timeout, timeout.SyscallWatcher).
-		Warning("Syscall did not complete within operation timeout. This may indicate a platform issue. If it appears to be making no forward progress, obtain the stacks and see if there is a syscall stuck in the platform API for a significant length of time.")
 }


### PR DESCRIPTION
This PR fixes two issues:

1. If the syscallWatcher function is started in a goroutine, the goroutine remains around for the length of `timeout.SyscallWatcher` (4 minutes). So a longrunning process can accumulate goroutines if it makes many syscalls that use the syscallWatcher in a 4 minute span.

2. There is a race condition where both the syscallWatcher goroutine and the main function access the `completed` variable. This will cause any test suites that: 
    - run under `go test -race`
    - call into hcsshim 
    - last longer than 4 minutes 

to fail due to the race detector.  An easy way to reproduce is:

```
completed := false
go syscallWatcher(context, &completed)
time.Sleep(timeout.SyscallWatcher + 5 * time.Second)
completed = true	
```

This PR fixes the issue by using a context.Context object to handle the timeout

Signed-off-by: Yechiel Kalmenson <ykalmenson@pivotal.io>