### PR TITLE
DNS Suffix Change for Alignment with Container Network Interface Specification

### DIFF
--- a/hcn/hcnnetwork.go
+++ b/hcn/hcnnetwork.go
@@ -42,7 +42,7 @@ type MacPool struct {
 
 // Dns (Domain Name System is associated with a network.
 type Dns struct {
-	Suffix     string   `json:",omitempty"`
+	Domain     string   `json:",omitempty"`
 	Search     []string `json:",omitempty"`
 	ServerList []string `json:",omitempty"`
 	Options    []string `json:",omitempty"`


### PR DESCRIPTION
Fixing the naming of the DNS struct to align with the Container Network Interface Specification.

This change won't effect anyone using the HNS V1 schema. It is for usage going forward using V2 schema in RS5+.

