### PR TITLE
Remote Subnet version

### DIFF
--- a/hcn/hcn.go
+++ b/hcn/hcn.go
@@ -134,6 +134,15 @@ func V2SchemaVersion() SchemaVersion {
 	}
 }
 
+// RemoteSubnetSupported returns an error if the HCN version does not support Remote Subnet policies.
+func RemoteSubnetSupported() error {
+	supported := GetSupportedFeatures()
+	if supported.RemoteSubnet {
+		return nil
+	}
+	return platformDoesNotSupportError("Remote Subnet")
+}
+
 // RequestType are the different operations performed to settings.
 // Used to update the settings of Endpoint/Namespace objects.
 type RequestType string

--- a/hcn/hcnglobals.go
+++ b/hcn/hcnglobals.go
@@ -25,6 +25,8 @@ var (
 	HNSVersion1803 = Version{Major: 7, Minor: 2}
 	// V2ApiSupport allows the use of V2 Api calls and V2 Schema.
 	V2ApiSupport = Version{Major: 9, Minor: 1}
+	// Remote Subnet allows for Remote Subnet policies on Overlay networks
+	RemoteSubnetVersion = Version{Major: 9, Minor: 2}
 )
 
 // GetGlobals returns the global properties of the HCN Service.

--- a/hcn/hcnsupport.go
+++ b/hcn/hcnsupport.go
@@ -6,8 +6,9 @@ import (
 
 // SupportedFeatures are the features provided by the Service.
 type SupportedFeatures struct {
-	Acl AclFeatures `json:"ACL"`
-	Api ApiSupport  `json:"API"`
+	Acl          AclFeatures `json:"ACL"`
+	Api          ApiSupport  `json:"API"`
+	RemoteSubnet bool        `json:"RemoteSubnet"`
 }
 
 // AclFeatures are the supported ACL possibilities.
@@ -46,6 +47,8 @@ func GetSupportedFeatures() SupportedFeatures {
 		V2: isFeatureSupported(globals.Version, V2ApiSupport),
 		V1: true, // HNSCall is still available.
 	}
+
+	features.RemoteSubnet = isFeatureSupported(globals.Version, RemoteSubnetVersion)
 
 	return features
 }

--- a/hcn/hcnsupport_test.go
+++ b/hcn/hcnsupport_test.go
@@ -23,3 +23,14 @@ func TestV2ApiSupport(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestRemoteSubnetSupport(t *testing.T) {
+	supportedFeatures := GetSupportedFeatures()
+	err := RemoteSubnetSupported()
+	if supportedFeatures.RemoteSubnet && err != nil {
+		t.Fatal(err)
+	}
+	if !supportedFeatures.RemoteSubnet && err == nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
Adds check to see if Remote Subnet network policies are supported. These are only supported in HNS version 9.2 (RS5 plus Remote Subnet DCR)