### PR TITLE
DSR version

### DIFF
--- a/hcn/hcn.go
+++ b/hcn/hcn.go
@@ -143,6 +143,15 @@ func RemoteSubnetSupported() error {
 	return platformDoesNotSupportError("Remote Subnet")
 }
 
+// DSRSupported returns an error if the HCN version does not support Direct Server Return.
+func DSRSupported() error {
+	supported := GetSupportedFeatures()
+	if supported.DSR {
+		return nil
+	}
+	return platformDoesNotSupportError("Direct Server Return (DSR)")
+}
+
 // RequestType are the different operations performed to settings.
 // Used to update the settings of Endpoint/Namespace objects.
 type RequestType string

--- a/hcn/hcnglobals.go
+++ b/hcn/hcnglobals.go
@@ -27,6 +27,8 @@ var (
 	V2ApiSupport = Version{Major: 9, Minor: 1}
 	// Remote Subnet allows for Remote Subnet policies on Overlay networks
 	RemoteSubnetVersion = Version{Major: 9, Minor: 2}
+	// HNS 10.2 allows for Direct Server Return for loadbalancing
+	DSRVersion = Version{Major: 10, Minor: 2}
 )
 
 // GetGlobals returns the global properties of the HCN Service.

--- a/hcn/hcnsupport.go
+++ b/hcn/hcnsupport.go
@@ -9,6 +9,7 @@ type SupportedFeatures struct {
 	Acl          AclFeatures `json:"ACL"`
 	Api          ApiSupport  `json:"API"`
 	RemoteSubnet bool        `json:"RemoteSubnet"`
+	DSR          bool        `json:"DSR"`
 }
 
 // AclFeatures are the supported ACL possibilities.
@@ -49,6 +50,7 @@ func GetSupportedFeatures() SupportedFeatures {
 	}
 
 	features.RemoteSubnet = isFeatureSupported(globals.Version, RemoteSubnetVersion)
+	features.DSR = isFeatureSupported(globals.Version, DSRVersion)
 
 	return features
 }

--- a/hcn/hcnsupport_test.go
+++ b/hcn/hcnsupport_test.go
@@ -18,8 +18,12 @@ func TestSupportedFeatures(t *testing.T) {
 }
 
 func TestV2ApiSupport(t *testing.T) {
+	supportedFeatures := GetSupportedFeatures()
 	err := V2ApiSupported()
-	if err != nil {
+	if supportedFeatures.Api.V2 && err != nil {
+		t.Fatal(err)
+	}
+	if !supportedFeatures.Api.V2 && err == nil {
 		t.Fatal(err)
 	}
 }
@@ -31,6 +35,17 @@ func TestRemoteSubnetSupport(t *testing.T) {
 		t.Fatal(err)
 	}
 	if !supportedFeatures.RemoteSubnet && err == nil {
+		t.Fatal(err)
+	}
+}
+
+func TestDSRSupport(t *testing.T) {
+	supportedFeatures := GetSupportedFeatures()
+	err := DSRSupported()
+	if supportedFeatures.DSR && err != nil {
+		t.Fatal(err)
+	}
+	if !supportedFeatures.DSR && err == nil {
 		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
Adding a check for DSR (Direct Server Return) and fixed the V2 API test to run regardless of version.