### PR TITLE
Refactor UVM output handling

### DIFF
--- a/internal/uvm/start.go
+++ b/internal/uvm/start.go
@@ -1,6 +1,7 @@
 package uvm
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"io/ioutil"
@@ -54,24 +55,43 @@ func parseLogrus(r io.Reader) {
 	}
 }
 
-func processOutput(l net.Listener, doneChan chan struct{}, handler OutputHandler) {
+type acceptResult struct {
+	c   net.Conn
+	err error
+}
+
+func processOutput(ctx context.Context, l net.Listener, doneChan chan struct{}, handler OutputHandler) {
 	defer close(doneChan)
 
-	c, err := l.Accept()
-	l.Close()
-	if err != nil {
-		logrus.Error("accepting log socket: ", err)
-		return
-	}
-	defer c.Close()
+	ch := make(chan acceptResult)
+	go func() {
+		c, err := l.Accept()
+		ch <- acceptResult{c, err}
+	}()
 
-	handler(c)
+	select {
+	case <-ctx.Done():
+		l.Close()
+		return
+	case ar := <-ch:
+		c, err := ar.c, ar.err
+		l.Close()
+		if err != nil {
+			logrus.Error("accepting log socket: ", err)
+			return
+		}
+		defer c.Close()
+
+		handler(c)
+	}
 }
 
 // Start synchronously starts the utility VM.
 func (uvm *UtilityVM) Start() error {
 	if uvm.outputListener != nil {
-		go processOutput(uvm.outputListener, uvm.outputProcessingDone, uvm.outputHandler)
+		ctx, cancel := context.WithCancel(context.Background())
+		go processOutput(ctx, uvm.outputListener, uvm.outputProcessingDone, uvm.outputHandler)
+		uvm.outputProcessingCancel = cancel
 		uvm.outputListener = nil
 	}
 	return uvm.hcsSystem.Start()

--- a/internal/uvm/types.go
+++ b/internal/uvm/types.go
@@ -3,6 +3,7 @@ package uvm
 // This package describes the external interface for utility VMs.
 
 import (
+	"context"
 	"net"
 	"sync"
 
@@ -97,7 +98,8 @@ type UtilityVM struct {
 
 	namespaces map[string]*namespaceInfo
 
-	outputListener       net.Listener
-	outputProcessingDone chan struct{}
-	outputHandler        OutputHandler
+	outputListener         net.Listener
+	outputProcessingDone   chan struct{}
+	outputHandler          OutputHandler
+	outputProcessingCancel context.CancelFunc
 }

--- a/internal/uvm/wait.go
+++ b/internal/uvm/wait.go
@@ -16,12 +16,31 @@ func (uvm *UtilityVM) waitForOutput() {
 // Waits synchronously waits for a utility VM to terminate.
 func (uvm *UtilityVM) Wait() error {
 	err := uvm.hcsSystem.Wait()
+
+	// outputProcessingCancel will only cancel waiting for the vsockexec
+	// connection, it won't stop output processing once the connection is
+	// established.
+	if uvm.outputProcessingCancel != nil {
+		uvm.outputProcessingCancel()
+	}
 	uvm.waitForOutput()
+
 	return err
 }
 
+// WaitExpectedError synchronously waits for a utility VM to terminate. If the
+// UVM terminates successfully, or if the given error is encountered internally
+// during the wait, this function returns nil.
 func (uvm *UtilityVM) WaitExpectedError(expected error) error {
 	err := uvm.hcsSystem.WaitExpectedError(expected)
+
+	// outputProcessingCancel will only cancel waiting for the vsockexec
+	// connection, it won't stop output processing once the connection is
+	// established.
+	if uvm.outputProcessingCancel != nil {
+		uvm.outputProcessingCancel()
+	}
 	uvm.waitForOutput()
+
 	return err
 }


### PR DESCRIPTION
Previously, if an issue in the kernel or initrd prevented the UVM from running
vsockexec, we would hang forever waiting for output processing from the UVM to
complete. With this change, there is now a separate signal for when the vsock
listener connects, and when it is done processing output (these signals are
implemented by closing channels). If the UVM dies before the connect signal
occurs, the wait completes. Otherwise, we wait until output processing has
completed before returning, as we did before.

Signed-off-by: Kevin Parsons <kevpar@ntdev.microsoft.com>