### PR TITLE
Fix issue with Docker SignalMap

### DIFF
--- a/cmd/runhcs/kill.go
+++ b/cmd/runhcs/kill.go
@@ -116,6 +116,9 @@ func validateSigstr(sigstr string, signalsSupported bool, isLcow bool) (int, err
 	sigstr = strings.ToUpper(sigstr)
 
 	if !signalsSupported {
+		// If signals arent supported we just validate that its a known signal.
+		// We already return 0 since we only supported a platform Kill() at that
+		// time.
 		if isLcow {
 			switch sigstr {
 			case "15":
@@ -123,16 +126,25 @@ func validateSigstr(sigstr string, signalsSupported bool, isLcow bool) (int, err
 			case "TERM":
 				fallthrough
 			case "SIGTERM":
-				return 0xf, nil
+				return 0, nil
 			default:
 				return 0, errInvalidSignal
 			}
 		}
 		switch sigstr {
+		// Docker sends a UNIX term in the supported Windows Signal map.
+		case "15":
+			fallthrough
+		case "TERM":
+			fallthrough
 		case "0":
 			fallthrough
 		case "CTRLC":
-			return 0x0, nil
+			return 0, nil
+		case "9":
+			fallthrough
+		case "KILL":
+			return 0, nil
 		default:
 			return 0, errInvalidSignal
 		}

--- a/cmd/runhcs/kill_test.go
+++ b/cmd/runhcs/kill_test.go
@@ -32,9 +32,9 @@ func TestValidateSigstrEmpty(t *testing.T) {
 }
 
 func TestValidateSigstrDefaultLCOW(t *testing.T) {
-	runValidateSigstrTest("15", false, true, 0xf, false, t)
-	runValidateSigstrTest("TERM", false, true, 0xf, false, t)
-	runValidateSigstrTest("SIGTERM", false, true, 0xf, false, t)
+	runValidateSigstrTest("15", false, true, 0, false, t)
+	runValidateSigstrTest("TERM", false, true, 0, false, t)
+	runValidateSigstrTest("SIGTERM", false, true, 0, false, t)
 }
 
 func TestValidateSigstrDefaultLCOWInvalid(t *testing.T) {
@@ -43,12 +43,16 @@ func TestValidateSigstrDefaultLCOWInvalid(t *testing.T) {
 }
 
 func TestValidateSigstrDefaultWCOW(t *testing.T) {
-	runValidateSigstrTest("0", false, false, 0x0, false, t)
-	runValidateSigstrTest("CTRLC", false, false, 0x0, false, t)
+	runValidateSigstrTest("15", false, false, 0, false, t)
+	runValidateSigstrTest("TERM", false, false, 0, false, t)
+	runValidateSigstrTest("0", false, false, 0, false, t)
+	runValidateSigstrTest("CTRLC", false, false, 0, false, t)
+	runValidateSigstrTest("9", false, false, 0, false, t)
+	runValidateSigstrTest("KILL", false, false, 0, false, t)
 }
 
 func TestValidateSigstrDefaultWCOWInvalid(t *testing.T) {
-	runValidateSigstrTest("15", false, false, 0, true, t)
+	runValidateSigstrTest("2", false, false, 0, true, t)
 	runValidateSigstrTest("test", false, false, 0, true, t)
 }
 

--- a/cmd/runhcs/signalmap.go
+++ b/cmd/runhcs/signalmap.go
@@ -43,4 +43,6 @@ var signalMapWindows = map[string]int{
 	"CTRLCLOSE":    0x2,
 	"CTRLLOGOFF":   0x5,
 	"CTRLSHUTDOWN": 0x6,
+	"TERM":         0x0, // Docker sends the UNIX signal. Convert to CTRLC
+	"KILL":         0x6, // Docker sends the UNIX signal. Convert to CTRLSHUTDOWN
 }


### PR DESCRIPTION
The Docker SignalMap for Windows passes the UNIX scheme so TERM and KILL. We
will no longer fail on Windows if a signal query comes in we simply convert it
to the correct Windows signal.

TERM = CTRLC
KILL = CTRLSHUTDOWN

Signed-off-by: Justin Terry (VM) <juterry@microsoft.com>