### PR TITLE
expose IsOperationAccessIsDenied, IsOperationInvalidState error checks

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -230,6 +230,20 @@ func IsNotSupported(err error) bool {
 	return hcs.IsNotSupported(getInnerError(err))
 }
 
+// On RS1, RS2 builds GetContainers may fail with access denied error
+// when there is race condition, you can have retry loop in order
+// to resolve this problem
+func IsOperationAccessIsDenied(err error) bool {
+	return hcs.IsOperationAccessIsDenied(getInnerError(err))
+}
+
+// On RS1, RS2 build GetContainers may fail with invalid state error
+// when there is race condition, you can have retry loop in order
+// to resolve this problem
+func IsOperationInvalidState(err error) bool {
+	return hcs.IsOperationInvalidState(getInnerError(err))
+}
+
 func getInnerError(err error) error {
 	switch pe := err.(type) {
 	case nil:

--- a/internal/hcs/errors.go
+++ b/internal/hcs/errors.go
@@ -272,6 +272,22 @@ func IsNotSupported(err error) bool {
 		err == ErrVmcomputeUnknownMessage
 }
 
+// On RS1, RS2 builds GetContainers may fail with access denied error
+// when there is race condition, you can have retry loop in order
+// to resolve this problem
+func IsOperationAccessIsDenied(err error) bool {
+	err = getInnerError(err)
+	return err == ErrVmcomputeOperationAccessIsDenied
+}
+
+// On RS1, RS2 build GetContainers may fail with invalid state error
+// when there is race condition, you can have retry loop in order
+// to resolve this problem
+func IsOperationInvalidState(err error) bool {
+	err = getInnerError(err)
+	return err == ErrVmcomputeOperationInvalidState
+}
+
 func getInnerError(err error) error {
 	switch pe := err.(type) {
 	case nil:


### PR DESCRIPTION
on RS1, RS2 builds call to GetContainers may fail with 'access denied' or
'invalid state' errors. You may want to have retry loop to resolve this
issue. But there should be a way to check if returned error is one of these
types. This commit exposes IsOperationAccessIsDenied and IsOperationInvalidState
for these cases.
one use case may be found here: https://github.com/moby/moby/blob/5ec31380a5d3ea92fc68e53cd1fc96f11ac02e6e/daemon/graphdriver/windows/windows.go#L276
