### PR TITLE
Fix bug in Plan9 case sensitivity

### DIFF
--- a/internal/uvm/plan9.go
+++ b/internal/uvm/plan9.go
@@ -35,7 +35,10 @@ func (uvm *UtilityVM) AddPlan9(hostPath string, uvmPath string, readOnly bool) e
 		shareFlagsCaseSensitive int32 = 0x00000008
 	)
 
-	flags := shareFlagsLinuxMetadata | shareFlagsCaseSensitive
+	// TODO: JTERRY75 - `shareFlagsCaseSensitive` only works if the Windows
+	// `hostPath` supports case sensitivity. We need to detect this case before
+	// forwarding this flag in all cases.
+	flags := shareFlagsLinuxMetadata // | shareFlagsCaseSensitive
 	if readOnly {
 		flags |= shareFlagsReadOnly
 	}


### PR DESCRIPTION
Case sensitivity can only be set on a Plan9 share in the guest if the
source Windows directory supports it. Until we have this detection logic
make all shares case insensitive.

Signed-off-by: Justin Terry (VM) <juterry@microsoft.com>