### PR TITLE
internal/safeopen: fix strings.Contains args order

### DIFF
--- a/internal/safefile/safeopen.go
+++ b/internal/safefile/safeopen.go
@@ -87,7 +87,7 @@ func OpenRoot(path string) (*os.File, error) {
 
 func ntRelativePath(path string) ([]uint16, error) {
 	path = filepath.Clean(path)
-	if strings.Contains(":", path) {
+	if strings.Contains(path, ":") {
 		// Since alternate data streams must follow the file they
 		// are attached to, finding one here (out of order) is invalid.
 		return nil, errors.New("path contains invalid character `:`")


### PR DESCRIPTION
The following (old) code:

    strings.Contains(":", path)

Only returns true if path is ":" or an empty string.
This is not what was intended.
The proper ":" check is:

    strings.Contains(path, ":")

Found by using new go-critic linter check.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>