### PR TITLE
Avoid panic in waitForNotification

### DIFF
--- a/internal/hcs/waithelper.go
+++ b/internal/hcs/waithelper.go
@@ -17,6 +17,11 @@ func processAsyncHcsResult(err error, resultp *uint16, callbackNumber uintptr, e
 
 func waitForNotification(callbackNumber uintptr, expectedNotification hcsNotification, timeout *time.Duration) error {
 	callbackMapLock.RLock()
+	if _, ok := callbackMap[callbackNumber]; !ok {
+		callbackMapLock.RUnlock()
+		logrus.Errorf("failed to waitForNotification: callbackNumber %d does not exist in callbackMap", callbackNumber)
+		return ErrHandleClose
+	}
 	channels := callbackMap[callbackNumber].channels
 	callbackMapLock.RUnlock()
 


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

Still trying to figure out the underlying cause of this, but this avoid a panic if `waitForNotification` is called with a callbackNumber which isn't in the callbackMap.

```
00:50:25.309 goroutine 26874 [running]:
00:50:25.311 github.com/docker/docker/vendor/github.com/Microsoft/hcsshim/internal/hcs.waitForNotification(0x433, 0x10000, 0x0, 0x0, 0x0)
00:50:25.311 	c:/go/src/github.com/docker/docker/vendor/github.com/Microsoft/hcsshim/internal/hcs/waithelper.go:20 +0x85
00:50:25.311 github.com/docker/docker/vendor/github.com/Microsoft/hcsshim/internal/hcs.(*Process).Wait(0xc0000c1db0, 0x0, 0x0)
00:50:25.313 	c:/go/src/github.com/docker/docker/vendor/github.com/Microsoft/hcsshim/internal/hcs/process.go:172 +0xc1
00:50:25.313 github.com/docker/docker/vendor/github.com/Microsoft/hcsshim.(*process).Wait(0xc000908790, 0x0, 0xc000bf8aa0)
00:50:25.313 	c:/go/src/github.com/docker/docker/vendor/github.com/Microsoft/hcsshim/process.go:27 +0x39
00:50:25.315 github.com/docker/docker/libcontainerd/local.(*client).Start.func1.1(0x20c3e60, 0xc000908790, 0xc0008f31d0)
00:50:25.315 	c:/go/src/github.com/docker/docker/libcontainerd/local/local_windows.go:705 +0x3c
00:50:25.315 created by github.com/docker/docker/libcontainerd/local.(*client).Start.func1
00:50:25.317 	c:/go/src/github.com/docker/docker/libcontainerd/local/local_windows.go:704 +0x8f
00:50:25.317 ----------- END DAEMON LOG --------
```