### PR TITLE
Fixes a bug in Xenon activation on RS1-RS4 hosts

### DIFF
--- a/cmd/containerd-shim-runhcs-v1/pod.go
+++ b/cmd/containerd-shim-runhcs-v1/pod.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/Microsoft/hcsshim/internal/oci"
 	"github.com/Microsoft/hcsshim/internal/uvm"
+	"github.com/Microsoft/hcsshim/osversion"
 	eventstypes "github.com/containerd/containerd/api/events"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/runtime"
@@ -55,6 +56,10 @@ func createPod(ctx context.Context, events publisher, req *task.CreateTaskReques
 	logrus.WithFields(logrus.Fields{
 		"tid": req.ID,
 	}).Debug("createPod")
+
+	if osversion.Get().Build < osversion.RS5 {
+		return nil, errors.Wrapf(errdefs.ErrFailedPrecondition, "pod support is not available on Windows versions previous to RS5 (%d)", osversion.RS5)
+	}
 
 	ct, sid, err := oci.GetSandboxTypeAndID(s.Annotations)
 	if err != nil {

--- a/cmd/containerd-shim-runhcs-v1/task_hcs.go
+++ b/cmd/containerd-shim-runhcs-v1/task_hcs.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Microsoft/hcsshim/internal/hcsoci"
 	"github.com/Microsoft/hcsshim/internal/oci"
 	"github.com/Microsoft/hcsshim/internal/uvm"
+	"github.com/Microsoft/hcsshim/osversion"
 	eventstypes "github.com/containerd/containerd/api/events"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/runtime"
@@ -45,7 +46,7 @@ func newHcsStandaloneTask(ctx context.Context, events publisher, req *task.Creat
 	}
 
 	var parent *uvm.UtilityVM
-	if oci.IsIsolated(s) {
+	if osversion.Get().Build >= osversion.RS5 && oci.IsIsolated(s) {
 		// Create the UVM parent
 		opts, err := oci.SpecToUVMCreateOpts(s, fmt.Sprintf("%s@vm", req.ID), owner)
 		if err != nil {
@@ -223,6 +224,9 @@ type hcsTask struct {
 	ownsHost bool
 	// host is the hosting VM for this exec if hypervisor isolated. If
 	// `host==nil` this is an Argon task so no UVM cleanup is required.
+	//
+	// NOTE: if `osversion.Get().Build < osversion.RS5` this will always be
+	// `nil`.
 	host *uvm.UtilityVM
 
 	// ecl is the exec create lock for all non-init execs and MUST be held


### PR DESCRIPTION
For RS1-RS4 hosts the utility VM was not managed directly but the OCI spec
still used the presence of the HyperV section to determine the isolation level.
This change will only craete the Utility VM if the Host OS is >= RS5.

Signed-off-by: Justin Terry (VM) <juterry@microsoft.com>