### PR TITLE
Setup stackdump correctly; add debugger event

### DIFF
--- a/cmd/containerd-shim-runhcs-v1/main.go
+++ b/cmd/containerd-shim-runhcs-v1/main.go
@@ -106,6 +106,9 @@ func main() {
 		return nil
 	}
 
+	// Setup the event for stack dump
+	setupDumpStacks()
+
 	if err := app.Run(os.Args); err != nil {
 		fmt.Fprintln(cli.ErrWriter, err)
 		os.Exit(1)

--- a/cmd/containerd-shim-runhcs-v1/service_internal.go
+++ b/cmd/containerd-shim-runhcs-v1/service_internal.go
@@ -69,6 +69,8 @@ func (s *service) stateInternal(ctx context.Context, req *task.StateRequest) (*t
 }
 
 func (s *service) createInternal(ctx context.Context, req *task.CreateTaskRequest) (*task.CreateTaskResponse, error) {
+	setupDebuggerEvent()
+
 	var shimOpts *runhcsopts.Options
 	if req.Options != nil {
 		v, err := typeurl.UnmarshalAny(req.Options)


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

Doing a blanket update of the event name for consistency across docker, containerd, containerd-shim-runhcs-v1 and docker-signal to make life a lot easier and less typing.

 - We weren't previously ever setting up the dump stack event 😲 
 - Adds a debugger wait event triggered during create

(https://github.com/moby/moby/pull/38741 for the related moby change.)


@jterry75 PTAL