### PR TITLE
Fix bugs in provisioning NetNS on UVM

### DIFF
--- a/internal/hcsoci/network.go
+++ b/internal/hcsoci/network.go
@@ -24,7 +24,15 @@ func createNetworkNamespace(coi *createOptionsInternal, resources *Resources) er
 	return nil
 }
 
-func getNamespaceEndpoints(netNS string) ([]*hns.HNSEndpoint, error) {
+// GetNamespaceEndpoints gets all endpoints in `netNS`
+func GetNamespaceEndpoints(netNS string) ([]*hns.HNSEndpoint, error) {
+	op := "hcsoci::GetNamespaceEndpoints"
+	log := logrus.WithField("netns-id", netNS)
+	log.Debug(op + " - Begin")
+	defer func() {
+		log.Debug(op + " - End")
+	}()
+
 	ids, err := hns.GetNamespaceEndpoints(netNS)
 	if err != nil {
 		return nil, err

--- a/internal/hcsoci/resources.go
+++ b/internal/hcsoci/resources.go
@@ -59,8 +59,7 @@ type Resources struct {
 // TODO: Method on the resources?
 func ReleaseResources(r *Resources, vm *uvm.UtilityVM, all bool) error {
 	if vm != nil && r.addedNetNSToVM {
-		err := vm.RemoveNetNS(r.netNS)
-		if err != nil {
+		if err := vm.RemoveNetNS(r.netNS); err != nil {
 			logrus.Warn(err)
 		}
 		r.addedNetNSToVM = false

--- a/internal/uvm/network.go
+++ b/internal/uvm/network.go
@@ -1,86 +1,54 @@
 package uvm
 
 import (
-	"fmt"
+	"errors"
 	"path"
+
+	"github.com/sirupsen/logrus"
 
 	"github.com/Microsoft/hcsshim/hcn"
 	"github.com/Microsoft/hcsshim/internal/guestrequest"
 	"github.com/Microsoft/hcsshim/internal/guid"
 	"github.com/Microsoft/hcsshim/internal/hns"
+	"github.com/Microsoft/hcsshim/internal/logfields"
 	"github.com/Microsoft/hcsshim/internal/requesttype"
 	"github.com/Microsoft/hcsshim/internal/schema1"
 	"github.com/Microsoft/hcsshim/internal/schema2"
 	"github.com/Microsoft/hcsshim/osversion"
-	"github.com/sirupsen/logrus"
 )
 
-// AddNetNS adds network namespace inside the guest & adds endpoints to the guest on that namepace
-func (uvm *UtilityVM) AddNetNS(id string, endpoints []*hns.HNSEndpoint) (err error) {
+var (
+	// ErrNetNSAlreadyAttached is an error indicating the guest UVM already has
+	// an endpoint by this id.
+	ErrNetNSAlreadyAttached = errors.New("network namespace already added")
+	// ErrNetNSNotFound is an error indicating the guest UVM does not have a
+	// network namespace by this id.
+	ErrNetNSNotFound = errors.New("network namespace not found")
+)
+
+// AddNetNS adds network namespace inside the guest.
+//
+// If a namespace with `id` already exists returns `ErrNetNSAlreadyAttached`.
+func (uvm *UtilityVM) AddNetNS(id string) error {
+	op := "uvm::AddNetNS"
+	log := logrus.WithFields(logrus.Fields{
+		logfields.UVMID: uvm.id,
+		"netns-id":      id,
+	})
+	log.Debug(op + " - Begin")
+	defer func() {
+		log.Debug(op + " - End")
+	}()
+
 	uvm.m.Lock()
 	defer uvm.m.Unlock()
-	ns := uvm.namespaces[id]
-	if ns == nil {
-		ns = &namespaceInfo{}
-
-		if uvm.isNetworkNamespaceSupported() {
-			// Add a Guest Network namespace. On LCOW we add the adapters
-			// dynamically.
-			if uvm.operatingSystem == "windows" {
-				hcnNamespace, err := hcn.GetNamespaceByID(id)
-				if err != nil {
-					return err
-				}
-				guestNamespace := hcsschema.ModifySettingRequest{
-					GuestRequest: guestrequest.GuestRequest{
-						ResourceType: guestrequest.ResourceTypeNetworkNamespace,
-						RequestType:  requesttype.Add,
-						Settings:     hcnNamespace,
-					},
-				}
-				if err := uvm.Modify(&guestNamespace); err != nil {
-					return err
-				}
-			}
-		}
-
-		defer func() {
-			if err != nil {
-				if e := uvm.removeNamespaceNICs(ns); e != nil {
-					logrus.Warnf("failed to undo NIC add: %v", e)
-				}
-			}
-		}()
-		for _, endpoint := range endpoints {
-			nicID := guid.New()
-			err = uvm.addNIC(nicID, endpoint)
-			if err != nil {
-				return err
-			}
-			ns.nics = append(ns.nics, nicInfo{nicID, endpoint})
-		}
-		if uvm.namespaces == nil {
-			uvm.namespaces = make(map[string]*namespaceInfo)
-		}
-		uvm.namespaces[id] = ns
-	}
-	ns.refCount++
-	return nil
-}
-
-//RemoveNetNS removes the namespace information
-func (uvm *UtilityVM) RemoveNetNS(id string) error {
-	uvm.m.Lock()
-	defer uvm.m.Unlock()
-	ns := uvm.namespaces[id]
-	if ns == nil || ns.refCount <= 0 {
-		panic(fmt.Errorf("removed a namespace that was not added: %s", id))
+	if _, ok := uvm.namespaces[id]; ok {
+		return ErrNetNSAlreadyAttached
 	}
 
-	ns.refCount--
-
-	// Remove the Guest Network namespace
 	if uvm.isNetworkNamespaceSupported() {
+		// Add a Guest Network namespace. On LCOW we add the adapters
+		// dynamically.
 		if uvm.operatingSystem == "windows" {
 			hcnNamespace, err := hcn.GetNamespaceByID(id)
 			if err != nil {
@@ -89,7 +57,7 @@ func (uvm *UtilityVM) RemoveNetNS(id string) error {
 			guestNamespace := hcsschema.ModifySettingRequest{
 				GuestRequest: guestrequest.GuestRequest{
 					ResourceType: guestrequest.ResourceTypeNetworkNamespace,
-					RequestType:  requesttype.Remove,
+					RequestType:  requesttype.Add,
 					Settings:     hcnNamespace,
 				},
 			}
@@ -99,13 +67,135 @@ func (uvm *UtilityVM) RemoveNetNS(id string) error {
 		}
 	}
 
-	var err error
-	if ns.refCount == 0 {
-		err = uvm.removeNamespaceNICs(ns)
-		delete(uvm.namespaces, id)
+	if uvm.namespaces == nil {
+		uvm.namespaces = make(map[string]*namespaceInfo)
+	}
+	uvm.namespaces[id] = &namespaceInfo{
+		nics: make(map[string]*nicInfo),
+	}
+	return nil
+}
+
+// AddEndpointsToNS adds all unique `endpoints` to the network namespace
+// matching `id`. On failure does not roll back any previously successfully
+// added endpoints.
+//
+// If no network namespace matches `id` returns `ErrNetNSNotFound`.
+func (uvm *UtilityVM) AddEndpointsToNS(id string, endpoints []*hns.HNSEndpoint) error {
+	op := "uvm::AddEndpointsToNS"
+	log := logrus.WithFields(logrus.Fields{
+		logfields.UVMID: uvm.id,
+		"netns-id":      id,
+	})
+	log.Debug(op + " - Begin")
+	defer func() {
+		log.Debug(op + " - End")
+	}()
+
+	uvm.m.Lock()
+	defer uvm.m.Unlock()
+
+	ns, ok := uvm.namespaces[id]
+	if !ok {
+		return ErrNetNSNotFound
 	}
 
-	return err
+	for _, endpoint := range endpoints {
+		if _, ok := ns.nics[endpoint.Id]; !ok {
+			nicID := guid.New()
+			if err := uvm.addNIC(nicID, endpoint); err != nil {
+				return err
+			}
+			ns.nics[endpoint.Id] = &nicInfo{
+				ID:       nicID,
+				Endpoint: endpoint,
+			}
+		}
+	}
+	return nil
+}
+
+// RemoveNetNS removes the namespace from the uvm and all remaining endpoints in
+// the namespace.
+//
+// If a namespace matching `id` is not found this command silently succeeds.
+func (uvm *UtilityVM) RemoveNetNS(id string) error {
+	op := "uvm::RemoveNetNS"
+	log := logrus.WithFields(logrus.Fields{
+		logfields.UVMID: uvm.id,
+		"netns-id":      id,
+	})
+	log.Debug(op + " - Begin")
+	defer func() {
+		log.Debug(op + " - End")
+	}()
+
+	uvm.m.Lock()
+	defer uvm.m.Unlock()
+	if ns, ok := uvm.namespaces[id]; ok {
+		for _, ninfo := range ns.nics {
+			if err := uvm.removeNIC(ninfo.ID, ninfo.Endpoint); err != nil {
+				return err
+			}
+			ns.nics[ninfo.Endpoint.Id] = nil
+		}
+		// Remove the Guest Network namespace
+		if uvm.isNetworkNamespaceSupported() {
+			if uvm.operatingSystem == "windows" {
+				hcnNamespace, err := hcn.GetNamespaceByID(id)
+				if err != nil {
+					return err
+				}
+				guestNamespace := hcsschema.ModifySettingRequest{
+					GuestRequest: guestrequest.GuestRequest{
+						ResourceType: guestrequest.ResourceTypeNetworkNamespace,
+						RequestType:  requesttype.Remove,
+						Settings:     hcnNamespace,
+					},
+				}
+				if err := uvm.Modify(&guestNamespace); err != nil {
+					return err
+				}
+			}
+		}
+		delete(uvm.namespaces, id)
+	}
+	return nil
+}
+
+// RemoveEndpointsFromNS removes all matching `endpoints` in the network
+// namespace matching `id`. If no endpoint matching `endpoint.Id` is found in
+// the network namespace this command silently succeeds.
+//
+// If no network namespace matches `id` returns `ErrNetNSNotFound`.
+func (uvm *UtilityVM) RemoveEndpointsFromNS(id string, endpoints []*hns.HNSEndpoint) error {
+	op := "uvm::RemoveEndpointsFromNS"
+	log := logrus.WithFields(logrus.Fields{
+		logfields.UVMID: uvm.id,
+		"netns-id":      id,
+	})
+	log.Debug(op + " - Begin")
+	defer func() {
+		log.Debug(op + " - End")
+	}()
+
+	uvm.m.Lock()
+	defer uvm.m.Unlock()
+
+	ns, ok := uvm.namespaces[id]
+	if !ok {
+		return ErrNetNSNotFound
+	}
+
+	for _, endpoint := range endpoints {
+		if ninfo, ok := ns.nics[endpoint.Id]; ok && ninfo != nil {
+			if err := uvm.removeNIC(ninfo.ID, ninfo.Endpoint); err != nil {
+				return err
+			}
+			delete(ns.nics, endpoint.Id)
+		}
+	}
+	return nil
 }
 
 // IsNetworkNamespaceSupported returns bool value specifying if network namespace is supported inside the guest
@@ -116,18 +206,6 @@ func (uvm *UtilityVM) isNetworkNamespaceSupported() bool {
 	}
 
 	return false
-}
-
-func (uvm *UtilityVM) removeNamespaceNICs(ns *namespaceInfo) error {
-	for len(ns.nics) != 0 {
-		nic := ns.nics[len(ns.nics)-1]
-		err := uvm.removeNIC(nic.ID, nic.Endpoint)
-		if err != nil {
-			return err
-		}
-		ns.nics = ns.nics[:len(ns.nics)-1]
-	}
-	return nil
 }
 
 func getNetworkModifyRequest(adapterID string, requestType string, settings interface{}) interface{} {

--- a/internal/uvm/types.go
+++ b/internal/uvm/types.go
@@ -52,8 +52,7 @@ type nicInfo struct {
 }
 
 type namespaceInfo struct {
-	nics     []nicInfo
-	refCount int
+	nics map[string]*nicInfo
 }
 
 // UtilityVM is the object used by clients representing a utility VM


### PR DESCRIPTION
1. We should only run the cleanup logic for a standalone or sandbox container
with networking but not for individual workload containers.

2. We now provision the guest NetNS in the UVM for WCOW as a seperate step since
we don't actually provision the container in the guest.

Signed-off-by: Justin Terry (VM) <juterry@microsoft.com>