### PR TITLE
Simplify the hcstask/exec exit state transitions.

### DIFF
--- a/cmd/containerd-shim-runhcs-v1/exec.go
+++ b/cmd/containerd-shim-runhcs-v1/exec.go
@@ -73,6 +73,14 @@ type shimExec interface {
 	// process is already in the `State() == shimExecStateExited` state, `Wait`
 	// MUST return immediately with the original exit state.
 	Wait(ctx context.Context) *task.StateResponse
+	// ForceExit forcibly terminates the exec, sets the exit status to `status`,
+	// and unblocks all waiters.
+	//
+	// This call is idempotent and safe to call even on an already exited exec
+	// in which case it does nothing.
+	//
+	// `ForceExit` is safe to call in any `State()`.
+	ForceExit(status int)
 }
 
 func newExecInvalidStateError(tid, eid string, state shimExecState, op string) error {

--- a/cmd/containerd-shim-runhcs-v1/exec_test.go
+++ b/cmd/containerd-shim-runhcs-v1/exec_test.go
@@ -67,3 +67,10 @@ func (tse *testShimExec) CloseIO(ctx context.Context, stdin bool) error {
 func (tse *testShimExec) Wait(ctx context.Context) *task.StateResponse {
 	return tse.Status()
 }
+func (tse *testShimExec) ForceExit(status int) {
+	if tse.state != shimExecStateExited {
+		tse.state = shimExecStateExited
+		tse.status = 1
+		tse.at = time.Now()
+	}
+}

--- a/cmd/containerd-shim-runhcs-v1/exec_wcow_podsandbox_test.go
+++ b/cmd/containerd-shim-runhcs-v1/exec_wcow_podsandbox_test.go
@@ -47,7 +47,11 @@ func verifyWcowPodSandboxExecStatus(t *testing.T, wasStarted bool, es containerd
 	case containerd_v1_types.StatusCreated, containerd_v1_types.StatusRunning:
 		expectedExitStatus = 255
 	case containerd_v1_types.StatusStopped:
-		expectedExitStatus = 0
+		if !wasStarted {
+			expectedExitStatus = 1
+		} else {
+			expectedExitStatus = 0
+		}
 	}
 	if status.ExitStatus != expectedExitStatus {
 		t.Fatalf("expected exitstatus: '%d' got: '%d'", expectedExitStatus, status.ExitStatus)

--- a/cmd/containerd-shim-runhcs-v1/task_wcow_podsandbox.go
+++ b/cmd/containerd-shim-runhcs-v1/task_wcow_podsandbox.go
@@ -38,7 +38,8 @@ func newWcowPodSandboxTask(ctx context.Context, events publisher, id, bundle str
 			// The UVM came down. Force transition the init task (if it wasn't
 			// already) to unblock any waiters since the platform wont send any
 			// events for this fake process.
-			wpst.init.Kill(context.Background(), 0x0)
+			wpst.init.ForceExit(1)
+			parent.Close()
 		}()
 	}
 	return wpst

--- a/internal/hcs/process.go
+++ b/internal/hcs/process.go
@@ -276,15 +276,20 @@ func (process *Process) ExitCode() (_ int, err error) {
 
 	properties, err := process.Properties()
 	if err != nil {
-		return 0, makeProcessError(process, operation, err, nil)
+		return -1, makeProcessError(process, operation, err, nil)
 	}
 
 	if properties.Exited == false {
-		return 0, makeProcessError(process, operation, ErrInvalidProcessState, nil)
+		return -1, makeProcessError(process, operation, ErrInvalidProcessState, nil)
 	}
 
 	if properties.LastWaitResult != 0 {
-		return 0, makeProcessError(process, operation, syscall.Errno(properties.LastWaitResult), nil)
+		logrus.WithFields(logrus.Fields{
+			logfields.ContainerID: process.SystemID(),
+			logfields.ProcessID:   process.processID,
+			"wait-result":         properties.LastWaitResult,
+		}).Warn("hcsshim::Process::ExitCode - Non-zero lat wait result")
+		return -1, nil
 	}
 
 	return int(properties.ExitCode), nil


### PR DESCRIPTION
There are some very subtile ways in which the code could fail to event the
exit and cause an upstream listener to continue to think the shim is still
running even though the task had indeed exited.

Signed-off-by: Justin Terry (VM) <juterry@microsoft.com>