### PR TITLE
Fix bug in runhcs shim with tty=true on close

### DIFF
--- a/cmd/containerd-shim-runhcs-v1/exec_hcs.go
+++ b/cmd/containerd-shim-runhcs-v1/exec_hcs.go
@@ -265,13 +265,15 @@ func (he *hcsExec) Start(ctx context.Context) (err error) {
 	}
 
 	if he.io.StdinPath() != "" {
-		he.ioWg.Add(1)
 		go func() {
 			io.Copy(in, he.io.Stdin())
+			logrus.WithFields(logrus.Fields{
+				"tid": he.tid,
+				"eid": he.id,
+			}).Debug("hcsExec::Start::Stdin - Copy completed")
 			in.Close()
 			he.p.CloseStdin()
 			he.io.CloseStdin()
-			he.ioWg.Done()
 		}()
 	}
 
@@ -279,6 +281,10 @@ func (he *hcsExec) Start(ctx context.Context) (err error) {
 		he.ioWg.Add(1)
 		go func() {
 			io.Copy(he.io.Stdout(), out)
+			logrus.WithFields(logrus.Fields{
+				"tid": he.tid,
+				"eid": he.id,
+			}).Debug("hcsExec::Start::Stdout - Copy completed")
 			out.Close()
 			he.ioWg.Done()
 		}()
@@ -288,6 +294,10 @@ func (he *hcsExec) Start(ctx context.Context) (err error) {
 		he.ioWg.Add(1)
 		go func() {
 			io.Copy(he.io.Stderr(), serr)
+			logrus.WithFields(logrus.Fields{
+				"tid": he.tid,
+				"eid": he.id,
+			}).Debug("hcsExec::Start::Stderr - Copy completed")
 			serr.Close()
 			he.ioWg.Done()
 		}()


### PR DESCRIPTION
On close in the case of a tty the caller does not know the close is taking
place and does not have the ability to unblock the upstream pipes. Since the
caller might not be issuing any stdin even though we close the hcs side of the
pipe there is nothing that alerts go to unblock the io.Copy.

This fix stops waiting for Stdin to finish the io.Copy on hcs process exit.

Signed-off-by: Justin Terry (VM) <juterry@microsoft.com>