### PR TITLE
Revert removal of WCOW pause container activation

### DIFF
--- a/internal/signals/signal.go
+++ b/internal/signals/signal.go
@@ -12,6 +12,11 @@ var (
 	ErrInvalidSignal = errors.New("invalid signal value")
 )
 
+// ShouldKill returns `true` if `signal` should terminate the process.
+func ShouldKill(signal uint32) bool {
+	return signal == sigKill || signal == sigTerm
+}
+
 // ValidateSigstr validates that `sigstr` is an acceptable signal for WCOW/LCOW
 // based on `signalsSupported`.
 //


### PR DESCRIPTION
As it turns out on RS5 a Windows Process Isolated container actually
does open the network compartment at the activation of the first
container. So we cannot skip creating the pause container when creating
the pod. This is not true for Windows Hypervisor Isolated which is held
open via the GNS.

Signed-off-by: Justin Terry (VM) <juterry@microsoft.com>