### PR TITLE
Fix NetworkNotFoundError and EndpointNotFoundError message strings

### DIFF
--- a/hcn/hcnerrors.go
+++ b/hcn/hcnerrors.go
@@ -41,10 +41,10 @@ type NetworkNotFoundError struct {
 }
 
 func (e NetworkNotFoundError) Error() string {
-	if e.NetworkName == "" {
-		return fmt.Sprintf("Network Name %s not found", e.NetworkName)
+	if e.NetworkName != "" {
+		return fmt.Sprintf("Network name %q not found", e.NetworkName)
 	}
-	return fmt.Sprintf("Network Id %s not found", e.NetworkID)
+	return fmt.Sprintf("Network ID %q not found", e.NetworkID)
 }
 
 // EndpointNotFoundError results from a failed seach for an endpoint by Id or Name
@@ -54,10 +54,10 @@ type EndpointNotFoundError struct {
 }
 
 func (e EndpointNotFoundError) Error() string {
-	if e.EndpointName == "" {
-		return fmt.Sprintf("Endpoint Name %s not found", e.EndpointName)
+	if e.EndpointName != "" {
+		return fmt.Sprintf("Endpoint name %q not found", e.EndpointName)
 	}
-	return fmt.Sprintf("Endpoint Id %s not found", e.EndpointID)
+	return fmt.Sprintf("Endpoint ID %q not found", e.EndpointID)
 }
 
 // NamespaceNotFoundError results from a failed seach for a namsepace by Id

--- a/hcn/hcnerrors_test.go
+++ b/hcn/hcnerrors_test.go
@@ -12,10 +12,13 @@ func TestMissingNetworkByName(t *testing.T) {
 		t.Fatal("Error was not thrown.")
 	}
 	if !IsNotFoundError(err) {
-		t.Fatal("Unrelated error was thrown.")
+		t.Fatal("Unrelated error was thrown.", err)
 	}
 	if _, ok := err.(NetworkNotFoundError); !ok {
-		t.Fatal("Wrong error type was thrown.")
+		t.Fatal("Wrong error type was thrown.", err)
+	}
+	if err.Error() != `Network name "Not found name" not found` {
+		t.Fatal("Wrong error message was returned", err.Error())
 	}
 }
 
@@ -23,12 +26,15 @@ func TestMissingNetworkById(t *testing.T) {
 	// Random guid
 	_, err := GetNetworkByID("5f0b1190-63be-4e0c-b974-bd0f55675a42")
 	if err == nil {
-		t.Fatal("Unrelated error was thrown.")
+		t.Fatal("Unrelated error was thrown.", err)
 	}
 	if !IsNotFoundError(err) {
-		t.Fatal("Unrelated error was thrown.")
+		t.Fatal("Unrelated error was thrown.", err)
 	}
 	if _, ok := err.(NetworkNotFoundError); !ok {
-		t.Fatal("Wrong error type was thrown.")
+		t.Fatal("Wrong error type was thrown.", err)
+	}
+	if err.Error() != `Network ID "5f0b1190-63be-4e0c-b974-bd0f55675a42" not found` {
+		t.Fatal("Wrong error message was returned", err.Error())
 	}
 }


### PR DESCRIPTION
It looks like it had its logic backwards. Added some test coverage and tried to make the test failures more helpful as well