### PR TITLE
Fix bug where we error on network creation if no subnet was provided

### DIFF
--- a/hcn/hcnnetwork.go
+++ b/hcn/hcnnetwork.go
@@ -320,23 +320,23 @@ func GetNetworkByName(networkName string) (*HostComputeNetwork, error) {
 // Create Network.
 func (network *HostComputeNetwork) Create() (*HostComputeNetwork, error) {
 	logrus.Debugf("hcn::HostComputeNetwork::Create id=%s", network.Id)
-	hasDefault := false
 	for _, ipam := range network.Ipams {
 		for _, subnet := range ipam.Subnets {
 			if subnet.IpAddressPrefix != "" {
+				hasDefault := false
 				for _, route := range subnet.Routes {
 					if route.NextHop == "" {
 						return nil, errors.New("network create error, subnet has address prefix but no gateway specified")
 					}
-					if route.DestinationPrefix == "0.0.0.0/0" {
+					if route.DestinationPrefix == "0.0.0.0/0" || route.DestinationPrefix == "::/0" {
 						hasDefault = true
 					}
 				}
+				if !hasDefault {
+					return nil, errors.New("network create error, no default gateway")
+				}
 			}
 		}
-	}
-	if !hasDefault {
-		return nil, errors.New("network create error, no default gateway")
 	}
 
 	jsonString, err := json.Marshal(network)

--- a/hcn/hcnnetwork_test.go
+++ b/hcn/hcnnetwork_test.go
@@ -4,14 +4,41 @@ package hcn
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"testing"
 )
 
-func TestCreateDeleteNetwork(t *testing.T) {
-	network, err := HcnCreateTestNATNetwork()
+type HcnNetworkMakerFunc func() (*HostComputeNetwork, error)
+
+func TestCreateDeleteNetworks(t *testing.T) {
+	var netMaker HcnNetworkMakerFunc
+	netMaker = HcnCreateTestNATNetwork
+	err := CreateDeleteNetworksHelper(t, netMaker)
 	if err != nil {
 		t.Fatal(err)
+	}
+	err = CreateDeleteNetworksHelper(t, func() (*HostComputeNetwork, error) { return HcnCreateTestNATNetworkWithSubnet(nil) })
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	snet1 := CreateSubnet("192.168.100.0/24", "192.168.100.1", "1.1.1.1/0")
+	err = CreateDeleteNetworksHelper(t, func() (*HostComputeNetwork, error) { return HcnCreateTestNATNetworkWithSubnet(snet1) })
+	if err == nil {
+		t.Fatal(errors.New("expected failure for subnet with no default gateway provided"))
+	}
+	snet2 := CreateSubnet("192.168.100.0/24", "", "")
+	err = CreateDeleteNetworksHelper(t, func() (*HostComputeNetwork, error) { return HcnCreateTestNATNetworkWithSubnet(snet2) })
+	if err == nil {
+		t.Fatal(errors.New("expected failure for subnet with no nexthop provided but a gateway provided"))
+	}
+}
+
+func CreateDeleteNetworksHelper(t *testing.T, networkFunction HcnNetworkMakerFunc) error {
+	network, err := networkFunction()
+	if err != nil {
+		return err
 	}
 	jsonString, err := json.Marshal(network)
 	if err != nil {
@@ -20,8 +47,9 @@ func TestCreateDeleteNetwork(t *testing.T) {
 	fmt.Printf("Network JSON:\n%s \n", jsonString)
 	err = network.Delete()
 	if err != nil {
-		t.Fatal(err)
+		return err
 	}
+	return nil
 }
 
 func TestGetNetworkByName(t *testing.T) {


### PR DESCRIPTION
Bad scoping - each subnet you provide must have a default gateway. If you provide no\empty subnet that is still valid in some cases.