### PR TITLE
Fix bug setting WCOW UVM processor count overrides

### DIFF
--- a/internal/uvm/create_wcow.go
+++ b/internal/uvm/create_wcow.go
@@ -140,7 +140,7 @@ func CreateWCOW(opts *OptionsWCOW) (_ *UtilityVM, err error) {
 					EnableDeferredCommit: opts.EnableDeferredCommit,
 				},
 				Processor: &hcsschema.Processor2{
-					Count: defaultProcessorCount(),
+					Count: opts.ProcessorCount,
 				},
 			},
 			GuestConnection: &hcsschema.GuestConnection{},


### PR DESCRIPTION
Signed-off-by: Justin Terry (VM) <juterry@microsoft.com>