### PR TITLE
Change HCS TaskExit ownership responsibility

### DIFF
--- a/internal/hcs/process.go
+++ b/internal/hcs/process.go
@@ -23,6 +23,9 @@ type Process struct {
 	callbackNumber uintptr
 
 	logctx logrus.Fields
+
+	waitBlock chan struct{}
+	waitError error
 }
 
 func newProcess(process hcsProcess, processID int, computeSystem *System) *Process {
@@ -34,6 +37,7 @@ func newProcess(process hcsProcess, processID int, computeSystem *System) *Proce
 			logfields.ContainerID: computeSystem.ID(),
 			logfields.ProcessID:   processID,
 		},
+		waitBlock: make(chan struct{}),
 	}
 }
 
@@ -163,33 +167,47 @@ func (process *Process) Kill() (err error) {
 	return nil
 }
 
-// Wait waits for the process to exit.
+// waitBackground waits for the process exit notification. Once received sets
+// `process.waitError` (if any) and unblocks all `Wait` and `WaitTimeout` calls.
+//
+// This MUST be called exactly once per `process.handle` but `Wait` and
+// `WaitTimeout` are safe to call multiple times.
+func (process *Process) waitBackground() {
+	process.waitError = waitForNotification(process.callbackNumber, hcsNotificationProcessExited, nil)
+	close(process.waitBlock)
+}
+
+// Wait waits for the process to exit. If the process has already exited returns
+// the pervious error (if any).
 func (process *Process) Wait() (err error) {
 	operation := "hcsshim::Process::Wait"
 	process.logOperationBegin(operation)
 	defer func() { process.logOperationEnd(operation, err) }()
 
-	err = waitForNotification(process.callbackNumber, hcsNotificationProcessExited, nil)
-	if err != nil {
+	<-process.waitBlock
+	if process.waitError != nil {
 		return makeProcessError(process, operation, err, nil)
 	}
-
 	return nil
 }
 
-// WaitTimeout waits for the process to exit or the duration to elapse. It returns
-// false if timeout occurs.
+// WaitTimeout waits for the process to exit or the duration to elapse. If the
+// process has already exited returns the pervious error (if any). If a timeout
+// occurs returns `ErrTimeout`.
 func (process *Process) WaitTimeout(timeout time.Duration) (err error) {
 	operation := "hcssshim::Process::WaitTimeout"
 	process.logOperationBegin(operation)
 	defer func() { process.logOperationEnd(operation, err) }()
 
-	err = waitForNotification(process.callbackNumber, hcsNotificationProcessExited, &timeout)
-	if err != nil {
-		return makeProcessError(process, operation, err, nil)
+	select {
+	case <-process.waitBlock:
+		if process.waitError != nil {
+			return makeProcessError(process, operation, process.waitError, nil)
+		}
+		return nil
+	case <-time.After(timeout):
+		return makeProcessError(process, operation, ErrTimeout, nil)
 	}
-
-	return nil
 }
 
 // ResizeConsole resizes the console of the process.

--- a/internal/hcs/system.go
+++ b/internal/hcs/system.go
@@ -43,6 +43,9 @@ type System struct {
 	callbackNumber uintptr
 
 	logctx logrus.Fields
+
+	waitBlock chan struct{}
+	waitError error
 }
 
 func newSystem(id string) *System {
@@ -51,6 +54,7 @@ func newSystem(id string) *System {
 		logctx: logrus.Fields{
 			logfields.ContainerID: id,
 		},
+		waitBlock: make(chan struct{}),
 	}
 }
 
@@ -121,6 +125,8 @@ func CreateComputeSystem(id string, hcsDocumentInterface interface{}) (_ *System
 		return nil, makeSystemError(computeSystem, operation, hcsDocument, err, events)
 	}
 
+	go computeSystem.waitBackground()
+
 	return computeSystem, nil
 }
 
@@ -153,6 +159,7 @@ func OpenComputeSystem(id string) (_ *System, err error) {
 	if err = computeSystem.registerCallback(); err != nil {
 		return nil, makeSystemError(computeSystem, operation, "", err, nil)
 	}
+	go computeSystem.waitBackground()
 
 	return computeSystem, nil
 }
@@ -335,48 +342,65 @@ func (computeSystem *System) Terminate() (err error) {
 	return nil
 }
 
-// Wait synchronously waits for the compute system to shutdown or terminate.
+// waitBackground waits for the compute system exit notification. Once received
+// sets `computeSystem.waitError` (if any) and unblocks all `Wait`,
+// `WaitExpectedError`, and `WaitTimeout` calls.
+//
+// This MUST be called exactly once per `computeSystem.handle` but `Wait`,
+// `WaitExpectedError`, and `WaitTimeout` are safe to call multiple times.
+func (computeSystem *System) waitBackground() {
+	computeSystem.waitError = waitForNotification(computeSystem.callbackNumber, hcsNotificationSystemExited, nil)
+	close(computeSystem.waitBlock)
+}
+
+// Wait synchronously waits for the compute system to shutdown or terminate. If
+// the compute system has already exited returns the previous error (if any).
 func (computeSystem *System) Wait() (err error) {
 	operation := "hcsshim::ComputeSystem::Wait"
 	computeSystem.logOperationBegin(operation)
 	defer func() { computeSystem.logOperationEnd(operation, err) }()
 
-	err = waitForNotification(computeSystem.callbackNumber, hcsNotificationSystemExited, nil)
-	if err != nil {
-		return makeSystemError(computeSystem, "Wait", "", err, nil)
+	<-computeSystem.waitBlock
+	if computeSystem.waitError != nil {
+		return makeSystemError(computeSystem, "Wait", "", computeSystem.waitError, nil)
 	}
 
 	return nil
 }
 
 // WaitExpectedError synchronously waits for the compute system to shutdown or
-// terminate, and ignores the passed error if it occurs.
+// terminate and returns the error (if any) as long as it does not match
+// `expected`. If the compute system has already exited returns the previous
+// error (if any) as long as it does not match `expected`.
 func (computeSystem *System) WaitExpectedError(expected error) (err error) {
 	operation := "hcsshim::ComputeSystem::WaitExpectedError"
 	computeSystem.logOperationBegin(operation)
 	defer func() { computeSystem.logOperationEnd(operation, err) }()
 
-	err = waitForNotification(computeSystem.callbackNumber, hcsNotificationSystemExited, nil)
-	if err != nil && getInnerError(err) != expected {
-		return makeSystemError(computeSystem, "WaitExpectedError", "", err, nil)
+	<-computeSystem.waitBlock
+	if computeSystem.waitError != nil && getInnerError(computeSystem.waitError) != expected {
+		return makeSystemError(computeSystem, "WaitExpectedError", "", computeSystem.waitError, nil)
 	}
-
 	return nil
 }
 
-// WaitTimeout synchronously waits for the compute system to terminate or the duration to elapse.
-// If the timeout expires, IsTimeout(err) == true
+// WaitTimeout synchronously waits for the compute system to terminate or the
+// duration to elapse. If the timeout expires, `IsTimeout(err) == true`. If
+// the compute system has already exited returns the previous error (if any).
 func (computeSystem *System) WaitTimeout(timeout time.Duration) (err error) {
 	operation := "hcsshim::ComputeSystem::WaitTimeout"
 	computeSystem.logOperationBegin(operation)
 	defer func() { computeSystem.logOperationEnd(operation, err) }()
 
-	err = waitForNotification(computeSystem.callbackNumber, hcsNotificationSystemExited, &timeout)
-	if err != nil {
-		return makeSystemError(computeSystem, "WaitTimeout", "", err, nil)
+	select {
+	case <-computeSystem.waitBlock:
+		if computeSystem.waitError != nil {
+			return makeSystemError(computeSystem, "WaitTimeout", "", computeSystem.waitError, nil)
+		}
+		return nil
+	case <-time.After(timeout):
+		return makeSystemError(computeSystem, "WaitTimeout", "", ErrTimeout, nil)
 	}
-
-	return nil
 }
 
 func (computeSystem *System) Properties(types ...schema1.PropertyType) (_ *schema1.ContainerProperties, err error) {
@@ -519,6 +543,7 @@ func (computeSystem *System) CreateProcess(c interface{}) (_ *Process, err error
 	if err = process.registerCallback(); err != nil {
 		return nil, makeSystemError(computeSystem, "CreateProcess", "", err, nil)
 	}
+	go process.waitBackground()
 
 	return process, nil
 }
@@ -557,6 +582,7 @@ func (computeSystem *System) OpenProcess(pid int) (_ *Process, err error) {
 	if err = process.registerCallback(); err != nil {
 		return nil, makeSystemError(computeSystem, "OpenProcess", "", err, nil)
 	}
+	go process.waitBackground()
 
 	return process, nil
 }


### PR DESCRIPTION
It turns out that eventing the TaskExit at the end of a process is not the
correct time on Windows. In all cases there is a container Silo seperate from
the init process and in Hypervisor isolated cases there is a parent UtilityVM.

This change makes the init process TaskExit notification only fire once the
Silo/UtilityVM are successfully torn down making sure there are no resources in
use when the TaskExit is sent.

Signed-off-by: Justin Terry (VM) <juterry@microsoft.com>