### PR TITLE
Don't nil deref on no shim options

### DIFF
--- a/cmd/containerd-shim-runhcs-v1/service_internal.go
+++ b/cmd/containerd-shim-runhcs-v1/service_internal.go
@@ -80,7 +80,7 @@ func (s *service) createInternal(ctx context.Context, req *task.CreateTaskReques
 		shimOpts = v.(*runhcsopts.Options)
 	}
 
-	if shimOpts.Debug {
+	if shimOpts != nil && shimOpts.Debug {
 		logrus.SetLevel(logrus.DebugLevel)
 	}
 

--- a/internal/oci/uvm.go
+++ b/internal/oci/uvm.go
@@ -345,7 +345,7 @@ func SpecToUVMCreateOpts(s *specs.Spec, id, owner string) (interface{}, error) {
 // UpdateSpecFromOptions sets extra annotations on the OCI spec based on the
 // `opts` struct.
 func UpdateSpecFromOptions(s specs.Spec, opts *runhcsopts.Options) specs.Spec {
-	if opts.BootFilesRootPath != "" {
+	if opts != nil && opts.BootFilesRootPath != "" {
 		s.Annotations[annotationBootFilesRootPath] = opts.BootFilesRootPath
 	}
 


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

@jterry PTAL. Looks like this is the cause of failures on https://github.com/containerd/containerd/pull/3132