### PR TITLE
Fix a bug in Wait when waiting on the init task

### DIFF
--- a/cmd/containerd-shim-runhcs-v1/exec_hcs.go
+++ b/cmd/containerd-shim-runhcs-v1/exec_hcs.go
@@ -208,6 +208,7 @@ func (he *hcsExec) Start(ctx context.Context) (err error) {
 		defer func() {
 			if err != nil {
 				he.c.Terminate()
+				he.c.Close()
 			}
 		}()
 	}

--- a/cmd/containerd-shim-runhcs-v1/service_internal.go
+++ b/cmd/containerd-shim-runhcs-v1/service_internal.go
@@ -366,11 +366,16 @@ func (s *service) waitInternal(ctx context.Context, req *task.WaitRequest) (*tas
 	if err != nil {
 		return nil, err
 	}
-	e, err := t.GetExec(req.ExecID)
-	if err != nil {
-		return nil, err
+	var state *task.StateResponse
+	if req.ExecID != "" {
+		e, err := t.GetExec(req.ExecID)
+		if err != nil {
+			return nil, err
+		}
+		state = e.Wait(ctx)
+	} else {
+		state = t.Wait(ctx)
 	}
-	state := e.Wait(ctx)
 	return &task.WaitResponse{
 		ExitStatus: state.ExitStatus,
 		ExitedAt:   state.ExitedAt,

--- a/cmd/containerd-shim-runhcs-v1/task.go
+++ b/cmd/containerd-shim-runhcs-v1/task.go
@@ -61,4 +61,12 @@ type shimTask interface {
 	// Pids returns all process pid's in this `shimTask` including ones not
 	// created by the caller via a `CreateExec`.
 	Pids(ctx context.Context) ([]options.ProcessDetails, error)
+	// Waits for the the init task to complete.
+	//
+	// Note: If the `request.ExecID == ""` the caller should instead call `Wait`
+	// rather than `exec.Wait` on the init exec. This is because  the lifetime
+	// of the task is larger than just the init process and on shutdown we need
+	// to wait for the container and potentially UVM before unblocking any event
+	// based listeners or `Wait` based listeners.
+	Wait(ctx context.Context) *task.StateResponse
 }

--- a/cmd/containerd-shim-runhcs-v1/task_hcs.go
+++ b/cmd/containerd-shim-runhcs-v1/task_hcs.go
@@ -147,6 +147,7 @@ func newHcsTask(
 		cr:       resources,
 		ownsHost: ownsParent,
 		host:     parent,
+		closed:   make(chan struct{}),
 	}
 	ht.init = newHcsExec(
 		ctx,
@@ -244,6 +245,7 @@ type hcsTask struct {
 	ecl   sync.Mutex
 	execs sync.Map
 
+	closed    chan struct{}
 	closeOnce sync.Once
 	// closeHostOnce is used to close `host`. This will only be used if
 	// `ownsHost==true` and `host != nil`.
@@ -444,6 +446,11 @@ func (ht *hcsTask) Pids(ctx context.Context) ([]options.ProcessDetails, error) {
 	return pairs, nil
 }
 
+func (ht *hcsTask) Wait(ctx context.Context) *task.StateResponse {
+	<-ht.closed
+	return ht.init.Wait(ctx)
+}
+
 // waitForHostExit waits for the host virtual machine to exit. Once exited
 // forcibly exits all additional exec's in this task.
 //
@@ -573,5 +580,6 @@ func (ht *hcsTask) closeHost() {
 				ExitStatus:  exit.ExitStatus,
 				ExitedAt:    exit.ExitedAt,
 			})
+		close(ht.closed)
 	})
 }

--- a/cmd/containerd-shim-runhcs-v1/task_hcs_test.go
+++ b/cmd/containerd-shim-runhcs-v1/task_hcs_test.go
@@ -16,6 +16,7 @@ func setupTestHcsTask(t *testing.T) (*hcsTask, *testShimExec, *testShimExec) {
 		events: fakePublisher,
 		id:     t.Name(),
 		init:   initExec,
+		closed: make(chan struct{}),
 	}
 	secondExecID := strconv.Itoa(rand.Int())
 	secondExec := newTestShimExec(t.Name(), secondExecID, int(rand.Int31()))

--- a/cmd/containerd-shim-runhcs-v1/task_test.go
+++ b/cmd/containerd-shim-runhcs-v1/task_test.go
@@ -73,3 +73,7 @@ func (tst *testShimTask) Pids(ctx context.Context) ([]options.ProcessDetails, er
 	}
 	return pairs, nil
 }
+
+func (tst *testShimTask) Wait(ctx context.Context) *task.StateResponse {
+	return tst.exec.Wait(ctx)
+}

--- a/cmd/containerd-shim-runhcs-v1/task_wcow_podsandbox.go
+++ b/cmd/containerd-shim-runhcs-v1/task_wcow_podsandbox.go
@@ -34,6 +34,7 @@ func newWcowPodSandboxTask(ctx context.Context, events publisher, id, bundle str
 		events: events,
 		id:     id,
 		init:   newWcowPodSandboxExec(ctx, events, id, bundle),
+		closed: make(chan struct{}),
 	}
 	if parent != nil {
 		// We have (and own) a parent UVM. Listen for its exit and forcibly
@@ -97,6 +98,7 @@ type wcowPodSandboxTask struct {
 	// `host==nil` this is an Argon task so no UVM cleanup is required.
 	host *uvm.UtilityVM
 
+	closed    chan struct{}
 	closeOnce sync.Once
 }
 
@@ -186,6 +188,11 @@ func (wpst *wcowPodSandboxTask) Pids(ctx context.Context) ([]options.ProcessDeta
 	}, nil
 }
 
+func (wpst *wcowPodSandboxTask) Wait(ctx context.Context) *task.StateResponse {
+	<-wpst.closed
+	return wpst.init.Wait(ctx)
+}
+
 // close safely closes the hosting UVM. Because of the specialty of this task it
 // is assumed that this is always the owner of `wpst.host`. Once closed and all
 // resources released it events the `runtime.TaskExitEventTopic` for all
@@ -211,5 +218,6 @@ func (wpst *wcowPodSandboxTask) close() {
 				ExitStatus:  exit.ExitStatus,
 				ExitedAt:    exit.ExitedAt,
 			})
+		close(wpst.closed)
 	})
 }


### PR DESCRIPTION
The async event TaskExit is sent post container/UVM shutdown but the actual
caller may have been unblocked on the call to Wait. We now return form Wait
after the container/UVM shutdown and alerting async TaskExit.

Signed-off-by: Justin Terry (VM) <juterry@microsoft.com>