### PR TITLE
Fix signal support for WCOW

### DIFF
--- a/internal/guestrequest/types.go
+++ b/internal/guestrequest/types.go
@@ -93,8 +93,24 @@ type RS4NetworkModifyRequest struct {
 	Settings          interface{} `json:"Settings,omitempty"`
 }
 
-// SignalProcessOptions is the options passed to either WCOW or LCOW
-// to signal a given process.
-type SignalProcessOptions struct {
+// SignalProcessOptionsLCOW is the options passed to LCOW to signal a given
+// process.
+type SignalProcessOptionsLCOW struct {
 	Signal int `json:,omitempty`
+}
+
+type SignalValueWCOW string
+
+const (
+	SignalValueWCOWCtrlC        SignalValueWCOW = "CtrlC"
+	SignalValueWCOWCtrlBreak    SignalValueWCOW = "CtrlBreak"
+	SignalValueWCOWCtrlClose    SignalValueWCOW = "CtrlClose"
+	SignalValueWCOWCtrlLogOff   SignalValueWCOW = "CtrlLogOff"
+	SignalValueWCOWCtrlShutdown SignalValueWCOW = "CtrlShutdown"
+)
+
+// SignalProcessOptionsWCOW is the options passed to WCOW to signal a given
+// process.
+type SignalProcessOptionsWCOW struct {
+	Signal SignalValueWCOW `json:",omitempty"`
 }

--- a/internal/hcs/hcs.go
+++ b/internal/hcs/hcs.go
@@ -27,7 +27,7 @@ import (
 //sys hcsOpenProcess(computeSystem hcsSystem, pid uint32, process *hcsProcess, result **uint16) (hr error) = vmcompute.HcsOpenProcess?
 //sys hcsCloseProcess(process hcsProcess) (hr error) = vmcompute.HcsCloseProcess?
 //sys hcsTerminateProcess(process hcsProcess, result **uint16) (hr error) = vmcompute.HcsTerminateProcess?
-//sys hcsSignalProcess(process hcsProcess, options string, result **uint16) (hr error) = vmcompute.HcsTerminateProcess?
+//sys hcsSignalProcess(process hcsProcess, options string, result **uint16) (hr error) = vmcompute.HcsSignalProcess?
 //sys hcsGetProcessInfo(process hcsProcess, processInformation *hcsProcessInformation, result **uint16) (hr error) = vmcompute.HcsGetProcessInfo?
 //sys hcsGetProcessProperties(process hcsProcess, processProperties **uint16, result **uint16) (hr error) = vmcompute.HcsGetProcessProperties?
 //sys hcsModifyProcess(process hcsProcess, settings string, result **uint16) (hr error) = vmcompute.HcsModifyProcess?

--- a/internal/hcs/process.go
+++ b/internal/hcs/process.go
@@ -7,7 +7,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/Microsoft/hcsshim/internal/guestrequest"
 	"github.com/Microsoft/hcsshim/internal/interop"
 	"github.com/Microsoft/hcsshim/internal/logfields"
 	"github.com/sirupsen/logrus"
@@ -112,7 +111,11 @@ func (process *Process) logOperationEnd(operation string, err error) {
 }
 
 // Signal signals the process with `options`.
-func (process *Process) Signal(options guestrequest.SignalProcessOptions) (err error) {
+//
+// For LCOW `guestrequest.SignalProcessOptionsLCOW`.
+//
+// For WCOW `guestrequest.SignalProcessOptionsWCOW`.
+func (process *Process) Signal(options interface{}) (err error) {
 	process.handleLock.RLock()
 	defer process.handleLock.RUnlock()
 

--- a/internal/hcs/zsyscall_windows.go
+++ b/internal/hcs/zsyscall_windows.go
@@ -56,13 +56,13 @@ var (
 	procHcsOpenProcess                     = modvmcompute.NewProc("HcsOpenProcess")
 	procHcsCloseProcess                    = modvmcompute.NewProc("HcsCloseProcess")
 	procHcsTerminateProcess                = modvmcompute.NewProc("HcsTerminateProcess")
-
-	procHcsGetProcessInfo            = modvmcompute.NewProc("HcsGetProcessInfo")
-	procHcsGetProcessProperties      = modvmcompute.NewProc("HcsGetProcessProperties")
-	procHcsModifyProcess             = modvmcompute.NewProc("HcsModifyProcess")
-	procHcsGetServiceProperties      = modvmcompute.NewProc("HcsGetServiceProperties")
-	procHcsRegisterProcessCallback   = modvmcompute.NewProc("HcsRegisterProcessCallback")
-	procHcsUnregisterProcessCallback = modvmcompute.NewProc("HcsUnregisterProcessCallback")
+	procHcsSignalProcess                   = modvmcompute.NewProc("HcsSignalProcess")
+	procHcsGetProcessInfo                  = modvmcompute.NewProc("HcsGetProcessInfo")
+	procHcsGetProcessProperties            = modvmcompute.NewProc("HcsGetProcessProperties")
+	procHcsModifyProcess                   = modvmcompute.NewProc("HcsModifyProcess")
+	procHcsGetServiceProperties            = modvmcompute.NewProc("HcsGetServiceProperties")
+	procHcsRegisterProcessCallback         = modvmcompute.NewProc("HcsRegisterProcessCallback")
+	procHcsUnregisterProcessCallback       = modvmcompute.NewProc("HcsUnregisterProcessCallback")
 )
 
 func hcsEnumerateComputeSystems(query string, computeSystems **uint16, result **uint16) (hr error) {
@@ -417,10 +417,10 @@ func hcsSignalProcess(process hcsProcess, options string, result **uint16) (hr e
 }
 
 func _hcsSignalProcess(process hcsProcess, options *uint16, result **uint16) (hr error) {
-	if hr = procHcsTerminateProcess.Find(); hr != nil {
+	if hr = procHcsSignalProcess.Find(); hr != nil {
 		return
 	}
-	r0, _, _ := syscall.Syscall(procHcsTerminateProcess.Addr(), 3, uintptr(process), uintptr(unsafe.Pointer(options)), uintptr(unsafe.Pointer(result)))
+	r0, _, _ := syscall.Syscall(procHcsSignalProcess.Addr(), 3, uintptr(process), uintptr(unsafe.Pointer(options)), uintptr(unsafe.Pointer(result)))
 	if int32(r0) < 0 {
 		if r0&0x1fff0000 == 0x00070000 {
 			r0 &= 0xffff

--- a/internal/signals/signal.go
+++ b/internal/signals/signal.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"strconv"
 	"strings"
+
+	"github.com/Microsoft/hcsshim/internal/guestrequest"
 )
 
 var (
@@ -12,33 +14,25 @@ var (
 	ErrInvalidSignal = errors.New("invalid signal value")
 )
 
-// ShouldKill returns `true` if `signal` should terminate the process.
-func ShouldKill(signal uint32) bool {
-	return signal == sigKill || signal == sigTerm
-}
-
-// ValidateSigstr validates that `sigstr` is an acceptable signal for WCOW/LCOW
+// ValidateSigstrLCOW validates that `sigstr` is an acceptable signal for LCOW
 // based on `signalsSupported`.
 //
 // `sigstr` may either be the text name or integer value of the signal.
 //
-// If `signalsSupported==false` we verify that only SIGTERM/SIGKILL and CTRLC
-// are sent. All other signals are not supported on downlevel platforms.
-//
-// By default WCOW orchestrators may still use Linux SIGTERM and SIGKILL
-// semantics which will be properly translated to CTRLC, CTRLSHUTDOWN.
-func ValidateSigstr(sigstr string, signalsSupported, isLcow bool) (int, error) {
+// If `signalsSupported==false` we verify that only SIGTERM/SIGKILL are sent.
+// All other signals are not supported on downlevel platforms.
+func ValidateSigstrLCOW(sigstr string, signalsSupported bool) (*guestrequest.SignalProcessOptionsLCOW, error) {
 	// All flavors including legacy default to SIGTERM on LCOW CtrlC on Windows
 	if sigstr == "" {
-		if isLcow {
-			return sigTerm, nil
+		if signalsSupported {
+			return &guestrequest.SignalProcessOptionsLCOW{Signal: sigTerm}, nil
 		}
-		return ctrlC, nil
+		return nil, nil
 	}
 
 	signal, err := strconv.Atoi(sigstr)
 	if err == nil {
-		return Validate(signal, signalsSupported, isLcow)
+		return ValidateLCOW(signal, signalsSupported)
 	}
 
 	sigstr = strings.ToUpper(sigstr)
@@ -46,103 +40,162 @@ func ValidateSigstr(sigstr string, signalsSupported, isLcow bool) (int, error) {
 		// If signals arent supported we just validate that its a known signal.
 		// We already return 0 since we only supported a platform Kill() at that
 		// time.
-		if isLcow {
-			switch sigstr {
-			case "TERM", "KILL":
-				return 0, nil
-			default:
-				return 0, ErrInvalidSignal
-			}
-		}
 		switch sigstr {
-		// Docker sends a UNIX term in the supported Windows Signal map.
-		case "TERM", "CTRLC", "KILL":
-			return 0, nil
+		case "TERM", "KILL":
+			return nil, nil
 		default:
-			return 0, ErrInvalidSignal
+			return nil, ErrInvalidSignal
 		}
-	} else {
-		if !isLcow {
-			// Docker sends the UNIX signal name or value. Convert them to the
-			// correct Windows signals.
-			switch sigstr {
-			case "TERM":
-				return ctrlC, nil
-			case "KILL":
-				return ctrlShutdown, nil
-			}
-		}
-	}
-
-	var sigmap map[string]int
-	if isLcow {
-		sigmap = signalMapLcow
-	} else {
-		sigmap = signalMapWindows
 	}
 
 	// Match signal string name
-	for k, v := range sigmap {
+	for k, v := range signalMapLcow {
 		if sigstr == k {
-			return v, nil
+			return &guestrequest.SignalProcessOptionsLCOW{Signal: v}, nil
 		}
 	}
-	return 0, ErrInvalidSignal
+	return nil, ErrInvalidSignal
 }
 
-// Validate validates that `signal` is an acceptable signal for WCOW/LCOW based
-// on `signalsSupported`.
+// ValidateSigstrWCOW validates that `sigstr` is an acceptable signal for WCOW
+// based on `signalsSupported`.
 //
-// If `signalsSupported==false` we verify that only SIGTERM/SIGKILL and CTRLC
-// are sent. All other signals are not supported on downlevel platforms.
+// `sigstr` may either be the text name or integer value of the signal.
 //
-// By default WCOW orechestrators may still use Linux SIGTERM and SIGKILL
-// semantics which will be properly translated to CTRLC, CTRLSHUTDOWN.
-func Validate(signal int, signalsSupported, isLcow bool) (int, error) {
+// If `signalsSupported==false` we verify that only SIGTERM/SIGKILL and
+// CTRLSHUTDOWN are sent. All other signals are not supported on downlevel
+// platforms.
+//
+// By default WCOW orchestrators may still use Linux SIGTERM and SIGKILL
+// semantics which will be properly translated to CTRLSHUTDOWN and `Terminate`.
+// To detect when WCOW needs to `Terminate` the return signal will be `nil` and
+// the return error will be `nil`.
+func ValidateSigstrWCOW(sigstr string, signalsSupported bool) (*guestrequest.SignalProcessOptionsWCOW, error) {
+	// All flavors including legacy default to SIGTERM on LCOW CtrlC on Windows
+	if sigstr == "" {
+		if signalsSupported {
+			return &guestrequest.SignalProcessOptionsWCOW{Signal: guestrequest.SignalValueWCOWCtrlShutdown}, nil
+		}
+		return nil, nil
+	}
+
+	signal, err := strconv.Atoi(sigstr)
+	if err == nil {
+		return ValidateWCOW(signal, signalsSupported)
+	}
+
+	sigstr = strings.ToUpper(sigstr)
 	if !signalsSupported {
 		// If signals arent supported we just validate that its a known signal.
 		// We already return 0 since we only supported a platform Kill() at that
 		// time.
-		if isLcow {
-			switch signal {
-			case sigTerm, sigKill:
-				return 0, nil
-			default:
-				return 0, ErrInvalidSignal
-			}
-		}
-		switch signal {
+		switch sigstr {
 		// Docker sends a UNIX term in the supported Windows Signal map.
-		case sigTerm, sigKill, 0:
-			return 0, nil
+		case "CTRLSHUTDOWN", "TERM", "KILL":
+			return nil, nil
 		default:
-			return 0, ErrInvalidSignal
+			return nil, ErrInvalidSignal
 		}
 	} else {
-		if !isLcow {
-			// Docker sends the UNIX signal name or value. Convert them to the
-			// correct Windows signals.
-			switch signal {
-			case sigTerm:
-				return ctrlC, nil
-			case sigKill:
-				return ctrlShutdown, nil
-			}
-		}
-	}
+		// Docker sends the UNIX signal name or value. Convert them to the
+		// correct Windows signals.
 
-	var sigmap map[string]int
-	if isLcow {
-		sigmap = signalMapLcow
-	} else {
-		sigmap = signalMapWindows
+		var signalString guestrequest.SignalValueWCOW
+		switch sigstr {
+		case "CTRLC":
+			signalString = guestrequest.SignalValueWCOWCtrlC
+		case "CTRLBREAK":
+			signalString = guestrequest.SignalValueWCOWCtrlBreak
+		case "CTRLCLOSE":
+			signalString = guestrequest.SignalValueWCOWCtrlClose
+		case "CTRLLOGOFF":
+			signalString = guestrequest.SignalValueWCOWCtrlLogOff
+		case "CTRLSHUTDOWN", "TERM":
+			// SIGTERM is most like CtrlShutdown on Windows convert it here.
+			signalString = guestrequest.SignalValueWCOWCtrlShutdown
+		case "KILL":
+			return nil, nil
+		default:
+			return nil, ErrInvalidSignal
+		}
+
+		return &guestrequest.SignalProcessOptionsWCOW{Signal: signalString}, nil
+	}
+}
+
+// ValidateLCOW validates that `signal` is an acceptable signal for LCOW based
+// on `signalsSupported`.
+//
+// If `signalsSupported==false` we verify that only SIGTERM/SIGKILL are sent.
+// All other signals are not supported on downlevel platforms.
+func ValidateLCOW(signal int, signalsSupported bool) (*guestrequest.SignalProcessOptionsLCOW, error) {
+	if !signalsSupported {
+		// If signals arent supported we just validate that its a known signal.
+		// We already return 0 since we only supported a platform Kill() at that
+		// time.
+		switch signal {
+		case ctrlShutdown, sigTerm, sigKill:
+			return nil, nil
+		default:
+			return nil, ErrInvalidSignal
+		}
 	}
 
 	// Match signal by value
-	for _, v := range sigmap {
+	for _, v := range signalMapLcow {
 		if signal == v {
-			return signal, nil
+			return &guestrequest.SignalProcessOptionsLCOW{Signal: signal}, nil
 		}
 	}
-	return 0, ErrInvalidSignal
+	return nil, ErrInvalidSignal
+}
+
+// ValidateWCOW validates that `signal` is an acceptable signal for WCOW based
+// on `signalsSupported`.
+//
+// If `signalsSupported==false` we verify that only SIGTERM/SIGKILL and
+// CTRLSHUTDOWN are sent. All other signals are not supported on downlevel
+// platforms.
+//
+// By default WCOW orchestrators may still use Linux SIGTERM and SIGKILL
+// semantics which will be properly translated to CTRLSHUTDOWN and `Terminate`.
+// To detect when WCOW needs to `Terminate` the return signal will be `nil` and
+// the return error will be `nil`.
+func ValidateWCOW(signal int, signalsSupported bool) (*guestrequest.SignalProcessOptionsWCOW, error) {
+	if !signalsSupported {
+		// If signals arent supported we just validate that its a known signal.
+		// We already return 0 since we only supported a platform Kill() at that
+		// time.
+		switch signal {
+		// Docker sends a UNIX term in the supported Windows Signal map.
+		case ctrlShutdown, sigTerm, sigKill:
+			return nil, nil
+		default:
+			return nil, ErrInvalidSignal
+		}
+	} else {
+		// Docker sends the UNIX signal name or value. Convert them to the
+		// correct Windows signals.
+
+		var signalString guestrequest.SignalValueWCOW
+		switch signal {
+		case ctrlC:
+			signalString = guestrequest.SignalValueWCOWCtrlC
+		case ctrlBreak:
+			signalString = guestrequest.SignalValueWCOWCtrlBreak
+		case ctrlClose:
+			signalString = guestrequest.SignalValueWCOWCtrlClose
+		case ctrlLogOff:
+			signalString = guestrequest.SignalValueWCOWCtrlLogOff
+		case ctrlShutdown, sigTerm:
+			// sigTerm is most like CtrlShutdown on Windows convert it here.
+			signalString = guestrequest.SignalValueWCOWCtrlShutdown
+		case sigKill:
+			return nil, nil
+		default:
+			return nil, ErrInvalidSignal
+		}
+
+		return &guestrequest.SignalProcessOptionsWCOW{Signal: signalString}, nil
+	}
 }

--- a/internal/signals/signalmap.go
+++ b/internal/signals/signalmap.go
@@ -49,11 +49,3 @@ const (
 	ctrlLogOff   = 0x5
 	ctrlShutdown = 0x6
 )
-
-var signalMapWindows = map[string]int{
-	"CTRLC":        ctrlC,
-	"CTRLBREAK":    ctrlBreak,
-	"CTRLCLOSE":    ctrlClose,
-	"CTRLLOGOFF":   ctrlLogOff,
-	"CTRLSHUTDOWN": ctrlShutdown,
-}


### PR DESCRIPTION
- There was a bug in hcs.go where hcsSignalProcess was actually the syscall for
HcsTerminateProcess due to a copy paste bug.
- Signal support on WCOW based on the HCS API is actually marshalled by string
value rather than integer value. This change makes sure that the signal struct
created for WCOW validates and uses the appropriate Ctrl* string.