### PR TITLE
 Serialize all shim errors to gRPC known types

### DIFF
--- a/cmd/containerd-shim-runhcs-v1/exec.go
+++ b/cmd/containerd-shim-runhcs-v1/exec.go
@@ -51,7 +51,7 @@ type shimExec interface {
 	// If `State() != shimExecStateRunning` this exec MUST return
 	// `errdefs.ErrFailedPrecondition`.
 	//
-	// If `State() == shimExecStateExited` this exec MUST silently succeed.
+	// If `State() == shimExecStateExited` this exec MUST return `errdefs.ErrNotFound`.
 	Kill(ctx context.Context, signal uint32) error
 	// ResizePty resizes the tty of this exec process.
 	//

--- a/cmd/containerd-shim-runhcs-v1/exec_hcs.go
+++ b/cmd/containerd-shim-runhcs-v1/exec_hcs.go
@@ -398,7 +398,7 @@ func (he *hcsExec) Kill(ctx context.Context, signal uint32) error {
 		// needs to issue a terminate.
 		return he.p.Kill()
 	case shimExecStateExited:
-		return nil
+		return errors.Wrapf(errdefs.ErrNotFound, "exec: '%s' in task: '%s' not found", he.id, he.tid)
 	default:
 		return newExecInvalidStateError(he.tid, he.id, he.state, "kill")
 	}

--- a/cmd/containerd-shim-runhcs-v1/exec_wcow_podsandbox.go
+++ b/cmd/containerd-shim-runhcs-v1/exec_wcow_podsandbox.go
@@ -173,7 +173,7 @@ func (wpse *wcowPodSandboxExec) Kill(ctx context.Context, signal uint32) error {
 		close(wpse.exited)
 		return nil
 	case shimExecStateExited:
-		return nil
+		return errors.Wrapf(errdefs.ErrNotFound, "exec: '%s' in task: '%s' not found", wpse.tid, wpse.tid)
 	default:
 		return newExecInvalidStateError(wpse.tid, wpse.tid, wpse.state, "kill")
 	}

--- a/cmd/containerd-shim-runhcs-v1/exec_wcow_podsandbox_test.go
+++ b/cmd/containerd-shim-runhcs-v1/exec_wcow_podsandbox_test.go
@@ -8,6 +8,7 @@ import (
 	containerd_v1_types "github.com/containerd/containerd/api/types/task"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/runtime/v2/task"
+	"github.com/pkg/errors"
 )
 
 func verifyWcowPodSandboxExecStatus(t *testing.T, wasStarted bool, es containerd_v1_types.Status, status *task.StateResponse) {
@@ -190,8 +191,8 @@ func Test_newWcowPodSandboxExec_Kill_Created(t *testing.T) {
 
 	// Call Kill again
 	err = wpse.Kill(context.TODO(), 0x0)
-	if err != nil {
-		t.Fatal("Kill should not fail in the exited state")
+	if errors.Cause(err) != errdefs.ErrNotFound {
+		t.Fatalf("Kill should fail with `ErrNotFound` in the exited state got: %v", err)
 	}
 }
 
@@ -215,8 +216,8 @@ func Test_newWcowPodSandboxExec_Kill_Started(t *testing.T) {
 
 	// Call Kill again
 	err = wpse.Kill(context.TODO(), 0x0)
-	if err != nil {
-		t.Fatal("Kill should not fail in the exited state")
+	if errors.Cause(err) != errdefs.ErrNotFound {
+		t.Fatalf("Kill should fail with `ErrNotFound` in the exited state got: %v", err)
 	}
 }
 

--- a/cmd/containerd-shim-runhcs-v1/service.go
+++ b/cmd/containerd-shim-runhcs-v1/service.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 	"sync/atomic"
 
+	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/runtime/v2/task"
 	google_protobuf1 "github.com/gogo/protobuf/types"
 	"github.com/sirupsen/logrus"
@@ -70,7 +71,8 @@ func (s *service) State(ctx context.Context, req *task.StateRequest) (_ *task.St
 	beginActivity(activity, af)
 	defer func() { endActivity(activity, af, err) }()
 
-	return s.stateInternal(ctx, req)
+	r, e := s.stateInternal(ctx, req)
+	return r, errdefs.ToGRPC(e)
 }
 
 func (s *service) Create(ctx context.Context, req *task.CreateTaskRequest) (_ *task.CreateTaskResponse, err error) {
@@ -93,7 +95,8 @@ func (s *service) Create(ctx context.Context, req *task.CreateTaskRequest) (_ *t
 		}, err)
 	}()
 
-	return s.createInternal(ctx, req)
+	r, e := s.createInternal(ctx, req)
+	return r, errdefs.ToGRPC(e)
 }
 
 func (s *service) Start(ctx context.Context, req *task.StartRequest) (_ *task.StartResponse, err error) {
@@ -106,7 +109,8 @@ func (s *service) Start(ctx context.Context, req *task.StartRequest) (_ *task.St
 	beginActivity(activity, af)
 	defer func() { endActivity(activity, af, err) }()
 
-	return s.startInternal(ctx, req)
+	r, e := s.startInternal(ctx, req)
+	return r, errdefs.ToGRPC(e)
 }
 
 func (s *service) Delete(ctx context.Context, req *task.DeleteRequest) (_ *task.DeleteResponse, err error) {
@@ -119,7 +123,8 @@ func (s *service) Delete(ctx context.Context, req *task.DeleteRequest) (_ *task.
 	beginActivity(activity, af)
 	defer func() { endActivity(activity, af, err) }()
 
-	return s.deleteInternal(ctx, req)
+	r, e := s.deleteInternal(ctx, req)
+	return r, errdefs.ToGRPC(e)
 }
 
 func (s *service) Pids(ctx context.Context, req *task.PidsRequest) (_ *task.PidsResponse, err error) {
@@ -131,7 +136,8 @@ func (s *service) Pids(ctx context.Context, req *task.PidsRequest) (_ *task.Pids
 	beginActivity(activity, af)
 	defer func() { endActivity(activity, af, err) }()
 
-	return s.pidsInternal(ctx, req)
+	r, e := s.pidsInternal(ctx, req)
+	return r, errdefs.ToGRPC(e)
 }
 
 func (s *service) Pause(ctx context.Context, req *task.PauseRequest) (_ *google_protobuf1.Empty, err error) {
@@ -143,7 +149,8 @@ func (s *service) Pause(ctx context.Context, req *task.PauseRequest) (_ *google_
 	beginActivity(activity, af)
 	defer func() { endActivity(activity, af, err) }()
 
-	return s.pauseInternal(ctx, req)
+	r, e := s.pauseInternal(ctx, req)
+	return r, errdefs.ToGRPC(e)
 }
 
 func (s *service) Resume(ctx context.Context, req *task.ResumeRequest) (_ *google_protobuf1.Empty, err error) {
@@ -155,7 +162,8 @@ func (s *service) Resume(ctx context.Context, req *task.ResumeRequest) (_ *googl
 	beginActivity(activity, af)
 	defer func() { endActivity(activity, af, err) }()
 
-	return s.resumeInternal(ctx, req)
+	r, e := s.resumeInternal(ctx, req)
+	return r, errdefs.ToGRPC(e)
 }
 
 func (s *service) Checkpoint(ctx context.Context, req *task.CheckpointTaskRequest) (_ *google_protobuf1.Empty, err error) {
@@ -168,7 +176,8 @@ func (s *service) Checkpoint(ctx context.Context, req *task.CheckpointTaskReques
 	beginActivity(activity, af)
 	defer func() { endActivity(activity, af, err) }()
 
-	return s.checkpointInternal(ctx, req)
+	r, e := s.checkpointInternal(ctx, req)
+	return r, errdefs.ToGRPC(e)
 }
 
 func (s *service) Kill(ctx context.Context, req *task.KillRequest) (_ *google_protobuf1.Empty, err error) {
@@ -183,7 +192,8 @@ func (s *service) Kill(ctx context.Context, req *task.KillRequest) (_ *google_pr
 	beginActivity(activity, af)
 	defer func() { endActivity(activity, af, err) }()
 
-	return s.killInternal(ctx, req)
+	r, e := s.killInternal(ctx, req)
+	return r, errdefs.ToGRPC(e)
 }
 
 func (s *service) Exec(ctx context.Context, req *task.ExecProcessRequest) (_ *google_protobuf1.Empty, err error) {
@@ -200,7 +210,8 @@ func (s *service) Exec(ctx context.Context, req *task.ExecProcessRequest) (_ *go
 	beginActivity(activity, af)
 	defer func() { endActivity(activity, af, err) }()
 
-	return s.execInternal(ctx, req)
+	r, e := s.execInternal(ctx, req)
+	return r, errdefs.ToGRPC(e)
 }
 
 func (s *service) ResizePty(ctx context.Context, req *task.ResizePtyRequest) (_ *google_protobuf1.Empty, err error) {
@@ -215,7 +226,8 @@ func (s *service) ResizePty(ctx context.Context, req *task.ResizePtyRequest) (_ 
 	beginActivity(activity, af)
 	defer func() { endActivity(activity, af, err) }()
 
-	return s.resizePtyInternal(ctx, req)
+	r, e := s.resizePtyInternal(ctx, req)
+	return r, errdefs.ToGRPC(e)
 }
 
 func (s *service) CloseIO(ctx context.Context, req *task.CloseIORequest) (_ *google_protobuf1.Empty, err error) {
@@ -229,7 +241,8 @@ func (s *service) CloseIO(ctx context.Context, req *task.CloseIORequest) (_ *goo
 	beginActivity(activity, af)
 	defer func() { endActivity(activity, af, err) }()
 
-	return s.closeIOInternal(ctx, req)
+	r, e := s.closeIOInternal(ctx, req)
+	return r, errdefs.ToGRPC(e)
 }
 
 func (s *service) Update(ctx context.Context, req *task.UpdateTaskRequest) (_ *google_protobuf1.Empty, err error) {
@@ -241,7 +254,8 @@ func (s *service) Update(ctx context.Context, req *task.UpdateTaskRequest) (_ *g
 	beginActivity(activity, af)
 	defer func() { endActivity(activity, af, err) }()
 
-	return s.updateInternal(ctx, req)
+	r, e := s.updateInternal(ctx, req)
+	return r, errdefs.ToGRPC(e)
 }
 
 func (s *service) Wait(ctx context.Context, req *task.WaitRequest) (_ *task.WaitResponse, err error) {
@@ -254,7 +268,8 @@ func (s *service) Wait(ctx context.Context, req *task.WaitRequest) (_ *task.Wait
 	beginActivity(activity, af)
 	defer func() { endActivity(activity, af, err) }()
 
-	return s.waitInternal(ctx, req)
+	r, e := s.waitInternal(ctx, req)
+	return r, errdefs.ToGRPC(e)
 }
 
 func (s *service) Stats(ctx context.Context, req *task.StatsRequest) (_ *task.StatsResponse, err error) {
@@ -266,7 +281,8 @@ func (s *service) Stats(ctx context.Context, req *task.StatsRequest) (_ *task.St
 	beginActivity(activity, af)
 	defer func() { endActivity(activity, af, err) }()
 
-	return s.statsInternal(ctx, req)
+	r, e := s.statsInternal(ctx, req)
+	return r, errdefs.ToGRPC(e)
 }
 
 func (s *service) Connect(ctx context.Context, req *task.ConnectRequest) (_ *task.ConnectResponse, err error) {
@@ -278,7 +294,8 @@ func (s *service) Connect(ctx context.Context, req *task.ConnectRequest) (_ *tas
 	beginActivity(activity, af)
 	defer func() { endActivity(activity, af, err) }()
 
-	return s.connectInternal(ctx, req)
+	r, e := s.connectInternal(ctx, req)
+	return r, errdefs.ToGRPC(e)
 }
 
 func (s *service) Shutdown(ctx context.Context, req *task.ShutdownRequest) (_ *google_protobuf1.Empty, err error) {
@@ -291,5 +308,6 @@ func (s *service) Shutdown(ctx context.Context, req *task.ShutdownRequest) (_ *g
 	beginActivity(activity, af)
 	defer func() { endActivity(activity, af, err) }()
 
-	return s.shutdownInternal(ctx, req)
+	r, e := s.shutdownInternal(ctx, req)
+	return r, errdefs.ToGRPC(e)
 }


### PR DESCRIPTION
- We should be using errdefs.ToGRPC when sending errors as a return value from
the shim. This converts known error types to a propery serialized chain and
maintains the Causer interface associated with the proper underlying error.
- Shims MUST return errdefs.ErrNotFound in process exited state 