### PR TITLE
shim:dump stack to file as well

### DIFF
--- a/cmd/containerd-shim-runhcs-v1/serve.go
+++ b/cmd/containerd-shim-runhcs-v1/serve.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"time"
@@ -224,4 +225,13 @@ func dumpStacks() {
 	}
 	buf = buf[:stackSize]
 	logrus.Infof("=== BEGIN goroutine stack dump ===\n%s\n=== END goroutine stack dump ===", buf)
+
+	// Also write to file to aid gathering diagnostics
+	name := filepath.Join(os.TempDir(), fmt.Sprintf("containerd-shim-runhcs-v1.%d.stacks.log", os.Getpid()))
+	f, err := os.Create(name)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+	f.WriteString(string(buf))
 }


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

@jterry75 Mirrors the PR to containerd (I'll do one for moby as well shortly) to dump the stack to file to make grabbing the logs in that diagnostic script work.