### PR TITLE
Get-ContainerLogs.ps1 for later analysis

### DIFF
--- a/scripts/Get-ContainerLogs.ps1
+++ b/scripts/Get-ContainerLogs.ps1
@@ -1,0 +1,77 @@
+$ErrorActionPreference = "Stop"
+$now=get-date -Format("yyyyMMdd-HHmmss")
+$outputPath = join-path $env:TEMP "container-logs-$now"
+mkdir $outputPath | Out-Null
+$ErrorActionPreference = "SilentlyContinue"
+Write-Host "- Gathering stack dumps and event logs"
+
+function gethveventlog($elName) {
+    $ErrorActionPreference = "SilentlyContinue"
+    Write-Host -NoNewLine "."
+    $out=join-path $outputPath "$elName.evtx"
+    if (Test-Path $out) { Remove-Item $out }
+    wevtutil.exe epl $elName $out 2>&1 | Out-Null
+}
+
+
+function getnteventlog($elName) {
+    $ErrorActionPreference = "SilentlyContinue"
+    Write-Host -NoNewLine "."
+    $log = Get-WmiObject -Class Win32_NTEventlogFile | Where-Object LogfileName -EQ "$elName" # | Out-Null
+    $outPath = join-path $outputPath "$elName.evtx"
+    if ($log -ne $null) {
+        $log.BackupEventlog($outPath) | Out-Null
+    }
+}
+
+$proc = (get-process containerd)
+if ($proc -ne $null) {
+    docker-signal.exe -pid $proc.Id  2>&1 | Out-Null
+    $lookingFor = Join-Path $env:TEMP containerd.$($proc.Id).stacks.log
+    if (Test-Path $lookingFor) {
+        Copy-Item $lookingFor $outputPath
+    }
+}
+
+$procs = (get-process containerd-shim-runhcs-v1)
+if ($procs.Length -gt 0) {
+    $procs | ForEach-Object {
+        docker-signal.exe -pid $($_.Id) | Out-Null
+        $lookingFor = Join-Path $env:TEMP containerd-shim-runhcs-v1.$($_.Id).stacks.log
+        if (Test-Path $lookingFor) {
+            Copy-Item $lookingFor $outputPath
+        }
+    }
+}
+
+$proc = (get-process dockerd)
+if ($proc -ne $null) {
+    docker-signal.exe -pid $proc.Id 2>&1 | Out-Null
+    $lookingFor = Join-Path $env:TEMP dockerd.$($proc.Id).stacks.log
+    if (Test-Path $lookingFor) {
+        Copy-Item $lookingFor $outputPath
+    }
+} 
+
+# Get the process list
+Write-Host -NoNewline "."
+tasklist.exe | Out-File $(Join-Path $outputPath tasklist.txt)
+
+# Save system an application event logs
+getnteventlog "System"
+getnteventlog "Application"
+
+# Save all the Hyper-V event logs
+$el = $(wevtutil.exe el)
+$el | ForEach-Object {
+    if ($_.StartsWith("Microsoft-Windows-Hyper")) {
+        gethveventlog  $_
+    }
+}
+
+$zip = "c:\container-logs-$now.zip"
+Write-Host ""
+Write-Host "- Compressing"
+Compress-Archive $outputPath/* -DestinationPath $zip
+Remove-Item $outputPath -Recurse -Force
+Write-Host "- Saved to $zip"


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

A rough-and-ready script to signal containerd, shims (and docker to make this generic for public use), grab the stack dumps, and also grab the system/application event logs, as well as as many Hyper-V event logs as it can, and zips them. Far from perfect, but better than nothing and a good start.

As discussed at standup: for use at 3AM during an ICM so that we have some hope of analysing what when wrong later.

@jterry75 PTAL

@kevpar - Your SF deploy script should probably binplace this somewhere in $env:PATH.


TODO subsequently:
 - [ ] Memory stuff?
 - [ ] Disk usage stuff?
 - [ ] CPU usage?
 - [ ] Bit of a tidy up
 - [ ] `Get-ComputeProcess` and/or `hcsdiag list` output
 - [ ] Zip up the state directory of containerd
 - [ ] docker version and docker info output
 - [ ] some way to get containerd and shim version/commit ID
 - [ ] Anything else anyone can think of?
