### PR TITLE
Dump stacks on ETW capture state

### DIFF
--- a/cmd/containerd-shim-runhcs-v1/main.go
+++ b/cmd/containerd-shim-runhcs-v1/main.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/Microsoft/go-winio/pkg/etw"
 	"github.com/Microsoft/go-winio/pkg/etwlogrus"
+	"github.com/Microsoft/go-winio/pkg/guid"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
@@ -60,10 +61,16 @@ func panicRecover() {
 	}
 }
 
+func etwCallback(sourceID *guid.GUID, state etw.ProviderState, level etw.Level, matchAnyKeyword uint64, matchAllKeyword uint64, filterData uintptr) {
+	if state == etw.ProviderStateCaptureState {
+		dumpStacks(false)
+	}
+}
+
 func main() {
 	// Provider ID: 0b52781f-b24d-5685-ddf6-69830ed40ec3
 	// Provider and hook aren't closed explicitly, as they will exist until process exit.
-	provider, err := etw.NewProvider("Microsoft.Virtualization.RunHCS", nil)
+	provider, err := etw.NewProvider("Microsoft.Virtualization.RunHCS", etwCallback)
 	if err != nil {
 		logrus.Error(err)
 	} else {

--- a/cmd/containerd-shim-runhcs-v1/serve.go
+++ b/cmd/containerd-shim-runhcs-v1/serve.go
@@ -206,13 +206,13 @@ func setupDumpStacks() {
 	go func() {
 		for {
 			windows.WaitForSingleObject(handle, windows.INFINITE)
-			dumpStacks()
+			dumpStacks(true)
 		}
 	}()
 	return
 }
 
-func dumpStacks() {
+func dumpStacks(writeToFile bool) {
 	var (
 		buf       []byte
 		stackSize int
@@ -226,12 +226,14 @@ func dumpStacks() {
 	buf = buf[:stackSize]
 	logrus.Infof("=== BEGIN goroutine stack dump ===\n%s\n=== END goroutine stack dump ===", buf)
 
-	// Also write to file to aid gathering diagnostics
-	name := filepath.Join(os.TempDir(), fmt.Sprintf("containerd-shim-runhcs-v1.%d.stacks.log", os.Getpid()))
-	f, err := os.Create(name)
-	if err != nil {
-		return
+	if writeToFile {
+		// Also write to file to aid gathering diagnostics
+		name := filepath.Join(os.TempDir(), fmt.Sprintf("containerd-shim-runhcs-v1.%d.stacks.log", os.Getpid()))
+		f, err := os.Create(name)
+		if err != nil {
+			return
+		}
+		defer f.Close()
+		f.WriteString(string(buf))
 	}
-	defer f.Close()
-	f.WriteString(string(buf))
 }


### PR DESCRIPTION
This allows us to collect the Goroutine stacks with WPR, rather than needing to trigger it with a kernel event.