### PR TITLE
Remove combinedlayers: rootfs not scratch

### DIFF
--- a/internal/hcsoci/layers.go
+++ b/internal/hcsoci/layers.go
@@ -262,13 +262,13 @@ func UnmountContainerLayers(layerFolders []string, guestRoot string, uvm *uvm.Ut
 
 	// Unload the storage filter followed by the SCSI scratch
 	if (op & UnmountOperationSCSI) == UnmountOperationSCSI {
-		containerScratchPathInUVM := ospath.Join(uvm.OS(), guestRoot, scratchPath)
-		logrus.Debugf("hcsshim::unmountContainerLayers CombinedLayers %s", containerScratchPathInUVM)
+		containerRoofFSPathInUVM := ospath.Join(uvm.OS(), guestRoot, rootfsPath)
+		logrus.Debugf("hcsshim::unmountContainerLayers CombinedLayers %s", containerRoofFSPathInUVM)
 		combinedLayersModification := &hcsschema.ModifySettingRequest{
 			GuestRequest: guestrequest.GuestRequest{
 				ResourceType: guestrequest.ResourceTypeCombinedLayers,
 				RequestType:  requesttype.Remove,
-				Settings:     guestrequest.CombinedLayers{ContainerRootPath: containerScratchPathInUVM},
+				Settings:     guestrequest.CombinedLayers{ContainerRootPath: containerRoofFSPathInUVM},
 			},
 		}
 		if err := uvm.Modify(combinedLayersModification); err != nil {
@@ -277,6 +277,7 @@ func UnmountContainerLayers(layerFolders []string, guestRoot string, uvm *uvm.Ut
 
 		// Hot remove the scratch from the SCSI controller
 		hostScratchFile := filepath.Join(layerFolders[len(layerFolders)-1], "sandbox.vhdx")
+		containerScratchPathInUVM := ospath.Join(uvm.OS(), guestRoot, scratchPath)
 		logrus.Debugf("hcsshim::unmountContainerLayers SCSI %s %s", containerScratchPathInUVM, hostScratchFile)
 		if err := uvm.RemoveSCSI(hostScratchFile); err != nil {
 			e := fmt.Errorf("failed to remove SCSI %s: %s", hostScratchFile, err)


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

@jterry75 as discussed offline.

Verified with docker LCOW/containerd. Confirmed the SCSI remove is correctly for the scratch, and the combined layers remove preceeding it is for the rootfs, not scratch.

```
time="2019-04-15T14:04:41.797268700-07:00" level=debug msg="opengcs::bridge - read message" message="{\"ContainerId\":\"00000000-0000-0000-0000-000000000000\",\"ActivityId\":\"00000000-0000-0000-2400-000000000000\",\"Request\":{\"RequestType\":\"Remove\",\"ResourceType\":\"CombinedLayers\",\"Settings\":{\"ContainerRootPath\":\"/run/gcs/c/1/rootfs\"}},\"v2Request\":null}" message-id=10 message-type=ComputeSystemModifySettingsV1 uvm-id=84d0afb29f1d534787eea5f7b2b9a8d163b3e04ad7605294cfb1b9c9c7ceed33@vm vm.time="2019-04-15 21:04:41 +0000 UTC"
time="2019-04-15T14:04:41.797268700-07:00" level=info msg="opengcs::bridge::modifySettings" activityID=00000000-0000-0000-2400-000000000000 cid=00000000-0000-0000-0000-000000000000 uvm-id=84d0afb29f1d534787eea5f7b2b9a8d163b3e04ad7605294cfb1b9c9c7ceed33@vm vm.time="2019-04-15 21:04:41 +0000 UTC"
time="2019-04-15T14:04:41.798286700-07:00" level=debug msg="storage::UnmountPath - Begin Operation" remove=true target=/run/gcs/c/1/rootfs uvm-id=84d0afb29f1d534787eea5f7b2b9a8d163b3e04ad7605294cfb1b9c9c7ceed33@vm vm.time="2019-04-15 21:04:41 +0000 UTC"
time="2019-04-15T14:04:41.805275000-07:00" level=debug msg="hcsshim::ComputeSystem::Modify - End Operation - Success" cid=84d0afb29f1d534787eea5f7b2b9a8d163b3e04ad7605294cfb1b9c9c7ceed33@vm
time="2019-04-15T14:04:41.806275400-07:00" level=debug msg="uvm::Modify - End Operation - Success" uvm-id=84d0afb29f1d534787eea5f7b2b9a8d163b3e04ad7605294cfb1b9c9c7ceed33@vm
time="2019-04-15T14:04:41.810274000-07:00" level=debug msg="hcsshim::unmountContainerLayers SCSI /run/gcs/c/1/scratch C:\\controlx\\lcow\\84d0afb29f1d534787eea5f7b2b9a8d163b3e04ad7605294cfb1b9c9c7ceed33\\sandbox.vhdx"
time="2019-04-15T14:04:41.810274000-07:00" level=debug msg="uvm::RemoveSCSI - Begin Operation" host-path="C:\\controlx\\lcow\\84d0afb29f1d534787eea5f7b2b9a8d163b3e04ad7605294cfb1b9c9c7ceed33\\sandbox.vhdx" uvm-id=84d0afb29f1d534787eea5f7b2b9a8d163b3e04ad7605294cfb1b9c9c7ceed33@vm
time="2019-04-15T14:04:41.806275400-07:00" level=debug msg="storage::UnmountPath - End Operation" remove=true target=/run/gcs/c/1/rootfs uvm-id=84d0afb29f1d534787eea5f7b2b9a8d163b3e04ad7605294cfb1b9c9c7ceed33@vm vm.time="2019-04-15 21:04:41 +0000 UTC"
time="2019-04-15T14:04:41.814274800-07:00" level=info msg="opengcs::bridge::requestResponseWriter" message-id=10 message-type=ComputeSystemResponseModifySettingsV1 uvm-id=84d0afb29f1d534787eea5f7b2b9a8d163b3e04ad7605294cfb1b9c9c7ceed33@vm vm.time="2019-04-15 21:04:41 +0000 UTC"
time="2019-04-15T14:04:41.815271600-07:00" level=debug msg="opengcs::bridge - response sent" message="{\"Result\":0,\"ActivityId\":\"00000000-0000-0000-2400-000000000000\"}" message-id=10 message-type=ComputeSystemResponseModifySettingsV1 uvm-id=84d0afb29f1d534787eea5f7b2b9a8d163b3e04ad7605294cfb1b9c9c7ceed33@vm vm.time="2019-04-15 21:04:41 +0000 UTC"
time="2019-04-15T14:04:41.815271600-07:00" level=debug msg="uvm::findSCSIAttachment" controller=0 host-path="C:\\controlx\\lcow\\84d0afb29f1d534787eea5f7b2b9a8d163b3e04ad7605294cfb1b9c9c7ceed33\\sandbox.vhdx" isLayer=false lun=0 refCount=0 uvm-id=84d0afb29f1d534787eea5f7b2b9a8d163b3e04ad7605294cfb1b9c9c7ceed33@vm uvm-path=/run/gcs/c/1/scratch
time="2019-04-15T14:04:41.821274400-07:00" level=debug msg="uvm::Modify - Begin Operation" uvm-id=84d0afb29f1d534787eea5f7b2b9a8d163b3e04ad7605294cfb1b9c9c7ceed33@vm
time="2019-04-15T14:04:41.822276600-07:00" level=debug msg="hcsshim::ComputeSystem::Modify - Begin Operation" cid=84d0afb29f1d534787eea5f7b2b9a8d163b3e04ad7605294cfb1b9c9c7ceed33@vm
time="2019-04-15T14:04:41.823278200-07:00" level=debug msg="HCS ComputeSystem Modify Document" cid=84d0afb29f1d534787eea5f7b2b9a8d163b3e04ad7605294cfb1b9c9c7ceed33@vm json="{\"ResourcePath\":\"VirtualMachine/Devices/Scsi/0/Attachments/0\",\"RequestType\":\"Remove\",\"GuestRequest\":{\"RequestType\":\"Remove\",\"ResourceType\":\"MappedVirtualDisk\",\"Settings\":{\"MountPath\":\"/run/gcs/c/1/scratch\"}}}"
time="2019-04-15T14:04:41.826272000-07:00" level=debug msg="opengcs::bridge - read message" message="{\"ContainerId\":\"00000000-0000-0000-0000-000000000000\",\"ActivityId\":\"00000000-0000-0000-2400-000000000000\",\"Request\":{\"RequestType\":\"Remove\",\"ResourceType\":\"MappedVirtualDisk\",\"Settings\":{\"MountPath\":\"/run/gcs/c/1/scratch\"}},\"v2Request\":null}" message-id=11 message-type=ComputeSystemModifySettingsV1 uvm-id=84d0afb29f1d534787eea5f7b2b9a8d163b3e04ad7605294cfb1b9c9c7ceed33@vm vm.time="2019-04-15 21:04:41 +0000 UTC"
```