### PR TITLE
Add more information to osversion build numbers

### DIFF
--- a/osversion/windowsbuilds.go
+++ b/osversion/windowsbuilds.go
@@ -1,10 +1,23 @@
 package osversion
 
 const (
-
-	// RS2 was a client-only release in case you're asking why it's not in the list.
+	// RS1 (version 1607, codename "Redstone 1") corresponds to Windows Server
+	// 2016 (ltsc2016) and Windows 10 (Anniversary Update).
 	RS1 = 14393
+
+	// RS2 (version 1703, codename "Redstone 2") was a client-only update, and
+	// corresponds to Windows 10 (Creators Update).
+	RS2 = 15063
+
+	// RS3 (version 1709, codename "Redstone 3") corresponds to Windows Server
+	// 1709 (Semi-Annual Channel (SAC)), and Windows 10 (Fall Creators Update).
 	RS3 = 16299
+
+	// RS4 (version 1803, codename "Redstone 4") corresponds to Windows Server
+	// 1809 (Semi-Annual Channel (SAC)), and Windows 10 (April 2018 Update).
 	RS4 = 17134
+
+	// RS5 (version 1809, codename "Redstone 5") corresponds to Windows Server
+	// 2019 (ltsc2019), and Windows 10 (October 2018 Update).
 	RS5 = 17763
 )


### PR DESCRIPTION
This adds some additional comments to the build-numbers, to help correlate versions to specific Windows Server and Windows Client releases.
