### PR TITLE
Handle Process/Container not found errors and force exits

### DIFF
--- a/internal/hcs/errors.go
+++ b/internal/hcs/errors.go
@@ -272,6 +272,13 @@ func IsNotSupported(err error) bool {
 		err == ErrVmcomputeUnknownMessage
 }
 
+// IsOperationInvalidState returns true when err is caused by
+// `ErrVmcomputeOperationInvalidState`.
+func IsOperationInvalidState(err error) bool {
+	err = getInnerError(err)
+	return err == ErrVmcomputeOperationInvalidState
+}
+
 func getInnerError(err error) error {
 	switch pe := err.(type) {
 	case nil:

--- a/internal/hcs/process.go
+++ b/internal/hcs/process.go
@@ -192,7 +192,7 @@ func (process *Process) Wait() (err error) {
 
 	<-process.waitBlock
 	if process.waitError != nil {
-		return makeProcessError(process, operation, err, nil)
+		return makeProcessError(process, operation, process.waitError, nil)
 	}
 	return nil
 }


### PR DESCRIPTION
- Fix panic on hcs/process.Close() with nil error
- Force HCS process exit on ERROR_NOT_FOUND
- Force UVM exit after 30 seconds of issuing SIGKILL