### PR TITLE
Fix Windows Server version for RS4 in comment

### DIFF
--- a/osversion/windowsbuilds.go
+++ b/osversion/windowsbuilds.go
@@ -14,7 +14,7 @@ const (
 	RS3 = 16299
 
 	// RS4 (version 1803, codename "Redstone 4") corresponds to Windows Server
-	// 1809 (Semi-Annual Channel (SAC)), and Windows 10 (April 2018 Update).
+	// 1803 (Semi-Annual Channel (SAC)), and Windows 10 (April 2018 Update).
 	RS4 = 17134
 
 	// RS5 (version 1809, codename "Redstone 5") corresponds to Windows Server


### PR DESCRIPTION
My bad; inadvertently used the wrong version on this line (added in 73d28eadd65466bcb6dfd92096909ccdf1bd6ee8 / https://github.com/Microsoft/hcsshim/pull/568)