### PR TITLE
hcs: Fail operations when the HCS service crashes

### DIFF
--- a/internal/hcs/callback.go
+++ b/internal/hcs/callback.go
@@ -98,21 +98,27 @@ type notificationChannels map[hcsNotification]notificationChannel
 
 func newSystemChannels() notificationChannels {
 	channels := make(notificationChannels)
-
-	channels[hcsNotificationSystemExited] = make(notificationChannel, 1)
-	channels[hcsNotificationSystemCreateCompleted] = make(notificationChannel, 1)
-	channels[hcsNotificationSystemStartCompleted] = make(notificationChannel, 1)
-	channels[hcsNotificationSystemPauseCompleted] = make(notificationChannel, 1)
-	channels[hcsNotificationSystemResumeCompleted] = make(notificationChannel, 1)
-
+	for _, notif := range []hcsNotification{
+		hcsNotificationServiceDisconnect,
+		hcsNotificationSystemExited,
+		hcsNotificationSystemCreateCompleted,
+		hcsNotificationSystemStartCompleted,
+		hcsNotificationSystemPauseCompleted,
+		hcsNotificationSystemResumeCompleted,
+	} {
+		channels[notif] = make(notificationChannel, 1)
+	}
 	return channels
 }
 
 func newProcessChannels() notificationChannels {
 	channels := make(notificationChannels)
-
-	channels[hcsNotificationProcessExited] = make(notificationChannel, 1)
-
+	for _, notif := range []hcsNotification{
+		hcsNotificationServiceDisconnect,
+		hcsNotificationProcessExited,
+	} {
+		channels[notif] = make(notificationChannel, 1)
+	}
 	return channels
 }
 
@@ -143,18 +149,7 @@ func notificationWatcher(notificationType hcsNotification, callbackNumber uintpt
 	if context.processID != 0 {
 		log.Data[logfields.ProcessID] = context.processID
 	}
-	log.Debug("")
-
-	// The HCS notification system can grow overtime. We explicitly opt-in to
-	// the notifications we would like to handle, all others we simply return.
-	// This means that as it grows we don't have issues associated with new
-	// notification types the code didn't know about.
-	switch notificationType {
-	case hcsNotificationSystemExited, hcsNotificationSystemCreateCompleted, hcsNotificationSystemStartCompleted, hcsNotificationSystemPauseCompleted, hcsNotificationSystemResumeCompleted:
-	case hcsNotificationProcessExited:
-	default:
-		return 0
-	}
+	log.Debug("HCS notification")
 
 	if channel, ok := context.channels[notificationType]; ok {
 		channel <- result


### PR DESCRIPTION
If the HCS service crashes, then all processes and compute systems get
notified of this. The code was previously ignoring this notification,
meaning outstanding waits would never be satisfied. Now the notification
causes all pending waits to complete with an error.