### PR TITLE
Use constant logrus messages everywhere

### DIFF
--- a/cmd/containerd-shim-runhcs-v1/main.go
+++ b/cmd/containerd-shim-runhcs-v1/main.go
@@ -52,12 +52,10 @@ func stack() []byte {
 
 func panicRecover() {
 	if r := recover(); r != nil {
-		logrus.Errorf("containerd-shim-runhcs-v1: panic: %s", r)
-		s := string(stack())
-		split := strings.Split(s, "\n")
-		for _, line := range split {
-			logrus.Error(line)
-		}
+		logrus.WithFields(logrus.Fields{
+			"panic": r,
+			"stack": string(stack()),
+		}).Error("containerd-shim-runhcs-v1: panic")
 	}
 }
 

--- a/cmd/containerd-shim-runhcs-v1/serve.go
+++ b/cmd/containerd-shim-runhcs-v1/serve.go
@@ -192,7 +192,7 @@ func setupDebuggerEvent() {
 	if err != nil {
 		return
 	}
-	logrus.Infof("Halting until %s is signalled", event)
+	logrus.WithField("event", event).Info("Halting until signalled")
 	windows.WaitForSingleObject(handle, windows.INFINITE)
 	return
 }
@@ -226,7 +226,7 @@ func dumpStacks(writeToFile bool) {
 		bufferLen *= 2
 	}
 	buf = buf[:stackSize]
-	logrus.Infof("=== BEGIN goroutine stack dump ===\n%s\n=== END goroutine stack dump ===", buf)
+	logrus.WithField("stack", string(buf)).Info("goroutine stack dump")
 
 	if writeToFile {
 		// Also write to file to aid gathering diagnostics

--- a/internal/copywithtimeout/copywithtimeout.go
+++ b/internal/copywithtimeout/copywithtimeout.go
@@ -62,7 +62,7 @@ func Copy(dst io.Writer, src io.Reader, size int64, context string, timeout time
 				if size > 0 {
 					bytes := make([]byte, size)
 					if _, err := buf.Read(bytes); err == nil {
-						logrus.Debugf("hcsshim::copyWithTimeout - Read bytes\n%s", hex.Dump(bytes))
+						logrus.WithField("bytes", hex.Dump(bytes)).Debug("hcsshim::copyWithTimeout - Read bytes")
 					}
 				}
 			}

--- a/internal/hcs/waithelper.go
+++ b/internal/hcs/waithelper.go
@@ -19,7 +19,7 @@ func waitForNotification(callbackNumber uintptr, expectedNotification hcsNotific
 	callbackMapLock.RLock()
 	if _, ok := callbackMap[callbackNumber]; !ok {
 		callbackMapLock.RUnlock()
-		logrus.Errorf("failed to waitForNotification: callbackNumber %d does not exist in callbackMap", callbackNumber)
+		logrus.WithField("callbackNumber", callbackNumber).Error("failed to waitForNotification: callbackNumber does not exist in callbackMap")
 		return ErrHandleClose
 	}
 	channels := callbackMap[callbackNumber].channels
@@ -27,7 +27,7 @@ func waitForNotification(callbackNumber uintptr, expectedNotification hcsNotific
 
 	expectedChannel := channels[expectedNotification]
 	if expectedChannel == nil {
-		logrus.Errorf("unknown notification type in waitForNotification %x", expectedNotification)
+		logrus.WithField("type", expectedNotification).Error("unknown notification type in waitForNotification")
 		return ErrInvalidNotificationType
 	}
 

--- a/internal/hcsoci/hcsdoc_lcow.go
+++ b/internal/hcsoci/hcsdoc_lcow.go
@@ -5,7 +5,7 @@ package hcsoci
 import (
 	"encoding/json"
 
-	"github.com/Microsoft/hcsshim/internal/schema2"
+	hcsschema "github.com/Microsoft/hcsshim/internal/schema2"
 	"github.com/Microsoft/hcsshim/internal/schemaversion"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/sirupsen/logrus"
@@ -90,7 +90,7 @@ func createLinuxContainerDocument(coi *createOptionsInternal, guestRoot string) 
 		return nil, err
 	}
 
-	logrus.Debugf("hcsshim::createLinuxContainerDoc: guestRoot:%s", guestRoot)
+	logrus.WithField("guestRoot", guestRoot).Debug("hcsshim::createLinuxContainerDoc")
 	v2 := &linuxComputeSystem{
 		Owner:                             coi.actualOwner,
 		SchemaVersion:                     schemaversion.SchemaV21(),

--- a/internal/hcsoci/hcsdoc_wcow.go
+++ b/internal/hcsoci/hcsdoc_wcow.go
@@ -12,7 +12,7 @@ import (
 	"github.com/Microsoft/hcsshim/internal/logfields"
 	"github.com/Microsoft/hcsshim/internal/oci"
 	"github.com/Microsoft/hcsshim/internal/schema1"
-	"github.com/Microsoft/hcsshim/internal/schema2"
+	hcsschema "github.com/Microsoft/hcsshim/internal/schema2"
 	"github.com/Microsoft/hcsshim/internal/schemaversion"
 	"github.com/Microsoft/hcsshim/internal/uvm"
 	"github.com/Microsoft/hcsshim/internal/uvmfolder"
@@ -25,7 +25,7 @@ import (
 // a container, both hosted and process isolated. It can create both v1 and v2
 // schema, WCOW only. The containers storage should have been mounted already.
 func createWindowsContainerDocument(coi *createOptionsInternal) (interface{}, error) {
-	logrus.Debugf("hcsshim: CreateHCSContainerDocument")
+	logrus.Debug("hcsshim: CreateHCSContainerDocument")
 	// TODO: Make this safe if exported so no null pointer dereferences.
 
 	if coi.Spec == nil {
@@ -95,7 +95,10 @@ func createWindowsContainerDocument(coi *createOptionsInternal) (interface{}, er
 			if coi.HostingSystem != nil {
 				log.Data[logfields.UVMID] = coi.HostingSystem.ID()
 			}
-			log.Warningf("Changing user requested CPUCount: %d to current number of processors: %d", cpuCount, hostCPUCount)
+			log.WithFields(logrus.Fields{
+				"requested": cpuCount,
+				"assigned":  hostCPUCount,
+			}).Warn("Changing user requested CPUCount to current number of processors")
 			cpuCount = hostCPUCount
 		}
 
@@ -112,7 +115,10 @@ func createWindowsContainerDocument(coi *createOptionsInternal) (interface{}, er
 			if coi.HostingSystem != nil {
 				log.Data[logfields.UVMID] = coi.HostingSystem.ID()
 			}
-			log.Warningf("silently ignoring Windows Process Container QoS for Limit: '%d' or Weight: '%d' until bug fix", cpuLimit, cpuWeight)
+			log.WithFields(logrus.Fields{
+				"limit":  cpuLimit,
+				"weight": cpuWeight,
+			}).Warning("silently ignoring Windows Process Container QoS for limit or weight until bug fix")
 		} else {
 			v2Container.Processor = &hcsschema.Processor{
 				Count: cpuCount,

--- a/internal/hcsoci/network.go
+++ b/internal/hcsoci/network.go
@@ -18,7 +18,10 @@ func createNetworkNamespace(coi *createOptionsInternal, resources *Resources) er
 	if err != nil {
 		return err
 	}
-	logrus.Infof("created network namespace %s for %s", netID, coi.ID)
+	logrus.WithFields(logrus.Fields{
+		"netID":               netID,
+		logfields.ContainerID: coi.ID,
+	}).Info("created network namespace for container")
 	resources.netNS = netID
 	resources.createdNetNS = true
 	for _, endpointID := range coi.Spec.Windows.Network.EndpointList {
@@ -26,7 +29,10 @@ func createNetworkNamespace(coi *createOptionsInternal, resources *Resources) er
 		if err != nil {
 			return err
 		}
-		logrus.Infof("added network endpoint %s to namespace %s", endpointID, netID)
+		logrus.WithFields(logrus.Fields{
+			"netID":      netID,
+			"endpointID": endpointID,
+		}).Info("added network endpoint to namespace")
 		resources.networkEndpoints = append(resources.networkEndpoints, endpointID)
 	}
 	return nil

--- a/internal/hcsoci/resources.go
+++ b/internal/hcsoci/resources.go
@@ -73,7 +73,10 @@ func ReleaseResources(r *Resources, vm *uvm.UtilityVM, all bool) error {
 				if !os.IsNotExist(err) {
 					return err
 				}
-				logrus.Warnf("removing endpoint %s from namespace %s: does not exist", endpoint, r.NetNS())
+				logrus.WithFields(logrus.Fields{
+					"endpointID": endpoint,
+					"netID":      r.NetNS(),
+				}).Warn("removing endpoint from namespace: does not exist")
 			}
 			r.networkEndpoints = r.networkEndpoints[:len(r.networkEndpoints)-1]
 		}

--- a/internal/hcsoci/resources_lcow.go
+++ b/internal/hcsoci/resources_lcow.go
@@ -25,7 +25,7 @@ func allocateLinuxResources(coi *createOptionsInternal, resources *Resources) er
 		coi.Spec.Root = &specs.Root{}
 	}
 	if coi.Spec.Windows != nil && len(coi.Spec.Windows.LayerFolders) > 0 {
-		logrus.Debugln("hcsshim::allocateLinuxResources mounting storage")
+		logrus.Debug("hcsshim::allocateLinuxResources mounting storage")
 		mcl, err := MountContainerLayers(coi.Spec.Windows.LayerFolders, resources.containerRootInUVM, coi.HostingSystem)
 		if err != nil {
 			return fmt.Errorf("failed to mount container storage: %s", err)
@@ -76,9 +76,9 @@ func allocateLinuxResources(coi *createOptionsInternal, resources *Resources) er
 					break
 				}
 			}
-
+			log := logrus.WithField("mount", fmt.Sprintf("%+v", mount))
 			if mount.Type == "physical-disk" {
-				logrus.Debugf("hcsshim::allocateLinuxResources Hot-adding SCSI physical disk for OCI mount %+v", mount)
+				log.Debug("hcsshim::allocateLinuxResources Hot-adding SCSI physical disk for OCI mount")
 				_, _, err := coi.HostingSystem.AddSCSIPhysicalDisk(hostPath, uvmPathForShare, readOnly)
 				if err != nil {
 					return fmt.Errorf("adding SCSI physical disk mount %+v: %s", mount, err)
@@ -86,7 +86,7 @@ func allocateLinuxResources(coi *createOptionsInternal, resources *Resources) er
 				resources.scsiMounts = append(resources.scsiMounts, hostPath)
 				coi.Spec.Mounts[i].Type = "none"
 			} else if mount.Type == "virtual-disk" {
-				logrus.Debugf("hcsshim::allocateLinuxResources Hot-adding SCSI virtual disk for OCI mount %+v", mount)
+				log.Debug("hcsshim::allocateLinuxResources Hot-adding SCSI virtual disk for OCI mount")
 				_, _, err := coi.HostingSystem.AddSCSI(hostPath, uvmPathForShare, readOnly)
 				if err != nil {
 					return fmt.Errorf("adding SCSI virtual disk mount %+v: %s", mount, err)
@@ -109,7 +109,7 @@ func allocateLinuxResources(coi *createOptionsInternal, resources *Resources) er
 					restrictAccess = true
 					uvmPathForFile = path.Join(uvmPathForShare, fileName)
 				}
-				logrus.Debugf("hcsshim::allocateLinuxResources Hot-adding Plan9 for OCI mount %+v", mount)
+				log.Debug("hcsshim::allocateLinuxResources Hot-adding Plan9 for OCI mount")
 				share, err := coi.HostingSystem.AddPlan9(hostPath, uvmPathForShare, readOnly, restrictAccess, allowedNames)
 				if err != nil {
 					return fmt.Errorf("adding plan9 mount %+v: %s", mount, err)

--- a/internal/lcow/process.go
+++ b/internal/lcow/process.go
@@ -104,7 +104,7 @@ func CreateProcess(opts *ProcessOptions) (*hcs.Process, *ByteCounts, error) {
 
 	proc, err := opts.HCSSystem.CreateProcess(processConfig)
 	if err != nil {
-		logrus.Debugf("failed to create process: %s", err)
+		logrus.WithError(err).Debug("failed to create process")
 		return nil, nil, err
 	}
 

--- a/internal/lcow/tar2vhd.go
+++ b/internal/lcow/tar2vhd.go
@@ -13,7 +13,7 @@ import (
 
 // TarToVhd streams a tarstream contained in an io.Reader to a fixed vhd file
 func TarToVhd(lcowUVM *uvm.UtilityVM, targetVHDFile string, reader io.Reader) (int64, error) {
-	logrus.Debugf("hcsshim: TarToVhd: %s", targetVHDFile)
+	logrus.WithField("target", targetVHDFile).Debug("hcsshim: TarToVhd")
 
 	if lcowUVM == nil {
 		return 0, fmt.Errorf("no utility VM passed")
@@ -41,6 +41,9 @@ func TarToVhd(lcowUVM *uvm.UtilityVM, targetVHDFile string, reader io.Reader) (i
 	}
 	defer tar2vhd.Close()
 
-	logrus.Debugf("hcsshim: TarToVhd: %s created, %d bytes", targetVHDFile, byteCounts.Out)
+	logrus.WithFields(logrus.Fields{
+		"target": targetVHDFile,
+		"size":   byteCounts.Out,
+	}).Debug("hcsshim: TarToVhd: created")
 	return byteCounts.Out, err
 }

--- a/internal/oci/uvm.go
+++ b/internal/oci/uvm.go
@@ -249,7 +249,10 @@ func parseAnnotationsPreferredRootFSType(a map[string]string, key string, def uv
 		case "vhd":
 			return uvm.PreferredRootFSTypeVHD
 		default:
-			logrus.Warningf("annotation: '%s', with value: '%s' must be 'initrd' or 'vhd'", key, v)
+			logrus.WithFields(logrus.Fields{
+				"annotation": key,
+				"value":      v,
+			}).Warn("annotation value must be 'initrd' or 'vhd'")
 		}
 	}
 	return def

--- a/internal/schemaversion/schemaversion.go
+++ b/internal/schemaversion/schemaversion.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/Microsoft/hcsshim/internal/schema2"
+	hcsschema "github.com/Microsoft/hcsshim/internal/schema2"
 	"github.com/Microsoft/hcsshim/osversion"
 	"github.com/sirupsen/logrus"
 )
@@ -74,7 +74,7 @@ func DetermineSchemaVersion(requestedSV *hcsschema.Version) *hcsschema.Version {
 		if err := IsSupported(requestedSV); err == nil {
 			sv = requestedSV
 		} else {
-			logrus.Warnf("Ignoring unsupported requested schema version %+v", requestedSV)
+			logrus.WithField("schemaVersion", requestedSV).Warn("Ignoring unsupported requested schema version")
 		}
 	}
 	return sv

--- a/internal/uvm/create.go
+++ b/internal/uvm/create.go
@@ -128,9 +128,9 @@ func (uvm *UtilityVM) normalizeProcessorCount(requested int32) {
 	if requested > hostCount {
 		logrus.WithFields(logrus.Fields{
 			logfields.UVMID: uvm.id,
-		}).Warningf("Changing user requested CPUCount: %d to current number of processors: %d",
-			requested,
-			hostCount)
+			"requested":     requested,
+			"assigned":      hostCount,
+		}).Warn("Changing user requested CPUCount to current number of processors")
 		uvm.processorCount = hostCount
 	} else {
 		uvm.processorCount = requested

--- a/internal/uvm/create_lcow.go
+++ b/internal/uvm/create_lcow.go
@@ -130,7 +130,7 @@ func CreateLCOW(opts *OptionsLCOW) (_ *UtilityVM, err error) {
 	log := logrus.WithFields(logrus.Fields{
 		logfields.UVMID: opts.ID,
 	})
-	log.Debugf(op+" - Begin Operation: %+v", opts)
+	log.WithField("options", fmt.Sprintf("%+v", opts)).Debug(op + " - Begin Operation")
 	defer func() {
 		if err != nil {
 			log.Data[logrus.ErrorKey] = err

--- a/internal/uvm/create_wcow.go
+++ b/internal/uvm/create_wcow.go
@@ -8,7 +8,7 @@ import (
 	"github.com/Microsoft/hcsshim/internal/hcs"
 	"github.com/Microsoft/hcsshim/internal/logfields"
 	"github.com/Microsoft/hcsshim/internal/mergemaps"
-	"github.com/Microsoft/hcsshim/internal/schema2"
+	hcsschema "github.com/Microsoft/hcsshim/internal/schema2"
 	"github.com/Microsoft/hcsshim/internal/schemaversion"
 	"github.com/Microsoft/hcsshim/internal/uvmfolder"
 	"github.com/Microsoft/hcsshim/internal/wcow"
@@ -45,7 +45,7 @@ func CreateWCOW(opts *OptionsWCOW) (_ *UtilityVM, err error) {
 	log := logrus.WithFields(logrus.Fields{
 		logfields.UVMID: opts.ID,
 	})
-	log.Debugf(op+" - Begin Operation: %+v", opts)
+	log.WithField("options", fmt.Sprintf("%+v", opts)).Debug(op + " - Begin Operation")
 	defer func() {
 		if err != nil {
 			log.Data[logrus.ErrorKey] = err
@@ -82,11 +82,11 @@ func CreateWCOW(opts *OptionsWCOW) (_ *UtilityVM, err error) {
 	//       - Update tests that rely on this current behaviour.
 	// Create the RW scratch in the top-most layer folder, creating the folder if it doesn't already exist.
 	scratchFolder := opts.LayerFolders[len(opts.LayerFolders)-1]
-	logrus.Debugf("uvm::CreateWCOW scratch folder: %s", scratchFolder)
+	logrus.WithField("scratchFolder", scratchFolder).Debug("uvm::CreateWCOW scratch folder")
 
 	// Create the directory if it doesn't exist
 	if _, err := os.Stat(scratchFolder); os.IsNotExist(err) {
-		logrus.Debugf("uvm::CreateWCOW creating folder: %s ", scratchFolder)
+		logrus.WithField("scratchFolder", scratchFolder).Debug("uvm::CreateWCOW creating folder")
 		if err := os.MkdirAll(scratchFolder, 0777); err != nil {
 			return nil, fmt.Errorf("failed to create utility VM scratch folder: %s", err)
 		}
@@ -184,7 +184,7 @@ func CreateWCOW(opts *OptionsWCOW) (_ *UtilityVM, err error) {
 
 	hcsSystem, err := hcs.CreateComputeSystem(uvm.id, fullDoc)
 	if err != nil {
-		logrus.Debugln("failed to create UVM: ", err)
+		logrus.WithError(err).Debug("failed to create UVM")
 		return nil, err
 	}
 	uvm.hcsSystem = hcsSystem

--- a/internal/uvm/vpmem.go
+++ b/internal/uvm/vpmem.go
@@ -6,7 +6,7 @@ import (
 	"github.com/Microsoft/hcsshim/internal/guestrequest"
 	"github.com/Microsoft/hcsshim/internal/logfields"
 	"github.com/Microsoft/hcsshim/internal/requesttype"
-	"github.com/Microsoft/hcsshim/internal/schema2"
+	hcsschema "github.com/Microsoft/hcsshim/internal/schema2"
 	"github.com/sirupsen/logrus"
 )
 
@@ -141,9 +141,11 @@ func (uvm *UtilityVM) AddVPMEM(hostPath string, expose bool) (_ uint32, _ string
 			uvmPath:  uvmPath}
 		uvm.vpmemDevices[deviceNumber] = pmemi
 	}
-	logrus.Debugf("hcsshim::AddVPMEM id:%s Success %+v", uvm.id, uvm.vpmemDevices[deviceNumber])
+	logrus.WithFields(logrus.Fields{
+		logfields.UVMID: uvm.id,
+		"device":        fmt.Sprintf("%+v", uvm.vpmemDevices[deviceNumber]),
+	}).Debug("hcsshim::AddVPMEM Success")
 	return deviceNumber, uvmPath, nil
-
 }
 
 // RemoveVPMEM removes a VPMEM disk from a utility VM. As an external API, it

--- a/internal/uvm/vsmb.go
+++ b/internal/uvm/vsmb.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/Microsoft/hcsshim/internal/logfields"
 	"github.com/Microsoft/hcsshim/internal/requesttype"
-	"github.com/Microsoft/hcsshim/internal/schema2"
+	hcsschema "github.com/Microsoft/hcsshim/internal/schema2"
 	"github.com/sirupsen/logrus"
 )
 
@@ -38,7 +38,10 @@ func (uvm *UtilityVM) AddVSMB(hostPath string, guestRequest interface{}, options
 		logfields.UVMID: uvm.id,
 		"host-path":     hostPath,
 	})
-	log.Debugf(op+" - GuestRequest: %+v, Options: %+v - Begin Operation", guestRequest, options)
+	log.WithFields(logrus.Fields{
+		"options":      fmt.Sprintf("%+v", options),
+		"guestRequest": fmt.Sprintf("%+v", guestRequest),
+	}).Debug(op + " - Begin Operation")
 	defer func() {
 		if err != nil {
 			log.Data[logrus.ErrorKey] = err

--- a/internal/uvmfolder/locate.go
+++ b/internal/uvmfolder/locate.go
@@ -30,6 +30,10 @@ func LocateUVMFolder(layerFolders []string) (string, error) {
 	if uvmFolder == "" {
 		return "", fmt.Errorf("utility VM folder could not be found in layers")
 	}
-	logrus.Debugf("hcsshim::LocateUVMFolder At %d of %d: %s", index+1, len(layerFolders), uvmFolder)
+	logrus.WithFields(logrus.Fields{
+		"index":  index + 1,
+		"count":  len(layerFolders),
+		"folder": uvmFolder,
+	}).Debug("hcsshim::LocateUVMFolder: found")
 	return uvmFolder, nil
 }

--- a/internal/wcow/scratch.go
+++ b/internal/wcow/scratch.go
@@ -14,7 +14,10 @@ import (
 func CreateUVMScratch(imagePath, destDirectory, vmID string) error {
 	sourceScratch := filepath.Join(imagePath, `UtilityVM\SystemTemplate.vhdx`)
 	targetScratch := filepath.Join(destDirectory, "sandbox.vhdx")
-	logrus.Debugf("uvm::CreateUVMScratch %s from %s", targetScratch, sourceScratch)
+	logrus.WithFields(logrus.Fields{
+		"target": targetScratch,
+		"source": sourceScratch,
+	}).Debug("uvm::CreateUVMScratch")
 	if err := copyfile.CopyFile(sourceScratch, targetScratch, true); err != nil {
 		return err
 	}


### PR DESCRIPTION
This change (intends to) replace all dynamically generated logrus
messages with constant values and to include dynamic data via separate
logrus fields. It does so for all non-test packages except HCN and HNS.

This makes it easier to extract data from log messages in post
processing, especially when the logrus ETW tracelogging hook is enabled.

With few exceptions, this change does not change the number of logged
events, nor does it add additional context to existing messages. There
are still many instances where events are redundant, and there are still
many events missing the necessary context to associate the message with
a container, VM, or request. These shortcomings should be addressed in
separate changes.