### PR TITLE
uvm: Round requested memory size to 2MB

### DIFF
--- a/internal/uvm/create.go
+++ b/internal/uvm/create.go
@@ -141,3 +141,15 @@ func (uvm *UtilityVM) normalizeProcessorCount(requested int32) {
 func (uvm *UtilityVM) ProcessorCount() int32 {
 	return uvm.processorCount
 }
+
+func (uvm *UtilityVM) normalizeMemorySize(requested int32) int32 {
+	actual := (requested + 1) &^ 1 // align up to an even number
+	if requested != actual {
+		logrus.WithFields(logrus.Fields{
+			logfields.UVMID: uvm.id,
+			"requested":     requested,
+			"assigned":      actual,
+		}).Warn("Changing user requested MemorySizeInMB to align to 2MB")
+	}
+	return actual
+}

--- a/internal/uvm/create_lcow.go
+++ b/internal/uvm/create_lcow.go
@@ -158,6 +158,9 @@ func CreateLCOW(opts *OptionsLCOW) (_ *UtilityVM, err error) {
 	// a user CPU count if the setting is not possible.
 	uvm.normalizeProcessorCount(opts.ProcessorCount)
 
+	// Align the requested memory size.
+	memorySizeInMB := uvm.normalizeMemorySize(opts.MemorySizeInMB)
+
 	kernelFullPath := filepath.Join(opts.BootFilesPath, opts.KernelFile)
 	if _, err := os.Stat(kernelFullPath); os.IsNotExist(err) {
 		return nil, fmt.Errorf("kernel: '%s' not found", kernelFullPath)
@@ -195,7 +198,7 @@ func CreateLCOW(opts *OptionsLCOW) (_ *UtilityVM, err error) {
 			Chipset:     &hcsschema.Chipset{},
 			ComputeTopology: &hcsschema.Topology{
 				Memory: &hcsschema.Memory2{
-					SizeInMB:             opts.MemorySizeInMB,
+					SizeInMB:             memorySizeInMB,
 					AllowOvercommit:      opts.AllowOvercommit,
 					EnableDeferredCommit: opts.EnableDeferredCommit,
 				},

--- a/internal/uvm/create_wcow.go
+++ b/internal/uvm/create_wcow.go
@@ -8,7 +8,7 @@ import (
 	"github.com/Microsoft/hcsshim/internal/hcs"
 	"github.com/Microsoft/hcsshim/internal/logfields"
 	"github.com/Microsoft/hcsshim/internal/mergemaps"
-	"github.com/Microsoft/hcsshim/internal/schema2"
+	hcsschema "github.com/Microsoft/hcsshim/internal/schema2"
 	"github.com/Microsoft/hcsshim/internal/schemaversion"
 	"github.com/Microsoft/hcsshim/internal/uvmfolder"
 	"github.com/Microsoft/hcsshim/internal/wcow"
@@ -67,6 +67,9 @@ func CreateWCOW(opts *OptionsWCOW) (_ *UtilityVM, err error) {
 	// a user CPU count if the setting is not possible.
 	uvm.normalizeProcessorCount(opts.ProcessorCount)
 
+	// Align the requested memory size.
+	memorySizeInMB := uvm.normalizeMemorySize(opts.MemorySizeInMB)
+
 	if len(opts.LayerFolders) < 2 {
 		return nil, fmt.Errorf("at least 2 LayerFolders must be supplied")
 	}
@@ -116,7 +119,7 @@ func CreateWCOW(opts *OptionsWCOW) (_ *UtilityVM, err error) {
 			},
 			ComputeTopology: &hcsschema.Topology{
 				Memory: &hcsschema.Memory2{
-					SizeInMB:        opts.MemorySizeInMB,
+					SizeInMB:        memorySizeInMB,
 					AllowOvercommit: opts.AllowOvercommit,
 					// EnableHotHint is not compatible with physical.
 					EnableHotHint:        opts.AllowOvercommit,


### PR DESCRIPTION
Hyper-V only supports 2MB aligned memory sizes (presumably to avoid
splitting large pages). Rather than fail with a cryptic error from the
platform, round the requested memory size up to the next 2MB boundary.