### PR TITLE
uvm: Reduce binding between hcs and uvm interfaces

### DIFF
--- a/cmd/containerd-shim-runhcs-v1/diag.go
+++ b/cmd/containerd-shim-runhcs-v1/diag.go
@@ -23,7 +23,7 @@ func execInUvm(ctx context.Context, vm *uvm.UtilityVM, req *shimdiag.ExecProcess
 			wd = "/"
 		}
 	}
-	proc, err := vm.ComputeSystem().CreateProcess(&hcsschema.ProcessParameters{
+	proc, err := vm.CreateProcess(&hcsschema.ProcessParameters{
 		CommandArgs:      req.Args,
 		CreateStdInPipe:  req.Stdin != "",
 		CreateStdOutPipe: req.Stdout != "",

--- a/internal/lcow/process.go
+++ b/internal/lcow/process.go
@@ -21,10 +21,14 @@ type ByteCounts struct {
 	Err int64
 }
 
+type ProcessHost interface {
+	CreateProcess(settings interface{}) (*hcs.Process, error)
+}
+
 // ProcessOptions are the set of options which are passed to CreateProcessEx() to
 // create a utility vm.
 type ProcessOptions struct {
-	HCSSystem         *hcs.System
+	Host              ProcessHost
 	Process           *specs.Process
 	Stdin             io.Reader     // Optional reader for sending on to the processes stdin stream
 	Stdout            io.Writer     // Optional writer for returning the processes stdout stream
@@ -62,7 +66,7 @@ func CreateProcess(opts *ProcessOptions) (*hcs.Process, *ByteCounts, error) {
 		return nil, nil, fmt.Errorf("no options supplied")
 	}
 
-	if opts.HCSSystem == nil {
+	if opts.Host == nil {
 		return nil, nil, fmt.Errorf("no HCS system supplied")
 	}
 
@@ -102,7 +106,7 @@ func CreateProcess(opts *ProcessOptions) (*hcs.Process, *ByteCounts, error) {
 		}
 	}
 
-	proc, err := opts.HCSSystem.CreateProcess(processConfig)
+	proc, err := opts.Host.CreateProcess(processConfig)
 	if err != nil {
 		logrus.WithError(err).Debug("failed to create process")
 		return nil, nil, err

--- a/internal/lcow/scratch.go
+++ b/internal/lcow/scratch.go
@@ -78,7 +78,7 @@ func CreateScratch(lcowUVM *uvm.UtilityVM, destFile string, sizeGB uint32, cache
 	for {
 		testdCommand := []string{"test", "-d", fmt.Sprintf("/sys/bus/scsi/devices/%d:0:0:%d", controller, lun)}
 		testdProc, _, err := CreateProcess(&ProcessOptions{
-			HCSSystem:         lcowUVM.ComputeSystem(),
+			Host:              lcowUVM,
 			CreateInUtilityVm: true,
 			CopyTimeout:       timeout.ExternalCommandToStart,
 			Process:           &specs.Process{Args: testdCommand},
@@ -111,7 +111,7 @@ func CreateScratch(lcowUVM *uvm.UtilityVM, destFile string, sizeGB uint32, cache
 	var lsOutput bytes.Buffer
 	lsCommand := []string{"ls", fmt.Sprintf("/sys/bus/scsi/devices/%d:0:0:%d/block", controller, lun)}
 	lsProc, _, err := CreateProcess(&ProcessOptions{
-		HCSSystem:         lcowUVM.ComputeSystem(),
+		Host:              lcowUVM,
 		CreateInUtilityVm: true,
 		CopyTimeout:       timeout.ExternalCommandToStart,
 		Process:           &specs.Process{Args: lsCommand},
@@ -142,7 +142,7 @@ func CreateScratch(lcowUVM *uvm.UtilityVM, destFile string, sizeGB uint32, cache
 	mkfsCommand := []string{"mkfs.ext4", "-q", "-E", "lazy_itable_init=1", "-O", `^has_journal,sparse_super2,uninit_bg,^resize_inode`, device}
 	var mkfsStderr bytes.Buffer
 	mkfsProc, _, err := CreateProcess(&ProcessOptions{
-		HCSSystem:         lcowUVM.ComputeSystem(),
+		Host:              lcowUVM,
 		CreateInUtilityVm: true,
 		CopyTimeout:       timeout.ExternalCommandToStart,
 		Process:           &specs.Process{Args: mkfsCommand},

--- a/internal/lcow/tar2vhd.go
+++ b/internal/lcow/tar2vhd.go
@@ -29,7 +29,7 @@ func TarToVhd(lcowUVM *uvm.UtilityVM, targetVHDFile string, reader io.Reader) (i
 	// BUGBUG Delete the file on failure
 
 	tar2vhd, byteCounts, err := CreateProcess(&ProcessOptions{
-		HCSSystem:         lcowUVM.ComputeSystem(),
+		Host:              lcowUVM,
 		Process:           &specs.Process{Args: []string{"tar2vhd"}},
 		CreateInUtilityVm: true,
 		Stdin:             reader,

--- a/internal/tools/uvmboot/main.go
+++ b/internal/tools/uvmboot/main.go
@@ -8,7 +8,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/Microsoft/hcsshim/internal/hcs"
 	"github.com/Microsoft/hcsshim/internal/lcow"
 	hcsschema "github.com/Microsoft/hcsshim/internal/schema2"
 	"github.com/Microsoft/hcsshim/internal/uvm"
@@ -267,18 +266,18 @@ func run(options *uvm.OptionsLCOW, c *cli.Context) error {
 	}
 
 	if options.UseGuestConnection {
-		if err := execViaGcs(uvm.ComputeSystem(), c); err != nil {
+		if err := execViaGcs(uvm, c); err != nil {
 			return err
 		}
-		uvm.ComputeSystem().Terminate()
+		uvm.Terminate()
 		uvm.Wait()
-		return uvm.ComputeSystem().ExitError()
+		return uvm.ExitError()
 	}
 
 	return uvm.Wait()
 }
 
-func execViaGcs(cs *hcs.System, c *cli.Context) error {
+func execViaGcs(vm *uvm.UtilityVM, c *cli.Context) error {
 	var copyOut, copyErr bool
 	if c.String(outputHandlingArgName) == "stdout" {
 		copyOut = c.Bool(forwardStdoutArgName)
@@ -294,7 +293,7 @@ func execViaGcs(cs *hcs.System, c *cli.Context) error {
 		},
 		CreateInUtilityVm: true,
 	}
-	p, err := cs.CreateProcess(popts)
+	p, err := vm.CreateProcess(popts)
 	if err != nil {
 		return err
 	}

--- a/internal/uvm/capabilities.go
+++ b/internal/uvm/capabilities.go
@@ -7,8 +7,11 @@ import "github.com/Microsoft/hcsshim/internal/schema1"
 //
 // This support was added RS5+ guests.
 func (uvm *UtilityVM) SignalProcessSupported() bool {
-	if props, err := uvm.hcsSystem.Properties(schema1.PropertyTypeGuestConnection); err == nil {
-		return props.GuestConnectionInfo.GuestDefinedCapabilities.SignalProcessSupported
-	}
-	return false
+	return uvm.guestCaps.SignalProcessSupported
+}
+
+// Capabilities returns the protocol version and the guest defined capabilities.
+// This should only be used for testing.
+func (uvm *UtilityVM) Capabilities() (uint32, schema1.GuestDefinedCapabilities) {
+	return uvm.protocol, uvm.guestCaps
 }

--- a/internal/uvm/network.go
+++ b/internal/uvm/network.go
@@ -12,8 +12,7 @@ import (
 	"github.com/Microsoft/hcsshim/internal/hns"
 	"github.com/Microsoft/hcsshim/internal/logfields"
 	"github.com/Microsoft/hcsshim/internal/requesttype"
-	"github.com/Microsoft/hcsshim/internal/schema1"
-	"github.com/Microsoft/hcsshim/internal/schema2"
+	hcsschema "github.com/Microsoft/hcsshim/internal/schema2"
 	"github.com/Microsoft/hcsshim/osversion"
 )
 
@@ -220,12 +219,7 @@ func (uvm *UtilityVM) RemoveEndpointsFromNS(id string, endpoints []*hns.HNSEndpo
 
 // IsNetworkNamespaceSupported returns bool value specifying if network namespace is supported inside the guest
 func (uvm *UtilityVM) isNetworkNamespaceSupported() bool {
-	p, err := uvm.ComputeSystem().Properties(schema1.PropertyTypeGuestConnection)
-	if err == nil {
-		return p.GuestConnectionInfo.GuestDefinedCapabilities.NamespaceAddRequestSupported
-	}
-
-	return false
+	return uvm.guestCaps.NamespaceAddRequestSupported
 }
 
 func getNetworkModifyRequest(adapterID string, requestType string, settings interface{}) interface{} {

--- a/internal/uvm/system.go
+++ b/internal/uvm/system.go
@@ -1,7 +1,0 @@
-package uvm
-
-import "github.com/Microsoft/hcsshim/internal/hcs"
-
-func (uvm *UtilityVM) ComputeSystem() *hcs.System {
-	return uvm.hcsSystem
-}

--- a/internal/uvm/types.go
+++ b/internal/uvm/types.go
@@ -7,9 +7,11 @@ import (
 	"net"
 	"sync"
 
-	"github.com/Microsoft/hcsshim/internal/guid"
+	"github.com/Microsoft/go-winio/pkg/guid"
+	iguid "github.com/Microsoft/hcsshim/internal/guid"
 	"github.com/Microsoft/hcsshim/internal/hcs"
 	"github.com/Microsoft/hcsshim/internal/hns"
+	"github.com/Microsoft/hcsshim/internal/schema1"
 )
 
 //                    | WCOW | LCOW
@@ -47,7 +49,7 @@ type vpmemInfo struct {
 }
 
 type nicInfo struct {
-	ID       guid.GUID
+	ID       iguid.GUID
 	Endpoint *hns.HNSEndpoint
 }
 
@@ -58,11 +60,16 @@ type namespaceInfo struct {
 // UtilityVM is the object used by clients representing a utility VM
 type UtilityVM struct {
 	id              string      // Identifier for the utility VM (user supplied or generated)
+	runtimeID       guid.GUID   // Hyper-V VM ID
 	owner           string      // Owner for the utility VM (user supplied or generated)
 	operatingSystem string      // "windows" or "linux"
 	hcsSystem       *hcs.System // The handle to the compute system
 	processorCount  int32
 	m               sync.Mutex // Lock for adding/removing devices
+
+	// GCS bridge protocol and capabilities
+	protocol  uint32
+	guestCaps schema1.GuestDefinedCapabilities
 
 	// containerCounter is the current number of containers that have been
 	// created. This is never decremented in the life of the UVM.

--- a/test/functional/lcow_test.go
+++ b/test/functional/lcow_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/Microsoft/hcsshim/internal/lcow"
 	"github.com/Microsoft/hcsshim/internal/uvm"
 	"github.com/Microsoft/hcsshim/osversion"
-	"github.com/Microsoft/hcsshim/test/functional/utilities"
+	testutilities "github.com/Microsoft/hcsshim/test/functional/utilities"
 )
 
 // TestLCOWUVMNoSCSINoVPMemInitrd starts an LCOW utility VM without a SCSI controller and
@@ -206,7 +206,7 @@ func TestLCOWSimplePodScenario(t *testing.T) {
 func runInitProcess(t *testing.T, s *hcs.System, expected string) {
 	var outB, errB bytes.Buffer
 	p, bc, err := lcow.CreateProcess(&lcow.ProcessOptions{
-		HCSSystem:   s,
+		Host:        s,
 		Stdout:      &outB,
 		Stderr:      &errB,
 		CopyTimeout: 30 * time.Second,

--- a/test/functional/uvm_properties_test.go
+++ b/test/functional/uvm_properties_test.go
@@ -6,9 +6,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/Microsoft/hcsshim/internal/schema1"
 	"github.com/Microsoft/hcsshim/osversion"
-	"github.com/Microsoft/hcsshim/test/functional/utilities"
+	testutilities "github.com/Microsoft/hcsshim/test/functional/utilities"
 )
 
 func TestPropertiesGuestConnection_LCOW(t *testing.T) {
@@ -17,15 +16,11 @@ func TestPropertiesGuestConnection_LCOW(t *testing.T) {
 	uvm := testutilities.CreateLCOWUVM(t, t.Name())
 	defer uvm.Close()
 
-	p, err := uvm.ComputeSystem().Properties(schema1.PropertyTypeGuestConnection)
-	if err != nil {
-		t.Fatalf("Failed to query properties: %s", err)
-	}
-
-	if p.GuestConnectionInfo.GuestDefinedCapabilities.NamespaceAddRequestSupported ||
-		!p.GuestConnectionInfo.GuestDefinedCapabilities.SignalProcessSupported ||
-		p.GuestConnectionInfo.ProtocolVersion < 4 {
-		t.Fatalf("unexpected values: %+v", p.GuestConnectionInfo)
+	p, gc := uvm.Capabilities()
+	if gc.NamespaceAddRequestSupported ||
+		!gc.SignalProcessSupported ||
+		p < 4 {
+		t.Fatalf("unexpected values: %d %+v", p, gc)
 	}
 }
 
@@ -35,14 +30,10 @@ func TestPropertiesGuestConnection_WCOW(t *testing.T) {
 	defer os.RemoveAll(uvmScratchDir)
 	defer uvm.Close()
 
-	p, err := uvm.ComputeSystem().Properties(schema1.PropertyTypeGuestConnection)
-	if err != nil {
-		t.Fatalf("Failed to query properties: %s", err)
-	}
-
-	if !p.GuestConnectionInfo.GuestDefinedCapabilities.NamespaceAddRequestSupported ||
-		!p.GuestConnectionInfo.GuestDefinedCapabilities.SignalProcessSupported ||
-		p.GuestConnectionInfo.ProtocolVersion < 4 {
-		t.Fatalf("unexpected values: %+v", p.GuestConnectionInfo)
+	p, gc := uvm.Capabilities()
+	if !gc.NamespaceAddRequestSupported ||
+		!gc.SignalProcessSupported ||
+		p < 4 {
+		t.Fatalf("unexpected values: %d %+v", p, gc)
 	}
 }


### PR DESCRIPTION
This change removes the ComputeSystem() call from uvm.UtilityVM and
provides wrapper functions for the few places that needed to get the
underlying compute system. This is necessary because these functions
(such as CreateProcess) will have different implementations depending on
whether the internal or external bridge is in use.

Also pre-cache some of the properties queries, caching the result of
such queries early rather than querying at each use.