### PR TITLE
uvm: Add UtilityVM.CreateContainer method

### DIFF
--- a/internal/hcsoci/hcsdoc_lcow.go
+++ b/internal/hcsoci/hcsdoc_lcow.go
@@ -67,41 +67,22 @@ func createLCOWSpec(coi *createOptionsInternal) (*specs.Spec, error) {
 	return spec, nil
 }
 
-// This is identical to hcsschema.ComputeSystem but HostedSystem is an LCOW specific type - the schema docs only include WCOW.
-type linuxComputeSystem struct {
-	Owner                             string                    `json:"Owner,omitempty"`
-	SchemaVersion                     *hcsschema.Version        `json:"SchemaVersion,omitempty"`
-	HostingSystemId                   string                    `json:"HostingSystemId,omitempty"`
-	HostedSystem                      *linuxHostedSystem        `json:"HostedSystem,omitempty"`
-	Container                         *hcsschema.Container      `json:"Container,omitempty"`
-	VirtualMachine                    *hcsschema.VirtualMachine `json:"VirtualMachine,omitempty"`
-	ShouldTerminateOnLastHandleClosed bool                      `json:"ShouldTerminateOnLastHandleClosed,omitempty"`
-}
-
 type linuxHostedSystem struct {
 	SchemaVersion    *hcsschema.Version
 	OciBundlePath    string
 	OciSpecification *specs.Spec
 }
 
-func createLinuxContainerDocument(coi *createOptionsInternal, guestRoot string) (interface{}, error) {
+func createLinuxContainerDocument(coi *createOptionsInternal, guestRoot string) (*linuxHostedSystem, error) {
 	spec, err := createLCOWSpec(coi)
 	if err != nil {
 		return nil, err
 	}
 
 	logrus.WithField("guestRoot", guestRoot).Debug("hcsshim::createLinuxContainerDoc")
-	v2 := &linuxComputeSystem{
-		Owner:                             coi.actualOwner,
-		SchemaVersion:                     schemaversion.SchemaV21(),
-		ShouldTerminateOnLastHandleClosed: true,
-		HostingSystemId:                   coi.HostingSystem.ID(),
-		HostedSystem: &linuxHostedSystem{
-			SchemaVersion:    schemaversion.SchemaV21(),
-			OciBundlePath:    guestRoot,
-			OciSpecification: spec,
-		},
-	}
-
-	return v2, nil
+	return &linuxHostedSystem{
+		SchemaVersion:    schemaversion.SchemaV21(),
+		OciBundlePath:    guestRoot,
+		OciSpecification: spec,
+	}, nil
 }

--- a/internal/schema2/compute_system.go
+++ b/internal/schema2/compute_system.go
@@ -10,14 +10,13 @@
 package hcsschema
 
 type ComputeSystem struct {
-
 	Owner string `json:"Owner,omitempty"`
 
 	SchemaVersion *Version `json:"SchemaVersion,omitempty"`
 
 	HostingSystemId string `json:"HostingSystemId,omitempty"`
 
-	HostedSystem *HostedSystem `json:"HostedSystem,omitempty"`
+	HostedSystem interface{} `json:"HostedSystem,omitempty"`
 
 	Container *Container `json:"Container,omitempty"`
 

--- a/internal/uvm/create.go
+++ b/internal/uvm/create.go
@@ -8,6 +8,8 @@ import (
 	"github.com/Microsoft/hcsshim/internal/guid"
 	"github.com/Microsoft/hcsshim/internal/hcs"
 	"github.com/Microsoft/hcsshim/internal/logfields"
+	hcsschema "github.com/Microsoft/hcsshim/internal/schema2"
+	"github.com/Microsoft/hcsshim/internal/schemaversion"
 	"github.com/sirupsen/logrus"
 )
 
@@ -146,6 +148,22 @@ func (uvm *UtilityVM) Close() (err error) {
 		return uvm.hcsSystem.Close()
 	}
 	return nil
+}
+
+// CreateContainer creates a container in the utility VM.
+func (uvm *UtilityVM) CreateContainer(id string, settings interface{}) (*hcs.System, error) {
+	doc := hcsschema.ComputeSystem{
+		HostingSystemId:                   uvm.id,
+		Owner:                             uvm.owner,
+		SchemaVersion:                     schemaversion.SchemaV21(),
+		ShouldTerminateOnLastHandleClosed: true,
+		HostedSystem:                      settings,
+	}
+	c, err := hcs.CreateComputeSystem(id, &doc)
+	if err != nil {
+		return nil, err
+	}
+	return c, err
 }
 
 // CreateProcess creates a process in the utility VM.


### PR DESCRIPTION
This change adds a CreateContainer method to UtilityVM and updates
hcsoci to use it. This change is necessary because if the external
bridge is in use, container creation goes through that instead of
through the HCS.