### PR TITLE
cow: Add and use interfaces for containers and processes

### DIFF
--- a/cmd/containerd-shim-runhcs-v1/exec_hcs.go
+++ b/cmd/containerd-shim-runhcs-v1/exec_hcs.go
@@ -8,8 +8,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/Microsoft/hcsshim/internal/cow"
 	"github.com/Microsoft/hcsshim/internal/guestrequest"
-	"github.com/Microsoft/hcsshim/internal/hcs"
 	"github.com/Microsoft/hcsshim/internal/lcow"
 	hcsschema "github.com/Microsoft/hcsshim/internal/schema2"
 	"github.com/Microsoft/hcsshim/internal/signals"
@@ -46,7 +46,7 @@ func newHcsExec(
 	events publisher,
 	tid string,
 	host *uvm.UtilityVM,
-	c *hcs.System,
+	c cow.Container,
 	id, bundle string,
 	isWCOW bool,
 	spec *specs.Process,
@@ -91,7 +91,7 @@ type hcsExec struct {
 	// c is the hosting container for this exec.
 	//
 	// This MUST be treated as read only in the lifetime of the exec.
-	c *hcs.System
+	c cow.Container
 	// id is the id of this process.
 	//
 	// This MUST be treated as read only in the lifetime of the exec.
@@ -129,7 +129,7 @@ type hcsExec struct {
 	pid        int
 	exitStatus uint32
 	exitedAt   time.Time
-	p          *hcs.Process
+	p          cow.Process
 	pCloseOnce sync.Once
 
 	// exited is a wait block which waits async for the process to exit.
@@ -223,7 +223,7 @@ func (he *hcsExec) Start(ctx context.Context) (err error) {
 		}()
 	}
 	var (
-		proc *hcs.Process
+		proc cow.Process
 	)
 	if he.isWCOW {
 		wpp := &hcsschema.ProcessParameters{

--- a/cmd/containerd-shim-runhcs-v1/task_hcs.go
+++ b/cmd/containerd-shim-runhcs-v1/task_hcs.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/Microsoft/hcsshim/cmd/containerd-shim-runhcs-v1/options"
+	"github.com/Microsoft/hcsshim/internal/cow"
 	"github.com/Microsoft/hcsshim/internal/hcs"
 	"github.com/Microsoft/hcsshim/internal/hcsoci"
 	"github.com/Microsoft/hcsshim/internal/oci"
@@ -217,7 +218,7 @@ type hcsTask struct {
 	//
 	// It MUST be treated as read only in the lifetime of this task EXCEPT after
 	// a Kill to the init task in which it must be shutdown.
-	c *hcs.System
+	c cow.Container
 	// cr is the container resources this task is holding.
 	//
 	// It MUST be treated as read only in the lifetime of this task EXCEPT after

--- a/cmd/runhcs/container.go
+++ b/cmd/runhcs/container.go
@@ -557,7 +557,7 @@ func createContainerInHost(c *container, vm *uvm.UtilityVM) (err error) {
 	if err != nil {
 		return err
 	}
-	c.hc = hc
+	c.hc = hc.(*hcs.System)
 	return nil
 }
 

--- a/cmd/runhcs/shim.go
+++ b/cmd/runhcs/shim.go
@@ -13,6 +13,7 @@ import (
 
 	winio "github.com/Microsoft/go-winio"
 	"github.com/Microsoft/hcsshim/internal/appargs"
+	"github.com/Microsoft/hcsshim/internal/cow"
 	"github.com/Microsoft/hcsshim/internal/hcs"
 	"github.com/Microsoft/hcsshim/internal/lcow"
 	"github.com/Microsoft/hcsshim/internal/runhcs"
@@ -166,7 +167,7 @@ var shimCommand = cli.Command{
 		var wpp *hcsschema.ProcessParameters // Windows Process Parameters
 		var lpp *lcow.ProcessParameters      // Linux Process Parameters
 
-		var p *hcs.Process
+		var p cow.Process
 
 		if c.Spec.Linux == nil {
 			environment := make(map[string]string)

--- a/container.go
+++ b/container.go
@@ -199,7 +199,7 @@ func (container *container) CreateProcess(c *ProcessConfig) (Process, error) {
 	if err != nil {
 		return nil, convertSystemError(err, container)
 	}
-	return &process{p: p}, nil
+	return &process{p: p.(*hcs.Process)}, nil
 }
 
 // OpenProcess gets an interface to an existing process within the container.

--- a/internal/cow/cow.go
+++ b/internal/cow/cow.go
@@ -1,0 +1,72 @@
+package cow
+
+import (
+	"io"
+
+	"github.com/Microsoft/hcsshim/internal/schema1"
+)
+
+// Process is the interface for an OS process running in a container or utility VM.
+type Process interface {
+	// Close releases resources associated with the process and closes the
+	// writer and readers returned by Stdio. Depending on the implementation,
+	// this may also terminate the process.
+	Close() error
+	// CloseStdin causes the process's stdin handle to receive EOF/EPIPE/whatever
+	// is appropriate to indicate that no more data is available.
+	CloseStdin() error
+	// Pid returns the process ID.
+	Pid() int
+	// Stdio returns the stdio streams for a process. These may be nil if a stream
+	// was not requested during CreateProcess.
+	Stdio() (_ io.Writer, _ io.Reader, _ io.Reader)
+	// ResizeConsole resizes the virtual terminal associated with the process.
+	ResizeConsole(width, height uint16) error
+	// Kill sends a SIGKILL or equivalent signal to the process and returns whether
+	// the signal was delivered. It does not wait for the process to terminate.
+	Kill() (bool, error)
+	// Signal sends a signal to the process and returns whether the signal was
+	// delivered. The input is OS specific (either
+	// guestrequest.SignalProcessOptionsWCOW or
+	// guestrequest.SignalProcessOptionsLCOW). It does not wait for the process
+	// to terminate.
+	Signal(options interface{}) (bool, error)
+	// Wait waits for the process to complete, or for a connection to the process to be
+	// terminated by some error condition (including calling Close).
+	Wait() error
+	// ExitCode returns the exit code of the process. Returns an error if the process is
+	// not running.
+	ExitCode() (int, error)
+}
+
+// ProcessHost is the interface for creating processes.
+type ProcessHost interface {
+	// CreateProcess creates a process. The configuration is host specific
+	// (either hcsschema.ProcessParameters or lcow.ProcessParameters).
+	CreateProcess(config interface{}) (Process, error)
+}
+
+// Container is the interface for container objects, either running on the host or
+// in a utility VM.
+type Container interface {
+	ProcessHost
+	// Close releases the resources associated with the container. Depending on
+	// the implementation, this may also terminate the container.
+	Close() error
+	// ID returns the container ID.
+	ID() string
+	// Properties returns the requested container properties.
+	Properties(types ...schema1.PropertyType) (*schema1.ContainerProperties, error)
+	// Start starts a container.
+	Start() error
+	// Shutdown sends a shutdown request to the container (but does not wait for
+	// the shutdown to complete).
+	Shutdown() error
+	// Terminate sends a terminate request to the container (but does not wait
+	// for the terminate to complete).
+	Terminate() error
+	// Wait waits for the container to terminate, or for the connection to the
+	// container to be terminated by some error condition (including calling
+	// Close).
+	Wait() error
+}

--- a/internal/hcs/system.go
+++ b/internal/hcs/system.go
@@ -9,6 +9,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/Microsoft/hcsshim/internal/cow"
 	"github.com/Microsoft/hcsshim/internal/interop"
 	"github.com/Microsoft/hcsshim/internal/logfields"
 	"github.com/Microsoft/hcsshim/internal/schema1"
@@ -466,7 +467,7 @@ func (computeSystem *System) Resume() (err error) {
 }
 
 // CreateProcess launches a new process within the computeSystem.
-func (computeSystem *System) CreateProcess(c interface{}) (_ *Process, err error) {
+func (computeSystem *System) CreateProcess(c interface{}) (_ cow.Process, err error) {
 	computeSystem.handleLock.RLock()
 	defer computeSystem.handleLock.RUnlock()
 

--- a/internal/hcsoci/create.go
+++ b/internal/hcsoci/create.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strconv"
 
+	"github.com/Microsoft/hcsshim/internal/cow"
 	"github.com/Microsoft/hcsshim/internal/guid"
 	"github.com/Microsoft/hcsshim/internal/hcs"
 	"github.com/Microsoft/hcsshim/internal/oci"
@@ -59,7 +60,7 @@ type createOptionsInternal struct {
 // case of an error. This provides support for the debugging option not to
 // release the resources on failure, so that the client can make the necessary
 // call to release resources that have been allocated as part of calling this function.
-func CreateContainer(createOptions *CreateOptions) (_ *hcs.System, _ *Resources, err error) {
+func CreateContainer(createOptions *CreateOptions) (_ cow.Container, _ *Resources, err error) {
 	coi := &createOptionsInternal{
 		CreateOptions: createOptions,
 		actualID:      createOptions.ID,

--- a/internal/lcow/process.go
+++ b/internal/lcow/process.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/Microsoft/hcsshim/internal/copywithtimeout"
+	"github.com/Microsoft/hcsshim/internal/cow"
 	"github.com/Microsoft/hcsshim/internal/hcs"
 	hcsschema "github.com/Microsoft/hcsshim/internal/schema2"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
@@ -21,14 +22,9 @@ type ByteCounts struct {
 	Err int64
 }
 
-type ProcessHost interface {
-	CreateProcess(settings interface{}) (*hcs.Process, error)
-}
-
-// ProcessOptions are the set of options which are passed to CreateProcessEx() to
-// create a utility vm.
+// ProcessOptions are the set of options which are passed to CreateProcess().
 type ProcessOptions struct {
-	Host              ProcessHost
+	Host              cow.ProcessHost
 	Process           *specs.Process
 	Stdin             io.Reader     // Optional reader for sending on to the processes stdin stream
 	Stdout            io.Writer     // Optional writer for returning the processes stdout stream
@@ -57,7 +53,7 @@ type ProcessOptions struct {
 //
 // It is the responsibility of the caller to call Close() on the process returned.
 
-func CreateProcess(opts *ProcessOptions) (*hcs.Process, *ByteCounts, error) {
+func CreateProcess(opts *ProcessOptions) (cow.Process, *ByteCounts, error) {
 
 	var environment = make(map[string]string)
 	copiedByteCounts := &ByteCounts{}

--- a/internal/lcow/scratch.go
+++ b/internal/lcow/scratch.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/Microsoft/go-winio/vhd"
 	"github.com/Microsoft/hcsshim/internal/copyfile"
-	"github.com/Microsoft/hcsshim/internal/hcs"
+	"github.com/Microsoft/hcsshim/internal/cow"
 	"github.com/Microsoft/hcsshim/internal/timeout"
 	"github.com/Microsoft/hcsshim/internal/uvm"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
@@ -179,7 +179,7 @@ func CreateScratch(lcowUVM *uvm.UtilityVM, destFile string, sizeGB uint32, cache
 	return nil
 }
 
-func waitForProcess(p *hcs.Process) (int, error) {
+func waitForProcess(p cow.Process) (int, error) {
 	ch := make(chan error, 1)
 	go func() {
 		ch <- p.Wait()

--- a/internal/uvm/create.go
+++ b/internal/uvm/create.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"runtime"
 
+	"github.com/Microsoft/hcsshim/internal/cow"
 	"github.com/Microsoft/hcsshim/internal/guid"
 	"github.com/Microsoft/hcsshim/internal/hcs"
 	"github.com/Microsoft/hcsshim/internal/logfields"
@@ -167,7 +168,7 @@ func (uvm *UtilityVM) CreateContainer(id string, settings interface{}) (*hcs.Sys
 }
 
 // CreateProcess creates a process in the utility VM.
-func (uvm *UtilityVM) CreateProcess(settings interface{}) (*hcs.Process, error) {
+func (uvm *UtilityVM) CreateProcess(settings interface{}) (cow.Process, error) {
 	return uvm.hcsSystem.CreateProcess(settings)
 }
 

--- a/test/functional/lcow_test.go
+++ b/test/functional/lcow_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Microsoft/hcsshim/internal/hcs"
+	"github.com/Microsoft/hcsshim/internal/cow"
 	"github.com/Microsoft/hcsshim/internal/hcsoci"
 	"github.com/Microsoft/hcsshim/internal/lcow"
 	"github.com/Microsoft/hcsshim/internal/uvm"
@@ -203,7 +203,7 @@ func TestLCOWSimplePodScenario(t *testing.T) {
 
 // Helper to run the init process in an LCOW container; verify it exits with exit
 // code 0; verify stderr is empty; check output is as expected.
-func runInitProcess(t *testing.T, s *hcs.System, expected string) {
+func runInitProcess(t *testing.T, s cow.Container, expected string) {
 	var outB, errB bytes.Buffer
 	p, bc, err := lcow.CreateProcess(&lcow.ProcessOptions{
 		Host:        s,

--- a/test/functional/test.go
+++ b/test/functional/test.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/Microsoft/hcsshim/internal/hcs"
+	"github.com/Microsoft/hcsshim/internal/cow"
 	"github.com/Microsoft/hcsshim/internal/hcsoci"
 	"github.com/sirupsen/logrus"
 )
@@ -33,7 +33,7 @@ func init() {
 
 }
 
-func CreateContainerTestWrapper(options *hcsoci.CreateOptions) (*hcs.System, *hcsoci.Resources, error) {
+func CreateContainerTestWrapper(options *hcsoci.CreateOptions) (cow.Container, *hcsoci.Resources, error) {
 	if pauseDurationOnCreateContainerFailure != 0 {
 		options.DoNotReleaseResourcesOnFailure = true
 	}


### PR DESCRIPTION
The external bridge will provide an alternate implementation of these
interfaces.

Note that the external bridge will not be compatible with clients that
call OpenProcess or OpenComputeSystem (since the bridge will run
in-proc). So runhcs, which relies on OpenComputeSystem, does not use
these types and will use a type assertion to get back to an hcs.System.