### PR TITLE
hcsoci: Add Cmd type for simplifying process launches

### DIFF
--- a/internal/cow/cow.go
+++ b/internal/cow/cow.go
@@ -44,6 +44,13 @@ type ProcessHost interface {
 	// CreateProcess creates a process. The configuration is host specific
 	// (either hcsschema.ProcessParameters or lcow.ProcessParameters).
 	CreateProcess(config interface{}) (Process, error)
+	// OS returns the host's operating system, "linux" or "windows".
+	OS() string
+	// IsOCI specifies whether this is an OCI-compliant process host. If true,
+	// then the configuration passed to CreateProcess should have an OCI process
+	// spec (or nil if this is the initial process in an OCI container).
+	// Otherwise, it should have the HCS-specific process parameters.
+	IsOCI() bool
 }
 
 // Container is the interface for container objects, either running on the host or

--- a/internal/hcsoci/cmd.go
+++ b/internal/hcsoci/cmd.go
@@ -1,0 +1,307 @@
+package hcsoci
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"github.com/Microsoft/hcsshim/internal/cow"
+	hcsschema "github.com/Microsoft/hcsshim/internal/schema2"
+	specs "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/sync/errgroup"
+	"golang.org/x/sys/windows"
+)
+
+// Cmd represents a command being prepared or run in a process host.
+type Cmd struct {
+	// Host is the process host in which to launch the process.
+	Host cow.ProcessHost
+
+	// The OCI spec for the process.
+	Spec *specs.Process
+
+	// Standard IO streams to relay to/from the process.
+	Stdin  io.Reader
+	Stdout io.Writer
+	Stderr io.Writer
+
+	// Log provides a logrus entry to use in logging IO copying status.
+	Log *logrus.Entry
+
+	// Context provides a context that terminates the process when it is done.
+	Context context.Context
+
+	// CopyAfterExitTimeout is the amount of time after process exit we allow the
+	// stdout, stderr relays to continue before forcibly closing them if not
+	// already completed. This is primarily a safety step against the HCS when
+	// it fails to send a close on the stdout, stderr pipes when the process
+	// exits and blocks the relay wait groups forever.
+	CopyAfterExitTimeout time.Duration
+
+	// Process is filled out after Start() returns.
+	Process cow.Process
+
+	// ExitState is filled out after Wait() (or Run() or Output()) completes.
+	ExitState *ExitState
+
+	iogrp     errgroup.Group
+	stdinErr  atomic.Value
+	allDoneCh chan struct{}
+}
+
+// ExitState contains whether a process has exited and with which exit code.
+type ExitState struct {
+	exited bool
+	code   int
+}
+
+// ExitCode returns the exit code of the process, or -1 if the exit code is not known.
+func (s *ExitState) ExitCode() int {
+	if !s.exited {
+		return -1
+	}
+	return s.code
+}
+
+// ExitError is used when a process exits with a non-zero exit code.
+type ExitError struct {
+	*ExitState
+}
+
+func (err *ExitError) Error() string {
+	return fmt.Sprintf("process exited with exit code %d", err.ExitCode())
+}
+
+// Additional fields to hcsschema.ProcessParameters used by LCOW
+type lcowProcessParameters struct {
+	hcsschema.ProcessParameters
+	OCIProcess *specs.Process `json:"OciProcess,omitempty"`
+}
+
+// escapeArgs makes a Windows-style escaped command line from a set of arguments
+func escapeArgs(args []string) string {
+	escapedArgs := make([]string, len(args))
+	for i, a := range args {
+		escapedArgs[i] = windows.EscapeArg(a)
+	}
+	return strings.Join(escapedArgs, " ")
+}
+
+// Command makes a Cmd for a given command and arguments.
+func Command(host cow.ProcessHost, name string, arg ...string) *Cmd {
+	cmd := &Cmd{
+		Host: host,
+		Spec: &specs.Process{
+			Args: append([]string{name}, arg...),
+		},
+	}
+	if host.OS() == "windows" {
+		cmd.Spec.Cwd = `C:\`
+	} else {
+		cmd.Spec.Cwd = "/"
+		cmd.Spec.Env = []string{"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"}
+	}
+	return cmd
+}
+
+// CommandContext makes a Cmd for a given command and arguments. After
+// it is launched, the process is killed when the context becomes done.
+func CommandContext(ctx context.Context, host cow.ProcessHost, name string, arg ...string) *Cmd {
+	cmd := Command(host, name, arg...)
+	cmd.Context = ctx
+	return cmd
+}
+
+func copyAndLog(w io.Writer, r io.Reader, log *logrus.Entry, name string) (int64, error) {
+	n, err := io.Copy(w, r)
+	if log != nil {
+		lvl := logrus.DebugLevel
+		log = log.WithFields(logrus.Fields{
+			"file":  name,
+			"bytes": n,
+		})
+		if err != nil {
+			lvl = logrus.ErrorLevel
+			log = log.WithError(err)
+		}
+		log.Log(lvl, "command copy complete")
+	}
+	return n, err
+}
+
+// Start starts a command. The caller must ensure that if Start succeeds,
+// Wait is eventually called to clean up resources.
+func (c *Cmd) Start() error {
+	c.allDoneCh = make(chan struct{})
+	var x interface{}
+	if !c.Host.IsOCI() {
+		wpp := &hcsschema.ProcessParameters{
+			CommandLine:      c.Spec.CommandLine,
+			User:             c.Spec.User.Username,
+			WorkingDirectory: c.Spec.Cwd,
+			EmulateConsole:   c.Spec.Terminal,
+			CreateStdInPipe:  c.Stdin != nil,
+			CreateStdOutPipe: c.Stdout != nil,
+			CreateStdErrPipe: c.Stderr != nil,
+		}
+
+		if c.Spec.CommandLine == "" {
+			if c.Host.OS() == "windows" {
+				wpp.CommandLine = escapeArgs(c.Spec.Args)
+			} else {
+				wpp.CommandArgs = c.Spec.Args
+			}
+		}
+
+		environment := make(map[string]string)
+		for _, v := range c.Spec.Env {
+			s := strings.SplitN(v, "=", 2)
+			if len(s) == 2 && len(s[1]) > 0 {
+				environment[s[0]] = s[1]
+			}
+		}
+		wpp.Environment = environment
+
+		if c.Spec.ConsoleSize != nil {
+			wpp.ConsoleSize = []int32{
+				int32(c.Spec.ConsoleSize.Height),
+				int32(c.Spec.ConsoleSize.Width),
+			}
+		}
+		x = wpp
+	} else {
+		lpp := &lcowProcessParameters{
+			ProcessParameters: hcsschema.ProcessParameters{
+				CreateStdInPipe:  c.Stdin != nil,
+				CreateStdOutPipe: c.Stdout != nil,
+				CreateStdErrPipe: c.Stderr != nil,
+			},
+			OCIProcess: c.Spec,
+		}
+		x = lpp
+	}
+	if c.Context != nil && c.Context.Err() != nil {
+		return c.Context.Err()
+	}
+	p, err := c.Host.CreateProcess(x)
+	if err != nil {
+		return err
+	}
+	c.Process = p
+	if c.Log != nil {
+		c.Log = c.Log.WithField("pid", p.Pid())
+	}
+
+	// Start relaying process IO.
+	stdin, stdout, stderr := p.Stdio()
+	if c.Stdin != nil {
+		// Do not make stdin part of the error group because there is no way for
+		// us or the caller to reliably unblock the c.Stdin read when the
+		// process exits.
+		go func() {
+			_, err := copyAndLog(stdin, c.Stdin, c.Log, "stdin")
+			// Report the stdin copy error. If the process has exited, then the
+			// caller may never see it, but if the error was due to a failure in
+			// stdin read, then it is likely the process is still running.
+			if err != nil {
+				c.stdinErr.Store(err)
+			}
+			// Notify the process that there is no more input.
+			p.CloseStdin()
+		}()
+	}
+
+	if c.Stdout != nil {
+		c.iogrp.Go(func() error {
+			_, err := copyAndLog(c.Stdout, stdout, c.Log, "stdout")
+			return err
+		})
+	}
+
+	if c.Stderr != nil {
+		c.iogrp.Go(func() error {
+			_, err := copyAndLog(c.Stderr, stderr, c.Log, "stderr")
+			return err
+		})
+	}
+
+	if c.Context != nil {
+		go func() {
+			select {
+			case <-c.Context.Done():
+				c.Process.Kill()
+			case <-c.allDoneCh:
+			}
+		}()
+	}
+	return nil
+}
+
+// Wait waits for a command and its IO to complete and closes the underlying
+// process. It can only be called once. It returns an ExitError if the command
+// runs and returns a non-zero exit code.
+func (c *Cmd) Wait() error {
+	waitErr := c.Process.Wait()
+	if waitErr != nil && c.Log != nil {
+		c.Log.WithError(waitErr).Warn("process wait failed")
+	}
+	state := &ExitState{}
+	code, exitErr := c.Process.ExitCode()
+	if exitErr == nil {
+		state.exited = true
+		state.code = code
+	}
+	// Terminate the IO if the copy does not complete in the requested time.
+	if c.CopyAfterExitTimeout != 0 {
+		go func() {
+			t := time.NewTimer(c.CopyAfterExitTimeout)
+			defer t.Stop()
+			select {
+			case <-c.allDoneCh:
+			case <-t.C:
+				// Close the process to cancel any reads to stdout or stderr.
+				c.Process.Close()
+				if c.Log != nil {
+					c.Log.Warn("timed out waiting for stdio relay")
+				}
+			}
+		}()
+	}
+	ioErr := c.iogrp.Wait()
+	if ioErr == nil {
+		ioErr, _ = c.stdinErr.Load().(error)
+	}
+	close(c.allDoneCh)
+	c.Process.Close()
+	c.ExitState = state
+	if exitErr != nil {
+		return exitErr
+	}
+	if state.exited && state.code != 0 {
+		return &ExitError{state}
+	}
+	return ioErr
+}
+
+// Run is equivalent to Start followed by Wait.
+func (c *Cmd) Run() error {
+	err := c.Start()
+	if err != nil {
+		return err
+	}
+	return c.Wait()
+}
+
+// Output runs a command via Run and collects its stdout into a buffer,
+// which it returns.
+func (c *Cmd) Output() ([]byte, error) {
+	var b bytes.Buffer
+	c.Stdout = &b
+	err := c.Run()
+	return b.Bytes(), err
+}

--- a/internal/hcsoci/cmd_test.go
+++ b/internal/hcsoci/cmd_test.go
@@ -1,0 +1,249 @@
+// build +windows
+
+package hcsoci
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/Microsoft/hcsshim/internal/cow"
+	hcsschema "github.com/Microsoft/hcsshim/internal/schema2"
+)
+
+type localProcessHost struct {
+}
+
+type localProcess struct {
+	p                     *os.Process
+	state                 *os.ProcessState
+	ch                    chan struct{}
+	stdin, stdout, stderr *os.File
+}
+
+func (h *localProcessHost) OS() string {
+	return "windows"
+}
+
+func (h *localProcessHost) IsOCI() bool {
+	return false
+}
+
+func (h *localProcessHost) CreateProcess(cfg interface{}) (_ cow.Process, err error) {
+	params := cfg.(*hcsschema.ProcessParameters)
+	lp := &localProcess{ch: make(chan struct{})}
+	defer func() {
+		if err != nil {
+			lp.Close()
+		}
+	}()
+	var stdin, stdout, stderr *os.File
+	if params.CreateStdInPipe {
+		stdin, lp.stdin, err = os.Pipe()
+		if err != nil {
+			return nil, err
+		}
+		defer stdin.Close()
+	}
+	if params.CreateStdOutPipe {
+		lp.stdout, stdout, err = os.Pipe()
+		if err != nil {
+			return nil, err
+		}
+		defer stdout.Close()
+	}
+	if params.CreateStdErrPipe {
+		lp.stderr, stderr, err = os.Pipe()
+		if err != nil {
+			return nil, err
+		}
+		defer stderr.Close()
+	}
+	path := strings.Split(params.CommandLine, " ")[0] // should be fixed for non-test use...
+	if ppath, err := exec.LookPath(path); err == nil {
+		path = ppath
+	}
+	lp.p, err = os.StartProcess(path, nil, &os.ProcAttr{
+		Files: []*os.File{stdin, stdout, stderr},
+		Sys: &syscall.SysProcAttr{
+			CmdLine: params.CommandLine,
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+	go func() {
+		lp.state, _ = lp.p.Wait()
+		close(lp.ch)
+	}()
+	return lp, nil
+}
+
+func (p *localProcess) Close() error {
+	if p.p != nil {
+		p.p.Release()
+	}
+	if p.stdin != nil {
+		p.stdin.Close()
+	}
+	if p.stdout != nil {
+		p.stdout.Close()
+	}
+	if p.stderr != nil {
+		p.stderr.Close()
+	}
+	return nil
+}
+
+func (p *localProcess) CloseStdin() error {
+	return p.stdin.Close()
+}
+
+func (p *localProcess) ExitCode() (int, error) {
+	select {
+	case <-p.ch:
+		return p.state.ExitCode(), nil
+	default:
+		return -1, errors.New("not exited")
+	}
+}
+
+func (p *localProcess) Kill() (bool, error) {
+	return true, p.p.Kill()
+}
+
+func (p *localProcess) Signal(interface{}) (bool, error) {
+	return p.Kill()
+}
+
+func (p *localProcess) Pid() int {
+	return p.p.Pid
+}
+
+func (p *localProcess) ResizeConsole(x, y uint16) error {
+	return errors.New("not supported")
+}
+
+func (p *localProcess) Stdio() (io.Writer, io.Reader, io.Reader) {
+	return p.stdin, p.stdout, p.stderr
+}
+
+func (p *localProcess) Wait() error {
+	<-p.ch
+	return nil
+}
+
+func TestCmdExitCode(t *testing.T) {
+	cmd := Command(&localProcessHost{}, "cmd", "/c", "exit", "/b", "64")
+	err := cmd.Run()
+	if e, ok := err.(*ExitError); !ok || e.ExitCode() != 64 {
+		t.Fatal("expected exit code 64, got ", err)
+	}
+}
+
+func TestCmdOutput(t *testing.T) {
+	cmd := Command(&localProcessHost{}, "cmd", "/c", "echo", "hello")
+	output, err := cmd.Output()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(output) != "hello\r\n" {
+		t.Fatalf("got %q", string(output))
+	}
+}
+
+func TestCmdContext(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 250*time.Millisecond)
+	defer cancel()
+	cmd := CommandContext(ctx, &localProcessHost{}, "cmd", "/c", "pause")
+	r, w := io.Pipe()
+	cmd.Stdin = r
+	err := cmd.Start()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cmd.Process.Wait()
+	w.Close()
+	err = cmd.Wait()
+	if e, ok := err.(*ExitError); !ok || e.ExitCode() != 1 || ctx.Err() == nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCmdStdin(t *testing.T) {
+	cmd := Command(&localProcessHost{}, "findstr", "x*")
+	cmd.Stdin = bytes.NewBufferString("testing 1 2 3")
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(out) != "testing 1 2 3\r\n" {
+		t.Fatalf("got %q", string(out))
+	}
+}
+
+func TestCmdStdinBlocked(t *testing.T) {
+	cmd := Command(&localProcessHost{}, "cmd", "/c", "pause")
+	r, w := io.Pipe()
+	defer r.Close()
+	go func() {
+		b := []byte{'\n'}
+		w.Write(b)
+	}()
+	cmd.Stdin = r
+	_, err := cmd.Output()
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+type stuckIoProcessHost struct {
+	cow.ProcessHost
+}
+
+type stuckIoProcess struct {
+	cow.Process
+	stdin, pstdout, pstderr *io.PipeWriter
+	pstdin, stdout, stderr  *io.PipeReader
+}
+
+func (h *stuckIoProcessHost) CreateProcess(cfg interface{}) (cow.Process, error) {
+	p, err := h.ProcessHost.CreateProcess(cfg)
+	if err != nil {
+		return nil, err
+	}
+	sp := &stuckIoProcess{
+		Process: p,
+	}
+	sp.pstdin, sp.stdin = io.Pipe()
+	sp.stdout, sp.pstdout = io.Pipe()
+	sp.stderr, sp.pstderr = io.Pipe()
+	return sp, nil
+}
+
+func (p *stuckIoProcess) Stdio() (io.Writer, io.Reader, io.Reader) {
+	return p.stdin, p.stdout, p.stderr
+}
+
+func (p *stuckIoProcess) Close() error {
+	p.stdin.Close()
+	p.stdout.Close()
+	p.stderr.Close()
+	return p.Process.Close()
+}
+
+func TestCmdStuckIo(t *testing.T) {
+	cmd := Command(&stuckIoProcessHost{&localProcessHost{}}, "cmd", "/c", "echo", "hello")
+	cmd.CopyAfterExitTimeout = time.Millisecond * 200
+	_, err := cmd.Output()
+	if err != io.ErrClosedPipe {
+		t.Fatal(err)
+	}
+}

--- a/internal/schema1/schema1.go
+++ b/internal/schema1/schema1.go
@@ -134,6 +134,7 @@ type ContainerProperties struct {
 	State                        string
 	Name                         string
 	SystemType                   string
+	RuntimeOSType                string `json:"RuntimeOsType,omitempty"`
 	Owner                        string
 	SiloGUID                     string                              `json:"SiloGuid,omitempty"`
 	RuntimeID                    *guid.GUID                          `json:"RuntimeId,omitempty"`

--- a/internal/uvm/create.go
+++ b/internal/uvm/create.go
@@ -172,6 +172,12 @@ func (uvm *UtilityVM) CreateProcess(settings interface{}) (cow.Process, error) {
 	return uvm.hcsSystem.CreateProcess(settings)
 }
 
+// IsOCI returns false, indicating the parameters to CreateProcess should not
+// include an OCI spec.
+func (uvm *UtilityVM) IsOCI() bool {
+	return false
+}
+
 // Terminate requests that the utility VM be terminated.
 func (uvm *UtilityVM) Terminate() error {
 	return uvm.hcsSystem.Terminate()


### PR DESCRIPTION
Cmd is modeled after os/exec.Cmd, which makes it easy to launch
and wait for processes and relay their stdio. This version of Cmd is
designed to take in an OCI process specification, and it can launch a
process on anything that implements cow.ProcessHost.