### PR TITLE
shim: Run diag exec processes on Windows as SYSTEM

### DIFF
--- a/cmd/containerd-shim-runhcs-v1/diag.go
+++ b/cmd/containerd-shim-runhcs-v1/diag.go
@@ -24,6 +24,9 @@ func execInUvm(ctx context.Context, vm *uvm.UtilityVM, req *shimdiag.ExecProcess
 	if req.Workdir != "" {
 		cmd.Spec.Cwd = req.Workdir
 	}
+	if vm.OS() == "windows" {
+		cmd.Spec.User.Username = `NT AUTHORITY\SYSTEM`
+	}
 	cmd.Spec.Terminal = req.Terminal
 	cmd.Stdin = np.Stdin()
 	cmd.Stdout = np.Stdout()


### PR DESCRIPTION
The default user for container processes does not exist for the utility
VM. Explicitly set the user to SYSTEM.