### PR TITLE
gcs: Add WCOW support

### DIFF
--- a/internal/gcs/guestconnection.go
+++ b/internal/gcs/guestconnection.go
@@ -113,6 +113,27 @@ func (gc *GuestConnection) connect(ctx context.Context) (err error) {
 	if gc.os == "" {
 		gc.os = "windows"
 	}
+	if resp.Capabilities.SendHostCreateMessage {
+		createReq := containerCreate{
+			requestBase: makeRequest(nullContainerID),
+			ContainerConfig: anyInString{&uvmConfig{
+				SystemType: "Container",
+			}},
+		}
+		var createResp responseBase
+		err = gc.brdg.RPC(ctx, rpcCreate, &createReq, &createResp, true)
+		if err != nil {
+			return err
+		}
+		if resp.Capabilities.SendHostStartMessage {
+			startReq := makeRequest(nullContainerID)
+			var startResp responseBase
+			err = gc.brdg.RPC(ctx, rpcStart, &startReq, &startResp, true)
+			if err != nil {
+				return err
+			}
+		}
+	}
 	return nil
 }
 

--- a/internal/gcs/process.go
+++ b/internal/gcs/process.go
@@ -50,8 +50,7 @@ func (gc *GuestConnection) exec(ctx context.Context, cid string, params interfac
 	req := containerExecuteProcess{
 		requestBase: makeRequest(cid),
 		Settings: executeProcessSettings{
-			ProcessParameters:       anyInString{params},
-			VsockStdioRelaySettings: &executeProcessVsockStdioRelaySettings{},
+			ProcessParameters: anyInString{params},
 		},
 	}
 
@@ -76,21 +75,24 @@ func (gc *GuestConnection) exec(ctx context.Context, cid string, params interfac
 		if err != nil {
 			return nil, err
 		}
-		hvsockSettings.StdIn = winio.VsockServiceID(vsockSettings.StdIn)
+		g := winio.VsockServiceID(vsockSettings.StdIn)
+		hvsockSettings.StdIn = &g
 	}
 	if bp.CreateStdOutPipe {
 		p.stdout, vsockSettings.StdOut, err = gc.newIoChannel()
 		if err != nil {
 			return nil, err
 		}
-		hvsockSettings.StdOut = winio.VsockServiceID(vsockSettings.StdOut)
+		g := winio.VsockServiceID(vsockSettings.StdOut)
+		hvsockSettings.StdOut = &g
 	}
 	if bp.CreateStdErrPipe {
 		p.stderr, vsockSettings.StdErr, err = gc.newIoChannel()
 		if err != nil {
 			return nil, err
 		}
-		hvsockSettings.StdErr = winio.VsockServiceID(vsockSettings.StdErr)
+		g := winio.VsockServiceID(vsockSettings.StdErr)
+		hvsockSettings.StdErr = &g
 	}
 
 	var resp containerExecuteProcessResponse

--- a/internal/gcs/protocol.go
+++ b/internal/gcs/protocol.go
@@ -174,6 +174,10 @@ type containerCreate struct {
 	ContainerConfig anyInString
 }
 
+type uvmConfig struct {
+	SystemType string // must be "Container"
+}
+
 type containerNotification struct {
 	requestBase
 	Type       string      // Compute.System.NotificationType
@@ -194,15 +198,15 @@ type executeProcessSettings struct {
 }
 
 type executeProcessStdioRelaySettings struct {
-	StdIn  guid.GUID
-	StdOut guid.GUID
-	StdErr guid.GUID
+	StdIn  *guid.GUID `json:",omitempty"`
+	StdOut *guid.GUID `json:",omitempty"`
+	StdErr *guid.GUID `json:",omitempty"`
 }
 
 type executeProcessVsockStdioRelaySettings struct {
-	StdIn  uint32
-	StdOut uint32
-	StdErr uint32
+	StdIn  uint32 `json:",omitempty"`
+	StdOut uint32 `json:",omitempty"`
+	StdErr uint32 `json:",omitempty"`
 }
 
 type containerResizeConsole struct {

--- a/internal/uvm/create_wcow.go
+++ b/internal/uvm/create_wcow.go
@@ -146,7 +146,6 @@ func CreateWCOW(opts *OptionsWCOW) (_ *UtilityVM, err error) {
 					Weight: opts.ProcessorWeight,
 				},
 			},
-			GuestConnection: &hcsschema.GuestConnection{},
 			Devices: &hcsschema.Devices{
 				Scsi: map[string]hcsschema.Scsi{
 					"0": {
@@ -183,6 +182,10 @@ func CreateWCOW(opts *OptionsWCOW) (_ *UtilityVM, err error) {
 				},
 			},
 		},
+	}
+
+	if !opts.ExternalGuestConnection {
+		doc.VirtualMachine.GuestConnection = &hcsschema.GuestConnection{}
 	}
 
 	// Handle StorageQoS if set


### PR DESCRIPTION
This change fixes various bugs to unblock WCOW support for UVMs that
support the RS5+ GCS protocol.