### PR TITLE
lcow: Eagerly initialize the ext4 inode tables

### DIFF
--- a/internal/lcow/scratch.go
+++ b/internal/lcow/scratch.go
@@ -110,7 +110,7 @@ func CreateScratch(lcowUVM *uvm.UtilityVM, destFile string, sizeGB uint32, cache
 
 	// Format it ext4
 	mkfsCtx, cancel := context.WithTimeout(context.TODO(), timeout.ExternalCommandToStart)
-	cmd = hcsoci.CommandContext(mkfsCtx, lcowUVM, "mkfs.ext4", "-q", "-E", "lazy_itable_init=1", "-O", `^has_journal,sparse_super2,uninit_bg,^resize_inode`, device)
+	cmd = hcsoci.CommandContext(mkfsCtx, lcowUVM, "mkfs.ext4", "-q", "-E", "lazy_itable_init=0,nodiscard", "-O", `^has_journal,sparse_super2,^resize_inode`, device)
 	var mkfsStderr bytes.Buffer
 	cmd.Stderr = &mkfsStderr
 	err = cmd.Run()


### PR DESCRIPTION
This change disables lazily initialization of the sandbox VHDX's inode
tables. This prevents the kernel from subsequently zeroing them in the
background at each container start.