### PR TITLE
Replace guid-to-array with APIs from guid package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/Microsoft/hcsshim
 go 1.12
 
 require (
-	github.com/Microsoft/go-winio v0.4.13-0.20190509182014-01fe22a8b81b
+	github.com/Microsoft/go-winio v0.4.13-0.20190516165658-12afdbf8b879
 	github.com/blang/semver v3.1.0+incompatible // indirect
 	github.com/containerd/console v0.0.0-20180822173158-c12b1e7919c1
 	github.com/containerd/containerd v0.0.0-20190214164719-faec567304bb

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/Microsoft/go-winio v0.4.13-0.20190509182014-01fe22a8b81b h1:4hq1MOP1J8lfX0c3nV3H6PlRjzMqfL9k4/J7tMh3lvA=
 github.com/Microsoft/go-winio v0.4.13-0.20190509182014-01fe22a8b81b/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=
+github.com/Microsoft/go-winio v0.4.13-0.20190516165658-12afdbf8b879 h1:fQb0usH3PEv/Lq1sH+OUtambUVdeS0e5UQ3afz/yuzs=
+github.com/Microsoft/go-winio v0.4.13-0.20190516165658-12afdbf8b879/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=
 github.com/blang/semver v3.1.0+incompatible h1:7hqmJYuaEK3qwVjWubYiht3j93YI0WQBuysxHIfUriU=
 github.com/blang/semver v3.1.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=

--- a/layer.go
+++ b/layer.go
@@ -2,7 +2,6 @@ package hcsshim
 
 import (
 	"crypto/sha1"
-	"encoding/binary"
 	"path/filepath"
 
 	"github.com/Microsoft/go-winio/pkg/guid"
@@ -76,27 +75,9 @@ type DriverInfo struct {
 
 type GUID [16]byte
 
-func guidToArray(g guid.GUID) GUID {
-	g2 := GUID{}
-	binary.LittleEndian.PutUint32(g2[0:3], g.Data1)
-	binary.LittleEndian.PutUint16(g2[4:5], g.Data2)
-	binary.LittleEndian.PutUint16(g2[6:7], g.Data3)
-	copy(g2[8:16], g.Data4[:])
-	return g2
-}
-
-func arrayToGUID(g GUID) guid.GUID {
-	g2 := guid.GUID{}
-	g2.Data1 = binary.LittleEndian.Uint32(g[0:3])
-	g2.Data2 = binary.LittleEndian.Uint16(g[4:5])
-	g2.Data3 = binary.LittleEndian.Uint16(g[6:7])
-	copy(g2.Data4[:], g[8:16])
-	return g2
-}
-
 func NameToGuid(name string) (id GUID, err error) {
 	g, err := wclayer.NameToGuid(name)
-	return guidToArray(g), err
+	return g.ToWindowsArray(), err
 }
 
 func NewGUID(source string) *GUID {
@@ -107,7 +88,7 @@ func NewGUID(source string) *GUID {
 }
 
 func (g *GUID) ToString() string {
-	return arrayToGUID(*g).String()
+	return guid.FromWindowsArray(*g).String()
 }
 
 type LayerReader = wclayer.LayerReader

--- a/vendor/github.com/Microsoft/go-winio/file.go
+++ b/vendor/github.com/Microsoft/go-winio/file.go
@@ -271,6 +271,10 @@ func (f *win32File) Flush() error {
 	return syscall.FlushFileBuffers(f.handle)
 }
 
+func (f *win32File) Fd() uintptr {
+	return uintptr(f.handle)
+}
+
 func (d *deadlineHandler) set(deadline time.Time) error {
 	d.setLock.Lock()
 	defer d.setLock.Unlock()

--- a/vendor/github.com/Microsoft/go-winio/pkg/guid/guid.go
+++ b/vendor/github.com/Microsoft/go-winio/pkg/guid/guid.go
@@ -1,19 +1,42 @@
+// Package guid provides a GUID type. The backing structure for a GUID is
+// identical to that used by the golang.org/x/sys/windows GUID type.
+// There are two main binary encodings used for a GUID, the big-endian encoding,
+// and the Windows (mixed-endian) encoding. See here for details:
+// https://en.wikipedia.org/wiki/Universally_unique_identifier#Encoding
 package guid
 
 import (
 	"crypto/rand"
+	"encoding"
 	"encoding/binary"
-	"encoding/json"
 	"fmt"
 	"strconv"
-	"strings"
 
-	"github.com/pkg/errors"
 	"golang.org/x/sys/windows"
 )
 
-var _ = (json.Marshaler)(GUID{})
-var _ = (json.Unmarshaler)(&GUID{})
+// Variant specifies which GUID variant (or "type") of the GUID. It determines
+// how the entirety of the rest of the GUID is interpreted.
+type Variant uint8
+
+// The variants specified by RFC 4122.
+const (
+	// VariantUnknown specifies a GUID variant which does not conform to one of
+	// the variant encodings specified in RFC 4122.
+	VariantUnknown Variant = iota
+	VariantNCS
+	VariantRFC4122
+	VariantMicrosoft
+	VariantFuture
+)
+
+// Version specifies how the bits in the GUID were generated. For instance, a
+// version 4 GUID is randomly generated, and a version 5 is generated from the
+// hash of an input string.
+type Version uint8
+
+var _ = (encoding.TextMarshaler)(GUID{})
+var _ = (encoding.TextUnmarshaler)(&GUID{})
 
 // GUID represents a GUID/UUID. It has the same structure as
 // golang.org/x/sys/windows.GUID so that it can be used with functions expecting
@@ -29,15 +52,50 @@ func NewV4() (GUID, error) {
 		return GUID{}, err
 	}
 
-	var g GUID
-	g.Data1 = binary.LittleEndian.Uint32(b[0:4])
-	g.Data2 = binary.LittleEndian.Uint16(b[4:6])
-	g.Data3 = binary.LittleEndian.Uint16(b[6:8])
-	copy(g.Data4[:], b[8:16])
+	b[6] = (b[6] & 0x0f) | 0x40 // Version 4 (randomly generated)
+	b[8] = (b[8] & 0x3f) | 0x80 // RFC4122 variant
 
-	g.Data3 = (g.Data3 & 0x0fff) | 0x4000   // Version 4 (randomly generated)
-	g.Data4[0] = (g.Data4[0] & 0x3f) | 0x80 // RFC4122 variant
-	return g, nil
+	return FromArray(b), nil
+}
+
+func fromArray(b [16]byte, order binary.ByteOrder) GUID {
+	var g GUID
+	g.Data1 = order.Uint32(b[0:4])
+	g.Data2 = order.Uint16(b[4:6])
+	g.Data3 = order.Uint16(b[6:8])
+	copy(g.Data4[:], b[8:16])
+	return g
+}
+
+func (g GUID) toArray(order binary.ByteOrder) [16]byte {
+	b := [16]byte{}
+	order.PutUint32(b[0:4], g.Data1)
+	order.PutUint16(b[4:6], g.Data2)
+	order.PutUint16(b[6:8], g.Data3)
+	copy(b[8:16], g.Data4[:])
+	return b
+}
+
+// FromArray constructs a GUID from a big-endian encoding array of 16 bytes.
+func FromArray(b [16]byte) GUID {
+	return fromArray(b, binary.BigEndian)
+}
+
+// ToArray returns an array of 16 bytes representing the GUID in big-endian
+// encoding.
+func (g GUID) ToArray() [16]byte {
+	return g.toArray(binary.BigEndian)
+}
+
+// FromWindowsArray constructs a GUID from a Windows encoding array of bytes.
+func FromWindowsArray(b [16]byte) GUID {
+	return fromArray(b, binary.LittleEndian)
+}
+
+// ToWindowsArray returns an array of 16 bytes representing the GUID in Windows
+// encoding.
+func (g GUID) ToWindowsArray() [16]byte {
+	return g.toArray(binary.LittleEndian)
 }
 
 func (g GUID) String() string {
@@ -55,36 +113,36 @@ func (g GUID) String() string {
 // format.
 func FromString(s string) (GUID, error) {
 	if len(s) != 36 {
-		return GUID{}, errors.New("invalid GUID format (length)")
+		return GUID{}, fmt.Errorf("invalid GUID %q", s)
 	}
 	if s[8] != '-' || s[13] != '-' || s[18] != '-' || s[23] != '-' {
-		return GUID{}, errors.New("invalid GUID format (dashes)")
+		return GUID{}, fmt.Errorf("invalid GUID %q", s)
 	}
 
 	var g GUID
 
 	data1, err := strconv.ParseUint(s[0:8], 16, 32)
 	if err != nil {
-		return GUID{}, errors.Wrap(err, "invalid GUID format (Data1)")
+		return GUID{}, fmt.Errorf("invalid GUID %q", s)
 	}
 	g.Data1 = uint32(data1)
 
 	data2, err := strconv.ParseUint(s[9:13], 16, 16)
 	if err != nil {
-		return GUID{}, errors.Wrap(err, "invalid GUID format (Data2)")
+		return GUID{}, fmt.Errorf("invalid GUID %q", s)
 	}
 	g.Data2 = uint16(data2)
 
 	data3, err := strconv.ParseUint(s[14:18], 16, 16)
 	if err != nil {
-		return GUID{}, errors.Wrap(err, "invalid GUID format (Data3)")
+		return GUID{}, fmt.Errorf("invalid GUID %q", s)
 	}
 	g.Data3 = uint16(data3)
 
 	for i, x := range []int{19, 21, 24, 26, 28, 30, 32, 34} {
 		v, err := strconv.ParseUint(s[x:x+2], 16, 8)
 		if err != nil {
-			return GUID{}, errors.Wrap(err, "invalid GUID format (Data4)")
+			return GUID{}, fmt.Errorf("invalid GUID %q", s)
 		}
 		g.Data4[i] = uint8(v)
 	}
@@ -92,16 +150,35 @@ func FromString(s string) (GUID, error) {
 	return g, nil
 }
 
-// MarshalJSON marshals the GUID to JSON representation and returns it as a
-// slice of bytes.
-func (g GUID) MarshalJSON() ([]byte, error) {
-	return json.Marshal(g.String())
+// Variant returns the GUID variant, as defined in RFC 4122.
+func (g GUID) Variant() Variant {
+	b := g.Data4[0]
+	if b&0x80 == 0 {
+		return VariantNCS
+	} else if b&0xc0 == 0x80 {
+		return VariantRFC4122
+	} else if b&0xe0 == 0xc0 {
+		return VariantMicrosoft
+	} else if b&0xe0 == 0xe0 {
+		return VariantFuture
+	}
+	return VariantUnknown
 }
 
-// UnmarshalJSON unmarshals a GUID from JSON representation and sets itself to
-// the unmarshaled GUID.
-func (g *GUID) UnmarshalJSON(data []byte) error {
-	g2, err := FromString(strings.Trim(string(data), "\""))
+// Version returns the GUID version, as defined in RFC 4122.
+func (g GUID) Version() Version {
+	return Version((g.Data3 & 0xF000) >> 12)
+}
+
+// MarshalText returns the textual representation of the GUID.
+func (g GUID) MarshalText() ([]byte, error) {
+	return []byte(g.String()), nil
+}
+
+// UnmarshalText takes the textual representation of a GUID, and unmarhals it
+// into this GUID.
+func (g *GUID) UnmarshalText(text []byte) error {
+	g2, err := FromString(string(text))
 	if err != nil {
 		return err
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,4 +1,4 @@
-# github.com/Microsoft/go-winio v0.4.13-0.20190509182014-01fe22a8b81b
+# github.com/Microsoft/go-winio v0.4.13-0.20190516165658-12afdbf8b879
 github.com/Microsoft/go-winio/pkg/guid
 github.com/Microsoft/go-winio
 github.com/Microsoft/go-winio/pkg/etw


### PR DESCRIPTION
This is part of fixing the guid-to-array functions in layer.go which
were using the wrong array indices. The best way to fix this now is to
use the functionality in the go-winio guid package.

Signed-off-by: Kevin Parsons <kevpar@microsoft.com>