### PR TITLE
Add new create process API to not save stdio pipes

### DIFF
--- a/container.go
+++ b/container.go
@@ -195,7 +195,7 @@ func (container *container) MappedVirtualDisks() (map[int]MappedVirtualDiskContr
 
 // CreateProcess launches a new process within the container.
 func (container *container) CreateProcess(c *ProcessConfig) (Process, error) {
-	p, err := container.system.CreateProcess(c)
+	p, err := container.system.CreateProcessNoStdio(c)
 	if err != nil {
 		return nil, convertSystemError(err, container)
 	}

--- a/internal/hcs/process.go
+++ b/internal/hcs/process.go
@@ -322,8 +322,8 @@ func (process *Process) ExitCode() (_ int, err error) {
 }
 
 // StdioLegacy returns the stdin, stdout, and stderr pipes, respectively. Closing
-// these pipes does not close the underlying pipes; it should be possible to
-// call this multiple times to get multiple interfaces.
+// these pipes does not close the underlying pipes; but this function can only
+// be called once on each Process.
 func (process *Process) StdioLegacy() (_ io.WriteCloser, _ io.ReadCloser, _ io.ReadCloser, err error) {
 	process.handleLock.RLock()
 	defer process.handleLock.RUnlock()


### PR DESCRIPTION
CreateIoCompletionPort (used by makeOpenFiles) can only be called once
successfully for a given underlying object, regardless of how many
handles we have to the object.

The previous behavior of process stdio was to call
HcsGetProcessInfo when Stdio was called, then call makeOpenFiles and
return the resulting handles[1].

As part of a recent change, CreateProcess was changed to call
makeOpenFiles on the stdio handles at process creation time, and save
the new handles on the process struct. These saved handles are now
returned directly by Stdio. In an effort to preserve legacy compat, a
new function, StdioLegacy, was added which preserved the old Stdio
behavior, and the legacy caller was changed to use StdioLegacy instead
of Stdio.

However, because CreateIoCompletionPort can only be called once for a
single object, and it has already been called on a handle for the stdio
pipe object at process creation time, StdioLegacy now fails.

This change addresses this issue by creating a new CreateProcessNoStdio
function which preserves the old process creation behavior, and just
closes the initial stdio handles received at process creation time. This
function is now used by the legacy caller, which should allow projects
like Docker to work properly.

[1] This actually means that although the comment on the old Stdio
implementation stated it could be called multiple times to receive
multiple sets of handles, it would actually fail after being called the
first time. This change does not fix this issue, but does remove the
incorrect comment.

Signed-off-by: Kevin Parsons <kevpar@microsoft.com>