### PR TITLE
Avoid panic: argon with VHD

### DIFF
--- a/cmd/containerd-shim-runhcs-v1/service.go
+++ b/cmd/containerd-shim-runhcs-v1/service.go
@@ -72,9 +72,11 @@ func (s *service) State(ctx context.Context, req *task.StateRequest) (resp *task
 	}
 	log := beginActivity(activity, af)
 	defer func() {
-		log.Data["status"] = resp.Status.String()
-		log.Data["exitStatus"] = resp.ExitStatus
-		log.Data["exitedAt"] = resp.ExitedAt
+		if resp != nil {
+			log.Data["status"] = resp.Status.String()
+			log.Data["exitStatus"] = resp.ExitStatus
+			log.Data["exitedAt"] = resp.ExitedAt
+		}
 		endActivity(log, activity, err)
 	}()
 
@@ -97,7 +99,9 @@ func (s *service) Create(ctx context.Context, req *task.CreateTaskRequest) (resp
 		"parentcheckpoint": req.ParentCheckpoint,
 	})
 	defer func() {
-		log.Data["pid"] = resp.Pid
+		if resp != nil {
+			log.Data["pid"] = resp.Pid
+		}
 		endActivity(log, activity, err)
 	}()
 
@@ -114,7 +118,9 @@ func (s *service) Start(ctx context.Context, req *task.StartRequest) (resp *task
 	}
 	log := beginActivity(activity, af)
 	defer func() {
-		log.Data["pid"] = resp.Pid
+		if resp != nil {
+			log.Data["pid"] = resp.Pid
+		}
 		endActivity(log, activity, err)
 	}()
 
@@ -131,9 +137,11 @@ func (s *service) Delete(ctx context.Context, req *task.DeleteRequest) (resp *ta
 	}
 	log := beginActivity(activity, af)
 	defer func() {
-		log.Data["pid"] = resp.Pid
-		log.Data["exitStatus"] = resp.ExitStatus
-		log.Data["exitedAt"] = resp.ExitedAt
+		if resp != nil {
+			log.Data["pid"] = resp.Pid
+			log.Data["exitStatus"] = resp.ExitStatus
+			log.Data["exitedAt"] = resp.ExitedAt
+		}
 		endActivity(log, activity, err)
 	}()
 
@@ -299,8 +307,10 @@ func (s *service) Wait(ctx context.Context, req *task.WaitRequest) (resp *task.W
 	}
 	log := beginActivity(activity, af)
 	defer func() {
-		log.Data["exitStatus"] = resp.ExitStatus
-		log.Data["exitedAt"] = resp.ExitedAt
+		if resp != nil {
+			log.Data["exitStatus"] = resp.ExitStatus
+			log.Data["exitedAt"] = resp.ExitedAt
+		}
 		endActivity(log, activity, err)
 	}()
 
@@ -329,9 +339,11 @@ func (s *service) Connect(ctx context.Context, req *task.ConnectRequest) (resp *
 	}
 	log := beginActivity(activity, af)
 	defer func() {
-		log.Data["shimPid"] = resp.ShimPid
-		log.Data["taskPid"] = resp.TaskPid
-		log.Data["version"] = resp.Version
+		if resp != nil {
+			log.Data["shimPid"] = resp.ShimPid
+			log.Data["taskPid"] = resp.TaskPid
+			log.Data["version"] = resp.Version
+		}
 		endActivity(log, activity, err)
 	}()
 


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

Found investigating 21355099. @jterry75 PTAL

Command being run: `ctr --debug run --rm --tty --runtime io.containerd.runhcs.v1 --mount="type=virtual-disk,src=c:\formatted.vhd,dst=c:\test" mcr.microsoft.com/windows/nanoserver:1809 mycontainer cmd`

(Note the end-to-end works fine with Xenon).

Shim panics with following stack:

```
runtime error: invalid memory address or nil pointer dereference" stack="goroutine
 7 [running]:
main.stack(0xc00019db40, 0xa13200, 0x9853b0)
	e:/go/src/github.com/Microsoft/hcsshim/cmd/containerd-shim-runhcs-v1/main.go:45 +0xa4
main.panicRecover()
	e:/go/src/github.com/Microsoft/hcsshim/cmd/containerd-shim-runhcs-v1/main.go:57 +0x78
panic(0xa13200, 0x9853b0)
	C:/Go/src/runtime/panic.go:522 +0x1c3
main.(*service).Create.func1(0xc00019dd28, 0xc0001621c0, 0xc00019dd30)
	e:/go/src/github.com/Microsoft/hcsshim/cmd/containerd-shim-runhcs-v1/service.go:100 +0x30
main.(*service).Create(0xc00005eac0, 0xb76380, 0xc000040100, 0xc00015e140, 0x0, 0xb66e60, 0xc0001c2260)
	e:/go/src/github.com/Microsoft/hcsshim/cmd/containerd-shim-runhcs-v1/service.go:105 +0x5e8
github.com/Microsoft/hcsshim/vendor/github.com/containerd/containerd/runtime/v2/task.RegisterTaskService.func2(0xb76380, 0xc000040100, 0xc000004120, 0xc0000180c8, 0x6, 0xc0000594e0, 0x0)
	e:/go/src/github.com/Microsoft/hcsshim/vendor/github.com/containerd/containerd/runtime/v2/task/shim.pb.go:2088 +0xcc
github.com/Microsoft/hcsshim/vendor/github.com/containerd/ttrpc.(*serviceSet).dispatch(0xc00008e068, 0xb76380, 0xc000040100, 0xc00001e280, 0x17, 0xc0000180c8, 0x6, 0xc000164000, 0x19b, 0x1a0, ...)
	e:/go/src/github.com/Microsoft/hcsshim/vendor/github.com/containerd/ttrpc/services.go:87 +0xff
github.com/Microsoft/hcsshim/vendor/github.com/containerd/ttrpc.(*serviceSet).call(0xc00008e068, 0xb76380, 0xc000040100, 0xc00001e280, 0x17, 0xc0000180c8, 0x6, 0xc000164000, 0x19b, 0x1a0, ...)
	e:/go/src/github.com/Microsoft/hcsshim/vendor/github.com/containerd/ttrpc/services.go:60 +0xbc
github.com/Microsoft/hcsshim/vendor/github.com/containerd/ttrpc.(*serverConn).run.func2(0xc000152000, 0xb76380, 0xc000040100, 0xc000000001, 0xc0000401c0, 0xc0001502a0, 0xc000150360, 0xc000000001)
	e:/go/src/github.com/Microsoft/hcsshim/vendor/github.com/containerd/ttrpc/server.go:417 +0xae
created by github.com/Microsoft/hcsshim/vendor/github.com/containerd/ttrpc.(*serverConn).run
	e:/go/src/github.com/Microsoft/hcsshim/vendor/github.com/containerd/ttrpc/server.go:416 +0x7b4
```

It still doesn't work, but doesn't panic at least....
