### PR TITLE
lcow: Explicitly pass CPU count to UVM via kernel command line

### DIFF
--- a/internal/uvm/create_lcow.go
+++ b/internal/uvm/create_lcow.go
@@ -343,6 +343,7 @@ func CreateLCOW(opts *OptionsLCOW) (_ *UtilityVM, err error) {
 		initArgs = `sh -c "` + initArgs + ` & exec sh"`
 	}
 
+	kernelArgs += fmt.Sprintf(" nr_cpus=%d", opts.ProcessorCount)
 	kernelArgs += ` pci=off brd.rd_nr=0 pmtmr=0 -- ` + initArgs
 
 	if !opts.KernelDirect {


### PR DESCRIPTION
Signed-off-by: Kevin Parsons <kevpar@microsoft.com>