### PR TITLE
Stop logging expected error values

### DIFF
--- a/cmd/containerd-shim-runhcs-v1/exec_wcow_podsandbox.go
+++ b/cmd/containerd-shim-runhcs-v1/exec_wcow_podsandbox.go
@@ -5,8 +5,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/Microsoft/hcsshim/internal/oc"
-
 	eventstypes "github.com/containerd/containerd/api/events"
 	containerd_v1_types "github.com/containerd/containerd/api/types/task"
 	"github.com/containerd/containerd/errdefs"
@@ -122,14 +120,7 @@ func (wpse *wcowPodSandboxExec) Status() *task.StateResponse {
 	}
 }
 
-func (wpse *wcowPodSandboxExec) Start(ctx context.Context) (err error) {
-	ctx, span := trace.StartSpan(ctx, "wcowPodSandboxExec::Start")
-	defer span.End()
-	defer func() { oc.SetSpanStatus(span, err) }()
-	span.AddAttributes(
-		trace.StringAttribute("tid", wpse.tid),
-		trace.StringAttribute("eid", wpse.tid)) // Init exec ID is always same as Task ID
-
+func (wpse *wcowPodSandboxExec) Start(ctx context.Context) error {
 	wpse.sl.Lock()
 	defer wpse.sl.Unlock()
 	if wpse.state != shimExecStateCreated {
@@ -152,15 +143,7 @@ func (wpse *wcowPodSandboxExec) Start(ctx context.Context) (err error) {
 	return nil
 }
 
-func (wpse *wcowPodSandboxExec) Kill(ctx context.Context, signal uint32) (err error) {
-	_, span := trace.StartSpan(ctx, "wcowPodSandboxExec::Kill")
-	defer span.End()
-	defer func() { oc.SetSpanStatus(span, err) }()
-	span.AddAttributes(
-		trace.StringAttribute("tid", wpse.tid),
-		trace.StringAttribute("eid", wpse.tid), // Init exec ID is always same as Task ID
-		trace.Int64Attribute("signal", int64(signal)))
-
+func (wpse *wcowPodSandboxExec) Kill(ctx context.Context, signal uint32) error {
 	wpse.sl.Lock()
 	defer wpse.sl.Unlock()
 	switch wpse.state {
@@ -188,16 +171,7 @@ func (wpse *wcowPodSandboxExec) Kill(ctx context.Context, signal uint32) (err er
 	}
 }
 
-func (wpse *wcowPodSandboxExec) ResizePty(ctx context.Context, width, height uint32) (err error) {
-	_, span := trace.StartSpan(ctx, "wcowPodSandboxExec::ResizePty")
-	defer span.End()
-	defer func() { oc.SetSpanStatus(span, err) }()
-	span.AddAttributes(
-		trace.StringAttribute("tid", wpse.tid),
-		trace.StringAttribute("eid", wpse.tid), // Init exec ID is always same as Task ID
-		trace.Int64Attribute("width", int64(width)),
-		trace.Int64Attribute("height", int64(height)))
-
+func (wpse *wcowPodSandboxExec) ResizePty(ctx context.Context, width, height uint32) error {
 	wpse.sl.Lock()
 	defer wpse.sl.Unlock()
 	if wpse.state != shimExecStateRunning {
@@ -209,23 +183,10 @@ func (wpse *wcowPodSandboxExec) ResizePty(ctx context.Context, width, height uin
 }
 
 func (wpse *wcowPodSandboxExec) CloseIO(ctx context.Context, stdin bool) error {
-	_, span := trace.StartSpan(ctx, "wcowPodSandboxExec::CloseIO")
-	defer span.End()
-	span.AddAttributes(
-		trace.StringAttribute("tid", wpse.tid),
-		trace.StringAttribute("eid", wpse.tid), // Init exec ID is always same as Task ID
-		trace.BoolAttribute("stdin", stdin))
-
 	return nil
 }
 
 func (wpse *wcowPodSandboxExec) Wait(ctx context.Context) *task.StateResponse {
-	ctx, span := trace.StartSpan(ctx, "wcowPodSandboxExec::Wait")
-	defer span.End()
-	span.AddAttributes(
-		trace.StringAttribute("tid", wpse.tid),
-		trace.StringAttribute("eid", wpse.tid)) // Init exec ID is always same as Task ID
-
 	<-wpse.exited
 	return wpse.Status()
 }

--- a/cmd/containerd-shim-runhcs-v1/pod.go
+++ b/cmd/containerd-shim-runhcs-v1/pod.go
@@ -249,15 +249,6 @@ func (p *pod) ID() string {
 }
 
 func (p *pod) CreateTask(ctx context.Context, req *task.CreateTaskRequest, s *specs.Spec) (_ shimTask, err error) {
-	ctx, span := trace.StartSpan(ctx, "pod::CreateTask")
-	defer span.End()
-	defer func() {
-		oc.SetSpanStatus(span, err)
-	}()
-	span.AddAttributes(
-		trace.StringAttribute("pod-id", p.id),
-		trace.StringAttribute("tid", req.ID))
-
 	if req.ID == p.id {
 		return nil, errors.Wrapf(errdefs.ErrAlreadyExists, "task with id: '%s' already exists", req.ID)
 	}
@@ -319,19 +310,7 @@ func (p *pod) GetTask(tid string) (shimTask, error) {
 	return raw.(shimTask), nil
 }
 
-func (p *pod) KillTask(ctx context.Context, tid, eid string, signal uint32, all bool) (err error) {
-	ctx, span := trace.StartSpan(ctx, "pod::KillTask")
-	defer span.End()
-	defer func() {
-		oc.SetSpanStatus(span, err)
-	}()
-	span.AddAttributes(
-		trace.StringAttribute("pod-id", p.id),
-		trace.StringAttribute("tid", tid),
-		trace.StringAttribute("eid", eid),
-		trace.Int64Attribute("signal", int64(signal)),
-		trace.BoolAttribute("all", all))
-
+func (p *pod) KillTask(ctx context.Context, tid, eid string, signal uint32, all bool) error {
 	t, err := p.GetTask(tid)
 	if err != nil {
 		return err

--- a/cmd/containerd-shim-runhcs-v1/service.go
+++ b/cmd/containerd-shim-runhcs-v1/service.go
@@ -129,7 +129,9 @@ func (s *service) Delete(ctx context.Context, req *task.DeleteRequest) (resp *ta
 				trace.Int64Attribute("exitStatus", int64(resp.ExitStatus)),
 				trace.StringAttribute("exitedAt", resp.ExitedAt.String()))
 		}
-		oc.SetSpanStatus(span, err)
+		if !errdefs.IsNotFound(err) {
+			oc.SetSpanStatus(span, err)
+		}
 	}()
 
 	span.AddAttributes(
@@ -203,7 +205,9 @@ func (s *service) Kill(ctx context.Context, req *task.KillRequest) (_ *google_pr
 	ctx, span := trace.StartSpan(ctx, "Kill")
 	defer span.End()
 	defer func() {
-		oc.SetSpanStatus(span, err)
+		if !errdefs.IsNotFound(err) {
+			oc.SetSpanStatus(span, err)
+		}
 	}()
 
 	span.AddAttributes(

--- a/cmd/containerd-shim-runhcs-v1/task_wcow_podsandbox.go
+++ b/cmd/containerd-shim-runhcs-v1/task_wcow_podsandbox.go
@@ -5,8 +5,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/Microsoft/hcsshim/internal/oc"
-
 	"github.com/Microsoft/hcsshim/cmd/containerd-shim-runhcs-v1/options"
 	"github.com/Microsoft/hcsshim/internal/log"
 	"github.com/Microsoft/hcsshim/internal/shimdiag"
@@ -89,14 +87,7 @@ func (wpst *wcowPodSandboxTask) ID() string {
 	return wpst.id
 }
 
-func (wpst *wcowPodSandboxTask) CreateExec(ctx context.Context, req *task.ExecProcessRequest, s *specs.Process) (err error) {
-	ctx, span := trace.StartSpan(ctx, "wcowPodSandboxTask::CreateExec")
-	defer span.End()
-	defer func() { oc.SetSpanStatus(span, err) }()
-	span.AddAttributes(
-		trace.StringAttribute("tid", wpst.id),
-		trace.StringAttribute("eid", req.ExecID))
-
+func (wpst *wcowPodSandboxTask) CreateExec(ctx context.Context, req *task.ExecProcessRequest, s *specs.Process) error {
 	return errors.Wrap(errdefs.ErrNotImplemented, "WCOW Pod task should never issue exec")
 }
 
@@ -108,16 +99,7 @@ func (wpst *wcowPodSandboxTask) GetExec(eid string) (shimExec, error) {
 	return nil, errors.Wrapf(errdefs.ErrNotFound, "exec: '%s' in task: '%s' not found", eid, wpst.id)
 }
 
-func (wpst *wcowPodSandboxTask) KillExec(ctx context.Context, eid string, signal uint32, all bool) (err error) {
-	ctx, span := trace.StartSpan(ctx, "wcowPodSandboxTask::KillExec")
-	defer span.End()
-	defer func() { oc.SetSpanStatus(span, err) }()
-	span.AddAttributes(
-		trace.StringAttribute("tid", wpst.id),
-		trace.StringAttribute("eid", eid),
-		trace.Int64Attribute("signal", int64(signal)),
-		trace.BoolAttribute("all", all))
-
+func (wpst *wcowPodSandboxTask) KillExec(ctx context.Context, eid string, signal uint32, all bool) error {
 	e, err := wpst.GetExec(eid)
 	if err != nil {
 		return err
@@ -132,14 +114,7 @@ func (wpst *wcowPodSandboxTask) KillExec(ctx context.Context, eid string, signal
 	return nil
 }
 
-func (wpst *wcowPodSandboxTask) DeleteExec(ctx context.Context, eid string) (_ int, _ uint32, _ time.Time, err error) {
-	ctx, span := trace.StartSpan(ctx, "wcowPodSandboxTask::DeleteExec")
-	defer span.End()
-	defer func() { oc.SetSpanStatus(span, err) }()
-	span.AddAttributes(
-		trace.StringAttribute("tid", wpst.id),
-		trace.StringAttribute("eid", eid))
-
+func (wpst *wcowPodSandboxTask) DeleteExec(ctx context.Context, eid string) (int, uint32, time.Time, error) {
 	e, err := wpst.GetExec(eid)
 	if err != nil {
 		return 0, 0, time.Time{}, err
@@ -168,10 +143,6 @@ func (wpst *wcowPodSandboxTask) DeleteExec(ctx context.Context, eid string) (_ i
 }
 
 func (wpst *wcowPodSandboxTask) Pids(ctx context.Context) ([]options.ProcessDetails, error) {
-	ctx, span := trace.StartSpan(ctx, "wcowPodSandboxTask::Pids")
-	defer span.End()
-	span.AddAttributes(trace.StringAttribute("tid", wpst.id))
-
 	return []options.ProcessDetails{
 		{
 			ProcessID: uint32(wpst.init.Pid()),
@@ -181,10 +152,6 @@ func (wpst *wcowPodSandboxTask) Pids(ctx context.Context) ([]options.ProcessDeta
 }
 
 func (wpst *wcowPodSandboxTask) Wait(ctx context.Context) *task.StateResponse {
-	ctx, span := trace.StartSpan(ctx, "wcowPodSandboxTask::Wait")
-	defer span.End()
-	span.AddAttributes(trace.StringAttribute("tid", wpst.id))
-
 	<-wpst.closed
 	return wpst.init.Wait(ctx)
 }

--- a/internal/hcs/process.go
+++ b/internal/hcs/process.go
@@ -145,7 +145,13 @@ func (process *Process) Signal(options interface{}) (_ bool, err error) {
 
 	operation := "hcsshim::Process::Signal"
 	process.logOperationBegin(operation)
-	defer func() { process.logOperationEnd(operation, err) }()
+	defer func() {
+		if !IsNotExist(err) {
+			process.logOperationEnd(operation, err)
+		} else {
+			process.logOperationEnd(operation, nil)
+		}
+	}()
 
 	if process.handle == 0 {
 		return false, makeProcessError(process, operation, ErrAlreadyClosed, nil)
@@ -175,7 +181,13 @@ func (process *Process) Kill() (_ bool, err error) {
 
 	operation := "hcsshim::Process::Kill"
 	process.logOperationBegin(operation)
-	defer func() { process.logOperationEnd(operation, err) }()
+	defer func() {
+		if !IsNotExist(err) {
+			process.logOperationEnd(operation, err)
+		} else {
+			process.logOperationEnd(operation, nil)
+		}
+	}()
 
 	if process.handle == 0 {
 		return false, makeProcessError(process, operation, ErrAlreadyClosed, nil)

--- a/internal/hcs/vmcompute.go
+++ b/internal/hcs/vmcompute.go
@@ -228,7 +228,11 @@ func hcsCloseProcessContext(ctx gcontext.Context, process hcsProcess) (hr error)
 func hcsTerminateProcessContext(ctx gcontext.Context, process hcsProcess, result **uint16) (hr error) {
 	ctx, span := trace.StartSpan(ctx, "HcsTerminateProcess")
 	defer span.End()
-	defer func() { oc.SetSpanStatus(span, hr) }()
+	defer func() {
+		if !IsNotExist(hr) {
+			oc.SetSpanStatus(span, hr)
+		}
+	}()
 
 	return execute(ctx, timeout.SyscallWatcher, func() error {
 		return hcsTerminateProcess(process, result)
@@ -238,7 +242,11 @@ func hcsTerminateProcessContext(ctx gcontext.Context, process hcsProcess, result
 func hcsSignalProcessContext(ctx gcontext.Context, process hcsProcess, options string, result **uint16) (hr error) {
 	ctx, span := trace.StartSpan(ctx, "HcsSignalProcess")
 	defer span.End()
-	defer func() { oc.SetSpanStatus(span, hr) }()
+	defer func() {
+		if !IsNotExist(hr) {
+			oc.SetSpanStatus(span, hr)
+		}
+	}()
 	span.AddAttributes(trace.StringAttribute("options", options))
 
 	return execute(ctx, timeout.SyscallWatcher, func() error {

--- a/internal/hcsoci/hcsdoc_lcow.go
+++ b/internal/hcsoci/hcsdoc_lcow.go
@@ -41,9 +41,6 @@ func createLCOWSpec(coi *createOptionsInternal) (*specs.Spec, error) {
 
 	// Clear unsupported features
 	if spec.Linux.Resources != nil {
-		if len(spec.Linux.Resources.Devices) > 0 {
-			logrus.Warning("clearing non-empty spec.Linux.Resources.Devices")
-		}
 		spec.Linux.Resources.Devices = nil
 		spec.Linux.Resources.Pids = nil
 		spec.Linux.Resources.BlockIO = nil


### PR DESCRIPTION
Some HCS* functions return errors to signify a success with additional
information. In these cases we need to skip logging the error because the use
cases is expected and this isn't an error for the client who handles it.

Signed-off-by: Justin Terry (VM) <juterry@microsoft.com>