### PR TITLE
Improve wclayer context logging

### DIFF
--- a/internal/hcsoci/hcsdoc_wcow.go
+++ b/internal/hcsoci/hcsdoc_wcow.go
@@ -227,7 +227,7 @@ func createWindowsContainerDocument(ctx context.Context, coi *createOptionsInter
 
 	if coi.HostingSystem == nil { // Argon v1 or v2
 		for _, layerPath := range coi.Spec.Windows.LayerFolders[:len(coi.Spec.Windows.LayerFolders)-1] {
-			layerID, err := wclayer.LayerID(layerPath)
+			layerID, err := wclayer.LayerID(ctx, layerPath)
 			if err != nil {
 				return nil, nil, err
 			}

--- a/internal/hcsoci/resources_wcow.go
+++ b/internal/hcsoci/resources_wcow.go
@@ -25,12 +25,10 @@ func allocateWindowsResources(ctx context.Context, coi *createOptionsInternal, r
 	}
 
 	scratchFolder := coi.Spec.Windows.LayerFolders[len(coi.Spec.Windows.LayerFolders)-1]
-	log.G(ctx).WithField("scratchFolder", scratchFolder).Debug("hcsshim::allocateWindowsResources scratch folder")
 
 	// TODO: Remove this code for auto-creation. Make the caller responsible.
 	// Create the directory for the RW scratch layer if it doesn't exist
 	if _, err := os.Stat(scratchFolder); os.IsNotExist(err) {
-		log.G(ctx).WithField("scratchFolder", scratchFolder).Debug("hcsshim::allocateWindowsResources container scratch folder does not exist so creating")
 		if err := os.MkdirAll(scratchFolder, 0777); err != nil {
 			return fmt.Errorf("failed to auto-create container scratch folder %s: %s", scratchFolder, err)
 		}
@@ -39,8 +37,7 @@ func allocateWindowsResources(ctx context.Context, coi *createOptionsInternal, r
 	// Create sandbox.vhdx if it doesn't exist in the scratch folder. It's called sandbox.vhdx
 	// rather than scratch.vhdx as in the v1 schema, it's hard-coded in HCS.
 	if _, err := os.Stat(filepath.Join(scratchFolder, "sandbox.vhdx")); os.IsNotExist(err) {
-		log.G(ctx).WithField("scratchFolder", scratchFolder).Debug("hcsshim::allocateWindowsResources container sandbox.vhdx does not exist so creating")
-		if err := wclayer.CreateScratchLayer(scratchFolder, coi.Spec.Windows.LayerFolders[:len(coi.Spec.Windows.LayerFolders)-1]); err != nil {
+		if err := wclayer.CreateScratchLayer(ctx, scratchFolder, coi.Spec.Windows.LayerFolders[:len(coi.Spec.Windows.LayerFolders)-1]); err != nil {
 			return fmt.Errorf("failed to CreateSandboxLayer %s", err)
 		}
 	}

--- a/internal/tools/zapdir/main.go
+++ b/internal/tools/zapdir/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -44,7 +45,7 @@ func main() {
 			return err
 		}
 
-		if err := wclayer.DestroyLayer(dir); err != nil {
+		if err := wclayer.DestroyLayer(context.Background(), dir); err != nil {
 			return err
 		}
 

--- a/internal/uvm/scsi.go
+++ b/internal/uvm/scsi.go
@@ -159,7 +159,7 @@ func (uvm *UtilityVM) addSCSIActual(ctx context.Context, hostPath, uvmPath, atta
 
 	// Ensure the utility VM has access
 	if !isLayer {
-		if err := wclayer.GrantVmAccess(uvm.id, hostPath); err != nil {
+		if err := wclayer.GrantVmAccess(ctx, uvm.id, hostPath); err != nil {
 			return -1, -1, err
 		}
 	}

--- a/internal/wclayer/activatelayer.go
+++ b/internal/wclayer/activatelayer.go
@@ -1,28 +1,23 @@
 package wclayer
 
 import (
+	"context"
+
 	"github.com/Microsoft/hcsshim/internal/hcserror"
-	"github.com/sirupsen/logrus"
+	"github.com/Microsoft/hcsshim/internal/oc"
+	"go.opencensus.io/trace"
 )
 
 // ActivateLayer will find the layer with the given id and mount it's filesystem.
 // For a read/write layer, the mounted filesystem will appear as a volume on the
 // host, while a read-only layer is generally expected to be a no-op.
 // An activated layer must later be deactivated via DeactivateLayer.
-func ActivateLayer(path string) (err error) {
+func ActivateLayer(ctx context.Context, path string) (err error) {
 	title := "hcsshim::ActivateLayer"
-	fields := logrus.Fields{
-		"path": path,
-	}
-	logrus.WithFields(fields).Debug(title)
-	defer func() {
-		if err != nil {
-			fields[logrus.ErrorKey] = err
-			logrus.WithFields(fields).Error(err)
-		} else {
-			logrus.WithFields(fields).Debug(title + " - succeeded")
-		}
-	}()
+	ctx, span := trace.StartSpan(ctx, title)
+	defer span.End()
+	defer func() { oc.SetSpanStatus(span, err) }()
+	span.AddAttributes(trace.StringAttribute("path", path))
 
 	err = activateLayer(&stdDriverInfo, path)
 	if err != nil {

--- a/internal/wclayer/baselayer.go
+++ b/internal/wclayer/baselayer.go
@@ -1,6 +1,7 @@
 package wclayer
 
 import (
+	"context"
 	"errors"
 	"os"
 	"path/filepath"
@@ -8,10 +9,15 @@ import (
 
 	"github.com/Microsoft/go-winio"
 	"github.com/Microsoft/hcsshim/internal/hcserror"
+	"github.com/Microsoft/hcsshim/internal/oc"
 	"github.com/Microsoft/hcsshim/internal/safefile"
+	"go.opencensus.io/trace"
 )
 
 type baseLayerWriter struct {
+	ctx context.Context
+	s   *trace.Span
+
 	root         *os.File
 	f            *os.File
 	bw           *winio.BackupFileWriter
@@ -136,12 +142,15 @@ func (w *baseLayerWriter) Write(b []byte) (int, error) {
 	return n, err
 }
 
-func (w *baseLayerWriter) Close() error {
+func (w *baseLayerWriter) Close() (err error) {
+	defer w.s.End()
+	defer func() { oc.SetSpanStatus(w.s, err) }()
 	defer func() {
 		w.root.Close()
 		w.root = nil
 	}()
-	err := w.closeCurrentFile()
+
+	err = w.closeCurrentFile()
 	if err != nil {
 		return err
 	}
@@ -153,7 +162,7 @@ func (w *baseLayerWriter) Close() error {
 			return err
 		}
 
-		err = ProcessBaseLayer(w.root.Name())
+		err = ProcessBaseLayer(w.ctx, w.root.Name())
 		if err != nil {
 			return err
 		}
@@ -163,7 +172,7 @@ func (w *baseLayerWriter) Close() error {
 			if err != nil {
 				return err
 			}
-			err = ProcessUtilityVMImage(filepath.Join(w.root.Name(), "UtilityVM"))
+			err = ProcessUtilityVMImage(w.ctx, filepath.Join(w.root.Name(), "UtilityVM"))
 			if err != nil {
 				return err
 			}

--- a/internal/wclayer/createscratchlayer.go
+++ b/internal/wclayer/createscratchlayer.go
@@ -1,31 +1,29 @@
 package wclayer
 
 import (
+	"context"
+	"strings"
+
 	"github.com/Microsoft/hcsshim/internal/hcserror"
-	"github.com/sirupsen/logrus"
+	"github.com/Microsoft/hcsshim/internal/oc"
+	"go.opencensus.io/trace"
 )
 
 // CreateScratchLayer creates and populates new read-write layer for use by a container.
 // This requires both the id of the direct parent layer, as well as the full list
 // of paths to all parent layers up to the base (and including the direct parent
 // whose id was provided).
-func CreateScratchLayer(path string, parentLayerPaths []string) (err error) {
+func CreateScratchLayer(ctx context.Context, path string, parentLayerPaths []string) (err error) {
 	title := "hcsshim::CreateScratchLayer"
-	fields := logrus.Fields{
-		"path": path,
-	}
-	logrus.WithFields(fields).Debug(title)
-	defer func() {
-		if err != nil {
-			fields[logrus.ErrorKey] = err
-			logrus.WithFields(fields).Error(err)
-		} else {
-			logrus.WithFields(fields).Debug(title + " - succeeded")
-		}
-	}()
+	ctx, span := trace.StartSpan(ctx, title)
+	defer span.End()
+	defer func() { oc.SetSpanStatus(span, err) }()
+	span.AddAttributes(
+		trace.StringAttribute("path", path),
+		trace.StringAttribute("parentLayerPaths", strings.Join(parentLayerPaths, ", ")))
 
 	// Generate layer descriptors
-	layers, err := layerPathsToDescriptors(parentLayerPaths)
+	layers, err := layerPathsToDescriptors(ctx, parentLayerPaths)
 	if err != nil {
 		return err
 	}

--- a/internal/wclayer/deactivatelayer.go
+++ b/internal/wclayer/deactivatelayer.go
@@ -1,25 +1,20 @@
 package wclayer
 
 import (
+	"context"
+
 	"github.com/Microsoft/hcsshim/internal/hcserror"
-	"github.com/sirupsen/logrus"
+	"github.com/Microsoft/hcsshim/internal/oc"
+	"go.opencensus.io/trace"
 )
 
 // DeactivateLayer will dismount a layer that was mounted via ActivateLayer.
-func DeactivateLayer(path string) (err error) {
+func DeactivateLayer(ctx context.Context, path string) (err error) {
 	title := "hcsshim::DeactivateLayer"
-	fields := logrus.Fields{
-		"path": path,
-	}
-	logrus.WithFields(fields).Debug(title)
-	defer func() {
-		if err != nil {
-			fields[logrus.ErrorKey] = err
-			logrus.WithFields(fields).Error(err)
-		} else {
-			logrus.WithFields(fields).Debug(title + " - succeeded")
-		}
-	}()
+	ctx, span := trace.StartSpan(ctx, title)
+	defer span.End()
+	defer func() { oc.SetSpanStatus(span, err) }()
+	span.AddAttributes(trace.StringAttribute("path", path))
 
 	err = deactivateLayer(&stdDriverInfo, path)
 	if err != nil {

--- a/internal/wclayer/destroylayer.go
+++ b/internal/wclayer/destroylayer.go
@@ -1,26 +1,21 @@
 package wclayer
 
 import (
+	"context"
+
 	"github.com/Microsoft/hcsshim/internal/hcserror"
-	"github.com/sirupsen/logrus"
+	"github.com/Microsoft/hcsshim/internal/oc"
+	"go.opencensus.io/trace"
 )
 
 // DestroyLayer will remove the on-disk files representing the layer with the given
 // path, including that layer's containing folder, if any.
-func DestroyLayer(path string) (err error) {
+func DestroyLayer(ctx context.Context, path string) (err error) {
 	title := "hcsshim::DestroyLayer"
-	fields := logrus.Fields{
-		"path": path,
-	}
-	logrus.WithFields(fields).Debug(title)
-	defer func() {
-		if err != nil {
-			fields[logrus.ErrorKey] = err
-			logrus.WithFields(fields).Error(err)
-		} else {
-			logrus.WithFields(fields).Debug(title + " - succeeded")
-		}
-	}()
+	ctx, span := trace.StartSpan(ctx, title)
+	defer span.End()
+	defer func() { oc.SetSpanStatus(span, err) }()
+	span.AddAttributes(trace.StringAttribute("path", path))
 
 	err = destroyLayer(&stdDriverInfo, path)
 	if err != nil {

--- a/internal/wclayer/expandscratchsize.go
+++ b/internal/wclayer/expandscratchsize.go
@@ -1,32 +1,27 @@
 package wclayer
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"syscall"
 	"unsafe"
 
 	"github.com/Microsoft/hcsshim/internal/hcserror"
+	"github.com/Microsoft/hcsshim/internal/oc"
 	"github.com/Microsoft/hcsshim/osversion"
-	"github.com/sirupsen/logrus"
+	"go.opencensus.io/trace"
 )
 
 // ExpandScratchSize expands the size of a layer to at least size bytes.
-func ExpandScratchSize(path string, size uint64) (err error) {
+func ExpandScratchSize(ctx context.Context, path string, size uint64) (err error) {
 	title := "hcsshim::ExpandScratchSize"
-	fields := logrus.Fields{
-		"path": path,
-		"size": size,
-	}
-	logrus.WithFields(fields).Debug(title)
-	defer func() {
-		if err != nil {
-			fields[logrus.ErrorKey] = err
-			logrus.WithFields(fields).Error(err)
-		} else {
-			logrus.WithFields(fields).Debug(title + " - succeeded")
-		}
-	}()
+	ctx, span := trace.StartSpan(ctx, title)
+	defer span.End()
+	defer func() { oc.SetSpanStatus(span, err) }()
+	span.AddAttributes(
+		trace.StringAttribute("path", path),
+		trace.Int64Attribute("size", int64(size)))
 
 	err = expandSandboxSize(&stdDriverInfo, path, size)
 	if err != nil {
@@ -36,7 +31,7 @@ func ExpandScratchSize(path string, size uint64) (err error) {
 	// Manually expand the volume now in order to work around bugs in 19H1 and
 	// prerelease versions of Vb. Remove once this is fixed in Windows.
 	if build := osversion.Get().Build; build >= osversion.V19H1 && build < 19020 {
-		err = expandSandboxVolume(path)
+		err = expandSandboxVolume(ctx, path)
 		if err != nil {
 			return err
 		}
@@ -84,7 +79,7 @@ func attachVhd(path string) (syscall.Handle, error) {
 	return handle, nil
 }
 
-func expandSandboxVolume(path string) error {
+func expandSandboxVolume(ctx context.Context, path string) error {
 	// Mount the sandbox VHD temporarily.
 	vhdPath := filepath.Join(path, "sandbox.vhdx")
 	vhd, err := attachVhd(vhdPath)
@@ -94,7 +89,7 @@ func expandSandboxVolume(path string) error {
 	defer syscall.Close(vhd)
 
 	// Open the volume.
-	volumePath, err := GetLayerMountPath(path)
+	volumePath, err := GetLayerMountPath(ctx, path)
 	if err != nil {
 		return err
 	}

--- a/internal/wclayer/exportlayer.go
+++ b/internal/wclayer/exportlayer.go
@@ -1,12 +1,15 @@
 package wclayer
 
 import (
+	"context"
 	"io/ioutil"
 	"os"
+	"strings"
 
 	"github.com/Microsoft/go-winio"
 	"github.com/Microsoft/hcsshim/internal/hcserror"
-	"github.com/sirupsen/logrus"
+	"github.com/Microsoft/hcsshim/internal/oc"
+	"go.opencensus.io/trace"
 )
 
 // ExportLayer will create a folder at exportFolderPath and fill that folder with
@@ -14,24 +17,18 @@ import (
 // format includes any metadata required for later importing the layer (using
 // ImportLayer), and requires the full list of parent layer paths in order to
 // perform the export.
-func ExportLayer(path string, exportFolderPath string, parentLayerPaths []string) (err error) {
+func ExportLayer(ctx context.Context, path string, exportFolderPath string, parentLayerPaths []string) (err error) {
 	title := "hcsshim::ExportLayer"
-	fields := logrus.Fields{
-		"path":             path,
-		"exportFolderPath": exportFolderPath,
-	}
-	logrus.WithFields(fields).Debug(title)
-	defer func() {
-		if err != nil {
-			fields[logrus.ErrorKey] = err
-			logrus.WithFields(fields).Error(err)
-		} else {
-			logrus.WithFields(fields).Debug(title + " - succeeded")
-		}
-	}()
+	ctx, span := trace.StartSpan(ctx, title)
+	defer span.End()
+	defer func() { oc.SetSpanStatus(span, err) }()
+	span.AddAttributes(
+		trace.StringAttribute("path", path),
+		trace.StringAttribute("exportFolderPath", exportFolderPath),
+		trace.StringAttribute("parentLayerPaths", strings.Join(parentLayerPaths, ", ")))
 
 	// Generate layer descriptors
-	layers, err := layerPathsToDescriptors(parentLayerPaths)
+	layers, err := layerPathsToDescriptors(ctx, parentLayerPaths)
 	if err != nil {
 		return err
 	}
@@ -52,25 +49,46 @@ type LayerReader interface {
 // NewLayerReader returns a new layer reader for reading the contents of an on-disk layer.
 // The caller must have taken the SeBackupPrivilege privilege
 // to call this and any methods on the resulting LayerReader.
-func NewLayerReader(path string, parentLayerPaths []string) (LayerReader, error) {
+func NewLayerReader(ctx context.Context, path string, parentLayerPaths []string) (_ LayerReader, err error) {
+	ctx, span := trace.StartSpan(ctx, "hcsshim::NewLayerReader")
+	defer func() {
+		if err != nil {
+			oc.SetSpanStatus(span, err)
+			span.End()
+		}
+	}()
+	span.AddAttributes(
+		trace.StringAttribute("path", path),
+		trace.StringAttribute("parentLayerPaths", strings.Join(parentLayerPaths, ", ")))
+
 	exportPath, err := ioutil.TempDir("", "hcs")
 	if err != nil {
 		return nil, err
 	}
-	err = ExportLayer(path, exportPath, parentLayerPaths)
+	err = ExportLayer(ctx, path, exportPath, parentLayerPaths)
 	if err != nil {
 		os.RemoveAll(exportPath)
 		return nil, err
 	}
-	return &legacyLayerReaderWrapper{newLegacyLayerReader(exportPath)}, nil
+	return &legacyLayerReaderWrapper{
+		ctx:               ctx,
+		s:                 span,
+		legacyLayerReader: newLegacyLayerReader(exportPath),
+	}, nil
 }
 
 type legacyLayerReaderWrapper struct {
+	ctx context.Context
+	s   *trace.Span
+
 	*legacyLayerReader
 }
 
-func (r *legacyLayerReaderWrapper) Close() error {
-	err := r.legacyLayerReader.Close()
+func (r *legacyLayerReaderWrapper) Close() (err error) {
+	defer r.s.End()
+	defer func() { oc.SetSpanStatus(r.s, err) }()
+
+	err = r.legacyLayerReader.Close()
 	os.RemoveAll(r.root)
 	return err
 }

--- a/internal/wclayer/getlayermountpath.go
+++ b/internal/wclayer/getlayermountpath.go
@@ -1,36 +1,31 @@
 package wclayer
 
 import (
+	"context"
 	"syscall"
 
 	"github.com/Microsoft/hcsshim/internal/hcserror"
-	"github.com/sirupsen/logrus"
+	"github.com/Microsoft/hcsshim/internal/log"
+	"github.com/Microsoft/hcsshim/internal/oc"
+	"go.opencensus.io/trace"
 )
 
 // GetLayerMountPath will look for a mounted layer with the given path and return
 // the path at which that layer can be accessed.  This path may be a volume path
 // if the layer is a mounted read-write layer, otherwise it is expected to be the
 // folder path at which the layer is stored.
-func GetLayerMountPath(path string) (_ string, err error) {
+func GetLayerMountPath(ctx context.Context, path string) (_ string, err error) {
 	title := "hcsshim::GetLayerMountPath"
-	fields := logrus.Fields{
-		"path": path,
-	}
-	logrus.WithFields(fields).Debug(title)
-	defer func() {
-		if err != nil {
-			fields[logrus.ErrorKey] = err
-			logrus.WithFields(fields).Error(err)
-		} else {
-			logrus.WithFields(fields).Debug(title + " - succeeded")
-		}
-	}()
+	ctx, span := trace.StartSpan(ctx, title)
+	defer span.End()
+	defer func() { oc.SetSpanStatus(span, err) }()
+	span.AddAttributes(trace.StringAttribute("path", path))
 
 	var mountPathLength uintptr
 	mountPathLength = 0
 
 	// Call the procedure itself.
-	logrus.WithFields(fields).Debug("Calling proc (1)")
+	log.G(ctx).Debug("Calling proc (1)")
 	err = getLayerMountPath(&stdDriverInfo, path, &mountPathLength, nil)
 	if err != nil {
 		return "", hcserror.New(err, title+" - failed", "(first call)")
@@ -44,13 +39,13 @@ func GetLayerMountPath(path string) (_ string, err error) {
 	mountPathp[0] = 0
 
 	// Call the procedure again
-	logrus.WithFields(fields).Debug("Calling proc (2)")
+	log.G(ctx).Debug("Calling proc (2)")
 	err = getLayerMountPath(&stdDriverInfo, path, &mountPathLength, &mountPathp[0])
 	if err != nil {
 		return "", hcserror.New(err, title+" - failed", "(second call)")
 	}
 
 	mountPath := syscall.UTF16ToString(mountPathp[0:])
-	fields["mountPath"] = mountPath
+	span.AddAttributes(trace.StringAttribute("mountPath", mountPath))
 	return mountPath, nil
 }

--- a/internal/wclayer/getsharedbaseimages.go
+++ b/internal/wclayer/getsharedbaseimages.go
@@ -1,29 +1,29 @@
 package wclayer
 
 import (
+	"context"
+
 	"github.com/Microsoft/hcsshim/internal/hcserror"
 	"github.com/Microsoft/hcsshim/internal/interop"
-	"github.com/sirupsen/logrus"
+	"github.com/Microsoft/hcsshim/internal/oc"
+	"go.opencensus.io/trace"
 )
 
 // GetSharedBaseImages will enumerate the images stored in the common central
 // image store and return descriptive info about those images for the purpose
 // of registering them with the graphdriver, graph, and tagstore.
-func GetSharedBaseImages() (imageData string, err error) {
+func GetSharedBaseImages(ctx context.Context) (_ string, err error) {
 	title := "hcsshim::GetSharedBaseImages"
-	logrus.Debug(title)
-	defer func() {
-		if err != nil {
-			logrus.WithError(err).Error(err)
-		} else {
-			logrus.WithField("imageData", imageData).Debug(title + " - succeeded")
-		}
-	}()
+	ctx, span := trace.StartSpan(ctx, title)
+	defer span.End()
+	defer func() { oc.SetSpanStatus(span, err) }()
 
 	var buffer *uint16
 	err = getBaseImages(&buffer)
 	if err != nil {
 		return "", hcserror.New(err, title+" - failed", "")
 	}
-	return interop.ConvertAndFreeCoTaskMemString(buffer), nil
+	imageData := interop.ConvertAndFreeCoTaskMemString(buffer)
+	span.AddAttributes(trace.StringAttribute("imageData", imageData))
+	return imageData, nil
 }

--- a/internal/wclayer/grantvmaccess.go
+++ b/internal/wclayer/grantvmaccess.go
@@ -1,26 +1,22 @@
 package wclayer
 
 import (
+	"context"
+
 	"github.com/Microsoft/hcsshim/internal/hcserror"
-	"github.com/sirupsen/logrus"
+	"github.com/Microsoft/hcsshim/internal/oc"
+	"go.opencensus.io/trace"
 )
 
 // GrantVmAccess adds access to a file for a given VM
-func GrantVmAccess(vmid string, filepath string) (err error) {
+func GrantVmAccess(ctx context.Context, vmid string, filepath string) (err error) {
 	title := "hcsshim::GrantVmAccess"
-	fields := logrus.Fields{
-		"vm-id": vmid,
-		"path":  filepath,
-	}
-	logrus.WithFields(fields).Debug(title)
-	defer func() {
-		if err != nil {
-			fields[logrus.ErrorKey] = err
-			logrus.WithFields(fields).Error(err)
-		} else {
-			logrus.WithFields(fields).Debug(title + " - succeeded")
-		}
-	}()
+	ctx, span := trace.StartSpan(ctx, title)
+	defer span.End()
+	defer func() { oc.SetSpanStatus(span, err) }()
+	span.AddAttributes(
+		trace.StringAttribute("vm-id", vmid),
+		trace.StringAttribute("path", filepath))
 
 	err = grantVmAccess(vmid, filepath)
 	if err != nil {

--- a/internal/wclayer/importlayer.go
+++ b/internal/wclayer/importlayer.go
@@ -1,38 +1,35 @@
 package wclayer
 
 import (
+	"context"
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/Microsoft/go-winio"
 	"github.com/Microsoft/hcsshim/internal/hcserror"
+	"github.com/Microsoft/hcsshim/internal/oc"
 	"github.com/Microsoft/hcsshim/internal/safefile"
-	"github.com/sirupsen/logrus"
+	"go.opencensus.io/trace"
 )
 
 // ImportLayer will take the contents of the folder at importFolderPath and import
 // that into a layer with the id layerId.  Note that in order to correctly populate
 // the layer and interperet the transport format, all parent layers must already
 // be present on the system at the paths provided in parentLayerPaths.
-func ImportLayer(path string, importFolderPath string, parentLayerPaths []string) (err error) {
+func ImportLayer(ctx context.Context, path string, importFolderPath string, parentLayerPaths []string) (err error) {
 	title := "hcsshim::ImportLayer"
-	fields := logrus.Fields{
-		"path":             path,
-		"importFolderPath": importFolderPath,
-	}
-	logrus.WithFields(fields).Debug(title)
-	defer func() {
-		if err != nil {
-			fields[logrus.ErrorKey] = err
-			logrus.WithFields(fields).Error(err)
-		} else {
-			logrus.WithFields(fields).Debug(title + " - succeeded")
-		}
-	}()
+	ctx, span := trace.StartSpan(ctx, title)
+	defer span.End()
+	defer func() { oc.SetSpanStatus(span, err) }()
+	span.AddAttributes(
+		trace.StringAttribute("path", path),
+		trace.StringAttribute("importFolderPath", importFolderPath),
+		trace.StringAttribute("parentLayerPaths", strings.Join(parentLayerPaths, ", ")))
 
 	// Generate layer descriptors
-	layers, err := layerPathsToDescriptors(parentLayerPaths)
+	layers, err := layerPathsToDescriptors(ctx, parentLayerPaths)
 	if err != nil {
 		return err
 	}
@@ -60,20 +57,26 @@ type LayerWriter interface {
 }
 
 type legacyLayerWriterWrapper struct {
+	ctx context.Context
+	s   *trace.Span
+
 	*legacyLayerWriter
 	path             string
 	parentLayerPaths []string
 }
 
-func (r *legacyLayerWriterWrapper) Close() error {
+func (r *legacyLayerWriterWrapper) Close() (err error) {
+	defer r.s.End()
+	defer func() { oc.SetSpanStatus(r.s, err) }()
 	defer os.RemoveAll(r.root.Name())
 	defer r.legacyLayerWriter.CloseRoots()
-	err := r.legacyLayerWriter.Close()
+
+	err = r.legacyLayerWriter.Close()
 	if err != nil {
 		return err
 	}
 
-	if err = ImportLayer(r.destRoot.Name(), r.path, r.parentLayerPaths); err != nil {
+	if err = ImportLayer(r.ctx, r.destRoot.Name(), r.path, r.parentLayerPaths); err != nil {
 		return err
 	}
 	for _, name := range r.Tombstones {
@@ -96,7 +99,7 @@ func (r *legacyLayerWriterWrapper) Close() error {
 		if err != nil {
 			return err
 		}
-		err = ProcessUtilityVMImage(filepath.Join(r.destRoot.Name(), "UtilityVM"))
+		err = ProcessUtilityVMImage(r.ctx, filepath.Join(r.destRoot.Name(), "UtilityVM"))
 		if err != nil {
 			return err
 		}
@@ -107,7 +110,18 @@ func (r *legacyLayerWriterWrapper) Close() error {
 // NewLayerWriter returns a new layer writer for creating a layer on disk.
 // The caller must have taken the SeBackupPrivilege and SeRestorePrivilege privileges
 // to call this and any methods on the resulting LayerWriter.
-func NewLayerWriter(path string, parentLayerPaths []string) (LayerWriter, error) {
+func NewLayerWriter(ctx context.Context, path string, parentLayerPaths []string) (_ LayerWriter, err error) {
+	ctx, span := trace.StartSpan(ctx, "hcsshim::NewLayerWriter")
+	defer func() {
+		if err != nil {
+			oc.SetSpanStatus(span, err)
+			span.End()
+		}
+	}()
+	span.AddAttributes(
+		trace.StringAttribute("path", path),
+		trace.StringAttribute("parentLayerPaths", strings.Join(parentLayerPaths, ", ")))
+
 	if len(parentLayerPaths) == 0 {
 		// This is a base layer. It gets imported differently.
 		f, err := safefile.OpenRoot(path)
@@ -115,6 +129,8 @@ func NewLayerWriter(path string, parentLayerPaths []string) (LayerWriter, error)
 			return nil, err
 		}
 		return &baseLayerWriter{
+			ctx:  ctx,
+			s:    span,
 			root: f,
 		}, nil
 	}
@@ -128,6 +144,8 @@ func NewLayerWriter(path string, parentLayerPaths []string) (LayerWriter, error)
 		return nil, err
 	}
 	return &legacyLayerWriterWrapper{
+		ctx:               ctx,
+		s:                 span,
 		legacyLayerWriter: w,
 		path:              importPath,
 		parentLayerPaths:  parentLayerPaths,

--- a/internal/wclayer/layerexists.go
+++ b/internal/wclayer/layerexists.go
@@ -1,26 +1,21 @@
 package wclayer
 
 import (
+	"context"
+
 	"github.com/Microsoft/hcsshim/internal/hcserror"
-	"github.com/sirupsen/logrus"
+	"github.com/Microsoft/hcsshim/internal/oc"
+	"go.opencensus.io/trace"
 )
 
 // LayerExists will return true if a layer with the given id exists and is known
 // to the system.
-func LayerExists(path string) (_ bool, err error) {
+func LayerExists(ctx context.Context, path string) (_ bool, err error) {
 	title := "hcsshim::LayerExists"
-	fields := logrus.Fields{
-		"path": path,
-	}
-	logrus.WithFields(fields).Debug(title)
-	defer func() {
-		if err != nil {
-			fields[logrus.ErrorKey] = err
-			logrus.WithFields(fields).Error(err)
-		} else {
-			logrus.WithFields(fields).Debug(title + " - succeeded")
-		}
-	}()
+	ctx, span := trace.StartSpan(ctx, title)
+	defer span.End()
+	defer func() { oc.SetSpanStatus(span, err) }()
+	span.AddAttributes(trace.StringAttribute("path", path))
 
 	// Call the procedure itself.
 	var exists uint32
@@ -28,6 +23,6 @@ func LayerExists(path string) (_ bool, err error) {
 	if err != nil {
 		return false, hcserror.New(err, title+" - failed", "")
 	}
-	fields["layer-exists"] = exists != 0
+	span.AddAttributes(trace.BoolAttribute("layer-exists", exists != 0))
 	return exists != 0, nil
 }

--- a/internal/wclayer/layerid.go
+++ b/internal/wclayer/layerid.go
@@ -1,13 +1,22 @@
 package wclayer
 
 import (
+	"context"
 	"path/filepath"
 
 	"github.com/Microsoft/go-winio/pkg/guid"
+	"github.com/Microsoft/hcsshim/internal/oc"
+	"go.opencensus.io/trace"
 )
 
 // LayerID returns the layer ID of a layer on disk.
-func LayerID(path string) (guid.GUID, error) {
+func LayerID(ctx context.Context, path string) (_ guid.GUID, err error) {
+	title := "hcsshim::LayerID"
+	ctx, span := trace.StartSpan(ctx, title)
+	defer span.End()
+	defer func() { oc.SetSpanStatus(span, err) }()
+	span.AddAttributes(trace.StringAttribute("path", path))
+
 	_, file := filepath.Split(path)
-	return NameToGuid(file)
+	return NameToGuid(ctx, file)
 }

--- a/internal/wclayer/layerutils.go
+++ b/internal/wclayer/layerutils.go
@@ -4,6 +4,7 @@ package wclayer
 // functionality.
 
 import (
+	"context"
 	"syscall"
 
 	"github.com/Microsoft/go-winio/pkg/guid"
@@ -68,12 +69,12 @@ type WC_LAYER_DESCRIPTOR struct {
 	Pathp   *uint16
 }
 
-func layerPathsToDescriptors(parentLayerPaths []string) ([]WC_LAYER_DESCRIPTOR, error) {
+func layerPathsToDescriptors(ctx context.Context, parentLayerPaths []string) ([]WC_LAYER_DESCRIPTOR, error) {
 	// Array of descriptors that gets constructed.
 	var layers []WC_LAYER_DESCRIPTOR
 
 	for i := 0; i < len(parentLayerPaths); i++ {
-		g, err := LayerID(parentLayerPaths[i])
+		g, err := LayerID(ctx, parentLayerPaths[i])
 		if err != nil {
 			logrus.WithError(err).Debug("Failed to convert name to guid")
 			return nil, err

--- a/internal/wclayer/nametoguid.go
+++ b/internal/wclayer/nametoguid.go
@@ -1,34 +1,29 @@
 package wclayer
 
 import (
+	"context"
+
 	"github.com/Microsoft/go-winio/pkg/guid"
 	"github.com/Microsoft/hcsshim/internal/hcserror"
-	"github.com/sirupsen/logrus"
+	"github.com/Microsoft/hcsshim/internal/oc"
+	"go.opencensus.io/trace"
 )
 
 // NameToGuid converts the given string into a GUID using the algorithm in the
 // Host Compute Service, ensuring GUIDs generated with the same string are common
 // across all clients.
-func NameToGuid(name string) (id guid.GUID, err error) {
+func NameToGuid(ctx context.Context, name string) (_ guid.GUID, err error) {
 	title := "hcsshim::NameToGuid"
-	fields := logrus.Fields{
-		"name": name,
-	}
-	logrus.WithFields(fields).Debug(title)
-	defer func() {
-		if err != nil {
-			fields[logrus.ErrorKey] = err
-			logrus.WithFields(fields).Error(err)
-		} else {
-			logrus.WithFields(fields).Debug(title + " - succeeded")
-		}
-	}()
+	ctx, span := trace.StartSpan(ctx, title)
+	defer span.End()
+	defer func() { oc.SetSpanStatus(span, err) }()
+	span.AddAttributes(trace.StringAttribute("name", name))
 
+	var id guid.GUID
 	err = nameToGuid(name, &id)
 	if err != nil {
-		err = hcserror.New(err, title+" - failed", "")
-		return
+		return guid.GUID{}, hcserror.New(err, title+" - failed", "")
 	}
-	fields["guid"] = id.String()
-	return
+	span.AddAttributes(trace.StringAttribute("guid", id.String()))
+	return id, nil
 }

--- a/internal/wclayer/processimage.go
+++ b/internal/wclayer/processimage.go
@@ -1,23 +1,41 @@
 package wclayer
 
-import "os"
+import (
+	"context"
+	"os"
+
+	"github.com/Microsoft/hcsshim/internal/oc"
+	"go.opencensus.io/trace"
+)
 
 // ProcessBaseLayer post-processes a base layer that has had its files extracted.
 // The files should have been extracted to <path>\Files.
-func ProcessBaseLayer(path string) error {
-	err := processBaseImage(path)
+func ProcessBaseLayer(ctx context.Context, path string) (err error) {
+	title := "hcsshim::ProcessBaseLayer"
+	ctx, span := trace.StartSpan(ctx, title)
+	defer span.End()
+	defer func() { oc.SetSpanStatus(span, err) }()
+	span.AddAttributes(trace.StringAttribute("path", path))
+
+	err = processBaseImage(path)
 	if err != nil {
-		return &os.PathError{Op: "ProcessBaseLayer", Path: path, Err: err}
+		return &os.PathError{Op: title, Path: path, Err: err}
 	}
 	return nil
 }
 
 // ProcessUtilityVMImage post-processes a utility VM image that has had its files extracted.
 // The files should have been extracted to <path>\Files.
-func ProcessUtilityVMImage(path string) error {
-	err := processUtilityImage(path)
+func ProcessUtilityVMImage(ctx context.Context, path string) (err error) {
+	title := "hcsshim::ProcessUtilityVMImage"
+	ctx, span := trace.StartSpan(ctx, title)
+	defer span.End()
+	defer func() { oc.SetSpanStatus(span, err) }()
+	span.AddAttributes(trace.StringAttribute("path", path))
+
+	err = processUtilityImage(path)
 	if err != nil {
-		return &os.PathError{Op: "ProcessUtilityVMImage", Path: path, Err: err}
+		return &os.PathError{Op: title, Path: path, Err: err}
 	}
 	return nil
 }

--- a/internal/wclayer/unpreparelayer.go
+++ b/internal/wclayer/unpreparelayer.go
@@ -1,26 +1,21 @@
 package wclayer
 
 import (
+	"context"
+
 	"github.com/Microsoft/hcsshim/internal/hcserror"
-	"github.com/sirupsen/logrus"
+	"github.com/Microsoft/hcsshim/internal/oc"
+	"go.opencensus.io/trace"
 )
 
 // UnprepareLayer disables the filesystem filter for the read-write layer with
 // the given id.
-func UnprepareLayer(path string) (err error) {
+func UnprepareLayer(ctx context.Context, path string) (err error) {
 	title := "hcsshim::UnprepareLayer"
-	fields := logrus.Fields{
-		"path": path,
-	}
-	logrus.WithFields(fields).Debug(title)
-	defer func() {
-		if err != nil {
-			fields[logrus.ErrorKey] = err
-			logrus.WithFields(fields).Error(err)
-		} else {
-			logrus.WithFields(fields).Debug(title + " - succeeded")
-		}
-	}()
+	ctx, span := trace.StartSpan(ctx, title)
+	defer span.End()
+	defer func() { oc.SetSpanStatus(span, err) }()
+	span.AddAttributes(trace.StringAttribute("path", path))
 
 	err = unprepareLayer(&stdDriverInfo, path)
 	if err != nil {

--- a/internal/wcow/scratch.go
+++ b/internal/wcow/scratch.go
@@ -23,7 +23,7 @@ func CreateUVMScratch(ctx context.Context, imagePath, destDirectory, vmID string
 	if err := copyfile.CopyFile(sourceScratch, targetScratch, true); err != nil {
 		return err
 	}
-	if err := wclayer.GrantVmAccess(vmID, targetScratch); err != nil {
+	if err := wclayer.GrantVmAccess(ctx, vmID, targetScratch); err != nil {
 		os.Remove(targetScratch)
 		return err
 	}

--- a/layer.go
+++ b/layer.go
@@ -1,6 +1,7 @@
 package hcsshim
 
 import (
+	"context"
 	"crypto/sha1"
 	"path/filepath"
 
@@ -13,59 +14,59 @@ func layerPath(info *DriverInfo, id string) string {
 }
 
 func ActivateLayer(info DriverInfo, id string) error {
-	return wclayer.ActivateLayer(layerPath(&info, id))
+	return wclayer.ActivateLayer(context.Background(), layerPath(&info, id))
 }
 func CreateLayer(info DriverInfo, id, parent string) error {
-	return wclayer.CreateLayer(layerPath(&info, id), parent)
+	return wclayer.CreateLayer(context.Background(), layerPath(&info, id), parent)
 }
 
 // New clients should use CreateScratchLayer instead. Kept in to preserve API compatibility.
 func CreateSandboxLayer(info DriverInfo, layerId, parentId string, parentLayerPaths []string) error {
-	return wclayer.CreateScratchLayer(layerPath(&info, layerId), parentLayerPaths)
+	return wclayer.CreateScratchLayer(context.Background(), layerPath(&info, layerId), parentLayerPaths)
 }
 func CreateScratchLayer(info DriverInfo, layerId, parentId string, parentLayerPaths []string) error {
-	return wclayer.CreateScratchLayer(layerPath(&info, layerId), parentLayerPaths)
+	return wclayer.CreateScratchLayer(context.Background(), layerPath(&info, layerId), parentLayerPaths)
 }
 func DeactivateLayer(info DriverInfo, id string) error {
-	return wclayer.DeactivateLayer(layerPath(&info, id))
+	return wclayer.DeactivateLayer(context.Background(), layerPath(&info, id))
 }
 func DestroyLayer(info DriverInfo, id string) error {
-	return wclayer.DestroyLayer(layerPath(&info, id))
+	return wclayer.DestroyLayer(context.Background(), layerPath(&info, id))
 }
 
 // New clients should use ExpandScratchSize instead. Kept in to preserve API compatibility.
 func ExpandSandboxSize(info DriverInfo, layerId string, size uint64) error {
-	return wclayer.ExpandScratchSize(layerPath(&info, layerId), size)
+	return wclayer.ExpandScratchSize(context.Background(), layerPath(&info, layerId), size)
 }
 func ExpandScratchSize(info DriverInfo, layerId string, size uint64) error {
-	return wclayer.ExpandScratchSize(layerPath(&info, layerId), size)
+	return wclayer.ExpandScratchSize(context.Background(), layerPath(&info, layerId), size)
 }
 func ExportLayer(info DriverInfo, layerId string, exportFolderPath string, parentLayerPaths []string) error {
-	return wclayer.ExportLayer(layerPath(&info, layerId), exportFolderPath, parentLayerPaths)
+	return wclayer.ExportLayer(context.Background(), layerPath(&info, layerId), exportFolderPath, parentLayerPaths)
 }
 func GetLayerMountPath(info DriverInfo, id string) (string, error) {
-	return wclayer.GetLayerMountPath(layerPath(&info, id))
+	return wclayer.GetLayerMountPath(context.Background(), layerPath(&info, id))
 }
 func GetSharedBaseImages() (imageData string, err error) {
-	return wclayer.GetSharedBaseImages()
+	return wclayer.GetSharedBaseImages(context.Background())
 }
 func ImportLayer(info DriverInfo, layerID string, importFolderPath string, parentLayerPaths []string) error {
-	return wclayer.ImportLayer(layerPath(&info, layerID), importFolderPath, parentLayerPaths)
+	return wclayer.ImportLayer(context.Background(), layerPath(&info, layerID), importFolderPath, parentLayerPaths)
 }
 func LayerExists(info DriverInfo, id string) (bool, error) {
-	return wclayer.LayerExists(layerPath(&info, id))
+	return wclayer.LayerExists(context.Background(), layerPath(&info, id))
 }
 func PrepareLayer(info DriverInfo, layerId string, parentLayerPaths []string) error {
-	return wclayer.PrepareLayer(layerPath(&info, layerId), parentLayerPaths)
+	return wclayer.PrepareLayer(context.Background(), layerPath(&info, layerId), parentLayerPaths)
 }
 func ProcessBaseLayer(path string) error {
-	return wclayer.ProcessBaseLayer(path)
+	return wclayer.ProcessBaseLayer(context.Background(), path)
 }
 func ProcessUtilityVMImage(path string) error {
-	return wclayer.ProcessUtilityVMImage(path)
+	return wclayer.ProcessUtilityVMImage(context.Background(), path)
 }
 func UnprepareLayer(info DriverInfo, layerId string) error {
-	return wclayer.UnprepareLayer(layerPath(&info, layerId))
+	return wclayer.UnprepareLayer(context.Background(), layerPath(&info, layerId))
 }
 
 type DriverInfo struct {
@@ -76,7 +77,7 @@ type DriverInfo struct {
 type GUID [16]byte
 
 func NameToGuid(name string) (id GUID, err error) {
-	g, err := wclayer.NameToGuid(name)
+	g, err := wclayer.NameToGuid(context.Background(), name)
 	return g.ToWindowsArray(), err
 }
 
@@ -94,13 +95,13 @@ func (g *GUID) ToString() string {
 type LayerReader = wclayer.LayerReader
 
 func NewLayerReader(info DriverInfo, layerID string, parentLayerPaths []string) (LayerReader, error) {
-	return wclayer.NewLayerReader(layerPath(&info, layerID), parentLayerPaths)
+	return wclayer.NewLayerReader(context.Background(), layerPath(&info, layerID), parentLayerPaths)
 }
 
 type LayerWriter = wclayer.LayerWriter
 
 func NewLayerWriter(info DriverInfo, layerID string, parentLayerPaths []string) (LayerWriter, error) {
-	return wclayer.NewLayerWriter(layerPath(&info, layerID), parentLayerPaths)
+	return wclayer.NewLayerWriter(context.Background(), layerPath(&info, layerID), parentLayerPaths)
 }
 
 type WC_LAYER_DESCRIPTOR = wclayer.WC_LAYER_DESCRIPTOR

--- a/test/functional/utilities/scratch.go
+++ b/test/functional/utilities/scratch.go
@@ -36,7 +36,7 @@ func CreateWCOWBlankRWLayer(t *testing.T, imageLayers []string) string {
 	//	}
 
 	tempDir := CreateTempDir(t)
-	if err := wclayer.CreateScratchLayer(tempDir, imageLayers); err != nil {
+	if err := wclayer.CreateScratchLayer(context.Background(), tempDir, imageLayers); err != nil {
 		t.Fatalf("Failed CreateScratchLayer: %s", err)
 	}
 	return tempDir

--- a/test/functional/uvm_scsi_test.go
+++ b/test/functional/uvm_scsi_test.go
@@ -181,7 +181,7 @@ func TestParallelScsiOps(t *testing.T) {
 					t.Errorf("failed to copy sandbox for worker: %d, iteration: %d with err: %v", scsiIndex, iteration, err)
 					continue
 				}
-				err = wclayer.GrantVmAccess(u.ID(), path)
+				err = wclayer.GrantVmAccess(context.Background(), u.ID(), path)
 				if err != nil {
 					os.Remove(path)
 					t.Errorf("failed to grantvmaccess for worker: %d, iteration: %d with err: %v", scsiIndex, iteration, err)

--- a/test/functional/wcow_test.go
+++ b/test/functional/wcow_test.go
@@ -352,7 +352,7 @@ func createTestMounts(t *testing.T) (string, string) {
 func generateShimLayersStruct(t *testing.T, imageLayers []string) []hcsshim.Layer {
 	var layers []hcsshim.Layer
 	for _, layerFolder := range imageLayers {
-		guid, _ := wclayer.NameToGuid(filepath.Base(layerFolder))
+		guid, _ := wclayer.NameToGuid(context.Background(), filepath.Base(layerFolder))
 		layers = append(layers, hcsshim.Layer{Path: layerFolder, ID: guid.String()})
 	}
 	return layers
@@ -365,7 +365,7 @@ func TestWCOWArgonShim(t *testing.T) {
 
 	argonShimScratchDir := testutilities.CreateTempDir(t)
 	defer os.RemoveAll(argonShimScratchDir)
-	if err := wclayer.CreateScratchLayer(argonShimScratchDir, imageLayers); err != nil {
+	if err := wclayer.CreateScratchLayer(context.Background(), argonShimScratchDir, imageLayers); err != nil {
 		t.Fatalf("failed to create argon scratch layer: %s", err)
 	}
 
@@ -429,7 +429,7 @@ func TestWCOWXenonShim(t *testing.T) {
 
 	xenonShimScratchDir := testutilities.CreateTempDir(t)
 	defer os.RemoveAll(xenonShimScratchDir)
-	if err := wclayer.CreateScratchLayer(xenonShimScratchDir, imageLayers); err != nil {
+	if err := wclayer.CreateScratchLayer(context.Background(), xenonShimScratchDir, imageLayers); err != nil {
 		t.Fatalf("failed to create xenon scratch layer: %s", err)
 	}
 
@@ -499,7 +499,7 @@ func TestWCOWArgonOciV1(t *testing.T) {
 	argonOci1Mounted := false
 	argonOci1ScratchDir := testutilities.CreateTempDir(t)
 	defer os.RemoveAll(argonOci1ScratchDir)
-	if err := wclayer.CreateScratchLayer(argonOci1ScratchDir, imageLayers); err != nil {
+	if err := wclayer.CreateScratchLayer(context.Background(), argonOci1ScratchDir, imageLayers); err != nil {
 		t.Fatalf("failed to create argon scratch layer: %s", err)
 	}
 
@@ -548,7 +548,7 @@ func TestWCOWXenonOciV1(t *testing.T) {
 
 	xenonOci1ScratchDir := testutilities.CreateTempDir(t)
 	defer os.RemoveAll(xenonOci1ScratchDir)
-	if err := wclayer.CreateScratchLayer(xenonOci1ScratchDir, imageLayers); err != nil {
+	if err := wclayer.CreateScratchLayer(context.Background(), xenonOci1ScratchDir, imageLayers); err != nil {
 		t.Fatalf("failed to create xenon scratch layer: %s", err)
 	}
 
@@ -605,7 +605,7 @@ func TestWCOWArgonOciV2(t *testing.T) {
 
 	argonOci2ScratchDir := testutilities.CreateTempDir(t)
 	defer os.RemoveAll(argonOci2ScratchDir)
-	if err := wclayer.CreateScratchLayer(argonOci2ScratchDir, imageLayers); err != nil {
+	if err := wclayer.CreateScratchLayer(context.Background(), argonOci2ScratchDir, imageLayers); err != nil {
 		t.Fatalf("failed to create argon scratch layer: %s", err)
 	}
 
@@ -657,7 +657,7 @@ func TestWCOWXenonOciV2(t *testing.T) {
 
 	xenonOci2ScratchDir := testutilities.CreateTempDir(t)
 	defer os.RemoveAll(xenonOci2ScratchDir)
-	if err := wclayer.CreateScratchLayer(xenonOci2ScratchDir, imageLayers); err != nil {
+	if err := wclayer.CreateScratchLayer(context.Background(), xenonOci2ScratchDir, imageLayers); err != nil {
 		t.Fatalf("failed to create xenon scratch layer: %s", err)
 	}
 


### PR DESCRIPTION
1. Add span support for all wclayer operations.
2. Remove excess storage logging since it is all logged at the wclayer
interface now.

Signed-off-by: Justin Terry (VM) <juterry@microsoft.com>