### PR TITLE
Forward Span context to all methods.

### DIFF
--- a/cmd/containerd-shim-runhcs-v1/exec.go
+++ b/cmd/containerd-shim-runhcs-v1/exec.go
@@ -72,7 +72,7 @@ type shimExec interface {
 	// A call to `Wait` is valid in any `State()`. Note that if this exec
 	// process is already in the `State() == shimExecStateExited` state, `Wait`
 	// MUST return immediately with the original exit state.
-	Wait(ctx context.Context) *task.StateResponse
+	Wait() *task.StateResponse
 	// ForceExit forcibly terminates the exec, sets the exit status to `status`,
 	// and unblocks all waiters.
 	//

--- a/cmd/containerd-shim-runhcs-v1/exec_hcs.go
+++ b/cmd/containerd-shim-runhcs-v1/exec_hcs.go
@@ -207,13 +207,13 @@ func (he *hcsExec) Start(ctx context.Context) (err error) {
 	}()
 	if he.id == he.tid {
 		// This is the init exec. We need to start the container itself
-		err = he.c.Start()
+		err = he.c.Start(ctx)
 		if err != nil {
 			return err
 		}
 		defer func() {
 			if err != nil {
-				he.c.Terminate()
+				he.c.Terminate(ctx)
 				he.c.Close()
 			}
 		}()
@@ -302,11 +302,11 @@ func (he *hcsExec) Kill(ctx context.Context, signal uint32) error {
 		}
 		var delivered bool
 		if supported && options != nil {
-			delivered, err = he.p.Process.Signal(options)
+			delivered, err = he.p.Process.Signal(ctx, options)
 		} else {
 			// legacy path before signals support OR if WCOW with signals
 			// support needs to issue a terminate.
-			delivered, err = he.p.Process.Kill()
+			delivered, err = he.p.Process.Kill(ctx)
 		}
 		if err != nil {
 			return err
@@ -332,7 +332,7 @@ func (he *hcsExec) ResizePty(ctx context.Context, width, height uint32) error {
 		return errors.Wrapf(errdefs.ErrFailedPrecondition, "exec: '%s' in task: '%s' is not a tty", he.id, he.tid)
 	}
 
-	return he.p.Process.ResizeConsole(uint16(width), uint16(height))
+	return he.p.Process.ResizeConsole(ctx, uint16(width), uint16(height))
 }
 
 func (he *hcsExec) CloseIO(ctx context.Context, stdin bool) error {
@@ -344,7 +344,7 @@ func (he *hcsExec) CloseIO(ctx context.Context, stdin bool) error {
 	return nil
 }
 
-func (he *hcsExec) Wait(ctx context.Context) *task.StateResponse {
+func (he *hcsExec) Wait() *task.StateResponse {
 	<-he.exited
 	return he.Status()
 }
@@ -365,7 +365,7 @@ func (he *hcsExec) ForceExit(ctx context.Context, status int) {
 			he.exitFromCreatedL(ctx, status)
 		case shimExecStateRunning:
 			// Kill the process to unblock `he.waitForExit`
-			he.p.Process.Kill()
+			he.p.Process.Kill(ctx)
 		}
 	}
 }
@@ -519,7 +519,7 @@ func (he *hcsExec) waitForContainerExit() {
 			he.exitFromCreatedL(ctx, 1)
 		case shimExecStateRunning:
 			// Kill the process to unblock `he.waitForExit`.
-			he.p.Process.Kill()
+			he.p.Process.Kill(ctx)
 		}
 		he.sl.Unlock()
 	case <-he.processDone:

--- a/cmd/containerd-shim-runhcs-v1/exec_test.go
+++ b/cmd/containerd-shim-runhcs-v1/exec_test.go
@@ -64,7 +64,7 @@ func (tse *testShimExec) ResizePty(ctx context.Context, width, height uint32) er
 func (tse *testShimExec) CloseIO(ctx context.Context, stdin bool) error {
 	return nil
 }
-func (tse *testShimExec) Wait(ctx context.Context) *task.StateResponse {
+func (tse *testShimExec) Wait() *task.StateResponse {
 	return tse.Status()
 }
 func (tse *testShimExec) ForceExit(ctx context.Context, status int) {

--- a/cmd/containerd-shim-runhcs-v1/exec_wcow_podsandbox.go
+++ b/cmd/containerd-shim-runhcs-v1/exec_wcow_podsandbox.go
@@ -186,7 +186,7 @@ func (wpse *wcowPodSandboxExec) CloseIO(ctx context.Context, stdin bool) error {
 	return nil
 }
 
-func (wpse *wcowPodSandboxExec) Wait(ctx context.Context) *task.StateResponse {
+func (wpse *wcowPodSandboxExec) Wait() *task.StateResponse {
 	<-wpse.exited
 	return wpse.Status()
 }

--- a/cmd/containerd-shim-runhcs-v1/exec_wcow_podsandbox_test.go
+++ b/cmd/containerd-shim-runhcs-v1/exec_wcow_podsandbox_test.go
@@ -287,7 +287,7 @@ func Test_newWcowPodSandboxExec_Wait_Created(t *testing.T) {
 
 	// Issue the wait in the created state
 	go func() {
-		waitExit <- wpse.Wait(context.TODO())
+		waitExit <- wpse.Wait()
 	}()
 
 	now := time.Now()
@@ -303,7 +303,7 @@ func Test_newWcowPodSandboxExec_Wait_Created(t *testing.T) {
 	}
 
 	// Verify the wait in the exited state doesnt block.
-	verifyWcowPodSandboxExecStatus(t, false, containerd_v1_types.StatusStopped, wpse.Wait(context.TODO()))
+	verifyWcowPodSandboxExecStatus(t, false, containerd_v1_types.StatusStopped, wpse.Wait())
 }
 
 func Test_newWcowPodSandboxExec_Wait_Started(t *testing.T) {
@@ -314,7 +314,7 @@ func Test_newWcowPodSandboxExec_Wait_Started(t *testing.T) {
 
 	// Issue the wait in the created state
 	go func() {
-		waitExit <- wpse.Wait(context.TODO())
+		waitExit <- wpse.Wait()
 	}()
 
 	err := wpse.Start(context.TODO())
@@ -335,5 +335,5 @@ func Test_newWcowPodSandboxExec_Wait_Started(t *testing.T) {
 	}
 
 	// Verify the wait in the exited state doesnt block.
-	verifyWcowPodSandboxExecStatus(t, true, containerd_v1_types.StatusStopped, wpse.Wait(context.TODO()))
+	verifyWcowPodSandboxExecStatus(t, true, containerd_v1_types.StatusStopped, wpse.Wait())
 }

--- a/cmd/containerd-shim-runhcs-v1/pod.go
+++ b/cmd/containerd-shim-runhcs-v1/pod.go
@@ -94,14 +94,14 @@ func createPod(ctx context.Context, events publisher, req *task.CreateTaskReques
 	var parent *uvm.UtilityVM
 	if oci.IsIsolated(s) {
 		// Create the UVM parent
-		opts, err := oci.SpecToUVMCreateOpts(s, fmt.Sprintf("%s@vm", req.ID), owner)
+		opts, err := oci.SpecToUVMCreateOpts(ctx, s, fmt.Sprintf("%s@vm", req.ID), owner)
 		if err != nil {
 			return nil, err
 		}
 		switch opts.(type) {
 		case *uvm.OptionsLCOW:
 			lopts := (opts).(*uvm.OptionsLCOW)
-			parent, err = uvm.CreateLCOW(lopts)
+			parent, err = uvm.CreateLCOW(ctx, lopts)
 			if err != nil {
 				return nil, err
 			}
@@ -123,12 +123,12 @@ func createPod(ctx context.Context, events publisher, req *task.CreateTaskReques
 			layers[layersLen-1] = vmPath
 			wopts.LayerFolders = layers
 
-			parent, err = uvm.CreateWCOW(wopts)
+			parent, err = uvm.CreateWCOW(ctx, wopts)
 			if err != nil {
 				return nil, err
 			}
 		}
-		err = parent.Start()
+		err = parent.Start(ctx)
 		if err != nil {
 			parent.Close()
 			return nil, err
@@ -165,15 +165,15 @@ func createPod(ctx context.Context, events publisher, req *task.CreateTaskReques
 			}
 
 			if nsid != "" {
-				endpoints, err := hcsoci.GetNamespaceEndpoints(nsid)
+				endpoints, err := hcsoci.GetNamespaceEndpoints(ctx, nsid)
 				if err != nil {
 					return nil, err
 				}
-				err = parent.AddNetNS(nsid)
+				err = parent.AddNetNS(ctx, nsid)
 				if err != nil {
 					return nil, err
 				}
-				err = parent.AddEndpointsToNS(nsid, endpoints)
+				err = parent.AddEndpointsToNS(ctx, nsid, endpoints)
 				if err != nil {
 					return nil, err
 				}

--- a/cmd/containerd-shim-runhcs-v1/service_internal.go
+++ b/cmd/containerd-shim-runhcs-v1/service_internal.go
@@ -388,9 +388,9 @@ func (s *service) waitInternal(ctx context.Context, req *task.WaitRequest) (*tas
 		if err != nil {
 			return nil, err
 		}
-		state = e.Wait(ctx)
+		state = e.Wait()
 	} else {
-		state = t.Wait(ctx)
+		state = t.Wait()
 	}
 	return &task.WaitResponse{
 		ExitStatus: state.ExitStatus,

--- a/cmd/containerd-shim-runhcs-v1/task.go
+++ b/cmd/containerd-shim-runhcs-v1/task.go
@@ -69,7 +69,7 @@ type shimTask interface {
 	// of the task is larger than just the init process and on shutdown we need
 	// to wait for the container and potentially UVM before unblocking any event
 	// based listeners or `Wait` based listeners.
-	Wait(ctx context.Context) *task.StateResponse
+	Wait() *task.StateResponse
 	// ExecInHost execs a process in the host UVM. It is not tracked in the
 	// other lifetimes of the task and is used only for diagnostics.
 	//

--- a/cmd/containerd-shim-runhcs-v1/task_test.go
+++ b/cmd/containerd-shim-runhcs-v1/task_test.go
@@ -76,8 +76,8 @@ func (tst *testShimTask) Pids(ctx context.Context) ([]options.ProcessDetails, er
 	return pairs, nil
 }
 
-func (tst *testShimTask) Wait(ctx context.Context) *task.StateResponse {
-	return tst.exec.Wait(ctx)
+func (tst *testShimTask) Wait() *task.StateResponse {
+	return tst.exec.Wait()
 }
 
 func (tst *testShimTask) ExecInHost(ctx context.Context, req *shimdiag.ExecProcessRequest) (int, error) {

--- a/cmd/containerd-shim-runhcs-v1/task_wcow_podsandbox.go
+++ b/cmd/containerd-shim-runhcs-v1/task_wcow_podsandbox.go
@@ -151,9 +151,9 @@ func (wpst *wcowPodSandboxTask) Pids(ctx context.Context) ([]options.ProcessDeta
 	}, nil
 }
 
-func (wpst *wcowPodSandboxTask) Wait(ctx context.Context) *task.StateResponse {
+func (wpst *wcowPodSandboxTask) Wait() *task.StateResponse {
 	<-wpst.closed
-	return wpst.init.Wait(ctx)
+	return wpst.init.Wait()
 }
 
 // close safely closes the hosting UVM. Because of the specialty of this task it
@@ -195,7 +195,7 @@ func (wpst *wcowPodSandboxTask) waitInitExit() {
 	span.AddAttributes(trace.StringAttribute("tid", wpst.id))
 
 	// Wait for it to exit on its own
-	wpst.init.Wait(context.Background())
+	wpst.init.Wait()
 
 	// Close the host and event the exit
 	wpst.close(ctx)

--- a/cmd/runhcs/kill.go
+++ b/cmd/runhcs/kill.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	gcontext "context"
+
 	"github.com/Microsoft/hcsshim/internal/appargs"
 	"github.com/Microsoft/hcsshim/internal/hcs"
 	"github.com/Microsoft/hcsshim/internal/schema1"
@@ -52,12 +54,12 @@ signal to the init process of the "ubuntu01" container:
 					// This is the Nth container in a Pod
 					hostID = c.HostID
 				}
-				uvm, err := hcs.OpenComputeSystem(hostID)
+				uvm, err := hcs.OpenComputeSystem(gcontext.Background(), hostID)
 				if err != nil {
 					return err
 				}
 				defer uvm.Close()
-				if props, err := uvm.Properties(schema1.PropertyTypeGuestConnection); err == nil &&
+				if props, err := uvm.Properties(gcontext.Background(), schema1.PropertyTypeGuestConnection); err == nil &&
 					props.GuestConnectionInfo.GuestDefinedCapabilities.SignalProcessSupported {
 					signalsSupported = true
 				}
@@ -90,17 +92,17 @@ signal to the init process of the "ubuntu01" container:
 			return err
 		}
 
-		p, err := c.hc.OpenProcess(pid)
+		p, err := c.hc.OpenProcess(gcontext.Background(), pid)
 		if err != nil {
 			return err
 		}
 		defer p.Close()
 
 		if signalsSupported && sigOptions != nil && (c.Spec.Linux != nil || !c.Spec.Process.Terminal) {
-			_, err = p.Signal(sigOptions)
+			_, err = p.Signal(gcontext.Background(), sigOptions)
 		} else {
 			// Legacy signal issue a kill
-			_, err = p.Kill()
+			_, err = p.Kill(gcontext.Background())
 		}
 
 		return err

--- a/cmd/runhcs/pause.go
+++ b/cmd/runhcs/pause.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	gcontext "context"
+
 	"github.com/Microsoft/hcsshim/internal/appargs"
 	"github.com/urfave/cli"
 )
@@ -23,7 +25,7 @@ Use runhcs list to identify instances of containers and their current status.`,
 			return err
 		}
 		defer container.Close()
-		if err := container.hc.Pause(); err != nil {
+		if err := container.hc.Pause(gcontext.Background()); err != nil {
 			return err
 		}
 
@@ -49,7 +51,7 @@ Use runhcs list to identify instances of containers and their current status.`,
 			return err
 		}
 		defer container.Close()
-		if err := container.hc.Resume(); err != nil {
+		if err := container.hc.Resume(gcontext.Background()); err != nil {
 			return err
 		}
 

--- a/cmd/runhcs/ps.go
+++ b/cmd/runhcs/ps.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	gcontext "context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -30,7 +31,7 @@ var psCommand = cli.Command{
 		}
 		defer container.Close()
 
-		props, err := container.hc.Properties(schema1.PropertyTypeProcessList)
+		props, err := container.hc.Properties(gcontext.Background(), schema1.PropertyTypeProcessList)
 		if err != nil {
 			return err
 		}

--- a/cmd/runhcs/shim.go
+++ b/cmd/runhcs/shim.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	gcontext "context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -123,7 +124,7 @@ var shimCommand = cli.Command{
 
 			defer func() {
 				if terminateOnFailure {
-					c.hc.Terminate()
+					c.hc.Terminate(gcontext.Background())
 					<-containerExitCh
 				}
 			}()
@@ -180,7 +181,7 @@ var shimCommand = cli.Command{
 			err = stateKey.Set(c.ID, keyInitPid, pid)
 			if err != nil {
 				stdin.Close()
-				cmd.Process.Kill()
+				cmd.Process.Kill(gcontext.Background())
 				cmd.Wait()
 				return err
 			}
@@ -190,7 +191,7 @@ var shimCommand = cli.Command{
 		err = stateKey.Set(c.ID, fmt.Sprintf(keyPidMapFmt, os.Getpid()), pid)
 		if err != nil {
 			stdin.Close()
-			cmd.Process.Kill()
+			cmd.Process.Kill(gcontext.Background())
 			cmd.Wait()
 			return err
 		}
@@ -213,7 +214,7 @@ var shimCommand = cli.Command{
 			// Shutdown the container, waiting 5 minutes before terminating is
 			// forcefully.
 			const shutdownTimeout = time.Minute * 5
-			err := c.hc.Shutdown()
+			err := c.hc.Shutdown(gcontext.Background())
 			if err != nil {
 				select {
 				case <-containerExitCh:
@@ -224,7 +225,7 @@ var shimCommand = cli.Command{
 			}
 
 			if err != nil {
-				c.hc.Terminate()
+				c.hc.Terminate(gcontext.Background())
 			}
 			<-containerExitCh
 			err = containerExitErr

--- a/cmd/runhcs/tty.go
+++ b/cmd/runhcs/tty.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	gcontext "context"
 	"fmt"
 	"strconv"
 
@@ -45,12 +46,12 @@ var resizeTtyCommand = cli.Command{
 			}
 		}
 
-		p, err := c.hc.OpenProcess(pid)
+		p, err := c.hc.OpenProcess(gcontext.Background(), pid)
 		if err != nil {
 			return err
 		}
 		defer p.Close()
 
-		return p.ResizeConsole(uint16(width), uint16(height))
+		return p.ResizeConsole(gcontext.Background(), uint16(width), uint16(height))
 	},
 }

--- a/cmd/runhcs/vm.go
+++ b/cmd/runhcs/vm.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	gcontext "context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -74,15 +75,15 @@ var vmshimCommand = cli.Command{
 
 		var vm *uvm.UtilityVM
 		if isLCOW {
-			vm, err = uvm.CreateLCOW(opts.(*uvm.OptionsLCOW))
+			vm, err = uvm.CreateLCOW(gcontext.Background(), opts.(*uvm.OptionsLCOW))
 		} else {
-			vm, err = uvm.CreateWCOW(opts.(*uvm.OptionsWCOW))
+			vm, err = uvm.CreateWCOW(gcontext.Background(), opts.(*uvm.OptionsWCOW))
 		}
 		if err != nil {
 			return err
 		}
 		defer vm.Close()
-		if err = vm.Start(); err != nil {
+		if err = vm.Start(gcontext.Background()); err != nil {
 			return err
 		}
 

--- a/internal/cow/cow.go
+++ b/internal/cow/cow.go
@@ -1,6 +1,7 @@
 package cow
 
 import (
+	"context"
 	"io"
 
 	"github.com/Microsoft/hcsshim/internal/schema1"
@@ -14,23 +15,23 @@ type Process interface {
 	Close() error
 	// CloseStdin causes the process's stdin handle to receive EOF/EPIPE/whatever
 	// is appropriate to indicate that no more data is available.
-	CloseStdin() error
+	CloseStdin(ctx context.Context) error
 	// Pid returns the process ID.
 	Pid() int
 	// Stdio returns the stdio streams for a process. These may be nil if a stream
 	// was not requested during CreateProcess.
 	Stdio() (_ io.Writer, _ io.Reader, _ io.Reader)
 	// ResizeConsole resizes the virtual terminal associated with the process.
-	ResizeConsole(width, height uint16) error
+	ResizeConsole(ctx context.Context, width, height uint16) error
 	// Kill sends a SIGKILL or equivalent signal to the process and returns whether
 	// the signal was delivered. It does not wait for the process to terminate.
-	Kill() (bool, error)
+	Kill(ctx context.Context) (bool, error)
 	// Signal sends a signal to the process and returns whether the signal was
 	// delivered. The input is OS specific (either
 	// guestrequest.SignalProcessOptionsWCOW or
 	// guestrequest.SignalProcessOptionsLCOW). It does not wait for the process
 	// to terminate.
-	Signal(options interface{}) (bool, error)
+	Signal(ctx context.Context, options interface{}) (bool, error)
 	// Wait waits for the process to complete, or for a connection to the process to be
 	// terminated by some error condition (including calling Close).
 	Wait() error
@@ -43,7 +44,7 @@ type Process interface {
 type ProcessHost interface {
 	// CreateProcess creates a process. The configuration is host specific
 	// (either hcsschema.ProcessParameters or lcow.ProcessParameters).
-	CreateProcess(config interface{}) (Process, error)
+	CreateProcess(ctx context.Context, config interface{}) (Process, error)
 	// OS returns the host's operating system, "linux" or "windows".
 	OS() string
 	// IsOCI specifies whether this is an OCI-compliant process host. If true,
@@ -63,15 +64,15 @@ type Container interface {
 	// ID returns the container ID.
 	ID() string
 	// Properties returns the requested container properties.
-	Properties(types ...schema1.PropertyType) (*schema1.ContainerProperties, error)
+	Properties(ctx context.Context, types ...schema1.PropertyType) (*schema1.ContainerProperties, error)
 	// Start starts a container.
-	Start() error
+	Start(ctx context.Context) error
 	// Shutdown sends a shutdown request to the container (but does not wait for
 	// the shutdown to complete).
-	Shutdown() error
+	Shutdown(ctx context.Context) error
 	// Terminate sends a terminate request to the container (but does not wait
 	// for the terminate to complete).
-	Terminate() error
+	Terminate(ctx context.Context) error
 	// Wait waits for the container to terminate, or for the connection to the
 	// container to be terminated by some error condition (including calling
 	// Close).

--- a/internal/gcs/guestconnection.go
+++ b/internal/gcs/guestconnection.go
@@ -158,8 +158,8 @@ func (gc *GuestConnection) Close() error {
 }
 
 // CreateProcess creates a process in the container host.
-func (gc *GuestConnection) CreateProcess(settings interface{}) (cow.Process, error) {
-	return gc.exec(context.TODO(), nullContainerID, settings)
+func (gc *GuestConnection) CreateProcess(ctx context.Context, settings interface{}) (cow.Process, error) {
+	return gc.exec(ctx, nullContainerID, settings)
 }
 
 // OS returns the operating system of the container's host, "windows" or "linux".

--- a/internal/gcs/guestconnection_test.go
+++ b/internal/gcs/guestconnection_test.go
@@ -178,7 +178,7 @@ func TestGcsWaitContainer(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer c.Close()
-	err = c.Terminate()
+	err = c.Terminate(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -207,7 +207,7 @@ func TestGcsWaitContainerBridgeTerminated(t *testing.T) {
 func TestGcsCreateProcess(t *testing.T) {
 	gc := connectGcs(context.Background(), t)
 	defer gc.Close()
-	p, err := gc.CreateProcess(&baseProcessParams{
+	p, err := gc.CreateProcess(context.Background(), &baseProcessParams{
 		CreateStdInPipe:  true,
 		CreateStdOutPipe: true,
 	})
@@ -220,7 +220,7 @@ func TestGcsCreateProcess(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = p.CloseStdin()
+	err = p.CloseStdin(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -238,7 +238,7 @@ func TestGcsWaitProcessBridgeTerminated(t *testing.T) {
 	defer cancel()
 	gc := connectGcs(ctx, t)
 	defer gc.Close()
-	p, err := gc.CreateProcess(nil)
+	p, err := gc.CreateProcess(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/hcs/errors.go
+++ b/internal/hcs/errors.go
@@ -1,6 +1,7 @@
 package hcs
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -8,6 +9,7 @@ import (
 	"syscall"
 
 	"github.com/Microsoft/hcsshim/internal/interop"
+	"github.com/Microsoft/hcsshim/internal/log"
 	"github.com/Microsoft/hcsshim/internal/logfields"
 	"github.com/sirupsen/logrus"
 )
@@ -118,14 +120,14 @@ func (ev *ErrorEvent) String() string {
 	return evs
 }
 
-func processHcsResult(resultp *uint16) []ErrorEvent {
+func processHcsResult(ctx context.Context, resultp *uint16) []ErrorEvent {
 	if resultp != nil {
 		resultj := interop.ConvertAndFreeCoTaskMemString(resultp)
-		logrus.WithField(logfields.JSON, resultj).
+		log.G(ctx).WithField(logfields.JSON, resultj).
 			Debug("HCS Result")
 		result := &hcsResult{}
 		if err := json.Unmarshal([]byte(resultj), result); err != nil {
-			logrus.WithFields(logrus.Fields{
+			log.G(ctx).WithFields(logrus.Fields{
 				logfields.JSON:  resultj,
 				logrus.ErrorKey: err,
 			}).Warning("Could not unmarshal HCS result")

--- a/internal/hcs/log.go
+++ b/internal/hcs/log.go
@@ -1,14 +1,19 @@
 package hcs
 
-import "github.com/sirupsen/logrus"
+import (
+	"context"
 
-func logOperationBegin(ctx logrus.Fields, msg string) {
-	logrus.WithFields(ctx).Debug(msg)
+	"github.com/Microsoft/hcsshim/internal/log"
+	"github.com/sirupsen/logrus"
+)
+
+func logOperationBegin(ctx context.Context, f logrus.Fields, msg string) {
+	log.G(ctx).WithFields(f).Debug(msg)
 }
 
-func logOperationEnd(ctx logrus.Fields, msg string, err error) {
+func logOperationEnd(ctx context.Context, f logrus.Fields, msg string, err error) {
 	// Copy the log and fields first.
-	log := logrus.WithFields(ctx)
+	log := log.G(ctx).WithFields(f)
 	if err == nil {
 		log.Debug(msg)
 	} else {

--- a/internal/hcs/waithelper.go
+++ b/internal/hcs/waithelper.go
@@ -1,13 +1,14 @@
 package hcs
 
 import (
+	"context"
 	"time"
 
 	"github.com/sirupsen/logrus"
 )
 
-func processAsyncHcsResult(err error, resultp *uint16, callbackNumber uintptr, expectedNotification hcsNotification, timeout *time.Duration) ([]ErrorEvent, error) {
-	events := processHcsResult(resultp)
+func processAsyncHcsResult(ctx context.Context, err error, resultp *uint16, callbackNumber uintptr, expectedNotification hcsNotification, timeout *time.Duration) ([]ErrorEvent, error) {
+	events := processHcsResult(ctx, resultp)
 	if IsPending(err) {
 		return nil, waitForNotification(callbackNumber, expectedNotification, timeout)
 	}

--- a/internal/hcsoci/cmd.go
+++ b/internal/hcsoci/cmd.go
@@ -188,7 +188,7 @@ func (c *Cmd) Start() error {
 	if c.Context != nil && c.Context.Err() != nil {
 		return c.Context.Err()
 	}
-	p, err := c.Host.CreateProcess(x)
+	p, err := c.Host.CreateProcess(context.TODO(), x)
 	if err != nil {
 		return err
 	}
@@ -212,7 +212,7 @@ func (c *Cmd) Start() error {
 				c.stdinErr.Store(err)
 			}
 			// Notify the process that there is no more input.
-			p.CloseStdin()
+			p.CloseStdin(context.TODO())
 		}()
 	}
 
@@ -234,7 +234,7 @@ func (c *Cmd) Start() error {
 		go func() {
 			select {
 			case <-c.Context.Done():
-				c.Process.Kill()
+				c.Process.Kill(context.TODO())
 			case <-c.allDoneCh:
 			}
 		}()

--- a/internal/hcsoci/cmd_test.go
+++ b/internal/hcsoci/cmd_test.go
@@ -36,7 +36,7 @@ func (h *localProcessHost) IsOCI() bool {
 	return false
 }
 
-func (h *localProcessHost) CreateProcess(cfg interface{}) (_ cow.Process, err error) {
+func (h *localProcessHost) CreateProcess(ctx context.Context, cfg interface{}) (_ cow.Process, err error) {
 	params := cfg.(*hcsschema.ProcessParameters)
 	lp := &localProcess{ch: make(chan struct{})}
 	defer func() {
@@ -102,7 +102,7 @@ func (p *localProcess) Close() error {
 	return nil
 }
 
-func (p *localProcess) CloseStdin() error {
+func (p *localProcess) CloseStdin(ctx context.Context) error {
 	return p.stdin.Close()
 }
 
@@ -115,19 +115,19 @@ func (p *localProcess) ExitCode() (int, error) {
 	}
 }
 
-func (p *localProcess) Kill() (bool, error) {
+func (p *localProcess) Kill(ctx context.Context) (bool, error) {
 	return true, p.p.Kill()
 }
 
-func (p *localProcess) Signal(interface{}) (bool, error) {
-	return p.Kill()
+func (p *localProcess) Signal(ctx context.Context, _ interface{}) (bool, error) {
+	return p.Kill(ctx)
 }
 
 func (p *localProcess) Pid() int {
 	return p.p.Pid
 }
 
-func (p *localProcess) ResizeConsole(x, y uint16) error {
+func (p *localProcess) ResizeConsole(ctx context.Context, x, y uint16) error {
 	return errors.New("not supported")
 }
 
@@ -214,8 +214,8 @@ type stuckIoProcess struct {
 	pstdin, stdout, stderr  *io.PipeReader
 }
 
-func (h *stuckIoProcessHost) CreateProcess(cfg interface{}) (cow.Process, error) {
-	p, err := h.ProcessHost.CreateProcess(cfg)
+func (h *stuckIoProcessHost) CreateProcess(ctx context.Context, cfg interface{}) (cow.Process, error) {
+	p, err := h.ProcessHost.CreateProcess(ctx, cfg)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/hcsoci/hcsdoc_lcow.go
+++ b/internal/hcsoci/hcsdoc_lcow.go
@@ -3,12 +3,13 @@
 package hcsoci
 
 import (
+	"context"
 	"encoding/json"
 
+	"github.com/Microsoft/hcsshim/internal/log"
 	hcsschema "github.com/Microsoft/hcsshim/internal/schema2"
 	"github.com/Microsoft/hcsshim/internal/schemaversion"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/sirupsen/logrus"
 )
 
 func createLCOWSpec(coi *createOptionsInternal) (*specs.Spec, error) {
@@ -58,13 +59,13 @@ type linuxHostedSystem struct {
 	OciSpecification *specs.Spec
 }
 
-func createLinuxContainerDocument(coi *createOptionsInternal, guestRoot string) (*linuxHostedSystem, error) {
+func createLinuxContainerDocument(ctx context.Context, coi *createOptionsInternal, guestRoot string) (*linuxHostedSystem, error) {
 	spec, err := createLCOWSpec(coi)
 	if err != nil {
 		return nil, err
 	}
 
-	logrus.WithField("guestRoot", guestRoot).Debug("hcsshim::createLinuxContainerDoc")
+	log.G(ctx).WithField("guestRoot", guestRoot).Debug("hcsshim::createLinuxContainerDoc")
 	return &linuxHostedSystem{
 		SchemaVersion:    schemaversion.SchemaV21(),
 		OciBundlePath:    guestRoot,

--- a/internal/hcsoci/layers.go
+++ b/internal/hcsoci/layers.go
@@ -3,12 +3,14 @@
 package hcsoci
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path"
 	"path/filepath"
 
 	"github.com/Microsoft/hcsshim/internal/guestrequest"
+	"github.com/Microsoft/hcsshim/internal/log"
 	"github.com/Microsoft/hcsshim/internal/ospath"
 	"github.com/Microsoft/hcsshim/internal/requesttype"
 	hcsschema "github.com/Microsoft/hcsshim/internal/schema2"
@@ -35,8 +37,8 @@ const scratchPath = "scratch"
 //                    inside the utility VM which is a GUID mapping of the scratch folder. Each
 //                    of the layers are the VSMB locations where the read-only layers are mounted.
 //
-func MountContainerLayers(layerFolders []string, guestRoot string, uvm *uvm.UtilityVM) (interface{}, error) {
-	logrus.WithField("layerFolders", layerFolders).Debug("hcsshim::mountContainerLayers")
+func MountContainerLayers(ctx context.Context, layerFolders []string, guestRoot string, uvm *uvm.UtilityVM) (interface{}, error) {
+	log.G(ctx).WithField("layerFolders", layerFolders).Debug("hcsshim::mountContainerLayers")
 
 	if uvm == nil {
 		if len(layerFolders) < 2 {
@@ -44,17 +46,17 @@ func MountContainerLayers(layerFolders []string, guestRoot string, uvm *uvm.Util
 		}
 		path := layerFolders[len(layerFolders)-1]
 		rest := layerFolders[:len(layerFolders)-1]
-		logrus.WithField("path", path).Debug("hcsshim::mountContainerLayers ActivateLayer")
+		log.G(ctx).WithField("path", path).Debug("hcsshim::mountContainerLayers ActivateLayer")
 		if err := wclayer.ActivateLayer(path); err != nil {
 			return nil, err
 		}
-		logrus.WithFields(logrus.Fields{
+		log.G(ctx).WithFields(logrus.Fields{
 			"path": path,
 			"rest": rest,
 		}).Debug("hcsshim::mountContainerLayers PrepareLayer")
 		if err := wclayer.PrepareLayer(path, rest); err != nil {
 			if err2 := wclayer.DeactivateLayer(path); err2 != nil {
-				logrus.WithFields(logrus.Fields{
+				log.G(ctx).WithFields(logrus.Fields{
 					logrus.ErrorKey: err,
 					"path":          path,
 				}).Warn("Failed to Deactivate")
@@ -65,13 +67,13 @@ func MountContainerLayers(layerFolders []string, guestRoot string, uvm *uvm.Util
 		mountPath, err := wclayer.GetLayerMountPath(path)
 		if err != nil {
 			if err := wclayer.UnprepareLayer(path); err != nil {
-				logrus.WithFields(logrus.Fields{
+				log.G(ctx).WithFields(logrus.Fields{
 					logrus.ErrorKey: err,
 					"path":          path,
 				}).Warn("Failed to Unprepare")
 			}
 			if err2 := wclayer.DeactivateLayer(path); err2 != nil {
-				logrus.WithFields(logrus.Fields{
+				log.G(ctx).WithFields(logrus.Fields{
 					logrus.ErrorKey: err,
 					"path":          path,
 				}).Warn("Failed to Deactivate")
@@ -82,7 +84,7 @@ func MountContainerLayers(layerFolders []string, guestRoot string, uvm *uvm.Util
 	}
 
 	// V2 UVM
-	logrus.WithField("os", uvm.OS()).Debug("hcsshim::mountContainerLayers V2 UVM")
+	log.G(ctx).WithField("os", uvm.OS()).Debug("hcsshim::mountContainerLayers V2 UVM")
 
 	// 	Add each read-only layers. For Windows, this is a VSMB share with the ResourceUri ending in
 	// a GUID based on the folder path. For Linux, this is a VPMEM device, except where is over the
@@ -103,7 +105,7 @@ func MountContainerLayers(layerFolders []string, guestRoot string, uvm *uvm.Util
 				CacheIo:             true,
 				ShareRead:           true,
 			}
-			err = uvm.AddVSMB(layerPath, "", options)
+			err = uvm.AddVSMB(ctx, layerPath, "", options)
 			if err == nil {
 				wcowLayersAdded = append(wcowLayersAdded, layerPath)
 			}
@@ -119,7 +121,7 @@ func MountContainerLayers(layerFolders []string, guestRoot string, uvm *uvm.Util
 					controller int
 					lun        int32
 				)
-				controller, lun, err = uvm.AddSCSILayer(hostPath)
+				controller, lun, err = uvm.AddSCSILayer(ctx, hostPath)
 				if err == nil {
 					lcowlayersAdded = append(lcowlayersAdded,
 						lcowLayerEntry{
@@ -129,7 +131,7 @@ func MountContainerLayers(layerFolders []string, guestRoot string, uvm *uvm.Util
 						})
 				}
 			} else {
-				_, uvmPath, err = uvm.AddVPMEM(hostPath, true) // UVM path is calculated. Will be /tmp/vN/
+				_, uvmPath, err = uvm.AddVPMEM(ctx, hostPath, true) // UVM path is calculated. Will be /tmp/vN/
 				if err == nil {
 					lcowlayersAdded = append(lcowlayersAdded,
 						lcowLayerEntry{
@@ -140,7 +142,7 @@ func MountContainerLayers(layerFolders []string, guestRoot string, uvm *uvm.Util
 			}
 		}
 		if err != nil {
-			cleanupOnMountFailure(uvm, wcowLayersAdded, lcowlayersAdded, attachedSCSIHostPath)
+			cleanupOnMountFailure(ctx, uvm, wcowLayersAdded, lcowlayersAdded, attachedSCSIHostPath)
 			return nil, err
 		}
 	}
@@ -151,9 +153,9 @@ func MountContainerLayers(layerFolders []string, guestRoot string, uvm *uvm.Util
 
 	// BUGBUG Rename guestRoot better.
 	containerScratchPathInUVM := ospath.Join(uvm.OS(), guestRoot, scratchPath)
-	_, _, err := uvm.AddSCSI(hostPath, containerScratchPathInUVM, false)
+	_, _, err := uvm.AddSCSI(ctx, hostPath, containerScratchPathInUVM, false)
 	if err != nil {
-		cleanupOnMountFailure(uvm, wcowLayersAdded, lcowlayersAdded, attachedSCSIHostPath)
+		cleanupOnMountFailure(ctx, uvm, wcowLayersAdded, lcowlayersAdded, attachedSCSIHostPath)
 		return nil, err
 	}
 	attachedSCSIHostPath = hostPath
@@ -161,9 +163,9 @@ func MountContainerLayers(layerFolders []string, guestRoot string, uvm *uvm.Util
 	if uvm.OS() == "windows" {
 		// 	Load the filter at the C:\s<ID> location calculated above. We pass into this request each of the
 		// 	read-only layer folders.
-		layers, err := computeV2Layers(uvm, wcowLayersAdded)
+		layers, err := computeV2Layers(ctx, uvm, wcowLayersAdded)
 		if err != nil {
-			cleanupOnMountFailure(uvm, wcowLayersAdded, lcowlayersAdded, attachedSCSIHostPath)
+			cleanupOnMountFailure(ctx, uvm, wcowLayersAdded, lcowlayersAdded, attachedSCSIHostPath)
 			return nil, err
 		}
 		guestRequest := guestrequest.CombinedLayers{
@@ -177,11 +179,11 @@ func MountContainerLayers(layerFolders []string, guestRoot string, uvm *uvm.Util
 				RequestType:  requesttype.Add,
 			},
 		}
-		if err := uvm.Modify(combinedLayersModification); err != nil {
-			cleanupOnMountFailure(uvm, wcowLayersAdded, lcowlayersAdded, attachedSCSIHostPath)
+		if err := uvm.Modify(ctx, combinedLayersModification); err != nil {
+			cleanupOnMountFailure(ctx, uvm, wcowLayersAdded, lcowlayersAdded, attachedSCSIHostPath)
 			return nil, err
 		}
-		logrus.Debug("hcsshim::mountContainerLayers Succeeded")
+		log.G(ctx).Debug("hcsshim::mountContainerLayers Succeeded")
 		return guestRequest, nil
 	}
 
@@ -218,11 +220,11 @@ func MountContainerLayers(layerFolders []string, guestRoot string, uvm *uvm.Util
 			Settings:     guestRequest,
 		},
 	}
-	if err := uvm.Modify(combinedLayersModification); err != nil {
-		cleanupOnMountFailure(uvm, wcowLayersAdded, lcowlayersAdded, attachedSCSIHostPath)
+	if err := uvm.Modify(ctx, combinedLayersModification); err != nil {
+		cleanupOnMountFailure(ctx, uvm, wcowLayersAdded, lcowlayersAdded, attachedSCSIHostPath)
 		return nil, err
 	}
-	logrus.Debug("hcsshim::mountContainerLayers Succeeded")
+	log.G(ctx).Debug("hcsshim::mountContainerLayers Succeeded")
 	return guestRequest, nil
 
 }
@@ -243,8 +245,8 @@ const (
 )
 
 // UnmountContainerLayers is a helper for clients to hide all the complexity of layer unmounting
-func UnmountContainerLayers(layerFolders []string, guestRoot string, uvm *uvm.UtilityVM, op UnmountOperation) error {
-	logrus.WithField("layerFolders", layerFolders).Debug("hcsshim::unmountContainerLayers")
+func UnmountContainerLayers(ctx context.Context, layerFolders []string, guestRoot string, uvm *uvm.UtilityVM, op UnmountOperation) error {
+	log.G(ctx).WithField("layerFolders", layerFolders).Debug("hcsshim::unmountContainerLayers")
 	if uvm == nil {
 		// Must be an argon - folders are mounted on the host
 		if op != UnmountOperationAll {
@@ -254,12 +256,12 @@ func UnmountContainerLayers(layerFolders []string, guestRoot string, uvm *uvm.Ut
 			return fmt.Errorf("need at least one layer for Unmount")
 		}
 		path := layerFolders[len(layerFolders)-1]
-		logrus.WithField("path", path).Debug("hcsshim::Unmount UnprepareLayer")
+		log.G(ctx).WithField("path", path).Debug("hcsshim::Unmount UnprepareLayer")
 		if err := wclayer.UnprepareLayer(path); err != nil {
 			return err
 		}
 		// TODO Should we try this anyway?
-		logrus.WithField("path", path).Debug("hcsshim::unmountContainerLayers DeactivateLayer")
+		log.G(ctx).WithField("path", path).Debug("hcsshim::unmountContainerLayers DeactivateLayer")
 		return wclayer.DeactivateLayer(path)
 	}
 
@@ -275,7 +277,7 @@ func UnmountContainerLayers(layerFolders []string, guestRoot string, uvm *uvm.Ut
 	// Unload the storage filter followed by the SCSI scratch
 	if (op & UnmountOperationSCSI) == UnmountOperationSCSI {
 		containerRoofFSPathInUVM := ospath.Join(uvm.OS(), guestRoot, rootfsPath)
-		logrus.WithField("rootPath", containerRoofFSPathInUVM).Debug("hcsshim::unmountContainerLayers CombinedLayers")
+		log.G(ctx).WithField("rootPath", containerRoofFSPathInUVM).Debug("hcsshim::unmountContainerLayers CombinedLayers")
 		combinedLayersModification := &hcsschema.ModifySettingRequest{
 			GuestRequest: guestrequest.GuestRequest{
 				ResourceType: guestrequest.ResourceTypeCombinedLayers,
@@ -283,20 +285,20 @@ func UnmountContainerLayers(layerFolders []string, guestRoot string, uvm *uvm.Ut
 				Settings:     guestrequest.CombinedLayers{ContainerRootPath: containerRoofFSPathInUVM},
 			},
 		}
-		if err := uvm.Modify(combinedLayersModification); err != nil {
-			logrus.WithError(err).Error("failed guest request to remove combined layers")
+		if err := uvm.Modify(ctx, combinedLayersModification); err != nil {
+			log.G(ctx).WithError(err).Error("failed guest request to remove combined layers")
 		}
 
 		// Hot remove the scratch from the SCSI controller
 		hostScratchFile := filepath.Join(layerFolders[len(layerFolders)-1], "sandbox.vhdx")
 		containerScratchPathInUVM := ospath.Join(uvm.OS(), guestRoot, scratchPath)
-		logrus.WithFields(logrus.Fields{
+		log.G(ctx).WithFields(logrus.Fields{
 			"scratchPath": containerScratchPathInUVM,
 			"scratchFile": hostScratchFile,
 		}).Debug("hcsshim::unmountContainerLayers SCSI")
-		if err := uvm.RemoveSCSI(hostScratchFile); err != nil {
+		if err := uvm.RemoveSCSI(ctx, hostScratchFile); err != nil {
 			e := fmt.Errorf("failed to remove SCSI %s: %s", hostScratchFile, err)
-			logrus.WithError(e).Error("failed to remove SCSI")
+			log.G(ctx).WithError(e).Error("failed to remove SCSI")
 			if retError == nil {
 				retError = e
 			} else {
@@ -310,8 +312,8 @@ func UnmountContainerLayers(layerFolders []string, guestRoot string, uvm *uvm.Ut
 	// to share layers.
 	if uvm.OS() == "windows" && len(layerFolders) > 1 && (op&UnmountOperationVSMB) == UnmountOperationVSMB {
 		for _, layerPath := range layerFolders[:len(layerFolders)-1] {
-			if e := uvm.RemoveVSMB(layerPath); e != nil {
-				logrus.WithError(e).Debug("remove VSMB failed")
+			if e := uvm.RemoveVSMB(ctx, layerPath); e != nil {
+				log.G(ctx).WithError(e).Debug("remove VSMB failed")
 				if retError == nil {
 					retError = e
 				} else {
@@ -330,12 +332,12 @@ func UnmountContainerLayers(layerFolders []string, guestRoot string, uvm *uvm.Ut
 			if fi, err := os.Stat(hostPath); err != nil {
 				var e error
 				if uint64(fi.Size()) > uvm.PMemMaxSizeBytes() {
-					e = uvm.RemoveSCSI(hostPath)
+					e = uvm.RemoveSCSI(ctx, hostPath)
 				} else {
-					e = uvm.RemoveVPMEM(hostPath)
+					e = uvm.RemoveVPMEM(ctx, hostPath)
 				}
 				if e != nil {
-					logrus.WithError(e).Debug("remove layer failed")
+					log.G(ctx).WithError(e).Debug("remove layer failed")
 					if retError == nil {
 						retError = e
 					} else {
@@ -351,31 +353,31 @@ func UnmountContainerLayers(layerFolders []string, guestRoot string, uvm *uvm.Ut
 	return retError
 }
 
-func cleanupOnMountFailure(uvm *uvm.UtilityVM, wcowLayers []string, lcowLayers []lcowLayerEntry, scratchHostPath string) {
+func cleanupOnMountFailure(ctx context.Context, uvm *uvm.UtilityVM, wcowLayers []string, lcowLayers []lcowLayerEntry, scratchHostPath string) {
 	for _, wl := range wcowLayers {
-		if err := uvm.RemoveVSMB(wl); err != nil {
-			logrus.WithError(err).Warn("Possibly leaked vsmbshare on error removal path")
+		if err := uvm.RemoveVSMB(ctx, wl); err != nil {
+			log.G(ctx).WithError(err).Warn("Possibly leaked vsmbshare on error removal path")
 		}
 	}
 	for _, ll := range lcowLayers {
 		if ll.scsi {
-			if err := uvm.RemoveSCSI(ll.hostPath); err != nil {
-				logrus.WithError(err).Warn("Possibly leaked SCSI on error removal path")
+			if err := uvm.RemoveSCSI(ctx, ll.hostPath); err != nil {
+				log.G(ctx).WithError(err).Warn("Possibly leaked SCSI on error removal path")
 			}
-		} else if err := uvm.RemoveVPMEM(ll.hostPath); err != nil {
-			logrus.WithError(err).Warn("Possibly leaked vpmemdevice on error removal path")
+		} else if err := uvm.RemoveVPMEM(ctx, ll.hostPath); err != nil {
+			log.G(ctx).WithError(err).Warn("Possibly leaked vpmemdevice on error removal path")
 		}
 	}
 	if scratchHostPath != "" {
-		if err := uvm.RemoveSCSI(scratchHostPath); err != nil {
-			logrus.WithError(err).Warn("Possibly leaked SCSI disk on error removal path")
+		if err := uvm.RemoveSCSI(ctx, scratchHostPath); err != nil {
+			log.G(ctx).WithError(err).Warn("Possibly leaked SCSI disk on error removal path")
 		}
 	}
 }
 
-func computeV2Layers(vm *uvm.UtilityVM, paths []string) (layers []hcsschema.Layer, err error) {
+func computeV2Layers(ctx context.Context, vm *uvm.UtilityVM, paths []string) (layers []hcsschema.Layer, err error) {
 	for _, path := range paths {
-		uvmPath, err := vm.GetVSMBUvmPath(path)
+		uvmPath, err := vm.GetVSMBUvmPath(ctx, path)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/hcsoci/network.go
+++ b/internal/hcsoci/network.go
@@ -1,24 +1,27 @@
 package hcsoci
 
 import (
+	"context"
+
 	"github.com/Microsoft/hcsshim/internal/hns"
+	"github.com/Microsoft/hcsshim/internal/log"
 	"github.com/Microsoft/hcsshim/internal/logfields"
 	"github.com/sirupsen/logrus"
 )
 
-func createNetworkNamespace(coi *createOptionsInternal, resources *Resources) error {
+func createNetworkNamespace(ctx context.Context, coi *createOptionsInternal, resources *Resources) error {
 	op := "hcsoci::createNetworkNamespace"
-	log := logrus.WithField(logfields.ContainerID, coi.ID)
-	log.Debug(op + " - Begin")
+	l := log.G(ctx).WithField(logfields.ContainerID, coi.ID)
+	l.Debug(op + " - Begin")
 	defer func() {
-		log.Debug(op + " - End")
+		l.Debug(op + " - End")
 	}()
 
 	netID, err := hns.CreateNamespace()
 	if err != nil {
 		return err
 	}
-	logrus.WithFields(logrus.Fields{
+	log.G(ctx).WithFields(logrus.Fields{
 		"netID":               netID,
 		logfields.ContainerID: coi.ID,
 	}).Info("created network namespace for container")
@@ -29,7 +32,7 @@ func createNetworkNamespace(coi *createOptionsInternal, resources *Resources) er
 		if err != nil {
 			return err
 		}
-		logrus.WithFields(logrus.Fields{
+		log.G(ctx).WithFields(logrus.Fields{
 			"netID":      netID,
 			"endpointID": endpointID,
 		}).Info("added network endpoint to namespace")
@@ -39,12 +42,12 @@ func createNetworkNamespace(coi *createOptionsInternal, resources *Resources) er
 }
 
 // GetNamespaceEndpoints gets all endpoints in `netNS`
-func GetNamespaceEndpoints(netNS string) ([]*hns.HNSEndpoint, error) {
+func GetNamespaceEndpoints(ctx context.Context, netNS string) ([]*hns.HNSEndpoint, error) {
 	op := "hcsoci::GetNamespaceEndpoints"
-	log := logrus.WithField("netns-id", netNS)
-	log.Debug(op + " - Begin")
+	l := log.G(ctx).WithField("netns-id", netNS)
+	l.Debug(op + " - Begin")
 	defer func() {
-		log.Debug(op + " - End")
+		l.Debug(op + " - End")
 	}()
 
 	ids, err := hns.GetNamespaceEndpoints(netNS)

--- a/internal/hcsoci/resources.go
+++ b/internal/hcsoci/resources.go
@@ -1,9 +1,11 @@
 package hcsoci
 
 import (
+	"context"
 	"os"
 
 	"github.com/Microsoft/hcsshim/internal/hns"
+	"github.com/Microsoft/hcsshim/internal/log"
 	"github.com/Microsoft/hcsshim/internal/uvm"
 	"github.com/sirupsen/logrus"
 )
@@ -57,10 +59,10 @@ type Resources struct {
 }
 
 // TODO: Method on the resources?
-func ReleaseResources(r *Resources, vm *uvm.UtilityVM, all bool) error {
+func ReleaseResources(ctx context.Context, r *Resources, vm *uvm.UtilityVM, all bool) error {
 	if vm != nil && r.addedNetNSToVM {
-		if err := vm.RemoveNetNS(r.netNS); err != nil {
-			logrus.Warn(err)
+		if err := vm.RemoveNetNS(ctx, r.netNS); err != nil {
+			log.G(ctx).Warn(err)
 		}
 		r.addedNetNSToVM = false
 	}
@@ -73,7 +75,7 @@ func ReleaseResources(r *Resources, vm *uvm.UtilityVM, all bool) error {
 				if !os.IsNotExist(err) {
 					return err
 				}
-				logrus.WithFields(logrus.Fields{
+				log.G(ctx).WithFields(logrus.Fields{
 					"endpointID": endpoint,
 					"netID":      r.NetNS(),
 				}).Warn("removing endpoint from namespace: does not exist")
@@ -93,7 +95,7 @@ func ReleaseResources(r *Resources, vm *uvm.UtilityVM, all bool) error {
 		if vm == nil || all {
 			op = UnmountOperationAll
 		}
-		err := UnmountContainerLayers(r.layers, r.containerRootInUVM, vm, op)
+		err := UnmountContainerLayers(ctx, r.layers, r.containerRootInUVM, vm, op)
 		if err != nil {
 			return err
 		}
@@ -103,7 +105,7 @@ func ReleaseResources(r *Resources, vm *uvm.UtilityVM, all bool) error {
 	if all {
 		for len(r.vsmbMounts) != 0 {
 			mount := r.vsmbMounts[len(r.vsmbMounts)-1]
-			if err := vm.RemoveVSMB(mount); err != nil {
+			if err := vm.RemoveVSMB(ctx, mount); err != nil {
 				return err
 			}
 			r.vsmbMounts = r.vsmbMounts[:len(r.vsmbMounts)-1]
@@ -111,14 +113,14 @@ func ReleaseResources(r *Resources, vm *uvm.UtilityVM, all bool) error {
 
 		for len(r.plan9Mounts) != 0 {
 			mount := r.plan9Mounts[len(r.plan9Mounts)-1]
-			if err := vm.RemovePlan9(mount); err != nil {
+			if err := vm.RemovePlan9(ctx, mount); err != nil {
 				return err
 			}
 			r.plan9Mounts = r.plan9Mounts[:len(r.plan9Mounts)-1]
 		}
 
 		for _, path := range r.scsiMounts {
-			if err := vm.RemoveSCSI(path); err != nil {
+			if err := vm.RemoveSCSI(ctx, path); err != nil {
 				return err
 			}
 			r.scsiMounts = nil

--- a/internal/hcsoci/resources_lcow.go
+++ b/internal/hcsoci/resources_lcow.go
@@ -5,6 +5,7 @@ package hcsoci
 // Contains functions relating to a LCOW container, as opposed to a utility VM
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -13,20 +14,20 @@ import (
 	"strings"
 
 	"github.com/Microsoft/hcsshim/internal/guestrequest"
+	"github.com/Microsoft/hcsshim/internal/log"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/sirupsen/logrus"
 )
 
 const rootfsPath = "rootfs"
 const mountPathPrefix = "m"
 
-func allocateLinuxResources(coi *createOptionsInternal, resources *Resources) error {
+func allocateLinuxResources(ctx context.Context, coi *createOptionsInternal, resources *Resources) error {
 	if coi.Spec.Root == nil {
 		coi.Spec.Root = &specs.Root{}
 	}
 	if coi.Spec.Windows != nil && len(coi.Spec.Windows.LayerFolders) > 0 {
-		logrus.Debug("hcsshim::allocateLinuxResources mounting storage")
-		mcl, err := MountContainerLayers(coi.Spec.Windows.LayerFolders, resources.containerRootInUVM, coi.HostingSystem)
+		log.G(ctx).Debug("hcsshim::allocateLinuxResources mounting storage")
+		mcl, err := MountContainerLayers(ctx, coi.Spec.Windows.LayerFolders, resources.containerRootInUVM, coi.HostingSystem)
 		if err != nil {
 			return fmt.Errorf("failed to mount container storage: %s", err)
 		}
@@ -41,7 +42,7 @@ func allocateLinuxResources(coi *createOptionsInternal, resources *Resources) er
 		// TODO: We need a test for this. Ask @jstarks how you can even lay this out on Windows.
 		hostPath := coi.Spec.Root.Path
 		uvmPathForContainersFileSystem := path.Join(resources.containerRootInUVM, rootfsPath)
-		share, err := coi.HostingSystem.AddPlan9(hostPath, uvmPathForContainersFileSystem, coi.Spec.Root.Readonly, false, nil)
+		share, err := coi.HostingSystem.AddPlan9(ctx, hostPath, uvmPathForContainersFileSystem, coi.Spec.Root.Readonly, false, nil)
 		if err != nil {
 			return fmt.Errorf("adding plan9 root: %s", err)
 		}
@@ -76,18 +77,18 @@ func allocateLinuxResources(coi *createOptionsInternal, resources *Resources) er
 					break
 				}
 			}
-			log := logrus.WithField("mount", fmt.Sprintf("%+v", mount))
+			l := log.G(ctx).WithField("mount", fmt.Sprintf("%+v", mount))
 			if mount.Type == "physical-disk" {
-				log.Debug("hcsshim::allocateLinuxResources Hot-adding SCSI physical disk for OCI mount")
-				_, _, err := coi.HostingSystem.AddSCSIPhysicalDisk(hostPath, uvmPathForShare, readOnly)
+				l.Debug("hcsshim::allocateLinuxResources Hot-adding SCSI physical disk for OCI mount")
+				_, _, err := coi.HostingSystem.AddSCSIPhysicalDisk(ctx, hostPath, uvmPathForShare, readOnly)
 				if err != nil {
 					return fmt.Errorf("adding SCSI physical disk mount %+v: %s", mount, err)
 				}
 				resources.scsiMounts = append(resources.scsiMounts, hostPath)
 				coi.Spec.Mounts[i].Type = "none"
 			} else if mount.Type == "virtual-disk" {
-				log.Debug("hcsshim::allocateLinuxResources Hot-adding SCSI virtual disk for OCI mount")
-				_, _, err := coi.HostingSystem.AddSCSI(hostPath, uvmPathForShare, readOnly)
+				l.Debug("hcsshim::allocateLinuxResources Hot-adding SCSI virtual disk for OCI mount")
+				_, _, err := coi.HostingSystem.AddSCSI(ctx, hostPath, uvmPathForShare, readOnly)
 				if err != nil {
 					return fmt.Errorf("adding SCSI virtual disk mount %+v: %s", mount, err)
 				}
@@ -109,8 +110,8 @@ func allocateLinuxResources(coi *createOptionsInternal, resources *Resources) er
 					restrictAccess = true
 					uvmPathForFile = path.Join(uvmPathForShare, fileName)
 				}
-				log.Debug("hcsshim::allocateLinuxResources Hot-adding Plan9 for OCI mount")
-				share, err := coi.HostingSystem.AddPlan9(hostPath, uvmPathForShare, readOnly, restrictAccess, allowedNames)
+				l.Debug("hcsshim::allocateLinuxResources Hot-adding Plan9 for OCI mount")
+				share, err := coi.HostingSystem.AddPlan9(ctx, hostPath, uvmPathForShare, readOnly, restrictAccess, allowedNames)
 				if err != nil {
 					return fmt.Errorf("adding plan9 mount %+v: %s", mount, err)
 				}

--- a/internal/lcow/scratch.go
+++ b/internal/lcow/scratch.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Microsoft/go-winio/vhd"
 	"github.com/Microsoft/hcsshim/internal/copyfile"
 	"github.com/Microsoft/hcsshim/internal/hcsoci"
+	"github.com/Microsoft/hcsshim/internal/log"
 	"github.com/Microsoft/hcsshim/internal/timeout"
 	"github.com/Microsoft/hcsshim/internal/uvm"
 	"github.com/sirupsen/logrus"
@@ -31,7 +32,7 @@ const (
 // size is non-default, or the cache file does not exist, it uses a utility VM
 // to create target. It is the responsibility of the caller to synchronise
 // simultaneous attempts to create the cache file.
-func CreateScratch(lcowUVM *uvm.UtilityVM, destFile string, sizeGB uint32, cacheFile string) error {
+func CreateScratch(ctx context.Context, lcowUVM *uvm.UtilityVM, destFile string, sizeGB uint32, cacheFile string) error {
 	if lcowUVM == nil {
 		return fmt.Errorf("no uvm")
 	}
@@ -40,7 +41,7 @@ func CreateScratch(lcowUVM *uvm.UtilityVM, destFile string, sizeGB uint32, cache
 		return errors.New("lcow::CreateScratch requires a linux utility VM to operate")
 	}
 
-	logrus.WithFields(logrus.Fields{
+	log.G(ctx).WithFields(logrus.Fields{
 		"dest":   destFile,
 		"sizeGB": sizeGB,
 		"cache":  cacheFile,
@@ -52,7 +53,7 @@ func CreateScratch(lcowUVM *uvm.UtilityVM, destFile string, sizeGB uint32, cache
 			if err := copyfile.CopyFile(cacheFile, destFile, false); err != nil {
 				return fmt.Errorf("failed to copy cached file '%s' to '%s': %s", cacheFile, destFile, err)
 			}
-			logrus.WithFields(logrus.Fields{
+			log.G(ctx).WithFields(logrus.Fields{
 				"dest":  destFile,
 				"cache": cacheFile,
 			}).Debug("lcow::CreateScratch copied from cache")
@@ -65,18 +66,18 @@ func CreateScratch(lcowUVM *uvm.UtilityVM, destFile string, sizeGB uint32, cache
 		return fmt.Errorf("failed to create VHDx %s: %s", destFile, err)
 	}
 
-	controller, lun, err := lcowUVM.AddSCSI(destFile, "", false) // No destination as not formatted
+	controller, lun, err := lcowUVM.AddSCSI(ctx, destFile, "", false) // No destination as not formatted
 	if err != nil {
 		return err
 	}
 	removeSCSI := true
 	defer func() {
 		if removeSCSI {
-			lcowUVM.RemoveSCSI(destFile)
+			lcowUVM.RemoveSCSI(ctx, destFile)
 		}
 	}()
 
-	logrus.WithFields(logrus.Fields{
+	log.G(ctx).WithFields(logrus.Fields{
 		"dest":       destFile,
 		"controller": controller,
 		"lun":        lun,
@@ -84,7 +85,7 @@ func CreateScratch(lcowUVM *uvm.UtilityVM, destFile string, sizeGB uint32, cache
 
 	// Validate /sys/bus/scsi/devices/C:0:0:L exists as a directory
 	devicePath := fmt.Sprintf("/sys/bus/scsi/devices/%d:0:0:%d/block", controller, lun)
-	testdCtx, cancel := context.WithTimeout(context.TODO(), timeout.TestDRetryLoop)
+	testdCtx, cancel := context.WithTimeout(ctx, timeout.TestDRetryLoop)
 	defer cancel()
 	for {
 		cmd := hcsoci.CommandContext(testdCtx, lcowUVM, "test", "-d", devicePath)
@@ -100,7 +101,7 @@ func CreateScratch(lcowUVM *uvm.UtilityVM, destFile string, sizeGB uint32, cache
 	cancel()
 
 	// Get the device from under the block subdirectory by doing a simple ls. This will come back as (eg) `sda`
-	lsCtx, cancel := context.WithTimeout(context.TODO(), timeout.ExternalCommandToStart)
+	lsCtx, cancel := context.WithTimeout(ctx, timeout.ExternalCommandToStart)
 	cmd := hcsoci.CommandContext(lsCtx, lcowUVM, "ls", devicePath)
 	lsOutput, err := cmd.Output()
 	cancel()
@@ -108,13 +109,13 @@ func CreateScratch(lcowUVM *uvm.UtilityVM, destFile string, sizeGB uint32, cache
 		return fmt.Errorf("failed to `%+v` following hot-add %s to utility VM: %s", cmd.Spec.Args, destFile, err)
 	}
 	device := fmt.Sprintf(`/dev/%s`, bytes.TrimSpace(lsOutput))
-	logrus.WithFields(logrus.Fields{
+	log.G(ctx).WithFields(logrus.Fields{
 		"dest":   destFile,
 		"device": device,
 	}).Debug("lcow::CreateScratch device guest location")
 
 	// Format it ext4
-	mkfsCtx, cancel := context.WithTimeout(context.TODO(), timeout.ExternalCommandToStart)
+	mkfsCtx, cancel := context.WithTimeout(ctx, timeout.ExternalCommandToStart)
 	cmd = hcsoci.CommandContext(mkfsCtx, lcowUVM, "mkfs.ext4", "-q", "-E", "lazy_itable_init=0,nodiscard", "-O", `^has_journal,sparse_super2,^resize_inode`, device)
 	var mkfsStderr bytes.Buffer
 	cmd.Stderr = &mkfsStderr
@@ -126,7 +127,7 @@ func CreateScratch(lcowUVM *uvm.UtilityVM, destFile string, sizeGB uint32, cache
 
 	// Hot-Remove before we copy it
 	removeSCSI = false
-	if err := lcowUVM.RemoveSCSI(destFile); err != nil {
+	if err := lcowUVM.RemoveSCSI(ctx, destFile); err != nil {
 		return fmt.Errorf("failed to hot-remove: %s", err)
 	}
 
@@ -137,6 +138,6 @@ func CreateScratch(lcowUVM *uvm.UtilityVM, destFile string, sizeGB uint32, cache
 		}
 	}
 
-	logrus.WithField("dest", destFile).Debug("lcow::CreateScratch created (non-cache)")
+	log.G(ctx).WithField("dest", destFile).Debug("lcow::CreateScratch created (non-cache)")
 	return nil
 }

--- a/internal/tools/uvmboot/lcow.go
+++ b/internal/tools/uvmboot/lcow.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"io"
 	"os"
 	"strings"
@@ -133,7 +134,7 @@ var lcowCommand = cli.Command{
 				options.ConsolePipe = c.String(consolePipeArgName)
 			}
 
-			if err := runLCOW(options, c); err != nil {
+			if err := runLCOW(context.TODO(), options, c); err != nil {
 				return err
 			}
 			return nil
@@ -143,14 +144,14 @@ var lcowCommand = cli.Command{
 	},
 }
 
-func runLCOW(options *uvm.OptionsLCOW, c *cli.Context) error {
-	uvm, err := uvm.CreateLCOW(options)
+func runLCOW(ctx context.Context, options *uvm.OptionsLCOW, c *cli.Context) error {
+	uvm, err := uvm.CreateLCOW(ctx, options)
 	if err != nil {
 		return err
 	}
 	defer uvm.Close()
 
-	if err := uvm.Start(); err != nil {
+	if err := uvm.Start(ctx); err != nil {
 		return err
 	}
 
@@ -158,7 +159,7 @@ func runLCOW(options *uvm.OptionsLCOW, c *cli.Context) error {
 		if err := execViaGcs(uvm, c); err != nil {
 			return err
 		}
-		uvm.Terminate()
+		uvm.Terminate(ctx)
 		uvm.Wait()
 		return uvm.ExitError()
 	}

--- a/internal/tools/uvmboot/wcow.go
+++ b/internal/tools/uvmboot/wcow.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -75,12 +76,12 @@ var wcowCommand = cli.Command{
 			}
 			defer os.RemoveAll(tempDir)
 			options.LayerFolders = append(layers, tempDir)
-			vm, err := uvm.CreateWCOW(options)
+			vm, err := uvm.CreateWCOW(context.TODO(), options)
 			if err != nil {
 				return err
 			}
 			defer vm.Close()
-			if err := vm.Start(); err != nil {
+			if err := vm.Start(context.TODO()); err != nil {
 				return err
 			}
 			if wcowCommandLine != "" {
@@ -108,7 +109,7 @@ var wcowCommand = cli.Command{
 					return err
 				}
 			}
-			vm.Terminate()
+			vm.Terminate(context.TODO())
 			vm.Wait()
 			return vm.ExitError()
 		})

--- a/internal/uvm/create_test.go
+++ b/internal/uvm/create_test.go
@@ -1,6 +1,7 @@
 package uvm
 
 import (
+	"context"
 	"testing"
 )
 
@@ -10,7 +11,7 @@ func TestCreateBadBootFilesPath(t *testing.T) {
 	opts := NewDefaultOptionsLCOW(t.Name(), "")
 	opts.BootFilesPath = `c:\does\not\exist\I\hope`
 
-	_, err := CreateLCOW(opts)
+	_, err := CreateLCOW(context.Background(), opts)
 	if err == nil || err.Error() != `kernel: 'c:\does\not\exist\I\hope\kernel' not found` {
 		t.Fatal(err)
 	}
@@ -18,7 +19,7 @@ func TestCreateBadBootFilesPath(t *testing.T) {
 
 func TestCreateWCOWBadLayerFolders(t *testing.T) {
 	opts := NewDefaultOptionsWCOW(t.Name(), "")
-	_, err := CreateWCOW(opts)
+	_, err := CreateWCOW(context.Background(), opts)
 	if err == nil || (err != nil && err.Error() != `at least 2 LayerFolders must be supplied`) {
 		t.Fatal(err)
 	}

--- a/internal/uvm/create_wcow.go
+++ b/internal/uvm/create_wcow.go
@@ -1,6 +1,7 @@
 package uvm
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -8,6 +9,7 @@ import (
 	"github.com/Microsoft/go-winio"
 	"github.com/Microsoft/go-winio/pkg/guid"
 	"github.com/Microsoft/hcsshim/internal/gcs"
+	"github.com/Microsoft/hcsshim/internal/log"
 	"github.com/Microsoft/hcsshim/internal/logfields"
 	"github.com/Microsoft/hcsshim/internal/mergemaps"
 	hcsschema "github.com/Microsoft/hcsshim/internal/schema2"
@@ -42,18 +44,18 @@ func NewDefaultOptionsWCOW(id, owner string) *OptionsWCOW {
 // WCOW Notes:
 //   - The scratch is always attached to SCSI 0:0
 //
-func CreateWCOW(opts *OptionsWCOW) (_ *UtilityVM, err error) {
+func CreateWCOW(ctx context.Context, opts *OptionsWCOW) (_ *UtilityVM, err error) {
 	op := "uvm::CreateWCOW"
-	log := logrus.WithFields(logrus.Fields{
+	l := log.G(ctx).WithFields(logrus.Fields{
 		logfields.UVMID: opts.ID,
 	})
-	log.WithField("options", fmt.Sprintf("%+v", opts)).Debug(op + " - Begin Operation")
+	l.WithField("options", fmt.Sprintf("%+v", opts)).Debug(op + " - Begin Operation")
 	defer func() {
 		if err != nil {
-			log.Data[logrus.ErrorKey] = err
-			log.Error(op + " - End Operation - Error")
+			l.Data[logrus.ErrorKey] = err
+			l.Error(op + " - End Operation - Error")
 		} else {
-			log.Debug(op + " - End Operation - Success")
+			l.Debug(op + " - End Operation - Success")
 		}
 	}()
 
@@ -80,15 +82,15 @@ func CreateWCOW(opts *OptionsWCOW) (_ *UtilityVM, err error) {
 
 	// To maintain compatability with Docker we need to automatically downgrade
 	// a user CPU count if the setting is not possible.
-	uvm.normalizeProcessorCount(opts.ProcessorCount)
+	uvm.normalizeProcessorCount(ctx, opts.ProcessorCount)
 
 	// Align the requested memory size.
-	memorySizeInMB := uvm.normalizeMemorySize(opts.MemorySizeInMB)
+	memorySizeInMB := uvm.normalizeMemorySize(ctx, opts.MemorySizeInMB)
 
 	if len(opts.LayerFolders) < 2 {
 		return nil, fmt.Errorf("at least 2 LayerFolders must be supplied")
 	}
-	uvmFolder, err := uvmfolder.LocateUVMFolder(opts.LayerFolders)
+	uvmFolder, err := uvmfolder.LocateUVMFolder(ctx, opts.LayerFolders)
 	if err != nil {
 		return nil, fmt.Errorf("failed to locate utility VM folder from layer folders: %s", err)
 	}
@@ -100,11 +102,11 @@ func CreateWCOW(opts *OptionsWCOW) (_ *UtilityVM, err error) {
 	//       - Update tests that rely on this current behaviour.
 	// Create the RW scratch in the top-most layer folder, creating the folder if it doesn't already exist.
 	scratchFolder := opts.LayerFolders[len(opts.LayerFolders)-1]
-	logrus.WithField("scratchFolder", scratchFolder).Debug("uvm::CreateWCOW scratch folder")
+	log.G(ctx).WithField("scratchFolder", scratchFolder).Debug("uvm::CreateWCOW scratch folder")
 
 	// Create the directory if it doesn't exist
 	if _, err := os.Stat(scratchFolder); os.IsNotExist(err) {
-		logrus.WithField("scratchFolder", scratchFolder).Debug("uvm::CreateWCOW creating folder")
+		log.G(ctx).WithField("scratchFolder", scratchFolder).Debug("uvm::CreateWCOW creating folder")
 		if err := os.MkdirAll(scratchFolder, 0777); err != nil {
 			return nil, fmt.Errorf("failed to create utility VM scratch folder: %s", err)
 		}
@@ -113,7 +115,7 @@ func CreateWCOW(opts *OptionsWCOW) (_ *UtilityVM, err error) {
 	// Create sandbox.vhdx in the scratch folder based on the template, granting the correct permissions to it
 	scratchPath := filepath.Join(scratchFolder, "sandbox.vhdx")
 	if _, err := os.Stat(scratchPath); os.IsNotExist(err) {
-		if err := wcow.CreateUVMScratch(uvmFolder, scratchFolder, uvm.id); err != nil {
+		if err := wcow.CreateUVMScratch(ctx, uvmFolder, scratchFolder, uvm.id); err != nil {
 			return nil, fmt.Errorf("failed to create scratch: %s", err)
 		}
 	}
@@ -203,7 +205,7 @@ func CreateWCOW(opts *OptionsWCOW) (_ *UtilityVM, err error) {
 		return nil, fmt.Errorf("failed to merge additional JSON '%s': %s", opts.AdditionHCSDocumentJSON, err)
 	}
 
-	err = uvm.create(fullDoc)
+	err = uvm.create(ctx, fullDoc)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/uvm/modify.go
+++ b/internal/uvm/modify.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/Microsoft/hcsshim/internal/log"
 	"github.com/Microsoft/hcsshim/internal/logfields"
 	"github.com/Microsoft/hcsshim/internal/requesttype"
 	hcsschema "github.com/Microsoft/hcsshim/internal/schema2"
@@ -11,51 +12,51 @@ import (
 )
 
 // Modify modifies the compute system by sending a request to HCS.
-func (uvm *UtilityVM) Modify(doc *hcsschema.ModifySettingRequest) (err error) {
+func (uvm *UtilityVM) Modify(ctx context.Context, doc *hcsschema.ModifySettingRequest) (err error) {
 	op := "uvm::Modify"
-	log := logrus.WithFields(logrus.Fields{
+	l := log.G(ctx).WithFields(logrus.Fields{
 		logfields.UVMID: uvm.id,
 	})
-	log.Debug(op + " - Begin Operation")
+	l.Debug(op + " - Begin Operation")
 	defer func() {
 		if err != nil {
-			log.Data[logrus.ErrorKey] = err
-			log.Error(op + " - End Operation - Error")
+			l.Data[logrus.ErrorKey] = err
+			l.Error(op + " - End Operation - Error")
 		} else {
-			log.Debug(op + " - End Operation - Success")
+			l.Debug(op + " - End Operation - Success")
 		}
 	}()
 
 	if doc.GuestRequest == nil || uvm.gc == nil {
-		return uvm.hcsSystem.Modify(doc)
+		return uvm.hcsSystem.Modify(ctx, doc)
 	}
 
 	hostdoc := *doc
 	hostdoc.GuestRequest = nil
 	if doc.ResourcePath != "" && doc.RequestType == requesttype.Add {
-		err = uvm.hcsSystem.Modify(&hostdoc)
+		err = uvm.hcsSystem.Modify(ctx, &hostdoc)
 		if err != nil {
 			return fmt.Errorf("adding VM resources: %s", err)
 		}
 		defer func() {
 			if err != nil {
 				hostdoc.RequestType = requesttype.Remove
-				rerr := uvm.hcsSystem.Modify(&hostdoc)
+				rerr := uvm.hcsSystem.Modify(ctx, &hostdoc)
 				if rerr != nil {
-					logrus.WithError(err).Error("failed to roll back resource add")
+					log.G(ctx).WithError(err).Error("failed to roll back resource add")
 				}
 			}
 		}()
 	}
-	err = uvm.gc.Modify(context.TODO(), doc.GuestRequest)
+	err = uvm.gc.Modify(ctx, doc.GuestRequest)
 	if err != nil {
 		return fmt.Errorf("guest modify: %s", err)
 	}
 	if doc.ResourcePath != "" && doc.RequestType == requesttype.Remove {
-		err = uvm.hcsSystem.Modify(&hostdoc)
+		err = uvm.hcsSystem.Modify(ctx, &hostdoc)
 		if err != nil {
 			err = fmt.Errorf("removing VM resources: %s", err)
-			logrus.WithError(err).Error("failed to remove host resources after successful guest request")
+			log.G(ctx).WithError(err).Error("failed to remove host resources after successful guest request")
 			return err
 		}
 	}

--- a/internal/uvm/network.go
+++ b/internal/uvm/network.go
@@ -1,6 +1,7 @@
 package uvm
 
 import (
+	"context"
 	"errors"
 	"path"
 
@@ -10,6 +11,7 @@ import (
 	"github.com/Microsoft/hcsshim/hcn"
 	"github.com/Microsoft/hcsshim/internal/guestrequest"
 	"github.com/Microsoft/hcsshim/internal/hns"
+	"github.com/Microsoft/hcsshim/internal/log"
 	"github.com/Microsoft/hcsshim/internal/logfields"
 	"github.com/Microsoft/hcsshim/internal/requesttype"
 	hcsschema "github.com/Microsoft/hcsshim/internal/schema2"
@@ -28,19 +30,19 @@ var (
 // AddNetNS adds network namespace inside the guest.
 //
 // If a namespace with `id` already exists returns `ErrNetNSAlreadyAttached`.
-func (uvm *UtilityVM) AddNetNS(id string) (err error) {
+func (uvm *UtilityVM) AddNetNS(ctx context.Context, id string) (err error) {
 	op := "uvm::AddNetNS"
-	log := logrus.WithFields(logrus.Fields{
+	l := log.G(ctx).WithFields(logrus.Fields{
 		logfields.UVMID: uvm.id,
 		"netns-id":      id,
 	})
-	log.Debug(op + " - Begin Operation")
+	l.Debug(op + " - Begin Operation")
 	defer func() {
 		if err != nil {
-			log.Data[logrus.ErrorKey] = err
-			log.Error(op + " - End Operation - Error")
+			l.Data[logrus.ErrorKey] = err
+			l.Error(op + " - End Operation - Error")
 		} else {
-			log.Debug(op + " - End Operation - Success")
+			l.Debug(op + " - End Operation - Success")
 		}
 	}()
 
@@ -65,7 +67,7 @@ func (uvm *UtilityVM) AddNetNS(id string) (err error) {
 					Settings:     hcnNamespace,
 				},
 			}
-			if err := uvm.Modify(&guestNamespace); err != nil {
+			if err := uvm.Modify(ctx, &guestNamespace); err != nil {
 				return err
 			}
 		}
@@ -85,19 +87,19 @@ func (uvm *UtilityVM) AddNetNS(id string) (err error) {
 // added endpoints.
 //
 // If no network namespace matches `id` returns `ErrNetNSNotFound`.
-func (uvm *UtilityVM) AddEndpointsToNS(id string, endpoints []*hns.HNSEndpoint) (err error) {
+func (uvm *UtilityVM) AddEndpointsToNS(ctx context.Context, id string, endpoints []*hns.HNSEndpoint) (err error) {
 	op := "uvm::AddEndpointsToNS"
-	log := logrus.WithFields(logrus.Fields{
+	l := log.G(ctx).WithFields(logrus.Fields{
 		logfields.UVMID: uvm.id,
 		"netns-id":      id,
 	})
-	log.Debug(op + " - Begin Operation")
+	l.Debug(op + " - Begin Operation")
 	defer func() {
 		if err != nil {
-			log.Data[logrus.ErrorKey] = err
-			log.Error(op + " - End Operation - Error")
+			l.Data[logrus.ErrorKey] = err
+			l.Error(op + " - End Operation - Error")
 		} else {
-			log.Debug(op + " - End Operation - Success")
+			l.Debug(op + " - End Operation - Success")
 		}
 	}()
 
@@ -115,7 +117,7 @@ func (uvm *UtilityVM) AddEndpointsToNS(id string, endpoints []*hns.HNSEndpoint) 
 			if err != nil {
 				return err
 			}
-			if err := uvm.addNIC(nicID, endpoint); err != nil {
+			if err := uvm.addNIC(ctx, nicID, endpoint); err != nil {
 				return err
 			}
 			ns.nics[endpoint.Id] = &nicInfo{
@@ -131,19 +133,19 @@ func (uvm *UtilityVM) AddEndpointsToNS(id string, endpoints []*hns.HNSEndpoint) 
 // the namespace.
 //
 // If a namespace matching `id` is not found this command silently succeeds.
-func (uvm *UtilityVM) RemoveNetNS(id string) (err error) {
+func (uvm *UtilityVM) RemoveNetNS(ctx context.Context, id string) (err error) {
 	op := "uvm::RemoveNetNS"
-	log := logrus.WithFields(logrus.Fields{
+	l := log.G(ctx).WithFields(logrus.Fields{
 		logfields.UVMID: uvm.id,
 		"netns-id":      id,
 	})
-	log.Debug(op + " - Begin Operation")
+	l.Debug(op + " - Begin Operation")
 	defer func() {
 		if err != nil {
-			log.Data[logrus.ErrorKey] = err
-			log.Error(op + " - End Operation - Error")
+			l.Data[logrus.ErrorKey] = err
+			l.Error(op + " - End Operation - Error")
 		} else {
-			log.Debug(op + " - End Operation - Success")
+			l.Debug(op + " - End Operation - Success")
 		}
 	}()
 
@@ -151,7 +153,7 @@ func (uvm *UtilityVM) RemoveNetNS(id string) (err error) {
 	defer uvm.m.Unlock()
 	if ns, ok := uvm.namespaces[id]; ok {
 		for _, ninfo := range ns.nics {
-			if err := uvm.removeNIC(ninfo.ID, ninfo.Endpoint); err != nil {
+			if err := uvm.removeNIC(ctx, ninfo.ID, ninfo.Endpoint); err != nil {
 				return err
 			}
 			ns.nics[ninfo.Endpoint.Id] = nil
@@ -170,7 +172,7 @@ func (uvm *UtilityVM) RemoveNetNS(id string) (err error) {
 						Settings:     hcnNamespace,
 					},
 				}
-				if err := uvm.Modify(&guestNamespace); err != nil {
+				if err := uvm.Modify(ctx, &guestNamespace); err != nil {
 					return err
 				}
 			}
@@ -185,19 +187,19 @@ func (uvm *UtilityVM) RemoveNetNS(id string) (err error) {
 // the network namespace this command silently succeeds.
 //
 // If no network namespace matches `id` returns `ErrNetNSNotFound`.
-func (uvm *UtilityVM) RemoveEndpointsFromNS(id string, endpoints []*hns.HNSEndpoint) (err error) {
+func (uvm *UtilityVM) RemoveEndpointsFromNS(ctx context.Context, id string, endpoints []*hns.HNSEndpoint) (err error) {
 	op := "uvm::RemoveEndpointsFromNS"
-	log := logrus.WithFields(logrus.Fields{
+	l := log.G(ctx).WithFields(logrus.Fields{
 		logfields.UVMID: uvm.id,
 		"netns-id":      id,
 	})
-	log.Debug(op + " - Begin Operation")
+	l.Debug(op + " - Begin Operation")
 	defer func() {
 		if err != nil {
-			log.Data[logrus.ErrorKey] = err
-			log.Error(op + " - End Operation - Error")
+			l.Data[logrus.ErrorKey] = err
+			l.Error(op + " - End Operation - Error")
 		} else {
-			log.Debug(op + " - End Operation - Success")
+			l.Debug(op + " - End Operation - Success")
 		}
 	}()
 
@@ -211,7 +213,7 @@ func (uvm *UtilityVM) RemoveEndpointsFromNS(id string, endpoints []*hns.HNSEndpo
 
 	for _, endpoint := range endpoints {
 		if ninfo, ok := ns.nics[endpoint.Id]; ok && ninfo != nil {
-			if err := uvm.removeNIC(ninfo.ID, ninfo.Endpoint); err != nil {
+			if err := uvm.removeNIC(ctx, ninfo.ID, ninfo.Endpoint); err != nil {
 				return err
 			}
 			delete(ns.nics, endpoint.Id)
@@ -240,7 +242,7 @@ func getNetworkModifyRequest(adapterID string, requestType string, settings inte
 	}
 }
 
-func (uvm *UtilityVM) addNIC(id guid.GUID, endpoint *hns.HNSEndpoint) error {
+func (uvm *UtilityVM) addNIC(ctx context.Context, id guid.GUID, endpoint *hns.HNSEndpoint) error {
 
 	// First a pre-add. This is a guest-only request and is only done on Windows.
 	if uvm.operatingSystem == "windows" {
@@ -254,7 +256,7 @@ func (uvm *UtilityVM) addNIC(id guid.GUID, endpoint *hns.HNSEndpoint) error {
 					endpoint),
 			},
 		}
-		if err := uvm.Modify(&preAddRequest); err != nil {
+		if err := uvm.Modify(ctx, &preAddRequest); err != nil {
 			return err
 		}
 	}
@@ -300,14 +302,14 @@ func (uvm *UtilityVM) addNIC(id guid.GUID, endpoint *hns.HNSEndpoint) error {
 		}
 	}
 
-	if err := uvm.Modify(&request); err != nil {
+	if err := uvm.Modify(ctx, &request); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-func (uvm *UtilityVM) removeNIC(id guid.GUID, endpoint *hns.HNSEndpoint) error {
+func (uvm *UtilityVM) removeNIC(ctx context.Context, id guid.GUID, endpoint *hns.HNSEndpoint) error {
 	request := hcsschema.ModifySettingRequest{
 		RequestType:  requesttype.Remove,
 		ResourcePath: path.Join("VirtualMachine/Devices/NetworkAdapters", id.String()),
@@ -339,7 +341,7 @@ func (uvm *UtilityVM) removeNIC(id guid.GUID, endpoint *hns.HNSEndpoint) error {
 		}
 	}
 
-	if err := uvm.Modify(&request); err != nil {
+	if err := uvm.Modify(ctx, &request); err != nil {
 		return err
 	}
 	return nil

--- a/internal/uvm/scsi.go
+++ b/internal/uvm/scsi.go
@@ -1,9 +1,11 @@
 package uvm
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/Microsoft/hcsshim/internal/guestrequest"
+	"github.com/Microsoft/hcsshim/internal/log"
 	"github.com/Microsoft/hcsshim/internal/logfields"
 	"github.com/Microsoft/hcsshim/internal/requesttype"
 	hcsschema "github.com/Microsoft/hcsshim/internal/schema2"
@@ -23,7 +25,7 @@ var (
 // allocateSCSI finds the next available slot on the
 // SCSI controllers associated with a utility VM to use.
 // Lock must be held when calling this function
-func (uvm *UtilityVM) allocateSCSI(hostPath string, uvmPath string, isLayer bool) (int, int32, error) {
+func (uvm *UtilityVM) allocateSCSI(ctx context.Context, hostPath string, uvmPath string, isLayer bool) (int, int32, error) {
 	for controller, luns := range uvm.scsiLocations {
 		for lun, si := range luns {
 			if si.hostPath == "" {
@@ -33,7 +35,7 @@ func (uvm *UtilityVM) allocateSCSI(hostPath string, uvmPath string, isLayer bool
 				if isLayer {
 					uvm.scsiLocations[controller][lun].refCount = 1
 				}
-				logrus.WithFields(logrus.Fields{
+				log.G(ctx).WithFields(logrus.Fields{
 					logfields.UVMID: uvm.id,
 					"host-path":     hostPath,
 					"uvm-path":      uvmPath,
@@ -50,13 +52,13 @@ func (uvm *UtilityVM) allocateSCSI(hostPath string, uvmPath string, isLayer bool
 	return -1, -1, ErrNoAvailableLocation
 }
 
-func (uvm *UtilityVM) deallocateSCSI(controller int, lun int32) {
+func (uvm *UtilityVM) deallocateSCSI(ctx context.Context, controller int, lun int32) {
 	uvm.m.Lock()
 	defer uvm.m.Unlock()
 	si := uvm.scsiLocations[controller][lun]
 	if si.hostPath != "" {
 		uvm.scsiLocations[controller][lun] = scsiInfo{}
-		logrus.WithFields(logrus.Fields{
+		log.G(ctx).WithFields(logrus.Fields{
 			logfields.UVMID: uvm.id,
 			"host-path":     si.hostPath,
 			"uvm-path":      si.uvmPath,
@@ -69,11 +71,11 @@ func (uvm *UtilityVM) deallocateSCSI(controller int, lun int32) {
 }
 
 // Lock must be held when calling this function.
-func (uvm *UtilityVM) findSCSIAttachment(findThisHostPath string) (int, int32, string, error) {
+func (uvm *UtilityVM) findSCSIAttachment(ctx context.Context, findThisHostPath string) (int, int32, string, error) {
 	for controller, luns := range uvm.scsiLocations {
 		for lun, si := range luns {
 			if si.hostPath == findThisHostPath {
-				logrus.WithFields(logrus.Fields{
+				log.G(ctx).WithFields(logrus.Fields{
 					logfields.UVMID: uvm.id,
 					"host-path":     findThisHostPath,
 					"uvm-path":      si.uvmPath,
@@ -99,25 +101,25 @@ func (uvm *UtilityVM) findSCSIAttachment(findThisHostPath string) (int, int32, s
 // `uvmPath` is optional.
 //
 // `readOnly` set to `true` if the vhd/vhdx should be attached read only.
-func (uvm *UtilityVM) AddSCSI(hostPath string, uvmPath string, readOnly bool) (_ int, _ int32, err error) {
+func (uvm *UtilityVM) AddSCSI(ctx context.Context, hostPath string, uvmPath string, readOnly bool) (_ int, _ int32, err error) {
 	op := "uvm::AddSCSI"
-	log := logrus.WithFields(logrus.Fields{
+	l := log.G(ctx).WithFields(logrus.Fields{
 		logfields.UVMID: uvm.id,
 		"host-path":     hostPath,
 		"uvm-path":      uvmPath,
 		"readOnly":      readOnly,
 	})
-	log.Debug(op + " - Begin Operation")
+	l.Debug(op + " - Begin Operation")
 	defer func() {
 		if err != nil {
-			log.Data[logrus.ErrorKey] = err
-			log.Error(op + " - End Operation - Error")
+			l.Data[logrus.ErrorKey] = err
+			l.Error(op + " - End Operation - Error")
 		} else {
-			log.Debug(op + " - End Operation - Success")
+			l.Debug(op + " - End Operation - Success")
 		}
 	}()
 
-	return uvm.addSCSIActual(hostPath, uvmPath, "VirtualDisk", false, readOnly)
+	return uvm.addSCSIActual(ctx, hostPath, uvmPath, "VirtualDisk", false, readOnly)
 }
 
 // AddSCSIPhysicalDisk attaches a physical disk from the host directly to the
@@ -128,43 +130,43 @@ func (uvm *UtilityVM) AddSCSI(hostPath string, uvmPath string, readOnly bool) (_
 // `uvmPath` is optional if a guest mount is not requested.
 //
 // `readOnly` set to `true` if the physical disk should be attached read only.
-func (uvm *UtilityVM) AddSCSIPhysicalDisk(hostPath, uvmPath string, readOnly bool) (_ int, _ int32, err error) {
+func (uvm *UtilityVM) AddSCSIPhysicalDisk(ctx context.Context, hostPath, uvmPath string, readOnly bool) (_ int, _ int32, err error) {
 	op := "uvm::AddSCSIPhysicalDisk"
-	log := logrus.WithFields(logrus.Fields{
+	l := log.G(ctx).WithFields(logrus.Fields{
 		logfields.UVMID: uvm.id,
 		"host-path":     hostPath,
 		"uvm-path":      uvmPath,
 		"readOnly":      readOnly,
 	})
-	log.Debug(op + " - Begin Operation")
+	l.Debug(op + " - Begin Operation")
 	defer func() {
 		if err != nil {
-			log.Data[logrus.ErrorKey] = err
-			log.Error(op + " - End Operation - Error")
+			l.Data[logrus.ErrorKey] = err
+			l.Error(op + " - End Operation - Error")
 		} else {
-			log.Debug(op + " - End Operation - Success")
+			l.Debug(op + " - End Operation - Success")
 		}
 	}()
 
-	return uvm.addSCSIActual(hostPath, uvmPath, "PassThru", false, readOnly)
+	return uvm.addSCSIActual(ctx, hostPath, uvmPath, "PassThru", false, readOnly)
 }
 
 // AddSCSILayer adds a read-only layer disk to a utility VM at the next available
 // location. This function is used by LCOW as an alternate to PMEM for large layers.
 // The UVMPath will always be /tmp/S<controller>/<lun>.
-func (uvm *UtilityVM) AddSCSILayer(hostPath string) (_ int, _ int32, err error) {
+func (uvm *UtilityVM) AddSCSILayer(ctx context.Context, hostPath string) (_ int, _ int32, err error) {
 	op := "uvm::AddSCSILayer"
-	log := logrus.WithFields(logrus.Fields{
+	l := log.G(ctx).WithFields(logrus.Fields{
 		logfields.UVMID: uvm.id,
 		"host-path":     hostPath,
 	})
-	log.Debug(op + " - Begin Operation")
+	l.Debug(op + " - Begin Operation")
 	defer func() {
 		if err != nil {
-			log.Data[logrus.ErrorKey] = err
-			log.Error(op + " - End Operation - Error")
+			l.Data[logrus.ErrorKey] = err
+			l.Error(op + " - End Operation - Error")
 		} else {
-			log.Debug(op + " - End Operation - Success")
+			l.Debug(op + " - End Operation - Success")
 		}
 	}()
 
@@ -172,7 +174,7 @@ func (uvm *UtilityVM) AddSCSILayer(hostPath string) (_ int, _ int32, err error) 
 		return -1, -1, ErrSCSILayerWCOWUnsupported
 	}
 
-	return uvm.addSCSIActual(hostPath, "", "VirtualDisk", true, true)
+	return uvm.addSCSIActual(ctx, hostPath, "", "VirtualDisk", true, true)
 }
 
 // addSCSIActual is the implementation behind the external functions AddSCSI and
@@ -195,7 +197,7 @@ func (uvm *UtilityVM) AddSCSILayer(hostPath string) (_ int, _ int32, err error) 
 // `readOnly` indicates the attachment should be added read only.
 //
 // Returns the controller ID (0..3) and LUN (0..63) where the disk is attached.
-func (uvm *UtilityVM) addSCSIActual(hostPath, uvmPath, attachmentType string, isLayer, readOnly bool) (_ int, _ int32, err error) {
+func (uvm *UtilityVM) addSCSIActual(ctx context.Context, hostPath, uvmPath, attachmentType string, isLayer, readOnly bool) (_ int, _ int32, err error) {
 	if uvm.scsiControllerCount == 0 {
 		return -1, -1, ErrNoSCSIControllers
 	}
@@ -213,7 +215,7 @@ func (uvm *UtilityVM) addSCSIActual(hostPath, uvmPath, attachmentType string, is
 	// these two operations. All failure paths between these two must release
 	// the lock.
 	uvm.m.Lock()
-	if controller, lun, _, err := uvm.findSCSIAttachment(hostPath); err == nil {
+	if controller, lun, _, err := uvm.findSCSIAttachment(ctx, hostPath); err == nil {
 		// So is attached
 		if isLayer {
 			// Increment the refcount
@@ -228,14 +230,14 @@ func (uvm *UtilityVM) addSCSIActual(hostPath, uvmPath, attachmentType string, is
 
 	// At this point, we know it's not attached, regardless of whether it's a
 	// ref-counted layer VHD, or not.
-	controller, lun, err := uvm.allocateSCSI(hostPath, uvmPath, isLayer)
+	controller, lun, err := uvm.allocateSCSI(ctx, hostPath, uvmPath, isLayer)
 	if err != nil {
 		uvm.m.Unlock()
 		return -1, -1, err
 	}
 	defer func() {
 		if err != nil {
-			uvm.deallocateSCSI(controller, lun)
+			uvm.deallocateSCSI(ctx, controller, lun)
 		}
 	}()
 
@@ -286,7 +288,7 @@ func (uvm *UtilityVM) addSCSIActual(hostPath, uvmPath, attachmentType string, is
 		}
 	}
 
-	if err := uvm.Modify(SCSIModification); err != nil {
+	if err := uvm.Modify(ctx, SCSIModification); err != nil {
 		return -1, -1, fmt.Errorf("uvm::AddSCSI: failed to modify utility VM configuration: %s", err)
 	}
 	return controller, lun, nil
@@ -294,19 +296,19 @@ func (uvm *UtilityVM) addSCSIActual(hostPath, uvmPath, attachmentType string, is
 }
 
 // RemoveSCSI removes a SCSI disk from a utility VM.
-func (uvm *UtilityVM) RemoveSCSI(hostPath string) (err error) {
+func (uvm *UtilityVM) RemoveSCSI(ctx context.Context, hostPath string) (err error) {
 	op := "uvm::RemoveSCSI"
-	log := logrus.WithFields(logrus.Fields{
+	l := log.G(ctx).WithFields(logrus.Fields{
 		logfields.UVMID: uvm.id,
 		"host-path":     hostPath,
 	})
-	log.Debug(op + " - Begin Operation")
+	l.Debug(op + " - Begin Operation")
 	defer func() {
 		if err != nil {
-			log.Data[logrus.ErrorKey] = err
-			log.Error(op + " - End Operation - Error")
+			l.Data[logrus.ErrorKey] = err
+			l.Error(op + " - End Operation - Error")
 		} else {
-			log.Debug(op + " - End Operation - Success")
+			l.Debug(op + " - End Operation - Success")
 		}
 	}()
 
@@ -318,7 +320,7 @@ func (uvm *UtilityVM) RemoveSCSI(hostPath string) (err error) {
 	}
 
 	// Make sure is actually attached
-	controller, lun, uvmPath, err := uvm.findSCSIAttachment(hostPath)
+	controller, lun, uvmPath, err := uvm.findSCSIAttachment(ctx, hostPath)
 	if err != nil {
 		return err
 	}
@@ -362,7 +364,7 @@ func (uvm *UtilityVM) RemoveSCSI(hostPath string) (err error) {
 		}
 	}
 
-	if err := uvm.Modify(scsiModification); err != nil {
+	if err := uvm.Modify(ctx, scsiModification); err != nil {
 		return fmt.Errorf("failed to remove SCSI disk %s from container %s: %s", hostPath, uvm.id, err)
 	}
 	uvm.scsiLocations[controller][lun] = scsiInfo{}
@@ -372,25 +374,25 @@ func (uvm *UtilityVM) RemoveSCSI(hostPath string) (err error) {
 // GetScsiUvmPath returns the guest mounted path of a SCSI drive.
 //
 // If `hostPath` is not mounted returns `ErrNotAttached`.
-func (uvm *UtilityVM) GetScsiUvmPath(hostPath string) (_ string, err error) {
+func (uvm *UtilityVM) GetScsiUvmPath(ctx context.Context, hostPath string) (_ string, err error) {
 	op := "uvm::GetScsiUvmPath"
-	log := logrus.WithFields(logrus.Fields{
+	l := logrus.WithFields(logrus.Fields{
 		logfields.UVMID: uvm.id,
 		"host-path":     hostPath,
 	})
-	log.Debug(op + " - Begin Operation")
+	l.Debug(op + " - Begin Operation")
 	defer func() {
 		if err != nil {
-			log.Data[logrus.ErrorKey] = err
-			log.Error(op + " - End Operation - Error")
+			l.Data[logrus.ErrorKey] = err
+			l.Error(op + " - End Operation - Error")
 		} else {
-			log.Debug(op + " - End Operation - Success")
+			l.Debug(op + " - End Operation - Success")
 		}
 	}()
 
 	uvm.m.Lock()
 	defer uvm.m.Unlock()
 
-	_, _, uvmPath, err := uvm.findSCSIAttachment(hostPath)
+	_, _, uvmPath, err := uvm.findSCSIAttachment(ctx, hostPath)
 	return uvmPath, err
 }

--- a/internal/uvm/vpmem.go
+++ b/internal/uvm/vpmem.go
@@ -1,9 +1,11 @@
 package uvm
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/Microsoft/hcsshim/internal/guestrequest"
+	"github.com/Microsoft/hcsshim/internal/log"
 	"github.com/Microsoft/hcsshim/internal/logfields"
 	"github.com/Microsoft/hcsshim/internal/requesttype"
 	hcsschema "github.com/Microsoft/hcsshim/internal/schema2"
@@ -12,11 +14,11 @@ import (
 
 // allocateVPMEM finds the next available VPMem slot. The lock MUST be held
 // when calling this function.
-func (uvm *UtilityVM) allocateVPMEM(hostPath string) (uint32, error) {
+func (uvm *UtilityVM) allocateVPMEM(ctx context.Context, hostPath string) (uint32, error) {
 	for index, vi := range uvm.vpmemDevices {
 		if vi.hostPath == "" {
 			vi.hostPath = hostPath
-			logrus.WithFields(logrus.Fields{
+			log.G(ctx).WithFields(logrus.Fields{
 				logfields.UVMID: uvm.id,
 				"host-path":     vi.hostPath,
 				"uvm-path":      vi.uvmPath,
@@ -29,29 +31,11 @@ func (uvm *UtilityVM) allocateVPMEM(hostPath string) (uint32, error) {
 	return 0, fmt.Errorf("no free VPMEM locations")
 }
 
-func (uvm *UtilityVM) deallocateVPMEM(deviceNumber uint32) error {
-	uvm.m.Lock()
-	defer uvm.m.Unlock()
-	vi := uvm.vpmemDevices[deviceNumber]
-	if vi.hostPath != "" {
-		logrus.WithFields(logrus.Fields{
-			logfields.UVMID: uvm.id,
-			"host-path":     vi.hostPath,
-			"uvm-path":      vi.uvmPath,
-			"refCount":      vi.refCount,
-			"deviceNumber":  deviceNumber,
-		}).Debug("uvm::deallocateVPMEM")
-		uvm.vpmemDevices[deviceNumber] = vpmemInfo{}
-	}
-
-	return nil
-}
-
 // Lock must be held when calling this function
-func (uvm *UtilityVM) findVPMEMDevice(findThisHostPath string) (uint32, string, error) {
+func (uvm *UtilityVM) findVPMEMDevice(ctx context.Context, findThisHostPath string) (uint32, string, error) {
 	for deviceNumber, vi := range uvm.vpmemDevices {
 		if vi.hostPath == findThisHostPath {
-			logrus.WithFields(logrus.Fields{
+			log.G(ctx).WithFields(logrus.Fields{
 				logfields.UVMID: uvm.id,
 				"host-path":     findThisHostPath,
 				"uvm-path":      vi.uvmPath,
@@ -68,20 +52,20 @@ func (uvm *UtilityVM) findVPMEMDevice(findThisHostPath string) (uint32, string, 
 //
 // Returns the location(0..MaxVPMEM-1) where the device is attached, and if exposed,
 // the utility VM path which will be /tmp/p<location>//
-func (uvm *UtilityVM) AddVPMEM(hostPath string, expose bool) (_ uint32, _ string, err error) {
+func (uvm *UtilityVM) AddVPMEM(ctx context.Context, hostPath string, expose bool) (_ uint32, _ string, err error) {
 	op := "uvm::AddVPMEM"
-	log := logrus.WithFields(logrus.Fields{
+	l := log.G(ctx).WithFields(logrus.Fields{
 		logfields.UVMID: uvm.id,
 		"host-path":     hostPath,
 		"expose":        expose,
 	})
-	log.Debug(op + " - Begin Operation")
+	l.Debug(op + " - Begin Operation")
 	defer func() {
 		if err != nil {
-			log.Data[logrus.ErrorKey] = err
-			log.Error(op + " - End Operation - Error")
+			l.Data[logrus.ErrorKey] = err
+			l.Error(op + " - End Operation - Error")
 		} else {
-			log.Debug(op + " - End Operation - Success")
+			l.Debug(op + " - End Operation - Success")
 		}
 	}()
 
@@ -95,10 +79,10 @@ func (uvm *UtilityVM) AddVPMEM(hostPath string, expose bool) (_ uint32, _ string
 	var deviceNumber uint32
 	uvmPath := ""
 
-	deviceNumber, uvmPath, err = uvm.findVPMEMDevice(hostPath)
+	deviceNumber, uvmPath, err = uvm.findVPMEMDevice(ctx, hostPath)
 	if err != nil {
 		// It doesn't exist, so we're going to allocate and hot-add it
-		deviceNumber, err = uvm.allocateVPMEM(hostPath)
+		deviceNumber, err = uvm.allocateVPMEM(ctx, hostPath)
 		if err != nil {
 			return 0, "", err
 		}
@@ -125,7 +109,7 @@ func (uvm *UtilityVM) AddVPMEM(hostPath string, expose bool) (_ uint32, _ string
 			}
 		}
 
-		if err := uvm.Modify(modification); err != nil {
+		if err := uvm.Modify(ctx, modification); err != nil {
 			uvm.vpmemDevices[deviceNumber] = vpmemInfo{}
 			return 0, "", fmt.Errorf("uvm::AddVPMEM: failed to modify utility VM configuration: %s", err)
 		}
@@ -141,7 +125,7 @@ func (uvm *UtilityVM) AddVPMEM(hostPath string, expose bool) (_ uint32, _ string
 			uvmPath:  uvmPath}
 		uvm.vpmemDevices[deviceNumber] = pmemi
 	}
-	logrus.WithFields(logrus.Fields{
+	log.G(ctx).WithFields(logrus.Fields{
 		logfields.UVMID: uvm.id,
 		"device":        fmt.Sprintf("%+v", uvm.vpmemDevices[deviceNumber]),
 	}).Debug("hcsshim::AddVPMEM Success")
@@ -149,19 +133,19 @@ func (uvm *UtilityVM) AddVPMEM(hostPath string, expose bool) (_ uint32, _ string
 }
 
 // RemoveVPMEM removes a VPMEM disk from a utility VM.
-func (uvm *UtilityVM) RemoveVPMEM(hostPath string) (err error) {
+func (uvm *UtilityVM) RemoveVPMEM(ctx context.Context, hostPath string) (err error) {
 	op := "uvm::RemoveVPMEM"
-	log := logrus.WithFields(logrus.Fields{
+	l := log.G(ctx).WithFields(logrus.Fields{
 		logfields.UVMID: uvm.id,
 		"host-path":     hostPath,
 	})
-	log.Debug(op + " - Begin Operation")
+	l.Debug(op + " - Begin Operation")
 	defer func() {
 		if err != nil {
-			log.Data[logrus.ErrorKey] = err
-			log.Error(op + " - End Operation - Error")
+			l.Data[logrus.ErrorKey] = err
+			l.Error(op + " - End Operation - Error")
 		} else {
-			log.Debug(op + " - End Operation - Success")
+			l.Debug(op + " - End Operation - Success")
 		}
 	}()
 
@@ -173,7 +157,7 @@ func (uvm *UtilityVM) RemoveVPMEM(hostPath string) (err error) {
 	defer uvm.m.Unlock()
 
 	// Make sure is actually attached
-	deviceNumber, uvmPath, err := uvm.findVPMEMDevice(hostPath)
+	deviceNumber, uvmPath, err := uvm.findVPMEMDevice(ctx, hostPath)
 	if err != nil {
 		return fmt.Errorf("cannot remove VPMEM %s as it is not attached to utility VM %s: %s", hostPath, uvm.id, err)
 	}
@@ -192,7 +176,7 @@ func (uvm *UtilityVM) RemoveVPMEM(hostPath string) (err error) {
 			},
 		}
 
-		if err := uvm.Modify(modification); err != nil {
+		if err := uvm.Modify(ctx, modification); err != nil {
 			return fmt.Errorf("failed to remove VPMEM %s from utility VM %s: %s", hostPath, uvm.id, err)
 		}
 		uvm.vpmemDevices[deviceNumber] = vpmemInfo{}

--- a/internal/uvmfolder/locate.go
+++ b/internal/uvmfolder/locate.go
@@ -1,10 +1,12 @@
 package uvmfolder
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
 
+	"github.com/Microsoft/hcsshim/internal/log"
 	"github.com/sirupsen/logrus"
 )
 
@@ -13,7 +15,7 @@ import (
 // Read-only-layers followed by an optional read-write layer. The RO layers are in reverse
 // order so that the upper-most RO layer is at the start, and the base OS layer is the
 // end.
-func LocateUVMFolder(layerFolders []string) (string, error) {
+func LocateUVMFolder(ctx context.Context, layerFolders []string) (string, error) {
 	var uvmFolder string
 	index := 0
 	for _, layerFolder := range layerFolders {
@@ -30,7 +32,7 @@ func LocateUVMFolder(layerFolders []string) (string, error) {
 	if uvmFolder == "" {
 		return "", fmt.Errorf("utility VM folder could not be found in layers")
 	}
-	logrus.WithFields(logrus.Fields{
+	log.G(ctx).WithFields(logrus.Fields{
 		"index":  index + 1,
 		"count":  len(layerFolders),
 		"folder": uvmFolder,

--- a/internal/wcow/scratch.go
+++ b/internal/wcow/scratch.go
@@ -1,20 +1,22 @@
 package wcow
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 
 	"github.com/Microsoft/hcsshim/internal/copyfile"
+	"github.com/Microsoft/hcsshim/internal/log"
 	"github.com/Microsoft/hcsshim/internal/wclayer"
 	"github.com/sirupsen/logrus"
 )
 
 // CreateUVMScratch is a helper to create a scratch for a Windows utility VM
 // with permissions to the specified VM ID in a specified directory
-func CreateUVMScratch(imagePath, destDirectory, vmID string) error {
+func CreateUVMScratch(ctx context.Context, imagePath, destDirectory, vmID string) error {
 	sourceScratch := filepath.Join(imagePath, `UtilityVM\SystemTemplate.vhdx`)
 	targetScratch := filepath.Join(destDirectory, "sandbox.vhdx")
-	logrus.WithFields(logrus.Fields{
+	log.G(ctx).WithFields(logrus.Fields{
 		"target": targetScratch,
 		"source": sourceScratch,
 	}).Debug("uvm::CreateUVMScratch")

--- a/process.go
+++ b/process.go
@@ -1,6 +1,7 @@
 package hcsshim
 
 import (
+	"context"
 	"io"
 	"sync"
 	"time"
@@ -23,7 +24,7 @@ func (process *process) Pid() int {
 
 // Kill signals the process to terminate but does not wait for it to finish terminating.
 func (process *process) Kill() error {
-	found, err := process.p.Kill()
+	found, err := process.p.Kill(context.Background())
 	if err != nil {
 		return convertProcessError(err, process)
 	}
@@ -70,7 +71,7 @@ func (process *process) ExitCode() (int, error) {
 
 // ResizeConsole resizes the console of the process.
 func (process *process) ResizeConsole(width, height uint16) error {
-	return convertProcessError(process.p.ResizeConsole(width, height), process)
+	return convertProcessError(process.p.ResizeConsole(context.Background(), width, height), process)
 }
 
 // Stdio returns the stdin, stdout, and stderr pipes, respectively. Closing
@@ -87,7 +88,7 @@ func (process *process) Stdio() (io.WriteCloser, io.ReadCloser, io.ReadCloser, e
 // CloseStdin closes the write side of the stdin pipe so that the process is
 // notified on the read side that there is no more data in stdin.
 func (process *process) CloseStdin() error {
-	return convertProcessError(process.p.CloseStdin(), process)
+	return convertProcessError(process.p.CloseStdin(context.Background()), process)
 }
 
 // Close cleans up any state associated with the process but does not kill

--- a/test/functional/test.go
+++ b/test/functional/test.go
@@ -1,6 +1,7 @@
 package functional
 
 import (
+	"context"
 	"os"
 	"os/exec"
 	"strconv"
@@ -33,15 +34,15 @@ func init() {
 
 }
 
-func CreateContainerTestWrapper(options *hcsoci.CreateOptions) (cow.Container, *hcsoci.Resources, error) {
+func CreateContainerTestWrapper(ctx context.Context, options *hcsoci.CreateOptions) (cow.Container, *hcsoci.Resources, error) {
 	if pauseDurationOnCreateContainerFailure != 0 {
 		options.DoNotReleaseResourcesOnFailure = true
 	}
-	s, r, err := hcsoci.CreateContainer(options)
+	s, r, err := hcsoci.CreateContainer(ctx, options)
 	if err != nil {
 		logrus.Warnf("Test is pausing for %s for debugging CreateContainer failure", pauseDurationOnCreateContainerFailure)
 		time.Sleep(pauseDurationOnCreateContainerFailure)
-		hcsoci.ReleaseResources(r, options.HostingSystem, true)
+		hcsoci.ReleaseResources(ctx, r, options.HostingSystem, true)
 	}
 	return s, r, err
 }

--- a/test/functional/utilities/createuvm.go
+++ b/test/functional/utilities/createuvm.go
@@ -1,6 +1,7 @@
 package testutilities
 
 import (
+	"context"
 	"os"
 	"testing"
 
@@ -9,22 +10,22 @@ import (
 
 // CreateWCOWUVM creates a WCOW utility VM with all default options. Returns the
 // UtilityVM object; folder used as its scratch
-func CreateWCOWUVM(t *testing.T, id, image string) (*uvm.UtilityVM, []string, string) {
-	return CreateWCOWUVMFromOptsWithImage(t, uvm.NewDefaultOptionsWCOW(id, ""), image)
+func CreateWCOWUVM(ctx context.Context, t *testing.T, id, image string) (*uvm.UtilityVM, []string, string) {
+	return CreateWCOWUVMFromOptsWithImage(ctx, t, uvm.NewDefaultOptionsWCOW(id, ""), image)
 
 }
 
 // CreateWCOWUVMFromOpts creates a WCOW utility VM with the passed opts.
-func CreateWCOWUVMFromOpts(t *testing.T, opts *uvm.OptionsWCOW) *uvm.UtilityVM {
+func CreateWCOWUVMFromOpts(ctx context.Context, t *testing.T, opts *uvm.OptionsWCOW) *uvm.UtilityVM {
 	if opts == nil || len(opts.LayerFolders) < 2 {
 		t.Fatalf("opts must bet set with LayerFolders")
 	}
 
-	uvm, err := uvm.CreateWCOW(opts)
+	uvm, err := uvm.CreateWCOW(ctx, opts)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := uvm.Start(); err != nil {
+	if err := uvm.Start(ctx); err != nil {
 		uvm.Close()
 		t.Fatal(err)
 	}
@@ -34,7 +35,7 @@ func CreateWCOWUVMFromOpts(t *testing.T, opts *uvm.OptionsWCOW) *uvm.UtilityVM {
 // CreateWCOWUVMFromOptsWithImage creates a WCOW utility VM with the passed opts
 // builds the LayerFolders based on `image`. Returns the UtilityVM object;
 // folder used as its scratch
-func CreateWCOWUVMFromOptsWithImage(t *testing.T, opts *uvm.OptionsWCOW, image string) (*uvm.UtilityVM, []string, string) {
+func CreateWCOWUVMFromOptsWithImage(ctx context.Context, t *testing.T, opts *uvm.OptionsWCOW, image string) (*uvm.UtilityVM, []string, string) {
 	if opts == nil {
 		t.Fatal("opts must be set")
 	}
@@ -50,25 +51,25 @@ func CreateWCOWUVMFromOptsWithImage(t *testing.T, opts *uvm.OptionsWCOW, image s
 	opts.LayerFolders = append(opts.LayerFolders, uvmLayers...)
 	opts.LayerFolders = append(opts.LayerFolders, scratchDir)
 
-	return CreateWCOWUVMFromOpts(t, opts), uvmLayers, scratchDir
+	return CreateWCOWUVMFromOpts(ctx, t, opts), uvmLayers, scratchDir
 }
 
 // CreateLCOWUVM with all default options.
-func CreateLCOWUVM(t *testing.T, id string) *uvm.UtilityVM {
-	return CreateLCOWUVMFromOpts(t, uvm.NewDefaultOptionsLCOW(id, ""))
+func CreateLCOWUVM(ctx context.Context, t *testing.T, id string) *uvm.UtilityVM {
+	return CreateLCOWUVMFromOpts(ctx, t, uvm.NewDefaultOptionsLCOW(id, ""))
 }
 
 // CreateLCOWUVMFromOpts creates an LCOW utility VM with the specified options.
-func CreateLCOWUVMFromOpts(t *testing.T, opts *uvm.OptionsLCOW) *uvm.UtilityVM {
+func CreateLCOWUVMFromOpts(ctx context.Context, t *testing.T, opts *uvm.OptionsLCOW) *uvm.UtilityVM {
 	if opts == nil {
 		t.Fatal("opts must be set")
 	}
 
-	uvm, err := uvm.CreateLCOW(opts)
+	uvm, err := uvm.CreateLCOW(ctx, opts)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := uvm.Start(); err != nil {
+	if err := uvm.Start(ctx); err != nil {
 		uvm.Close()
 		t.Fatal(err)
 	}

--- a/test/functional/utilities/scratch.go
+++ b/test/functional/utilities/scratch.go
@@ -1,6 +1,7 @@
 package testutilities
 
 import (
+	"context"
 	"path/filepath"
 	"testing"
 
@@ -18,8 +19,8 @@ var (
 )
 
 func init() {
-	if hcsSystem, err := hcs.OpenComputeSystem(lcowGlobalSVMID); err == nil {
-		hcsSystem.Terminate()
+	if hcsSystem, err := hcs.OpenComputeSystem(context.Background(), lcowGlobalSVMID); err == nil {
+		hcsSystem.Terminate(context.Background())
 	}
 }
 
@@ -44,14 +45,14 @@ func CreateWCOWBlankRWLayer(t *testing.T, imageLayers []string) string {
 // CreateLCOWBlankRWLayer uses an LCOW utility VM to create a blank VHDX and
 // format it ext4. This can then be used as a scratch space for a container, or
 // for a "service VM".
-func CreateLCOWBlankRWLayer(t *testing.T) string {
+func CreateLCOWBlankRWLayer(ctx context.Context, t *testing.T) string {
 	if lcowGlobalSVM == nil {
-		lcowGlobalSVM = CreateLCOWUVM(t, lcowGlobalSVMID)
+		lcowGlobalSVM = CreateLCOWUVM(ctx, t, lcowGlobalSVMID)
 		lcowCacheScratchFile = filepath.Join(CreateTempDir(t), "sandbox.vhdx")
 	}
 	tempDir := CreateTempDir(t)
 
-	if err := lcow.CreateScratch(lcowGlobalSVM, filepath.Join(tempDir, "sandbox.vhdx"), lcow.DefaultScratchSizeGB, lcowCacheScratchFile); err != nil {
+	if err := lcow.CreateScratch(ctx, lcowGlobalSVM, filepath.Join(tempDir, "sandbox.vhdx"), lcow.DefaultScratchSizeGB, lcowCacheScratchFile); err != nil {
 		t.Fatalf("failed to create EXT4 scratch for LCOW test cases: %s", err)
 	}
 	return tempDir

--- a/test/functional/uvm_mem_backingtype_test.go
+++ b/test/functional/uvm_mem_backingtype_test.go
@@ -3,6 +3,7 @@
 package functional
 
 import (
+	"context"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -14,12 +15,12 @@ import (
 )
 
 func runMemStartLCOWTest(t *testing.T, opts *uvm.OptionsLCOW) {
-	u := testutilities.CreateLCOWUVMFromOpts(t, opts)
+	u := testutilities.CreateLCOWUVMFromOpts(context.Background(), t, opts)
 	u.Close()
 }
 
 func runMemStartWCOWTest(t *testing.T, opts *uvm.OptionsWCOW) {
-	u, _, scratchDir := testutilities.CreateWCOWUVMFromOptsWithImage(t, opts, "microsoft/nanoserver")
+	u, _, scratchDir := testutilities.CreateWCOWUVMFromOptsWithImage(context.Background(), t, opts, "microsoft/nanoserver")
 	defer os.RemoveAll(scratchDir)
 	u.Close()
 }
@@ -65,12 +66,12 @@ func TestMemBackingTypeLCOW(t *testing.T) {
 
 func runBenchMemStartTest(b *testing.B, opts *uvm.OptionsLCOW) {
 	// Cant use testutilities here because its `testing.B` not `testing.T`
-	u, err := uvm.CreateLCOW(opts)
+	u, err := uvm.CreateLCOW(context.Background(), opts)
 	if err != nil {
 		b.Fatal(err)
 	}
 	defer u.Close()
-	if err := u.Start(); err != nil {
+	if err := u.Start(context.Background()); err != nil {
 		b.Fatal(err)
 	}
 }

--- a/test/functional/uvm_plannine_test.go
+++ b/test/functional/uvm_plannine_test.go
@@ -5,6 +5,7 @@
 package functional
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -12,7 +13,7 @@ import (
 
 	"github.com/Microsoft/hcsshim/internal/uvm"
 	"github.com/Microsoft/hcsshim/osversion"
-	"github.com/Microsoft/hcsshim/test/functional/utilities"
+	testutilities "github.com/Microsoft/hcsshim/test/functional/utilities"
 )
 
 // TestPlan9 tests adding/removing Plan9 shares to/from a v2 Linux utility VM
@@ -20,7 +21,7 @@ import (
 func TestPlan9(t *testing.T) {
 	testutilities.RequiresBuild(t, osversion.RS5)
 
-	vm := testutilities.CreateLCOWUVM(t, t.Name())
+	vm := testutilities.CreateLCOWUVM(context.Background(), t, t.Name())
 	defer vm.Close()
 
 	dir := testutilities.CreateTempDir(t)
@@ -28,7 +29,7 @@ func TestPlan9(t *testing.T) {
 	var iterations uint32 = 64
 	var shares []*uvm.Plan9Share
 	for i := 0; i < int(iterations); i++ {
-		share, err := vm.AddPlan9(dir, fmt.Sprintf("/tmp/%s", filepath.Base(dir)), false, false, nil)
+		share, err := vm.AddPlan9(context.Background(), dir, fmt.Sprintf("/tmp/%s", filepath.Base(dir)), false, false, nil)
 		if err != nil {
 			t.Fatalf("AddPlan9 failed: %s", err)
 		}
@@ -37,7 +38,7 @@ func TestPlan9(t *testing.T) {
 
 	// Remove them all
 	for _, share := range shares {
-		if err := vm.RemovePlan9(share); err != nil {
+		if err := vm.RemovePlan9(context.Background(), share); err != nil {
 			t.Fatalf("RemovePlan9 failed: %s", err)
 		}
 	}

--- a/test/functional/uvm_properties_test.go
+++ b/test/functional/uvm_properties_test.go
@@ -3,6 +3,7 @@
 package functional
 
 import (
+	"context"
 	"os"
 	"testing"
 
@@ -13,7 +14,7 @@ import (
 func TestPropertiesGuestConnection_LCOW(t *testing.T) {
 	testutilities.RequiresBuild(t, osversion.RS5)
 
-	uvm := testutilities.CreateLCOWUVM(t, t.Name())
+	uvm := testutilities.CreateLCOWUVM(context.Background(), t, t.Name())
 	defer uvm.Close()
 
 	p, gc := uvm.Capabilities()
@@ -26,7 +27,7 @@ func TestPropertiesGuestConnection_LCOW(t *testing.T) {
 
 func TestPropertiesGuestConnection_WCOW(t *testing.T) {
 	testutilities.RequiresBuild(t, osversion.RS5)
-	uvm, _, uvmScratchDir := testutilities.CreateWCOWUVM(t, t.Name(), "microsoft/nanoserver")
+	uvm, _, uvmScratchDir := testutilities.CreateWCOWUVM(context.Background(), t, t.Name(), "microsoft/nanoserver")
 	defer os.RemoveAll(uvmScratchDir)
 	defer uvm.Close()
 

--- a/test/functional/uvm_scratch_test.go
+++ b/test/functional/uvm_scratch_test.go
@@ -3,13 +3,14 @@
 package functional
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/Microsoft/hcsshim/internal/lcow"
 	"github.com/Microsoft/hcsshim/osversion"
-	"github.com/Microsoft/hcsshim/test/functional/utilities"
+	testutilities "github.com/Microsoft/hcsshim/test/functional/utilities"
 )
 
 func TestScratchCreateLCOW(t *testing.T) {
@@ -17,14 +18,14 @@ func TestScratchCreateLCOW(t *testing.T) {
 	tempDir := testutilities.CreateTempDir(t)
 	defer os.RemoveAll(tempDir)
 
-	firstUVM := testutilities.CreateLCOWUVM(t, "TestCreateLCOWScratch")
+	firstUVM := testutilities.CreateLCOWUVM(context.Background(), t, "TestCreateLCOWScratch")
 	defer firstUVM.Close()
 
 	cacheFile := filepath.Join(tempDir, "cache.vhdx")
 	destOne := filepath.Join(tempDir, "destone.vhdx")
 	destTwo := filepath.Join(tempDir, "desttwo.vhdx")
 
-	if err := lcow.CreateScratch(firstUVM, destOne, lcow.DefaultScratchSizeGB, cacheFile); err != nil {
+	if err := lcow.CreateScratch(context.Background(), firstUVM, destOne, lcow.DefaultScratchSizeGB, cacheFile); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := os.Stat(destOne); err != nil {
@@ -34,16 +35,16 @@ func TestScratchCreateLCOW(t *testing.T) {
 		t.Fatalf("cacheFile wasn't created!")
 	}
 
-	targetUVM := testutilities.CreateLCOWUVM(t, "TestCreateLCOWScratch_target")
+	targetUVM := testutilities.CreateLCOWUVM(context.Background(), t, "TestCreateLCOWScratch_target")
 	defer targetUVM.Close()
 
 	// A non-cached create
-	if err := lcow.CreateScratch(firstUVM, destTwo, lcow.DefaultScratchSizeGB, cacheFile); err != nil {
+	if err := lcow.CreateScratch(context.Background(), firstUVM, destTwo, lcow.DefaultScratchSizeGB, cacheFile); err != nil {
 		t.Fatal(err)
 	}
 
 	// Make sure it can be added (verifies it has access correctly)
-	c, l, err := targetUVM.AddSCSI(destTwo, "", false)
+	c, l, err := targetUVM.AddSCSI(context.Background(), destTwo, "", false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/functional/uvm_vpmem_test.go
+++ b/test/functional/uvm_vpmem_test.go
@@ -3,6 +3,7 @@
 package functional
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -10,7 +11,7 @@ import (
 	"github.com/Microsoft/hcsshim/internal/copyfile"
 	"github.com/Microsoft/hcsshim/internal/uvm"
 	"github.com/Microsoft/hcsshim/osversion"
-	"github.com/Microsoft/hcsshim/test/functional/utilities"
+	testutilities "github.com/Microsoft/hcsshim/test/functional/utilities"
 	"github.com/sirupsen/logrus"
 )
 
@@ -19,7 +20,7 @@ func TestVPMEM(t *testing.T) {
 	testutilities.RequiresBuild(t, osversion.RS5)
 	alpineLayers := testutilities.LayerFolders(t, "alpine")
 
-	u := testutilities.CreateLCOWUVM(t, t.Name())
+	u := testutilities.CreateLCOWUVM(context.Background(), t, t.Name())
 	defer u.Close()
 
 	var iterations uint32 = uvm.MaxVPMEMCount
@@ -32,7 +33,7 @@ func TestVPMEM(t *testing.T) {
 	defer os.RemoveAll(tempDir)
 
 	for i := 0; i < int(iterations); i++ {
-		deviceNumber, uvmPath, err := u.AddVPMEM(filepath.Join(tempDir, "layer.vhd"), true)
+		deviceNumber, uvmPath, err := u.AddVPMEM(context.Background(), filepath.Join(tempDir, "layer.vhd"), true)
 		if err != nil {
 			t.Fatalf("AddVPMEM failed: %s", err)
 		}
@@ -41,7 +42,7 @@ func TestVPMEM(t *testing.T) {
 
 	// Remove them all
 	for i := 0; i < int(iterations); i++ {
-		if err := u.RemoveVPMEM(filepath.Join(tempDir, "layer.vhd")); err != nil {
+		if err := u.RemoveVPMEM(context.Background(), filepath.Join(tempDir, "layer.vhd")); err != nil {
 			t.Fatalf("RemoveVPMEM failed: %s", err)
 		}
 	}

--- a/test/functional/uvm_vsmb_test.go
+++ b/test/functional/uvm_vsmb_test.go
@@ -3,18 +3,19 @@
 package functional
 
 import (
+	"context"
 	"os"
 	"testing"
 
-	"github.com/Microsoft/hcsshim/internal/schema2"
+	hcsschema "github.com/Microsoft/hcsshim/internal/schema2"
 	"github.com/Microsoft/hcsshim/osversion"
-	"github.com/Microsoft/hcsshim/test/functional/utilities"
+	testutilities "github.com/Microsoft/hcsshim/test/functional/utilities"
 )
 
 // TestVSMB tests adding/removing VSMB layers from a v2 Windows utility VM
 func TestVSMB(t *testing.T) {
 	testutilities.RequiresBuild(t, osversion.RS5)
-	uvm, _, uvmScratchDir := testutilities.CreateWCOWUVM(t, t.Name(), "microsoft/nanoserver")
+	uvm, _, uvmScratchDir := testutilities.CreateWCOWUVM(context.Background(), t, t.Name(), "microsoft/nanoserver")
 	defer os.RemoveAll(uvmScratchDir)
 	defer uvm.Close()
 
@@ -29,14 +30,14 @@ func TestVSMB(t *testing.T) {
 		ShareRead:           true,
 	}
 	for i := 0; i < int(iterations); i++ {
-		if err := uvm.AddVSMB(dir, "", options); err != nil {
+		if err := uvm.AddVSMB(context.Background(), dir, "", options); err != nil {
 			t.Fatalf("AddVSMB failed: %s", err)
 		}
 	}
 
 	// Remove them all
 	for i := 0; i < int(iterations); i++ {
-		if err := uvm.RemoveVSMB(dir); err != nil {
+		if err := uvm.RemoveVSMB(context.Background(), dir); err != nil {
 			t.Fatalf("RemoveVSMB failed: %s", err)
 		}
 	}


### PR DESCRIPTION
1. Forwards the entry Span context to all methods from the shim.
2. Updates most logrus. messages to log.G(ctx). messages so that span
information will be forwarded as well.
3. Updates the various tests/infra to the new calling patterns.