### PR TITLE
Fixing an issue with NAT network type and omitempty using the V2 schema

### DIFF
--- a/hcn/hcnnetwork.go
+++ b/hcn/hcnnetwork.go
@@ -133,9 +133,12 @@ func getNetwork(networkGuid guid.GUID, query string) (*HostComputeNetwork, error
 	}
 	// Convert output to HostComputeNetwork
 	var outputNetwork HostComputeNetwork
-	outputNetwork.Type = NAT // If HNS sets the network type to NAT (i.e. '0' in HNS.Schema.Network.NetworkMode), 
-							 // the value will be omitted from the JSON blob. We therefore need to initialize NAT here before
-							 // unmarshaling the JSON blob.
+
+	// If HNS sets the network type to NAT (i.e. '0' in HNS.Schema.Network.NetworkMode),
+	// the value will be omitted from the JSON blob. We therefore need to initialize NAT here before
+	// unmarshaling the JSON blob.
+	outputNetwork.Type = NAT
+
 	if err := json.Unmarshal([]byte(properties), &outputNetwork); err != nil {
 		return nil, err
 	}
@@ -200,9 +203,12 @@ func createNetwork(settings string) (*HostComputeNetwork, error) {
 	}
 	// Convert output to HostComputeNetwork
 	var outputNetwork HostComputeNetwork
-	outputNetwork.Type = NAT // If HNS sets the network type to NAT (i.e. '0' in HNS.Schema.Network.NetworkMode), 
-							 // the value will be omitted from the JSON blob. We therefore need to initialize NAT here before
-							 // unmarshaling the JSON blob.
+
+	// If HNS sets the network type to NAT (i.e. '0' in HNS.Schema.Network.NetworkMode),
+	// the value will be omitted from the JSON blob. We therefore need to initialize NAT here before
+	// unmarshaling the JSON blob.
+	outputNetwork.Type = NAT
+
 	if err := json.Unmarshal([]byte(properties), &outputNetwork); err != nil {
 		return nil, err
 	}
@@ -247,9 +253,12 @@ func modifyNetwork(networkId string, settings string) (*HostComputeNetwork, erro
 	}
 	// Convert output to HostComputeNetwork
 	var outputNetwork HostComputeNetwork
-	outputNetwork.Type = NAT // If HNS sets the network type to NAT (i.e. '0' in HNS.Schema.Network.NetworkMode), 
-							 // the value will be omitted from the JSON blob. We therefore need to initialize NAT here before
-							 // unmarshaling the JSON blob.
+
+	// If HNS sets the network type to NAT (i.e. '0' in HNS.Schema.Network.NetworkMode),
+	// the value will be omitted from the JSON blob. We therefore need to initialize NAT here before
+	// unmarshaling the JSON blob.
+	outputNetwork.Type = NAT
+
 	if err := json.Unmarshal([]byte(properties), &outputNetwork); err != nil {
 		return nil, err
 	}

--- a/hcn/hcnnetwork.go
+++ b/hcn/hcnnetwork.go
@@ -133,6 +133,9 @@ func getNetwork(networkGuid guid.GUID, query string) (*HostComputeNetwork, error
 	}
 	// Convert output to HostComputeNetwork
 	var outputNetwork HostComputeNetwork
+	outputNetwork.Type = NAT // If HNS sets the network type to NAT (i.e. '0' in HNS.Schema.Network.NetworkMode), 
+							 // the value will be omitted from the JSON blob. We therefore need to initialize NAT here before
+							 // unmarshaling the JSON blob.
 	if err := json.Unmarshal([]byte(properties), &outputNetwork); err != nil {
 		return nil, err
 	}
@@ -197,6 +200,9 @@ func createNetwork(settings string) (*HostComputeNetwork, error) {
 	}
 	// Convert output to HostComputeNetwork
 	var outputNetwork HostComputeNetwork
+	outputNetwork.Type = NAT // If HNS sets the network type to NAT (i.e. '0' in HNS.Schema.Network.NetworkMode), 
+							 // the value will be omitted from the JSON blob. We therefore need to initialize NAT here before
+							 // unmarshaling the JSON blob.
 	if err := json.Unmarshal([]byte(properties), &outputNetwork); err != nil {
 		return nil, err
 	}
@@ -241,6 +247,9 @@ func modifyNetwork(networkId string, settings string) (*HostComputeNetwork, erro
 	}
 	// Convert output to HostComputeNetwork
 	var outputNetwork HostComputeNetwork
+	outputNetwork.Type = NAT // If HNS sets the network type to NAT (i.e. '0' in HNS.Schema.Network.NetworkMode), 
+							 // the value will be omitted from the JSON blob. We therefore need to initialize NAT here before
+							 // unmarshaling the JSON blob.
 	if err := json.Unmarshal([]byte(properties), &outputNetwork); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fixing an issue where the network Type is missing for NAT networks. The issue comes from how HNS defines network types in the mars schema. The network type in the HNS schema V2 is defined as an "omitempty" integer-based enum where NAT is encoded as value '0'. Since '0' is interpreted by the mars compiler as an empty value, the value is omited during schema encoding. As a result, the HCSShim needs to compensate for the lack of explicit type when NAT networks are being used.

Tests run: manually tested the behavior using a private tool.