### PR TITLE
Receive shim options via stdin

### DIFF
--- a/cmd/containerd-shim-runhcs-v1/service_internal.go
+++ b/cmd/containerd-shim-runhcs-v1/service_internal.go
@@ -18,7 +18,6 @@ import (
 	google_protobuf1 "github.com/gogo/protobuf/types"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 )
 
 var empty = &google_protobuf1.Empty{}
@@ -79,10 +78,6 @@ func (s *service) createInternal(ctx context.Context, req *task.CreateTaskReques
 			return nil, err
 		}
 		shimOpts = v.(*runhcsopts.Options)
-	}
-
-	if shimOpts != nil && shimOpts.Debug {
-		logrus.SetLevel(logrus.DebugLevel)
 	}
 
 	var spec specs.Spec

--- a/cmd/containerd-shim-runhcs-v1/start.go
+++ b/cmd/containerd-shim-runhcs-v1/start.go
@@ -144,6 +144,7 @@ The start command can either start a new shim or return an address to an existin
 				Args:   args,
 				Env:    os.Environ(),
 				Dir:    cwd,
+				Stdin:  os.Stdin,
 				Stdout: w,
 				Stderr: f,
 			}


### PR DESCRIPTION
containerd has an option struct for our shim which contains both
shim-wide options (e.g. logging level) and task specific options (e.g.
sandbox image to use). Previously containerd only passed these options
in as part of the task creation call, but recently also added support
to pass them in directly to the shim via a protobuf message in stdin.

Now that containerd supports passing the options directly to the shim,
we can use that as the source for shim-wide options, instead of doing
that only when a task is created. This will also make it easier to add
more shim-wide options in the future, as their affect can be applied
immediately on shim start.

Signed-off-by: Kevin Parsons <kevpar@microsoft.com>