### PR TITLE
Add tests for the L4 proxy policy

### DIFF
--- a/hcn/hcnendpoint.go
+++ b/hcn/hcnendpoint.go
@@ -353,7 +353,7 @@ func ModifyEndpointSettings(endpointId string, request *ModifyEndpointSettingReq
 }
 
 // ApplyPolicy applies a Policy (ex: ACL) on the Endpoint.
-func (endpoint *HostComputeEndpoint) ApplyPolicy(endpointPolicy PolicyEndpointRequest) error {
+func (endpoint *HostComputeEndpoint) ApplyPolicy(requestType RequestType, endpointPolicy PolicyEndpointRequest) error {
 	logrus.Debugf("hcn::HostComputeEndpoint::ApplyPolicy id=%s", endpoint.Id)
 
 	settingsJson, err := json.Marshal(endpointPolicy)
@@ -362,7 +362,7 @@ func (endpoint *HostComputeEndpoint) ApplyPolicy(endpointPolicy PolicyEndpointRe
 	}
 	requestMessage := &ModifyEndpointSettingRequest{
 		ResourceType: EndpointResourceTypePolicy,
-		RequestType:  RequestTypeUpdate,
+		RequestType:  requestType,
 		Settings:     settingsJson,
 	}
 

--- a/hcn/hcnendpoint_test.go
+++ b/hcn/hcnendpoint_test.go
@@ -182,18 +182,28 @@ func TestEndpointNamespaceAttachDetach(t *testing.T) {
 	}
 }
 
-// setupL4ProxyPolicyTest creates an endpoint inside a new overlay network and
-// returns the request to be sent.
-func setupL4ProxyPolicyTest(t *testing.T) (*HostComputeNetwork, *HostComputeEndpoint, PolicyEndpointRequest) {
+func TestAddL4ProxyPolicyOnEndpoint(t *testing.T) {
 	network, err := CreateTestOverlayNetwork()
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer func() {
+		err = network.Delete()
+		if err != nil {
+			t.Fatal(err)
+		}
+	}()
 
 	endpoint, err := HcnCreateTestEndpoint(network)
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer func() {
+		err = endpoint.Delete()
+		if err != nil {
+			t.Fatal(err)
+		}
+	}()
 
 	policySetting := L4ProxyPolicySetting{
 		Port: "80",
@@ -219,39 +229,10 @@ func setupL4ProxyPolicyTest(t *testing.T) (*HostComputeNetwork, *HostComputeEndp
 		Policies: []EndpointPolicy{endpointPolicy},
 	}
 
-	return network, endpoint, request
-}
-
-// tearDownL4ProxyPolicyTest deletes the endpoint and the network that were
-// created for the test.
-func tearDownL4ProxyPolicyTest(t *testing.T, network *HostComputeNetwork, endpoint *HostComputeEndpoint) {
-	err := endpoint.Delete()
+	err = endpoint.ApplyPolicy(RequestTypeAdd, request)
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	err = network.Delete()
-	if err != nil {
-		t.Fatal(err)
-	}
-}
-
-func TestAddL4ProxyPolicyOnEndpoint(t *testing.T) {
-	network, endpoint, request := setupL4ProxyPolicyTest(t)
-	err := endpoint.ApplyPolicy(RequestTypeAdd, request)
-	if err != nil {
-		t.Fatal(err)
-	}
-	tearDownL4ProxyPolicyTest(t, network, endpoint)
-}
-
-func TestUpdateL4ProxyPolicyOnEndpoint(t *testing.T) {
-	network, endpoint, request := setupL4ProxyPolicyTest(t)
-	err := endpoint.ApplyPolicy(RequestTypeUpdate, request)
-	if err != nil {
-		t.Fatal(err)
-	}
-	tearDownL4ProxyPolicyTest(t, network, endpoint)
 }
 
 func TestApplyPolicyOnEndpoint(t *testing.T) {

--- a/hcn/hcnpolicy.go
+++ b/hcn/hcnpolicy.go
@@ -1,6 +1,10 @@
 package hcn
 
-import "encoding/json"
+import (
+	"encoding/json"
+
+	"github.com/Microsoft/go-winio/pkg/guid"
+)
 
 // EndpointPolicyType are the potential Policies that apply to Endpoints.
 type EndpointPolicyType string
@@ -135,6 +139,26 @@ type SDNRoutePolicySetting struct {
 	NeedEncap         bool   `json:",omitempty"`
 }
 
+// A ProxyType is a type of proxy used by the L4 proxy policy.
+type ProxyType int
+
+const (
+	// ProxyTypeVFP specifies a Virtual Filtering Protocol proxy.
+	ProxyTypeVFP ProxyType = iota
+	// ProxyTypeWFP specifies a Windows Filtering Platform proxy.
+	ProxyTypeWFP
+)
+
+// FiveTuple is nested in L4ProxyPolicySetting for WFP support.
+type FiveTuple struct {
+	Protocols       string `json:",omitempty"`
+	LocalAddresses  string `json:",omitempty"`
+	RemoteAddresses string `json:",omitempty"`
+	LocalPorts      string `json:",omitempty"`
+	RemotePorts     string `json:",omitempty"`
+	Priority        uint16 `json:",omitempty"`
+}
+
 // L4ProxyPolicySetting sets Layer-4 Proxy on an endpoint.
 type L4ProxyPolicySetting struct {
 	IP            string   `json:",omitempty"`
@@ -143,6 +167,13 @@ type L4ProxyPolicySetting struct {
 	ExceptionList []string `json:",omitempty"`
 	Destination   string   `json:","`
 	OutboundNat   bool     `json:",omitempty"`
+
+	// For the WFP proxy
+	FilterTuple          FiveTuple `json:",omitempty"`
+	ProxyType            ProxyType `json:",omitempty"`
+	ID                   guid.GUID `json:",omitempty"`
+	UserSID              string    `json:",omitempty"`
+	NetworkCompartmentID uint32    `json:",omitempty"`
 }
 
 // PortnameEndpointPolicySetting sets the port name for an endpoint.

--- a/hcn/hcnpolicy.go
+++ b/hcn/hcnpolicy.go
@@ -2,8 +2,6 @@ package hcn
 
 import (
 	"encoding/json"
-
-	"github.com/Microsoft/go-winio/pkg/guid"
 )
 
 // EndpointPolicyType are the potential Policies that apply to Endpoints.
@@ -171,7 +169,6 @@ type L4ProxyPolicySetting struct {
 	// For the WFP proxy
 	FilterTuple          FiveTuple `json:",omitempty"`
 	ProxyType            ProxyType `json:",omitempty"`
-	ID                   guid.GUID `json:",omitempty"`
 	UserSID              string    `json:",omitempty"`
 	NetworkCompartmentID uint32    `json:",omitempty"`
 }


### PR DESCRIPTION
This tests that HNS doesn't spit back errors in case we send either an Add or Create request to it for a detached endpoint.

In addition, I added some fields to the L4ProxyPolicySetting struct to support the WFP proxy. I also added the ability to specify the request type when calling HostComputeEndpoint.ApplyPolicy().

**Note**: This PR is ready for review, but shouldn't be merged yet as HNS doesn't fully support this yet.