### PR TITLE
Add support for different log output modes

### DIFF
--- a/cmd/containerd-shim-runhcs-v1/nopformatter.go
+++ b/cmd/containerd-shim-runhcs-v1/nopformatter.go
@@ -1,0 +1,10 @@
+package main
+
+import (
+	"github.com/sirupsen/logrus"
+)
+
+type nopFormatter struct{}
+
+// Format does nothing and returns a nil slice.
+func (nopFormatter) Format(*logrus.Entry) ([]byte, error) { return nil, nil }


### PR DESCRIPTION
Log output modes determine where logging output is sent from the serve
shim:

- NPIPE, the default, causes log output to be sent over the log pipe
  that containerd provides.
- FILE, is unsupported and causes the shim to panic.
- ETW, causes log output to be sent only to ETW via the Logrus hook.

Log output mode can be set via the DebugType enumeration on the shim
options struct.

Signed-off-by: Kevin Parsons <kevpar@microsoft.com>