### PR TITLE
Fix VM processor.limit in tests

### DIFF
--- a/test/cri-containerd/runpodsandbox_test.go
+++ b/test/cri-containerd/runpodsandbox_test.go
@@ -351,7 +351,7 @@ func Test_RunPodSandbox_CPULimit_WCOW_Hypervisor(t *testing.T) {
 				Namespace: testNamespace,
 			},
 			Annotations: map[string]string{
-				"io.microsoft.virtualmachine.computetopology.processor.limit": "9000",
+				"io.microsoft.virtualmachine.computetopology.processor.limit": "90000",
 			},
 		},
 		RuntimeHandler: wcowHypervisorRuntimeHandler,
@@ -370,7 +370,7 @@ func Test_RunPodSandbox_CPULimit_LCOW(t *testing.T) {
 				Namespace: testNamespace,
 			},
 			Annotations: map[string]string{
-				"io.microsoft.virtualmachine.computetopology.processor.limit": "9000",
+				"io.microsoft.virtualmachine.computetopology.processor.limit": "90000",
 			},
 		},
 		RuntimeHandler: lcowRuntimeHandler,


### PR DESCRIPTION
The setting for VM processor limit is out of 100,000 not 10,000 so previously
only 9% CPU limit was being applied for the entire UVM.

Signed-off-by: Justin Terry (VM) <juterry@microsoft.com>