### PR TITLE
Cleanup excess or duplicate internal/uvm package logs

### DIFF
--- a/internal/uvm/modify.go
+++ b/internal/uvm/modify.go
@@ -5,28 +5,12 @@ import (
 	"fmt"
 
 	"github.com/Microsoft/hcsshim/internal/log"
-	"github.com/Microsoft/hcsshim/internal/logfields"
 	"github.com/Microsoft/hcsshim/internal/requesttype"
 	hcsschema "github.com/Microsoft/hcsshim/internal/schema2"
-	"github.com/sirupsen/logrus"
 )
 
 // Modify modifies the compute system by sending a request to HCS.
 func (uvm *UtilityVM) Modify(ctx context.Context, doc *hcsschema.ModifySettingRequest) (err error) {
-	op := "uvm::Modify"
-	l := log.G(ctx).WithFields(logrus.Fields{
-		logfields.UVMID: uvm.id,
-	})
-	l.Debug(op + " - Begin Operation")
-	defer func() {
-		if err != nil {
-			l.Data[logrus.ErrorKey] = err
-			l.Error(op + " - End Operation - Error")
-		} else {
-			l.Debug(op + " - End Operation - Success")
-		}
-	}()
-
 	if doc.GuestRequest == nil || uvm.gc == nil {
 		return uvm.hcsSystem.Modify(ctx, doc)
 	}
@@ -43,7 +27,7 @@ func (uvm *UtilityVM) Modify(ctx context.Context, doc *hcsschema.ModifySettingRe
 				hostdoc.RequestType = requesttype.Remove
 				rerr := uvm.hcsSystem.Modify(ctx, &hostdoc)
 				if rerr != nil {
-					log.G(ctx).WithError(err).Error("failed to roll back resource add")
+					log.G(ctx).WithError(rerr).Error("failed to roll back resource add")
 				}
 			}
 		}()

--- a/internal/uvm/network.go
+++ b/internal/uvm/network.go
@@ -5,14 +5,10 @@ import (
 	"errors"
 	"path"
 
-	"github.com/sirupsen/logrus"
-
 	"github.com/Microsoft/go-winio/pkg/guid"
 	"github.com/Microsoft/hcsshim/hcn"
 	"github.com/Microsoft/hcsshim/internal/guestrequest"
 	"github.com/Microsoft/hcsshim/internal/hns"
-	"github.com/Microsoft/hcsshim/internal/log"
-	"github.com/Microsoft/hcsshim/internal/logfields"
 	"github.com/Microsoft/hcsshim/internal/requesttype"
 	hcsschema "github.com/Microsoft/hcsshim/internal/schema2"
 	"github.com/Microsoft/hcsshim/osversion"
@@ -30,22 +26,7 @@ var (
 // AddNetNS adds network namespace inside the guest.
 //
 // If a namespace with `id` already exists returns `ErrNetNSAlreadyAttached`.
-func (uvm *UtilityVM) AddNetNS(ctx context.Context, id string) (err error) {
-	op := "uvm::AddNetNS"
-	l := log.G(ctx).WithFields(logrus.Fields{
-		logfields.UVMID: uvm.id,
-		"netns-id":      id,
-	})
-	l.Debug(op + " - Begin Operation")
-	defer func() {
-		if err != nil {
-			l.Data[logrus.ErrorKey] = err
-			l.Error(op + " - End Operation - Error")
-		} else {
-			l.Debug(op + " - End Operation - Success")
-		}
-	}()
-
+func (uvm *UtilityVM) AddNetNS(ctx context.Context, id string) error {
 	uvm.m.Lock()
 	defer uvm.m.Unlock()
 	if _, ok := uvm.namespaces[id]; ok {
@@ -87,22 +68,7 @@ func (uvm *UtilityVM) AddNetNS(ctx context.Context, id string) (err error) {
 // added endpoints.
 //
 // If no network namespace matches `id` returns `ErrNetNSNotFound`.
-func (uvm *UtilityVM) AddEndpointsToNS(ctx context.Context, id string, endpoints []*hns.HNSEndpoint) (err error) {
-	op := "uvm::AddEndpointsToNS"
-	l := log.G(ctx).WithFields(logrus.Fields{
-		logfields.UVMID: uvm.id,
-		"netns-id":      id,
-	})
-	l.Debug(op + " - Begin Operation")
-	defer func() {
-		if err != nil {
-			l.Data[logrus.ErrorKey] = err
-			l.Error(op + " - End Operation - Error")
-		} else {
-			l.Debug(op + " - End Operation - Success")
-		}
-	}()
-
+func (uvm *UtilityVM) AddEndpointsToNS(ctx context.Context, id string, endpoints []*hns.HNSEndpoint) error {
 	uvm.m.Lock()
 	defer uvm.m.Unlock()
 
@@ -133,22 +99,7 @@ func (uvm *UtilityVM) AddEndpointsToNS(ctx context.Context, id string, endpoints
 // the namespace.
 //
 // If a namespace matching `id` is not found this command silently succeeds.
-func (uvm *UtilityVM) RemoveNetNS(ctx context.Context, id string) (err error) {
-	op := "uvm::RemoveNetNS"
-	l := log.G(ctx).WithFields(logrus.Fields{
-		logfields.UVMID: uvm.id,
-		"netns-id":      id,
-	})
-	l.Debug(op + " - Begin Operation")
-	defer func() {
-		if err != nil {
-			l.Data[logrus.ErrorKey] = err
-			l.Error(op + " - End Operation - Error")
-		} else {
-			l.Debug(op + " - End Operation - Success")
-		}
-	}()
-
+func (uvm *UtilityVM) RemoveNetNS(ctx context.Context, id string) error {
 	uvm.m.Lock()
 	defer uvm.m.Unlock()
 	if ns, ok := uvm.namespaces[id]; ok {
@@ -187,22 +138,7 @@ func (uvm *UtilityVM) RemoveNetNS(ctx context.Context, id string) (err error) {
 // the network namespace this command silently succeeds.
 //
 // If no network namespace matches `id` returns `ErrNetNSNotFound`.
-func (uvm *UtilityVM) RemoveEndpointsFromNS(ctx context.Context, id string, endpoints []*hns.HNSEndpoint) (err error) {
-	op := "uvm::RemoveEndpointsFromNS"
-	l := log.G(ctx).WithFields(logrus.Fields{
-		logfields.UVMID: uvm.id,
-		"netns-id":      id,
-	})
-	l.Debug(op + " - Begin Operation")
-	defer func() {
-		if err != nil {
-			l.Data[logrus.ErrorKey] = err
-			l.Error(op + " - End Operation - Error")
-		} else {
-			l.Debug(op + " - End Operation - Success")
-		}
-	}()
-
+func (uvm *UtilityVM) RemoveEndpointsFromNS(ctx context.Context, id string, endpoints []*hns.HNSEndpoint) error {
 	uvm.m.Lock()
 	defer uvm.m.Unlock()
 
@@ -243,7 +179,6 @@ func getNetworkModifyRequest(adapterID string, requestType string, settings inte
 }
 
 func (uvm *UtilityVM) addNIC(ctx context.Context, id guid.GUID, endpoint *hns.HNSEndpoint) error {
-
 	// First a pre-add. This is a guest-only request and is only done on Windows.
 	if uvm.operatingSystem == "windows" {
 		preAddRequest := hcsschema.ModifySettingRequest{

--- a/internal/uvm/plan9.go
+++ b/internal/uvm/plan9.go
@@ -7,12 +7,9 @@ import (
 	"strconv"
 
 	"github.com/Microsoft/hcsshim/internal/guestrequest"
-	"github.com/Microsoft/hcsshim/internal/log"
-	"github.com/Microsoft/hcsshim/internal/logfields"
 	"github.com/Microsoft/hcsshim/internal/requesttype"
 	hcsschema "github.com/Microsoft/hcsshim/internal/schema2"
 	"github.com/Microsoft/hcsshim/osversion"
-	"github.com/sirupsen/logrus"
 )
 
 type Plan9Share struct {
@@ -22,26 +19,7 @@ type Plan9Share struct {
 const plan9Port = 564
 
 // AddPlan9 adds a Plan9 share to a utility VM.
-func (uvm *UtilityVM) AddPlan9(ctx context.Context, hostPath string, uvmPath string, readOnly bool, restrict bool, allowedNames []string) (_ *Plan9Share, err error) {
-	op := "uvm::AddPlan9"
-	l := log.G(ctx).WithFields(logrus.Fields{
-		logfields.UVMID: uvm.id,
-		"host-path":     hostPath,
-		"uvm-path":      uvmPath,
-		"readOnly":      readOnly,
-		"restrict":      restrict,
-		"allowedNames":  allowedNames,
-	})
-	l.Debug(op + " - Begin Operation")
-	defer func() {
-		if err != nil {
-			l.Data[logrus.ErrorKey] = err
-			l.Error(op + " - End Operation - Error")
-		} else {
-			l.Debug(op + " - End Operation - Success")
-		}
-	}()
-
+func (uvm *UtilityVM) AddPlan9(ctx context.Context, hostPath string, uvmPath string, readOnly bool, restrict bool, allowedNames []string) (*Plan9Share, error) {
 	if uvm.operatingSystem != "linux" {
 		return nil, errNotSupported
 	}
@@ -111,23 +89,7 @@ func (uvm *UtilityVM) AddPlan9(ctx context.Context, hostPath string, uvmPath str
 
 // RemovePlan9 removes a Plan9 share from a utility VM. Each Plan9 share is ref-counted
 // and only actually removed when the ref-count drops to zero.
-func (uvm *UtilityVM) RemovePlan9(ctx context.Context, share *Plan9Share) (err error) {
-	op := "uvm::RemovePlan9"
-	l := log.G(ctx).WithFields(logrus.Fields{
-		logfields.UVMID: uvm.id,
-		"name":          share.name,
-		"uvm-path":      share.uvmPath,
-	})
-	l.Debug(op + " - Begin Operation")
-	defer func() {
-		if err != nil {
-			l.Data[logrus.ErrorKey] = err
-			l.Error(op + " - End Operation - Error")
-		} else {
-			l.Debug(op + " - End Operation - Success")
-		}
-	}()
-
+func (uvm *UtilityVM) RemovePlan9(ctx context.Context, share *Plan9Share) error {
 	if uvm.operatingSystem != "linux" {
 		return errNotSupported
 	}

--- a/internal/uvm/start.go
+++ b/internal/uvm/start.go
@@ -127,7 +127,7 @@ func processOutput(ctx context.Context, l net.Listener, doneChan chan struct{}, 
 		c, err := ar.c, ar.err
 		l.Close()
 		if err != nil {
-			logrus.Error("accepting log socket: ", err)
+			log.G(ctx).Error("accepting log socket: ", err)
 			return
 		}
 		defer c.Close()
@@ -140,19 +140,6 @@ func processOutput(ctx context.Context, l net.Listener, doneChan chan struct{}, 
 func (uvm *UtilityVM) Start(ctx context.Context) (err error) {
 	ctx, cancel := context.WithTimeout(ctx, 2*time.Minute)
 	defer cancel()
-	op := "uvm::Start"
-	l := log.G(ctx).WithFields(logrus.Fields{
-		logfields.UVMID: uvm.id,
-	})
-	l.Debug(op + " - Begin Operation")
-	defer func() {
-		if err != nil {
-			l.Data[logrus.ErrorKey] = err
-			l.Error(op + " - End Operation - Error")
-		} else {
-			l.Debug(op + " - End Operation - Success")
-		}
-	}()
 
 	if uvm.outputListener != nil {
 		ctx, cancel := context.WithCancel(context.Background())
@@ -190,7 +177,7 @@ func (uvm *UtilityVM) Start(ctx context.Context) (err error) {
 		// Start the GCS protocol.
 		gcc := &gcs.GuestConnectionConfig{
 			Conn:     conn,
-			Log:      logrus.WithField(logfields.UVMID, uvm.id), // TODO: JTERRY75 - should this be log.G(ctx)
+			Log:      log.G(ctx).WithField(logfields.UVMID, uvm.id),
 			IoListen: gcs.HvsockIoListen(uvm.runtimeID),
 		}
 		uvm.gc, err = gcc.Connect(ctx)

--- a/internal/uvm/wait.go
+++ b/internal/uvm/wait.go
@@ -15,7 +15,7 @@ func (uvm *UtilityVM) Wait() error {
 	if uvm.outputProcessingCancel != nil {
 		uvm.outputProcessingCancel()
 	}
-	logrus.WithField(logfields.UVMID, uvm.id).Debug("UVM exited, waiting for output processing to complete")
+	logrus.WithField(logfields.UVMID, uvm.id).Debug("uvm exited, waiting for output processing to complete")
 	if uvm.outputProcessingDone != nil {
 		<-uvm.outputProcessingDone
 	}


### PR DESCRIPTION
Almost all logs at this level are duplicate as they translate to a message that
is sent to either the gcs or hcs package which logs all RPC messages already.

Signed-off-by: Justin Terry (VM) <juterry@microsoft.com>