### PR TITLE
Include context identifiers on DumpStacks requests

### DIFF
--- a/cmd/containerd-shim-runhcs-v1/main.go
+++ b/cmd/containerd-shim-runhcs-v1/main.go
@@ -69,10 +69,10 @@ func etwCallback(sourceID guid.GUID, state etw.ProviderState, level etw.Level, m
 		if err != nil {
 			return
 		}
-
-		logrus.WithField("stack", resp.Stacks).Info("goroutine stack dump")
+		log := logrus.WithField("tid", svc.tid)
+		log.WithField("stack", resp.Stacks).Info("goroutine stack dump")
 		if resp.GuestStacks != "" {
-			logrus.WithField("stack", resp.GuestStacks).Info("guest stack dump")
+			log.WithField("stack", resp.GuestStacks).Info("guest stack dump")
 		}
 	}
 }

--- a/cmd/containerd-shim-runhcs-v1/task.go
+++ b/cmd/containerd-shim-runhcs-v1/task.go
@@ -75,4 +75,8 @@ type shimTask interface {
 	//
 	// If the host is not hypervisor isolated returns error.
 	ExecInHost(ctx context.Context, req *shimdiag.ExecProcessRequest) (int, error)
+	// DumpGuestStacks dumps the GCS stacks associated with this task host.
+	//
+	// If the host is not hypervisor isolated returns `""`.
+	DumpGuestStacks(ctx context.Context) string
 }

--- a/cmd/containerd-shim-runhcs-v1/task_hcs.go
+++ b/cmd/containerd-shim-runhcs-v1/task_hcs.go
@@ -610,3 +610,15 @@ func (ht *hcsTask) ExecInHost(ctx context.Context, req *shimdiag.ExecProcessRequ
 	}
 	return execInUvm(ctx, ht.host, req)
 }
+
+func (ht *hcsTask) DumpGuestStacks(ctx context.Context) string {
+	if ht.host != nil {
+		stacks, err := ht.host.DumpStacks(ctx)
+		if err != nil {
+			log.G(ctx).WithError(err).Warn("failed to capture guest stacks")
+		} else {
+			return stacks
+		}
+	}
+	return ""
+}

--- a/cmd/containerd-shim-runhcs-v1/task_test.go
+++ b/cmd/containerd-shim-runhcs-v1/task_test.go
@@ -83,3 +83,7 @@ func (tst *testShimTask) Wait() *task.StateResponse {
 func (tst *testShimTask) ExecInHost(ctx context.Context, req *shimdiag.ExecProcessRequest) (int, error) {
 	return 0, errors.New("not implemented")
 }
+
+func (wpst *testShimTask) DumpGuestStacks(ctx context.Context) string {
+	return ""
+}

--- a/cmd/containerd-shim-runhcs-v1/task_wcow_podsandbox.go
+++ b/cmd/containerd-shim-runhcs-v1/task_wcow_podsandbox.go
@@ -225,3 +225,15 @@ func (wpst *wcowPodSandboxTask) ExecInHost(ctx context.Context, req *shimdiag.Ex
 	}
 	return execInUvm(ctx, wpst.host, req)
 }
+
+func (wpst *wcowPodSandboxTask) DumpGuestStacks(ctx context.Context) string {
+	if wpst.host != nil {
+		stacks, err := wpst.host.DumpStacks(ctx)
+		if err != nil {
+			log.G(ctx).WithError(err).Warn("failed to capture guest stacks")
+		} else {
+			return stacks
+		}
+	}
+	return ""
+}


### PR DESCRIPTION
1. Adds context to the dump stack trace so that it can be correlated.
2. Adds support for guet DumpStacks on standalone LCOW/WCOW as well.
3. Limits the guest timeout from 5 minutes to 5 seconds for a guest stack trace.

Signed-off-by: Justin Terry (VM) <juterry@microsoft.com>