### PR TITLE
Revendor containerd/ttrpc

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/containerd/continuity v0.0.0-20190426062206-aaeac12a7ffc // indirect
 	github.com/containerd/fifo v0.0.0-20190226154929-a9fb20d87448 // indirect
 	github.com/containerd/go-runc v0.0.0-20180907222934-5a6d9f37cfa3
-	github.com/containerd/ttrpc v0.0.0-20190613183316-1fb3814edf44
+	github.com/containerd/ttrpc v0.0.0-20190826154248-f969a7f076a2
 	github.com/containerd/typeurl v0.0.0-20180627222232-a93fcdb778cd
 	github.com/gogo/protobuf v1.2.1
 	github.com/hashicorp/errwrap v0.0.0-20141028054710-7554cd9344ce // indirect

--- a/go.sum
+++ b/go.sum
@@ -19,6 +19,8 @@ github.com/containerd/ttrpc v0.0.0-20180920185216-2a805f718635 h1:Hh9KYLzbpTyhtC
 github.com/containerd/ttrpc v0.0.0-20180920185216-2a805f718635/go.mod h1:PvCDdDGpgqzQIzDW1TphrGLssLDZp2GuS+X5DkEJB8o=
 github.com/containerd/ttrpc v0.0.0-20190613183316-1fb3814edf44 h1:vG5QXCUakUhR2CRI44aD3joCWcvb5mfZRxcwVqBVGeU=
 github.com/containerd/ttrpc v0.0.0-20190613183316-1fb3814edf44/go.mod h1:PvCDdDGpgqzQIzDW1TphrGLssLDZp2GuS+X5DkEJB8o=
+github.com/containerd/ttrpc v0.0.0-20190826154248-f969a7f076a2 h1:uR0Zz83OrfOhXWwDdwVYirFZI/LMdZXMzCHzfnQFO9w=
+github.com/containerd/ttrpc v0.0.0-20190826154248-f969a7f076a2/go.mod h1:PvCDdDGpgqzQIzDW1TphrGLssLDZp2GuS+X5DkEJB8o=
 github.com/containerd/typeurl v0.0.0-20180627222232-a93fcdb778cd h1:JNn81o/xG+8NEo3bC/vx9pbi/g2WI8mtP2/nXzu297Y=
 github.com/containerd/typeurl v0.0.0-20180627222232-a93fcdb778cd/go.mod h1:Cm3kwCdlkCfMSHURc+r6fwoGH6/F1hH3S4sg0rLFWPc=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/vendor/github.com/containerd/ttrpc/services.go
+++ b/vendor/github.com/containerd/ttrpc/services.go
@@ -152,5 +152,5 @@ func convertCode(err error) codes.Code {
 }
 
 func fullPath(service, method string) string {
-	return "/" + path.Join("/", service, method)
+	return "/" + path.Join(service, method)
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -28,7 +28,7 @@ github.com/containerd/containerd/events
 github.com/containerd/fifo
 # github.com/containerd/go-runc v0.0.0-20180907222934-5a6d9f37cfa3
 github.com/containerd/go-runc
-# github.com/containerd/ttrpc v0.0.0-20190613183316-1fb3814edf44
+# github.com/containerd/ttrpc v0.0.0-20190826154248-f969a7f076a2
 github.com/containerd/ttrpc
 # github.com/containerd/typeurl v0.0.0-20180627222232-a93fcdb778cd
 github.com/containerd/typeurl


### PR DESCRIPTION
This is just to bring in the fix to TTRPC service names as seen by
interceptors.

Signed-off-by: Kevin Parsons <kevpar@microsoft.com>