### PR TITLE
Namespace not found error.

### DIFF
--- a/hcn/hcnerrors.go
+++ b/hcn/hcnerrors.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/Microsoft/hcsshim/internal/hcs"
 	"github.com/Microsoft/hcsshim/internal/hcserror"
 	"github.com/Microsoft/hcsshim/internal/interop"
 	"github.com/sirupsen/logrus"
@@ -89,7 +90,7 @@ func (e LoadBalancerNotFoundError) Error() string {
 // IsNotFoundError returns a boolean indicating whether the error was caused by
 // a resource not being found.
 func IsNotFoundError(err error) bool {
-	switch err.(type) {
+	switch pe := err.(type) {
 	case NetworkNotFoundError:
 		return true
 	case EndpointNotFoundError:
@@ -98,6 +99,8 @@ func IsNotFoundError(err error) bool {
 		return true
 	case LoadBalancerNotFoundError:
 		return true
+	case *hcserror.HcsError:
+		return pe.Err == hcs.ErrElementNotFound
 	}
 	return false
 }

--- a/hcn/hcnerrors_test.go
+++ b/hcn/hcnerrors_test.go
@@ -4,6 +4,8 @@ package hcn
 
 import (
 	"testing"
+
+	"github.com/Microsoft/hcsshim/internal/hcserror"
 )
 
 func TestMissingNetworkByName(t *testing.T) {
@@ -23,12 +25,26 @@ func TestMissingNetworkById(t *testing.T) {
 	// Random guid
 	_, err := GetNetworkByID("5f0b1190-63be-4e0c-b974-bd0f55675a42")
 	if err == nil {
-		t.Fatal("Unrelated error was thrown.")
+		t.Fatal("Error was not thrown.")
 	}
 	if !IsNotFoundError(err) {
 		t.Fatal("Unrelated error was thrown.")
 	}
 	if _, ok := err.(NetworkNotFoundError); !ok {
+		t.Fatal("Wrong error type was thrown.")
+	}
+}
+
+func TestMissingNamespaceById(t *testing.T) {
+	// Random guid
+	_, err := GetNamespaceByID("5f0b1190-63be-4e0c-b974-bd0f55675a42")
+	if err == nil {
+		t.Fatal("Error was not thrown.")
+	}
+	if !IsNotFoundError(err) {
+		t.Fatal("Unrelated error was thrown.")
+	}
+	if _, ok := err.(*hcserror.HcsError); !ok {
 		t.Fatal("Wrong error type was thrown.")
 	}
 }


### PR DESCRIPTION
Handle namespace not found in IsNotFoundError.

This is needed to reliably handle network in containerd/cri.

Signed-off-by: Lantao Liu <lantaol@google.com>