### PR TITLE
Remove CompartmentID from L4ProxyPolicySetting

### DIFF
--- a/hcn/hcnpolicy.go
+++ b/hcn/hcnpolicy.go
@@ -167,10 +167,9 @@ type L4ProxyPolicySetting struct {
 	OutboundNat   bool     `json:",omitempty"`
 
 	// For the WFP proxy
-	FilterTuple   FiveTuple `json:",omitempty"`
-	ProxyType     ProxyType `json:",omitempty"`
-	UserSID       string    `json:",omitempty"`
-	CompartmentID uint32    `json:",omitempty"`
+	FilterTuple FiveTuple `json:",omitempty"`
+	ProxyType   ProxyType `json:",omitempty"`
+	UserSID     string    `json:",omitempty"`
 }
 
 // PortnameEndpointPolicySetting sets the port name for an endpoint.


### PR DESCRIPTION
In an upcoming version of HNS, the L4 proxy policy does not take a compartment ID anymore, instead HNS figures out the compartment ID from the endpoint the policy is attached to.

Of course, this should only be merged when that HNS version becomes publicly available (made the PR a draft to prevent an accidental merge before that happens).