### PR TITLE
uvm: Send entropy to Linux UVMs during boot

### DIFF
--- a/internal/uvm/start.go
+++ b/internal/uvm/start.go
@@ -3,6 +3,7 @@ package uvm
 import (
 	"bytes"
 	"context"
+	"crypto/rand"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -14,11 +15,20 @@ import (
 
 	"github.com/Microsoft/hcsshim/internal/gcs"
 	"github.com/Microsoft/hcsshim/internal/log"
-
 	"github.com/Microsoft/hcsshim/internal/logfields"
 	"github.com/Microsoft/hcsshim/internal/schema1"
 	"github.com/sirupsen/logrus"
+	"golang.org/x/sync/errgroup"
 )
+
+// entropyBytes is the number of bytes of random data to send to a Linux UVM
+// during boot to seed the CRNG. There is not much point in making this too
+// large since the random data collected from the host is likely computed from a
+// relatively small key (256 bits?), so additional bytes would not actually
+// increase the entropy of the guest's pool. However, send enough to convince
+// containers that there is a large amount of entropy since this idea is
+// generally misunderstood.
+const entropyBytes = 512
 
 type gcsLogEntryStandard struct {
 	Time    time.Time    `json:"time"`
@@ -105,48 +115,49 @@ func parseLogrus(vmid string) func(r io.Reader) {
 	}
 }
 
-type acceptResult struct {
-	c   net.Conn
-	err error
-}
-
-func processOutput(ctx context.Context, l net.Listener, doneChan chan struct{}, handler OutputHandler) {
-	defer close(doneChan)
-
-	ch := make(chan acceptResult)
-	go func() {
-		c, err := l.Accept()
-		ch <- acceptResult{c, err}
-	}()
-
-	select {
-	case <-ctx.Done():
-		l.Close()
-		return
-	case ar := <-ch:
-		c, err := ar.c, ar.err
-		l.Close()
-		if err != nil {
-			log.G(ctx).Error("accepting log socket: ", err)
-			return
-		}
-		defer c.Close()
-
-		handler(c)
-	}
-}
-
 // Start synchronously starts the utility VM.
 func (uvm *UtilityVM) Start(ctx context.Context) (err error) {
 	ctx, cancel := context.WithTimeout(ctx, 2*time.Minute)
+	g, gctx := errgroup.WithContext(ctx)
+	defer g.Wait()
 	defer cancel()
 
-	if uvm.outputListener != nil {
-		ctx, cancel := context.WithCancel(context.Background())
-		go processOutput(ctx, uvm.outputListener, uvm.outputProcessingDone, uvm.outputHandler)
-		uvm.outputProcessingCancel = cancel
-		uvm.outputListener = nil
+	// Prepare to provide entropy to the init process in the background. This
+	// must be done in a goroutine since, when using the internal bridge, the
+	// call to Start() will block until the GCS launches, and this cannot occur
+	// until the host accepts and closes the entropy connection.
+	if uvm.entropyListener != nil {
+		g.Go(func() error {
+			conn, err := uvm.acceptAndClose(gctx, uvm.entropyListener)
+			uvm.entropyListener = nil
+			if err != nil {
+				return fmt.Errorf("failed to connect to entropy socket: %s", err)
+			}
+			defer conn.Close()
+			_, err = io.CopyN(conn, rand.Reader, entropyBytes)
+			if err != nil {
+				return fmt.Errorf("failed to write entropy: %s", err)
+			}
+			return nil
+		})
 	}
+
+	if uvm.outputListener != nil {
+		g.Go(func() error {
+			conn, err := uvm.acceptAndClose(gctx, uvm.outputListener)
+			uvm.outputListener = nil
+			if err != nil {
+				close(uvm.outputProcessingDone)
+				return fmt.Errorf("failed to connect to log socket: %s", err)
+			}
+			go func() {
+				uvm.outputHandler(conn)
+				close(uvm.outputProcessingDone)
+			}()
+			return nil
+		})
+	}
+
 	err = uvm.hcsSystem.Start(ctx)
 	if err != nil {
 		return err
@@ -157,6 +168,7 @@ func (uvm *UtilityVM) Start(ctx context.Context) (err error) {
 			uvm.hcsSystem.Wait()
 		}
 	}()
+
 	// Start waiting on the utility VM.
 	uvm.exitCh = make(chan struct{})
 	go func() {
@@ -167,6 +179,13 @@ func (uvm *UtilityVM) Start(ctx context.Context) (err error) {
 		uvm.exitErr = err
 		close(uvm.exitCh)
 	}()
+
+	// Collect any errors from writing entropy or establishing the log
+	// connection.
+	if err = g.Wait(); err != nil {
+		return err
+	}
+
 	if uvm.gcListener != nil {
 		// Accept the GCS connection.
 		conn, err := uvm.acceptAndClose(ctx, uvm.gcListener)

--- a/internal/uvm/types.go
+++ b/internal/uvm/types.go
@@ -3,7 +3,6 @@ package uvm
 // This package describes the external interface for utility VMs.
 
 import (
-	"context"
 	"net"
 	"sync"
 
@@ -102,8 +101,9 @@ type UtilityVM struct {
 
 	namespaces map[string]*namespaceInfo
 
-	outputListener         net.Listener
-	outputProcessingDone   chan struct{}
-	outputHandler          OutputHandler
-	outputProcessingCancel context.CancelFunc
+	outputListener       net.Listener
+	outputProcessingDone chan struct{}
+	outputHandler        OutputHandler
+
+	entropyListener net.Listener
 }

--- a/internal/uvm/wait.go
+++ b/internal/uvm/wait.go
@@ -9,12 +9,6 @@ import (
 func (uvm *UtilityVM) Wait() error {
 	err := uvm.hcsSystem.Wait()
 
-	// outputProcessingCancel will only cancel waiting for the vsockexec
-	// connection, it won't stop output processing once the connection is
-	// established.
-	if uvm.outputProcessingCancel != nil {
-		uvm.outputProcessingCancel()
-	}
 	logrus.WithField(logfields.UVMID, uvm.id).Debug("uvm exited, waiting for output processing to complete")
 	if uvm.outputProcessingDone != nil {
 		<-uvm.outputProcessingDone


### PR DESCRIPTION
This change updates the Linux UVM boot sequence to open a vsock
connection to send entropy data to seed the kernel RNG. This is
necessary so that early uses of the kernel RNG reliably get
unpredictable data.

This depends on the corresponding change to init in the opengcs repo.