### PR TITLE
Explicitly set namespace when publishing an event

### DIFF
--- a/cmd/containerd-shim-runhcs-v1/events.go
+++ b/cmd/containerd-shim-runhcs-v1/events.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/Microsoft/hcsshim/internal/log"
 	"github.com/Microsoft/hcsshim/internal/oc"
+	"github.com/containerd/containerd/namespaces"
 	shim "github.com/containerd/containerd/runtime/v2/shim"
 	"github.com/sirupsen/logrus"
 	"go.opencensus.io/trace"
@@ -49,5 +50,5 @@ func (e *eventPublisher) publishEvent(ctx context.Context, topic string, event i
 		return nil
 	}
 
-	return e.remotePublisher.Publish(ctx, topic, event)
+	return e.remotePublisher.Publish(namespaces.WithNamespace(ctx, namespaceFlag), topic, event)
 }


### PR DESCRIPTION
This fixes a regression introduced when we switched to TTRPC for
publishing events to containerd. Previously we explicitly passed the
namespace for each event as a command line parameter to containerd.exe,
which was invoked to publish the event. Now that TTRPC is used, the
context passed to Publish is expected to include the namespace as a
stored value.

Signed-off-by: Kevin Parsons <kevpar@microsoft.com>