### PR TITLE
Fix LCOW run-as-user test to use own PID namespace

### DIFF
--- a/test/cri-containerd/execcontainer_test.go
+++ b/test/cri-containerd/execcontainer_test.go
@@ -84,6 +84,12 @@ func execContainerLCOW(t *testing.T, uid int64, cmd []string) *runtime.ExecSyncR
 			},
 			Linux: &runtime.LinuxContainerConfig{
 				SecurityContext: &runtime.LinuxContainerSecurityContext{
+					// Our tests rely on the init process for the workload
+					// container being pid 1, but the CRI default is to use the
+					// pod's pid namespace.
+					NamespaceOptions: &runtime.NamespaceOption{
+						Pid: runtime.NamespaceMode_CONTAINER,
+					},
 					RunAsUser: &runtime.Int64Value{
 						Value: uid,
 					},


### PR DESCRIPTION
Previously execcontainer_test.go was marked with a failing_tests build
tag which caused it to not actually be built. At some point after we
added support for run-as-user to LCOW, the build tag was removed.
However, it appears the test actually didn't work. The CRI default is to
put all containers in the same pod PID namespace, but the test assumed
the workload container's init would be PID 1 (PID 1 was actually the
sandbox container's init).

To fix this, we now specify the container PID namespace mode for the
workload container, so that it won't share a namespace with other
containers.

Signed-off-by: Kevin Parsons <kevpar@microsoft.com>