### PR TITLE
Add check for number of vpmem devices on uvm

### DIFF
--- a/internal/hcsoci/layers.go
+++ b/internal/hcsoci/layers.go
@@ -115,7 +115,8 @@ func MountContainerLayers(ctx context.Context, layerFolders []string, guestRoot 
 
 			var fi os.FileInfo
 			fi, err = os.Stat(hostPath)
-			if err == nil && uint64(fi.Size()) > uvm.PMemMaxSizeBytes() {
+
+			if err == nil && uvm.ExceededVPMem(fi.Size()) {
 				// Too big for PMEM. Add on SCSI instead (at /tmp/S<C>/<L>).
 				var (
 					controller int

--- a/internal/uvm/create_lcow.go
+++ b/internal/uvm/create_lcow.go
@@ -292,6 +292,7 @@ func CreateLCOW(ctx context.Context, opts *OptionsLCOW) (_ *UtilityVM, err error
 			uvmPath:  "/",
 			refCount: 1,
 		}
+		uvm.vpmemNumDevices++
 	}
 
 	vmDebugging := false

--- a/internal/uvm/types.go
+++ b/internal/uvm/types.go
@@ -89,8 +89,9 @@ type UtilityVM struct {
 	// VPMEM devices that are mapped into a Linux UVM. These are used for read-only layers, or for
 	// booting from VHD.
 	vpmemDevices      [MaxVPMEMCount]vpmemInfo // Limited by ACPI size.
-	vpmemMaxCount     uint32                   // Actual number of VPMem devices
-	vpmemMaxSizeBytes uint64                   // Actual size of VPMem devices
+	vpmemNumDevices   uint32                   // Current number of VPMem devices
+	vpmemMaxCount     uint32                   // Actual max number of VPMem devices
+	vpmemMaxSizeBytes uint64                   // Actual max size of VPMem devices
 
 	// SCSI devices that are mapped into a Windows or Linux utility VM
 	scsiLocations       [4][64]scsiInfo // Hyper-V supports 4 controllers, 64 slots per controller. Limited to 1 controller for now though.

--- a/internal/uvm/vpmem.go
+++ b/internal/uvm/vpmem.go
@@ -99,6 +99,8 @@ func (uvm *UtilityVM) AddVPMEM(ctx context.Context, hostPath string, expose bool
 			hostPath: hostPath,
 			refCount: 1,
 			uvmPath:  uvmPath}
+
+		uvm.vpmemNumDevices++
 	} else {
 		pmemi := vpmemInfo{
 			hostPath: hostPath,
@@ -142,6 +144,7 @@ func (uvm *UtilityVM) RemoveVPMEM(ctx context.Context, hostPath string) (err err
 			return fmt.Errorf("failed to remove VPMEM %s from utility VM %s: %s", hostPath, uvm.id, err)
 		}
 		uvm.vpmemDevices[deviceNumber] = vpmemInfo{}
+		uvm.vpmemNumDevices--
 		return nil
 	}
 	uvm.vpmemDevices[deviceNumber].refCount--
@@ -151,4 +154,9 @@ func (uvm *UtilityVM) RemoveVPMEM(ctx context.Context, hostPath string) (err err
 // PMemMaxSizeBytes returns the maximum size of a PMEM layer (LCOW)
 func (uvm *UtilityVM) PMemMaxSizeBytes() uint64 {
 	return uvm.vpmemMaxSizeBytes
+}
+
+// ExceededVPMem returns true if the addition of a new vpmem device exceeds uvm limits on vpmem
+func (uvm *UtilityVM) ExceededVPMem(fileSize int64) bool {
+	return (uint64(fileSize) > uvm.vpmemMaxSizeBytes) || (uvm.vpmemNumDevices >= uvm.vpmemMaxCount)
 }


### PR DESCRIPTION
This PR fixes the bug where cri could not run a sandbox when the max number of VPMem devices is set to one. 

Signed-off-by: Kathryn Baldauf <kabaldau@microsoft.com>