### PR TITLE
Fix an issue where un-exited exec's can stop container kill

### DIFF
--- a/cmd/containerd-shim-runhcs-v1/exec_test.go
+++ b/cmd/containerd-shim-runhcs-v1/exec_test.go
@@ -11,9 +11,10 @@ import (
 // exec `tid==id` MUST be true by containerd convention.
 func newTestShimExec(tid, id string, pid int) *testShimExec {
 	return &testShimExec{
-		tid: tid,
-		id:  id,
-		pid: pid,
+		tid:   tid,
+		id:    id,
+		pid:   pid,
+		state: shimExecStateCreated,
 	}
 }
 

--- a/test/cri-containerd/container.go
+++ b/test/cri-containerd/container.go
@@ -1,0 +1,50 @@
+// +build functional
+
+package cri_containerd
+
+import (
+	"context"
+	"testing"
+
+	runtime "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2"
+)
+
+func createContainer(t *testing.T, client runtime.RuntimeServiceClient, ctx context.Context, request *runtime.CreateContainerRequest) string {
+	response, err := client.CreateContainer(ctx, request)
+	if err != nil {
+		t.Fatalf("failed CreateContainer in sandbox: %s, with: %v", request.PodSandboxId, err)
+	}
+	return response.ContainerId
+}
+
+func startContainer(t *testing.T, client runtime.RuntimeServiceClient, ctx context.Context, containerID string) {
+	_, err := client.StartContainer(ctx, &runtime.StartContainerRequest{
+		ContainerId: containerID,
+	})
+	if err != nil {
+		t.Fatalf("failed StartContainer request for container: %s, with: %v", containerID, err)
+	}
+}
+
+func stopContainer(t *testing.T, client runtime.RuntimeServiceClient, ctx context.Context, containerID string) {
+	stopContainerWithTimeout(t, client, ctx, containerID, 0)
+}
+
+func stopContainerWithTimeout(t *testing.T, client runtime.RuntimeServiceClient, ctx context.Context, containerID string, timeout int64) {
+	_, err := client.StopContainer(ctx, &runtime.StopContainerRequest{
+		ContainerId: containerID,
+		Timeout:     timeout,
+	})
+	if err != nil {
+		t.Fatalf("failed StopContainer request for container: %s, with: %v", containerID, err)
+	}
+}
+
+func removeContainer(t *testing.T, client runtime.RuntimeServiceClient, ctx context.Context, containerID string) {
+	_, err := client.RemoveContainer(ctx, &runtime.RemoveContainerRequest{
+		ContainerId: containerID,
+	})
+	if err != nil {
+		t.Fatalf("failed StopContainer request for container: %s, with: %v", containerID, err)
+	}
+}

--- a/test/cri-containerd/createcontainer_test.go
+++ b/test/cri-containerd/createcontainer_test.go
@@ -14,30 +14,6 @@ import (
 	runtime "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2"
 )
 
-func createContainer(t *testing.T, client runtime.RuntimeServiceClient, ctx context.Context, request *runtime.CreateContainerRequest) string {
-	response, err := client.CreateContainer(ctx, request)
-	if err != nil {
-		t.Fatalf("failed CreateContainer in sandbox: %s, with: %v", request.PodSandboxId, err)
-	}
-	return response.ContainerId
-}
-
-func stopAndRemoveContainer(t *testing.T, client runtime.RuntimeServiceClient, ctx context.Context, containerID string) {
-	_, err := client.StopContainer(ctx, &runtime.StopContainerRequest{
-		ContainerId: containerID,
-	})
-	if err != nil {
-		// Error here so we can still attempt the delete
-		t.Errorf("failed StopContainer request for container: %s, with: %v", containerID, err)
-	}
-	_, err = client.RemoveContainer(ctx, &runtime.RemoveContainerRequest{
-		ContainerId: containerID,
-	})
-	if err != nil {
-		t.Fatalf("failed StopContainer request for container: %s, with: %v", containerID, err)
-	}
-}
-
 func runCreateContainerTest(t *testing.T, runtimeHandler string, request *runtime.CreateContainerRequest) {
 	sandboxRequest := &runtime.RunPodSandboxRequest{
 		Config: &runtime.PodSandboxConfig{
@@ -52,29 +28,23 @@ func runCreateContainerTest(t *testing.T, runtimeHandler string, request *runtim
 	runCreateContainerTestWithSandbox(t, sandboxRequest, request)
 }
 
-func runCreateContainerTestWithSandbox(t *testing.T, sandboxRequest *runtime.RunPodSandboxRequest, request *runtime.CreateContainerRequest) string {
+func runCreateContainerTestWithSandbox(t *testing.T, sandboxRequest *runtime.RunPodSandboxRequest, request *runtime.CreateContainerRequest) {
 	client := newTestRuntimeClient(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	podID := runPodSandbox(t, client, ctx, sandboxRequest)
-	defer func() {
-		stopAndRemovePodSandbox(t, client, ctx, podID)
-	}()
+	defer removePodSandbox(t, client, ctx, podID)
+	defer stopPodSandbox(t, client, ctx, podID)
 
 	request.PodSandboxId = podID
 	request.SandboxConfig = sandboxRequest.Config
+
 	containerID := createContainer(t, client, ctx, request)
-	defer func() {
-		stopAndRemoveContainer(t, client, ctx, containerID)
-	}()
-	_, err := client.StartContainer(ctx, &runtime.StartContainerRequest{
-		ContainerId: containerID,
-	})
-	if err != nil {
-		t.Fatalf("failed StartContainer request for container: %s, with: %v", containerID, err)
-	}
-	return containerID
+	defer removeContainer(t, client, ctx, containerID)
+
+	startContainer(t, client, ctx, containerID)
+	stopContainer(t, client, ctx, containerID)
 }
 
 func Test_CreateContainer_WCOW_Process(t *testing.T) {

--- a/test/cri-containerd/exec.go
+++ b/test/cri-containerd/exec.go
@@ -1,0 +1,26 @@
+// +build functional
+
+package cri_containerd
+
+import (
+	"context"
+	"testing"
+
+	runtime "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2"
+)
+
+func execSync(t *testing.T, client runtime.RuntimeServiceClient, ctx context.Context, request *runtime.ExecSyncRequest) *runtime.ExecSyncResponse {
+	response, err := client.ExecSync(ctx, request)
+	if err != nil {
+		t.Fatalf("failed ExecSync request with: %v", err)
+	}
+	return response
+}
+
+func exec(t *testing.T, client runtime.RuntimeServiceClient, ctx context.Context, request *runtime.ExecRequest) string {
+	response, err := client.Exec(ctx, request)
+	if err != nil {
+		t.Fatalf("failed Exec request with: %v", err)
+	}
+	return response.Url
+}

--- a/test/cri-containerd/sandbox.go
+++ b/test/cri-containerd/sandbox.go
@@ -1,0 +1,36 @@
+// +build functional
+
+package cri_containerd
+
+import (
+	"context"
+	"testing"
+
+	runtime "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2"
+)
+
+func runPodSandbox(t *testing.T, client runtime.RuntimeServiceClient, ctx context.Context, request *runtime.RunPodSandboxRequest) string {
+	response, err := client.RunPodSandbox(ctx, request)
+	if err != nil {
+		t.Fatalf("failed RunPodSandbox request with: %v", err)
+	}
+	return response.PodSandboxId
+}
+
+func stopPodSandbox(t *testing.T, client runtime.RuntimeServiceClient, ctx context.Context, podID string) {
+	_, err := client.StopPodSandbox(ctx, &runtime.StopPodSandboxRequest{
+		PodSandboxId: podID,
+	})
+	if err != nil {
+		t.Fatalf("failed StopPodSandbox for sandbox: %s, request with: %v", podID, err)
+	}
+}
+
+func removePodSandbox(t *testing.T, client runtime.RuntimeServiceClient, ctx context.Context, podID string) {
+	_, err := client.RemovePodSandbox(ctx, &runtime.RemovePodSandboxRequest{
+		PodSandboxId: podID,
+	})
+	if err != nil {
+		t.Fatalf("failed RemovePodSandbox for sandbox: %s, request with: %v", podID, err)
+	}
+}

--- a/test/cri-containerd/stopcontainer_test.go
+++ b/test/cri-containerd/stopcontainer_test.go
@@ -1,0 +1,150 @@
+// +build functional
+
+package cri_containerd
+
+import (
+	"context"
+	"testing"
+
+	runtime "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2"
+)
+
+func Test_StopContainer_LCOW(t *testing.T) {
+	pullRequiredLcowImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
+
+	client := newTestRuntimeClient(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	sandboxRequest := &runtime.RunPodSandboxRequest{
+		Config: &runtime.PodSandboxConfig{
+			Metadata: &runtime.PodSandboxMetadata{
+				Name:      t.Name() + "-Sandbox",
+				Namespace: testNamespace,
+			},
+		},
+		RuntimeHandler: lcowRuntimeHandler,
+	}
+
+	podID := runPodSandbox(t, client, ctx, sandboxRequest)
+	defer removePodSandbox(t, client, ctx, podID)
+	defer stopPodSandbox(t, client, ctx, podID)
+
+	request := &runtime.CreateContainerRequest{
+		PodSandboxId: podID,
+		Config: &runtime.ContainerConfig{
+			Metadata: &runtime.ContainerMetadata{
+				Name: t.Name() + "-Container",
+			},
+			Image: &runtime.ImageSpec{
+				Image: imageLcowAlpine,
+			},
+			Command: []string{
+				"top",
+			},
+		},
+		SandboxConfig: sandboxRequest.Config,
+	}
+
+	containerID := createContainer(t, client, ctx, request)
+	defer removeContainer(t, client, ctx, containerID)
+
+	startContainer(t, client, ctx, containerID)
+	stopContainer(t, client, ctx, containerID)
+}
+
+func Test_StopContainer_WithTimeout_LCOW(t *testing.T) {
+	pullRequiredLcowImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
+
+	client := newTestRuntimeClient(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	sandboxRequest := &runtime.RunPodSandboxRequest{
+		Config: &runtime.PodSandboxConfig{
+			Metadata: &runtime.PodSandboxMetadata{
+				Name:      t.Name() + "-Sandbox",
+				Namespace: testNamespace,
+			},
+		},
+		RuntimeHandler: lcowRuntimeHandler,
+	}
+
+	podID := runPodSandbox(t, client, ctx, sandboxRequest)
+	defer removePodSandbox(t, client, ctx, podID)
+	defer stopPodSandbox(t, client, ctx, podID)
+
+	request := &runtime.CreateContainerRequest{
+		PodSandboxId: podID,
+		Config: &runtime.ContainerConfig{
+			Metadata: &runtime.ContainerMetadata{
+				Name: t.Name() + "-Container",
+			},
+			Image: &runtime.ImageSpec{
+				Image: imageLcowAlpine,
+			},
+			Command: []string{
+				"top",
+			},
+		},
+		SandboxConfig: sandboxRequest.Config,
+	}
+
+	containerID := createContainer(t, client, ctx, request)
+	defer removeContainer(t, client, ctx, containerID)
+
+	startContainer(t, client, ctx, containerID)
+	stopContainerWithTimeout(t, client, ctx, containerID, 10)
+}
+
+func Test_StopContainer_WithExec_LCOW(t *testing.T) {
+	pullRequiredLcowImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
+
+	client := newTestRuntimeClient(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	sandboxRequest := &runtime.RunPodSandboxRequest{
+		Config: &runtime.PodSandboxConfig{
+			Metadata: &runtime.PodSandboxMetadata{
+				Name:      t.Name() + "-Sandbox",
+				Namespace: testNamespace,
+			},
+		},
+		RuntimeHandler: lcowRuntimeHandler,
+	}
+
+	podID := runPodSandbox(t, client, ctx, sandboxRequest)
+	defer removePodSandbox(t, client, ctx, podID)
+	defer stopPodSandbox(t, client, ctx, podID)
+
+	request := &runtime.CreateContainerRequest{
+		PodSandboxId: podID,
+		Config: &runtime.ContainerConfig{
+			Metadata: &runtime.ContainerMetadata{
+				Name: t.Name() + "-Container",
+			},
+			Image: &runtime.ImageSpec{
+				Image: imageLcowAlpine,
+			},
+			Command: []string{
+				"top",
+			},
+		},
+		SandboxConfig: sandboxRequest.Config,
+	}
+
+	containerID := createContainer(t, client, ctx, request)
+	defer removeContainer(t, client, ctx, containerID)
+
+	startContainer(t, client, ctx, containerID)
+	defer stopContainer(t, client, ctx, containerID)
+
+	exec(t, client, ctx, &runtime.ExecRequest{
+		ContainerId: containerID,
+		Cmd: []string{
+			"top",
+		},
+		Stdout: true,
+	})
+}


### PR DESCRIPTION
1. When issuing a Kill we know log any error from outstanding execs but do not
stop iterating to all other execs. We finally always send that signal to the
init exec.
2. We no longer verify that when sending a signal to the init exec that all
other execs are in the exited state. This was allowing a non-exited exec to
prevent the container from stopping.
3. When issuing a delete on the init exec we now forcibly exit all outstanding
execs.

Signed-off-by: Justin Terry (VM) <juterry@microsoft.com>