### PR TITLE
doc: clarify usage & deprecated tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ This package contains the Golang interface for using the Windows [Host Compute S
 
 It is primarily used in the [Moby Project](https://github.com/moby/moby), but it can be freely used by other projects as well.
 
+This is a code-only repository and does not have a stable release. 0.8.6 is the last tagged release, and it is out of date for ContainerD and Kubernetes. Downstream projects should vendor in this codebase using commit ids instead of tags, then validate fixes and do a full test pass of the whole project.
+
 ## Contributing
 
 This project welcomes contributions and suggestions.  Most contributions require you to agree to a

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This package contains the Golang interface for using the Windows [Host Compute S
 
 It is primarily used in the [Moby Project](https://github.com/moby/moby), but it can be freely used by other projects as well.
 
-This is a code-only repository and does not have a stable release. 0.8.6 is the last tagged release, and it is out of date for ContainerD and Kubernetes. Downstream projects should vendor in this codebase using commit ids instead of tags, then validate fixes and do a full test pass of the whole project.
+The tags in this repo are from a vendoring scheme intended the Docker repos, and is only stable for the v1 container and process API's. Newer projects vendoring this repo such as ContainerD or Kubernetes should use commit ids instead of tags, then validate fixes and do a test pass of the whole project. Hcsshim is not tested or released as an isolated unit.
 
 ## Contributing
 


### PR DESCRIPTION
There has been a lot of confusion since this repo used tags in the past, but that practice has stopped. I see that ContainerD has moved on to vendoring based on commitid, and after discussion is was recommended that Kubernetes do the same. This PR puts that recommendation in the README.


Related discussion:

https://github.com/kubernetes/kubernetes/pull/80116#issuecomment-534135678