### PR TITLE
Update ttrpc to fix status check error.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/containerd/continuity v0.0.0-20190426062206-aaeac12a7ffc // indirect
 	github.com/containerd/fifo v0.0.0-20190226154929-a9fb20d87448 // indirect
 	github.com/containerd/go-runc v0.0.0-20180907222934-5a6d9f37cfa3
-	github.com/containerd/ttrpc v0.0.0-20190826154248-f969a7f076a2
+	github.com/containerd/ttrpc v0.0.0-20190828154514-0e0f228740de
 	github.com/containerd/typeurl v0.0.0-20180627222232-a93fcdb778cd
 	github.com/docker/distribution v2.7.1+incompatible // indirect
 	github.com/docker/go-events v0.0.0-20190806004212-e31b211e4f1c // indirect

--- a/go.sum
+++ b/go.sum
@@ -28,6 +28,8 @@ github.com/containerd/ttrpc v0.0.0-20190613183316-1fb3814edf44 h1:vG5QXCUakUhR2C
 github.com/containerd/ttrpc v0.0.0-20190613183316-1fb3814edf44/go.mod h1:PvCDdDGpgqzQIzDW1TphrGLssLDZp2GuS+X5DkEJB8o=
 github.com/containerd/ttrpc v0.0.0-20190826154248-f969a7f076a2 h1:uR0Zz83OrfOhXWwDdwVYirFZI/LMdZXMzCHzfnQFO9w=
 github.com/containerd/ttrpc v0.0.0-20190826154248-f969a7f076a2/go.mod h1:PvCDdDGpgqzQIzDW1TphrGLssLDZp2GuS+X5DkEJB8o=
+github.com/containerd/ttrpc v0.0.0-20190828154514-0e0f228740de h1:dlfGmNcE3jDAecLqwKPMNX6nk2qh1c1Vg1/YTzpOOF4=
+github.com/containerd/ttrpc v0.0.0-20190828154514-0e0f228740de/go.mod h1:PvCDdDGpgqzQIzDW1TphrGLssLDZp2GuS+X5DkEJB8o=
 github.com/containerd/typeurl v0.0.0-20180627222232-a93fcdb778cd h1:JNn81o/xG+8NEo3bC/vx9pbi/g2WI8mtP2/nXzu297Y=
 github.com/containerd/typeurl v0.0.0-20180627222232-a93fcdb778cd/go.mod h1:Cm3kwCdlkCfMSHURc+r6fwoGH6/F1hH3S4sg0rLFWPc=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/vendor/github.com/containerd/ttrpc/.travis.yml
+++ b/vendor/github.com/containerd/ttrpc/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - "1.10.x"
+  - "1.12.x"
 
 install:
   - go get -u github.com/vbatts/git-validation

--- a/vendor/github.com/containerd/ttrpc/client.go
+++ b/vendor/github.com/containerd/ttrpc/client.go
@@ -29,6 +29,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
 
@@ -134,11 +135,10 @@ func (c *Client) Call(ctx context.Context, service, method string, req, resp int
 		return err
 	}
 
-	if cresp.Status == nil {
-		return errors.New("no status provided on response")
+	if cresp.Status != nil && cresp.Status.Code != int32(codes.OK) {
+		return status.ErrorProto(cresp.Status)
 	}
-
-	return status.ErrorProto(cresp.Status)
+	return nil
 }
 
 func (c *Client) dispatch(ctx context.Context, req *Request, resp *Response) error {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -32,7 +32,7 @@ github.com/containerd/containerd/sys/reaper
 github.com/containerd/fifo
 # github.com/containerd/go-runc v0.0.0-20180907222934-5a6d9f37cfa3
 github.com/containerd/go-runc
-# github.com/containerd/ttrpc v0.0.0-20190826154248-f969a7f076a2
+# github.com/containerd/ttrpc v0.0.0-20190828154514-0e0f228740de
 github.com/containerd/ttrpc
 # github.com/containerd/typeurl v0.0.0-20180627222232-a93fcdb778cd
 github.com/containerd/typeurl


### PR DESCRIPTION
I see a lot of `no status provided on response` errors right now:
```
time="2019-09-25T04:25:24.786235700Z" level=error msg="forward event" error="no status provided on response"
time="2019-09-25T04:25:25.649597000Z" level=error msg="forward event" error="no status provided on response"
time="2019-09-25T04:25:26.795661200Z" level=error msg="forward event" error="no status provided on response"
time="2019-09-25T04:25:28.651497300Z" level=error msg="forward event" error="no status provided on response"
time="2019-09-25T04:25:29.810168200Z" level=error msg="forward event" error="no status provided on response"
time="2019-09-25T04:25:32.664288500Z" level=error msg="forward event" error="no status provided on response"
time="2019-09-25T04:25:33.820457100Z" level=error msg="forward event" error="no status provided on response"
time="2019-09-25T04:25:37.670542700Z" level=error msg="forward event" error="no status provided on response"
time="2019-09-25T04:25:38.829335400Z" level=error msg="forward event" error="no status provided on response"
```

See https://github.com/containerd/ttrpc/pull/46

@jterry75 

Signed-off-by: Lantao Liu <lantaol@google.com>