### PR TITLE
Reliability and logging improvements to UVM stats

### DIFF
--- a/internal/uvm/types.go
+++ b/internal/uvm/types.go
@@ -112,6 +112,8 @@ type UtilityVM struct {
 	// Handle to the vmmem process associated with this UVM. Used to look up
 	// memory metrics for the UVM.
 	vmmemProcess windows.Handle
+	// Tracks the error returned when looking up the vmmem process.
+	vmmemErr error
 	// We only need to look up the vmmem process once, then we keep a handle
 	// open.
 	vmmemOnce sync.Once


### PR DESCRIPTION
This change does several things to make querying UVM stats more robust:
- Regardless of the error encountered when checking a process to see if
  it is the correct vmmem instance, log the error and skip to the next
  process. Previously we only skipped if the error was
  ERROR_ACCESS_DENIED. One case this will handle better now is if the
  process has exited by the time we try to open it, we will now continue
  looking at the other processes.
- The error returned by the vmmem lookup is now saved and returned every
  time we retrieve the saved vmmem process. This will make it easier to
  understand what the original error was even if we only have logs from
  the Nth time querying for stats.
- Added additional logging during vmmem lookup:
  - Every time we fail to check a process
  - Every vmmem process right before we check its user identity.

Signed-off-by: Kevin Parsons <kevpar@microsoft.com>