### PR TITLE
Support WCOW single-file mounts 

### DIFF
--- a/internal/hcsoci/resources_wcow.go
+++ b/internal/hcsoci/resources_wcow.go
@@ -117,8 +117,7 @@ func allocateWindowsResources(ctx context.Context, coi *createOptionsInternal, r
 					break
 				}
 
-				err := coi.HostingSystem.AddVSMB(ctx, mount.Source, "", options)
-				if err != nil {
+				if err := coi.HostingSystem.AddVSMB(ctx, mount.Source, "", options); err != nil {
 					return fmt.Errorf("failed to add VSMB share to utility VM for mount %+v: %s", mount, err)
 				}
 				resources.vsmbMounts = append(resources.vsmbMounts, mount.Source)

--- a/internal/requesttype/types.go
+++ b/internal/requesttype/types.go
@@ -7,4 +7,5 @@ const (
 	Add    = "Add"
 	Remove = "Remove"
 	PreAdd = "PreAdd" // For networking
+	Update = "Update"
 )

--- a/internal/uvm/create_wcow.go
+++ b/internal/uvm/create_wcow.go
@@ -66,7 +66,8 @@ func CreateWCOW(ctx context.Context, opts *OptionsWCOW) (_ *UtilityVM, err error
 		owner:               opts.Owner,
 		operatingSystem:     "windows",
 		scsiControllerCount: 1,
-		vsmbShares:          make(map[string]*vsmbShare),
+		vsmbDirShares:       make(map[string]*vsmbShare),
+		vsmbFileShares:      make(map[string]*vsmbShare),
 	}
 	defer func() {
 		if err != nil {

--- a/internal/uvm/types.go
+++ b/internal/uvm/types.go
@@ -25,6 +25,7 @@ type vsmbShare struct {
 	refCount     uint32
 	name         string
 	guestRequest interface{}
+	allowedFiles []string
 }
 
 // scsiInfo is an internal structure used for determining what is mapped to a utility VM.
@@ -83,9 +84,14 @@ type UtilityVM struct {
 	containerCounter uint64
 
 	// VSMB shares that are mapped into a Windows UVM. These are used for read-only
-	// layers and mapped directories
-	vsmbShares  map[string]*vsmbShare
-	vsmbCounter uint64 // Counter to generate a unique share name for each VSMB share.
+	// layers and mapped directories.
+	// We maintain two sets of maps, `vsmbDirShares` tracks shares that are
+	// unrestricted mappings of directories. `vsmbFileShares` tracks shares that
+	// are restricted to some subset of files in the directory. This is used as
+	// part of a temporary fix to allow WCOW single-file mapping to function.
+	vsmbDirShares  map[string]*vsmbShare
+	vsmbFileShares map[string]*vsmbShare
+	vsmbCounter    uint64 // Counter to generate a unique share name for each VSMB share.
 
 	// VPMEM devices that are mapped into a Linux UVM. These are used for read-only layers, or for
 	// booting from VHD.

--- a/test/cri-containerd/createcontainer_test.go
+++ b/test/cri-containerd/createcontainer_test.go
@@ -844,3 +844,81 @@ func Test_CreateContainer_Dir_Hostpath_LCOW(t *testing.T) {
 	}
 	runCreateContainerTest(t, lcowRuntimeHandler, request)
 }
+
+func Test_CreateContainer_File_Hostpath_WCOW(t *testing.T) {
+	pullRequiredImages(t, []string{imageWindowsRS5Nanoserver})
+
+	tempFile, err := ioutil.TempFile("", "test")
+
+	if err != nil {
+		t.Fatalf("Failed to create temp file: %s", err)
+	}
+
+	tempFile.Close()
+
+	defer func() {
+		if err := os.Remove(tempFile.Name()); err != nil {
+			t.Fatalf("Failed to remove temp file: %s", err)
+		}
+	}()
+
+	containerFilePath := `C:\foo\test`
+
+	request := &runtime.CreateContainerRequest{
+		Config: &runtime.ContainerConfig{
+			Metadata: &runtime.ContainerMetadata{
+				Name: t.Name() + "-Container",
+			},
+			Mounts: []*runtime.Mount{
+				{
+					HostPath:      tempFile.Name(),
+					ContainerPath: containerFilePath,
+				},
+			},
+			Image: &runtime.ImageSpec{
+				Image: imageWindowsRS5Nanoserver,
+			},
+			Command: []string{
+				"ping",
+				"-t",
+				"127.0.0.1",
+			},
+		},
+	}
+	runCreateContainerTest(t, wcowHypervisorRuntimeHandler, request)
+}
+
+func Test_CreateContainer_Dir_Hostpath_WCOW(t *testing.T) {
+	pullRequiredImages(t, []string{imageWindowsRS5Nanoserver})
+
+	tempDir, err := ioutil.TempDir("", "")
+
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %s", err)
+	}
+
+	containerFilePath := "C:\\foo"
+
+	request := &runtime.CreateContainerRequest{
+		Config: &runtime.ContainerConfig{
+			Metadata: &runtime.ContainerMetadata{
+				Name: t.Name() + "-Container",
+			},
+			Mounts: []*runtime.Mount{
+				{
+					HostPath:      tempDir,
+					ContainerPath: containerFilePath,
+				},
+			},
+			Image: &runtime.ImageSpec{
+				Image: imageWindowsRS5Nanoserver,
+			},
+			Command: []string{
+				"ping",
+				"-t",
+				"127.0.0.1",
+			},
+		},
+	}
+	runCreateContainerTest(t, wcowHypervisorRuntimeHandler, request)
+}


### PR DESCRIPTION
We currently support a temporary fix here to allow WCOW single-file
mounts to function. VSMB does not support directly mapping a single file
into a UVM, but rather supports an `AllowedFileList` along with options
`RestrictFileAccess` and `SingleFileMapping`, which are together used to
ensure that the share only presents a subset of the actual present
files. We map the file into the UVM using this approach, and then use
bindflt in the UVM to present the file in the share at the desired
location in the container file system.

However, naively implementing this introduces some problems. Notably,
the VSMB share map tracks shares by the host path, leading to problems
if you try to map an additional single file from the same directory, or
map a directory as both a set of single files, as well as in another
location as the entire directory.

To fully resolve this issue, we require broader changes to how resources
are managed in hcsshim. But for now we introduce a temporary fix. We now
separately track VSMB shares that present an unrestricted directory, and
those that allow only specific file access. When the VSMB functions
receive a host path, they take the appropriate action based on if that
path points to a  file (map its directory as a share restricted to only
the desired files), or if it points to a directory (map the directory
without restriction).

Signed-off-by: Kevin Parsons <kevpar@microsoft.com>

Originally I tried to fix this more robustly. However, it quickly became clear that broader changes to resource management in hcsshim were needed to enable that. So instead I am putting in this somewhat hacky fix to quickly enable WCOW single-file mounts, and then will revisit the broader issues later.