### PR TITLE
Shorten Shutdown and Terminate timeout to 30 seconds

### DIFF
--- a/cmd/containerd-shim-runhcs-v1/task_hcs.go
+++ b/cmd/containerd-shim-runhcs-v1/task_hcs.go
@@ -506,7 +506,7 @@ func (ht *hcsTask) close(ctx context.Context) {
 			if err != nil {
 				log.G(ctx).WithError(err).Error("failed to shutdown container")
 			} else {
-				t := time.NewTimer(time.Minute * 5)
+				t := time.NewTimer(time.Second * 30)
 				select {
 				case <-ch:
 					err = werr

--- a/internal/gcs/container.go
+++ b/internal/gcs/container.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"sync"
+	"time"
 
 	"github.com/Microsoft/hcsshim/internal/cow"
 	"github.com/Microsoft/hcsshim/internal/log"
@@ -167,6 +168,8 @@ func (c *Container) Shutdown(ctx context.Context) (err error) {
 	defer func() { oc.SetSpanStatus(span, err) }()
 	span.AddAttributes(trace.StringAttribute("cid", c.id))
 
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
 	return c.shutdown(ctx, rpcShutdownGraceful)
 }
 
@@ -179,6 +182,8 @@ func (c *Container) Terminate(ctx context.Context) (err error) {
 	defer func() { oc.SetSpanStatus(span, err) }()
 	span.AddAttributes(trace.StringAttribute("cid", c.id))
 
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
 	return c.shutdown(ctx, rpcShutdownForced)
 }
 


### PR DESCRIPTION
1. When issuing a Shutdown/Terminate over external bridge shorten the timeout
window to 30 seconds to protect against a misbehaving guest.
2. When waiting for a Shutdown to complete and the container to exit shorten
the timeout to 30 seconds to protect against a misbehaving guest.

Signed-off-by: Justin Terry (VM) <juterry@microsoft.com>