### PR TITLE
Do not remove sandbox prefix for sandbox mount before passing to opengcs

### DIFF
--- a/internal/hcsoci/resources_lcow.go
+++ b/internal/hcsoci/resources_lcow.go
@@ -98,9 +98,8 @@ func allocateLinuxResources(ctx context.Context, coi *createOptionsInternal, res
 				coi.Spec.Mounts[i].Type = "none"
 			} else if strings.HasPrefix(mount.Source, "sandbox://") {
 				// Mounts that map to a path in UVM are specified with 'sandbox://' prefix.
-				// we remove the prefix before passing them to GCS. Mount format looks like below
-				// source: sandbox:///a/dirInUvm destination:/b/dirInContainer
-				uvmPathForFile = strings.TrimPrefix(mount.Source, "sandbox://")
+				// example: sandbox:///a/dirInUvm destination:/b/dirInContainer
+				uvmPathForFile = mount.Source
 			} else {
 				st, err := os.Stat(hostPath)
 				if err != nil {


### PR DESCRIPTION
Signed-off-by: Kathryn Baldauf <kabaldau@microsoft.com>