### PR TITLE
Clear Linux.CgroupsPath in LCOW activation

### DIFF
--- a/internal/hcsoci/hcsdoc_lcow.go
+++ b/internal/hcsoci/hcsdoc_lcow.go
@@ -41,6 +41,7 @@ func createLCOWSpec(coi *createOptionsInternal) (*specs.Spec, error) {
 	spec.Hooks = nil
 
 	// Clear unsupported features
+	spec.Linux.CgroupsPath = "" // GCS controls its cgroups hierarchy on its own.
 	if spec.Linux.Resources != nil {
 		spec.Linux.Resources.Devices = nil
 		spec.Linux.Resources.Pids = nil


### PR DESCRIPTION
The GCS itself sets the cgroup parent based on its internal layout. Disallow
users to set this themselves.

Signed-off-by: Justin Terry (VM) <juterry@microsoft.com>