### PR TITLE
Support forwarding named pipes to WCOW hypervisor container

### DIFF
--- a/internal/hcsoci/hcsdoc_wcow.go
+++ b/internal/hcsoci/hcsdoc_wcow.go
@@ -245,13 +245,13 @@ func createWindowsContainerDocument(ctx context.Context, coi *createOptionsInter
 		mpsv2 []hcsschema.MappedPipe
 	)
 	for _, mount := range coi.Spec.Mounts {
-		const pipePrefix = `\\.\pipe\`
 		if mount.Type != "" {
 			return nil, nil, fmt.Errorf("invalid container spec - Mount.Type '%s' must not be set", mount.Type)
 		}
-		if strings.HasPrefix(strings.ToLower(mount.Destination), pipePrefix) {
-			mpsv1 = append(mpsv1, schema1.MappedPipe{HostPath: mount.Source, ContainerPipeName: mount.Destination[len(pipePrefix):]})
-			mpsv2 = append(mpsv2, hcsschema.MappedPipe{HostPath: mount.Source, ContainerPipeName: mount.Destination[len(pipePrefix):]})
+		if uvm.IsPipe(mount.Source) {
+			src, dst := uvm.GetContainerPipeMapping(coi.HostingSystem, mount)
+			mpsv1 = append(mpsv1, schema1.MappedPipe{HostPath: src, ContainerPipeName: dst})
+			mpsv2 = append(mpsv2, hcsschema.MappedPipe{HostPath: src, ContainerPipeName: dst})
 		} else {
 			readOnly := false
 			for _, o := range mount.Options {

--- a/internal/hcsoci/resources.go
+++ b/internal/hcsoci/resources.go
@@ -37,6 +37,10 @@ type Resources struct {
 	// (bind-)mounts into a WCOW v2 Xenon.
 	vsmbMounts []string
 
+	// pipeMounts is an array of the host-paths of named pipes mounted into a utility
+	// VM.
+	pipeMounts []string
+
 	// plan9Mounts is an array of all the host paths which have been added to
 	// an LCOW utility VM
 	plan9Mounts []*uvm.Plan9Share
@@ -117,6 +121,14 @@ func ReleaseResources(ctx context.Context, r *Resources, vm *uvm.UtilityVM, all 
 				return err
 			}
 			r.vsmbMounts = r.vsmbMounts[:len(r.vsmbMounts)-1]
+		}
+
+		for len(r.pipeMounts) != 0 {
+			mount := r.pipeMounts[len(r.pipeMounts)-1]
+			if err := vm.RemovePipe(ctx, mount); err != nil {
+				return err
+			}
+			r.pipeMounts = r.pipeMounts[:len(r.pipeMounts)-1]
 		}
 
 		for len(r.plan9Mounts) != 0 {

--- a/internal/uvm/pipes.go
+++ b/internal/uvm/pipes.go
@@ -1,0 +1,53 @@
+package uvm
+
+import (
+	"context"
+	"strings"
+
+	"github.com/Microsoft/hcsshim/internal/requesttype"
+	hcsschema "github.com/Microsoft/hcsshim/internal/schema2"
+	specs "github.com/opencontainers/runtime-spec/specs-go"
+)
+
+const pipePrefix = `\\.\pipe\`
+
+// AddPipe shares a named pipe into the UVM.
+func (uvm *UtilityVM) AddPipe(ctx context.Context, hostPath string) error {
+	modification := &hcsschema.ModifySettingRequest{
+		RequestType:  requesttype.Add,
+		ResourcePath: "VirtualMachine/Devices/MappedPipes/" + hostPath,
+	}
+	if err := uvm.Modify(ctx, modification); err != nil {
+		return err
+	}
+	return nil
+}
+
+// RemovePipe removes a shared named pipe from the UVM.
+func (uvm *UtilityVM) RemovePipe(ctx context.Context, hostPath string) error {
+	modification := &hcsschema.ModifySettingRequest{
+		RequestType:  requesttype.Remove,
+		ResourcePath: "VirtualMachine/Devices/MappedPipes/" + hostPath,
+	}
+	if err := uvm.Modify(ctx, modification); err != nil {
+		return err
+	}
+	return nil
+}
+
+// IsPipe returns true if the given path references a named pipe.
+func IsPipe(hostPath string) bool {
+	return strings.HasPrefix(hostPath, pipePrefix)
+}
+
+// GetContainerPipeMapping returns the source and destination to use for a given
+// pipe mount in a container.
+func GetContainerPipeMapping(uvm *UtilityVM, mount specs.Mount) (src string, dst string) {
+	if uvm == nil {
+		src = mount.Source
+	} else {
+		src = vsmbSharePrefix + `IPC$\` + strings.TrimPrefix(mount.Source, pipePrefix)
+	}
+	dst = strings.TrimPrefix(mount.Destination, pipePrefix)
+	return src, dst
+}

--- a/internal/uvm/vsmb.go
+++ b/internal/uvm/vsmb.go
@@ -11,6 +11,8 @@ import (
 	hcsschema "github.com/Microsoft/hcsshim/internal/schema2"
 )
 
+const vsmbSharePrefix = `\\?\VMSMB\VSMB-{dcc079ae-60ba-4d07-847c-3493609c0870}\`
+
 // findVSMBShare finds a share by `hostPath`. If not found returns `ErrNotAttached`.
 func (uvm *UtilityVM) findVSMBShare(ctx context.Context, m map[string]*vsmbShare, hostPath string) (*vsmbShare, error) {
 	share, ok := m[hostPath]
@@ -21,7 +23,7 @@ func (uvm *UtilityVM) findVSMBShare(ctx context.Context, m map[string]*vsmbShare
 }
 
 func (share *vsmbShare) GuestPath() string {
-	return `\\?\VMSMB\VSMB-{dcc079ae-60ba-4d07-847c-3493609c0870}\` + share.name
+	return vsmbSharePrefix + share.name
 }
 
 // AddVSMB adds a VSMB share to a Windows utility VM. Each VSMB share is ref-counted and

--- a/test/cri-containerd/runpodsandbox_test.go
+++ b/test/cri-containerd/runpodsandbox_test.go
@@ -789,8 +789,8 @@ func Test_RunPodSandbox_CustomizableScratchCustomSize_LCOW(t *testing.T) {
 	}
 }
 
-func Test_RunPodSandbox_ContainerUvmMount_LCOW(t *testing.T) {
-	pullRequiredLcowImages(t, []string{imageLcowK8sPause})
+func Test_RunPodSandbox_Mount_SandboxDir_LCOW(t *testing.T) {
+	pullRequiredLcowImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
 
 	annotations := map[string]string{
 		"io.microsoft.virtualmachine.computetopology.memory.allowovercommit": "true",
@@ -809,7 +809,7 @@ func Test_RunPodSandbox_ContainerUvmMount_LCOW(t *testing.T) {
 	output, errorMsg, exitCode := createSandboxContainerAndExec(t, annotations, mounts, cmd)
 
 	if exitCode != 0 {
-		t.Fatalf("Exec into container failed with: %v and exit code: %d, Test_RunPodSandbox_ContainerUvmMount_LCOW", errorMsg, exitCode)
+		t.Fatalf("Exec into container failed with: %v and exit code: %d, %s", errorMsg, exitCode, t.Name())
 	}
 
 	t.Log(output)


### PR DESCRIPTION
Adds support for forwarding a named pipe from the host into a WCOW
hypervisor container (forwarding to a process container appears to
already have been supported). To forward a pipe into a hypervisor
container, the pipe must first be mapped into the UVM via the
MappedPipes resource type. The MappedPipes resource actually just sets
up a VSMB share for the pipes, so in the future we could choose to
manage this concept directly as a VSMB share rather than via the
MappedPipes resource.

Signed-off-by: Kevin Parsons <kevpar@microsoft.com>