### PR TITLE
Adding Slash32EndpointPrefixes and AclSupportForProtocol252 feature detection logic

### DIFF
--- a/hcn/hcn.go
+++ b/hcn/hcn.go
@@ -161,6 +161,24 @@ func DSRSupported() error {
 	return platformDoesNotSupportError("Direct Server Return (DSR)")
 }
 
+// Slash32EndpointPrefixesSupported returns an error if the HCN version does not support configuring endpoints with /32 prefixes.
+func Slash32EndpointPrefixesSupported() error {
+	supported := GetSupportedFeatures()
+	if supported.Slash32EndpointPrefixes {
+		return nil
+	}
+	return platformDoesNotSupportError("Slash 32 Endpoint prefixes")
+}
+
+// AclSupportForProtocol252Supported returns an error if the HCN version does not support HNS ACL Policies to support protocol 252 for VXLAN.
+func AclSupportForProtocol252Supported() error {
+	supported := GetSupportedFeatures()
+	if supported.AclSupportForProtocol252 {
+		return nil
+	}
+	return platformDoesNotSupportError("HNS ACL Policies to support protocol 252 for VXLAN")
+}
+
 // RequestType are the different operations performed to settings.
 // Used to update the settings of Endpoint/Namespace objects.
 type RequestType string

--- a/hcn/hcnglobals.go
+++ b/hcn/hcnglobals.go
@@ -3,6 +3,7 @@ package hcn
 import (
 	"encoding/json"
 	"fmt"
+	"math"
 
 	"github.com/Microsoft/hcsshim/internal/hcserror"
 	"github.com/Microsoft/hcsshim/internal/interop"
@@ -20,17 +21,34 @@ type Version struct {
 	Minor int `json:"Minor"`
 }
 
+type VersionRange struct {
+	MinVersion Version
+	MaxVersion Version
+}
+
+type VersionRanges []VersionRange
+
 var (
 	// HNSVersion1803 added ACL functionality.
-	HNSVersion1803 = Version{Major: 7, Minor: 2}
+	HNSVersion1803 = VersionRanges{VersionRange{MinVersion: Version{Major: 7, Minor: 2}, MaxVersion: Version{Major: math.MaxInt32, Minor: math.MaxInt32}}}
 	// V2ApiSupport allows the use of V2 Api calls and V2 Schema.
-	V2ApiSupport = Version{Major: 9, Minor: 2}
+	V2ApiSupport = VersionRanges{VersionRange{MinVersion: Version{Major: 9, Minor: 2}, MaxVersion: Version{Major: math.MaxInt32, Minor: math.MaxInt32}}}
 	// Remote Subnet allows for Remote Subnet policies on Overlay networks
-	RemoteSubnetVersion = Version{Major: 9, Minor: 2}
+	RemoteSubnetVersion = VersionRanges{VersionRange{MinVersion: Version{Major: 9, Minor: 2}, MaxVersion: Version{Major: math.MaxInt32, Minor: math.MaxInt32}}}
 	// A Host Route policy allows for local container to local host communication Overlay networks
-	HostRouteVersion = Version{Major: 9, Minor: 2}
+	HostRouteVersion = VersionRanges{VersionRange{MinVersion: Version{Major: 9, Minor: 2}, MaxVersion: Version{Major: math.MaxInt32, Minor: math.MaxInt32}}}
 	// HNS 10.2 allows for Direct Server Return for loadbalancing
-	DSRVersion = Version{Major: 10, Minor: 2}
+	DSRVersion = VersionRanges{VersionRange{MinVersion: Version{Major: 10, Minor: 2}, MaxVersion: Version{Major: math.MaxInt32, Minor: math.MaxInt32}}}
+	// HNS 9.3 through 10.0 (not included) and, 10.4+ provide support for configuring endpoints with /32 prefixes
+	Slash32EndpointPrefixesVersion = VersionRanges{
+		VersionRange{MinVersion: Version{Major: 9, Minor: 3}, MaxVersion: Version{Major: 9, Minor: math.MaxInt32}},
+		VersionRange{MinVersion: Version{Major: 10, Minor: 4}, MaxVersion: Version{Major: math.MaxInt32, Minor: math.MaxInt32}},
+	}
+	// HNS 9.3 through 10.0 (not included) and, 10.4+ allow for HNS ACL Policies to support protocol 252 for VXLAN
+	AclSupportForProtocol252Version = VersionRanges{
+		VersionRange{MinVersion: Version{Major: 9, Minor: 3}, MaxVersion: Version{Major: 9, Minor: math.MaxInt32}},
+		VersionRange{MinVersion: Version{Major: 10, Minor: 4}, MaxVersion: Version{Major: math.MaxInt32, Minor: math.MaxInt32}},
+	}
 )
 
 // GetGlobals returns the global properties of the HCN Service.

--- a/hcn/hcnsupport.go
+++ b/hcn/hcnsupport.go
@@ -6,11 +6,13 @@ import (
 
 // SupportedFeatures are the features provided by the Service.
 type SupportedFeatures struct {
-	Acl          AclFeatures `json:"ACL"`
-	Api          ApiSupport  `json:"API"`
-	RemoteSubnet bool        `json:"RemoteSubnet"`
-	HostRoute    bool        `json:"HostRoute"`
-	DSR          bool        `json:"DSR"`
+	Acl                      AclFeatures `json:"ACL"`
+	Api                      ApiSupport  `json:"API"`
+	RemoteSubnet             bool        `json:"RemoteSubnet"`
+	HostRoute                bool        `json:"HostRoute"`
+	DSR                      bool        `json:"DSR"`
+	Slash32EndpointPrefixes  bool        `json:"Slash32EndpointPrefixes"`
+	AclSupportForProtocol252 bool        `json:"AclSupportForProtocol252"`
 }
 
 // AclFeatures are the supported ACL possibilities.
@@ -53,18 +55,37 @@ func GetSupportedFeatures() SupportedFeatures {
 	features.RemoteSubnet = isFeatureSupported(globals.Version, RemoteSubnetVersion)
 	features.HostRoute = isFeatureSupported(globals.Version, HostRouteVersion)
 	features.DSR = isFeatureSupported(globals.Version, DSRVersion)
+	features.Slash32EndpointPrefixes = isFeatureSupported(globals.Version, Slash32EndpointPrefixesVersion)
+	features.AclSupportForProtocol252 = isFeatureSupported(globals.Version, AclSupportForProtocol252Version)
 
 	return features
 }
 
-func isFeatureSupported(currentVersion Version, minVersionSupported Version) bool {
-	if currentVersion.Major < minVersionSupported.Major {
+func isFeatureSupported(currentVersion Version, versionsSupported VersionRanges) bool {
+	isFeatureSupported := false
+
+	for _, versionRange := range versionsSupported {
+		isFeatureSupported = isFeatureSupported || isFeatureInRange(currentVersion, versionRange)
+	}
+
+	return isFeatureSupported
+}
+
+func isFeatureInRange(currentVersion Version, versionRange VersionRange) bool {
+	if currentVersion.Major < versionRange.MinVersion.Major {
+		logrus.Infof("currentVersion.Major < versionRange.MinVersion.Major: %v, %v", currentVersion.Major, versionRange.MinVersion.Major)
 		return false
 	}
-	if currentVersion.Major > minVersionSupported.Major {
-		return true
+	if currentVersion.Major > versionRange.MaxVersion.Major {
+		logrus.Infof("currentVersion.Major > versionRange.MaxVersion.Major: %v, %v", currentVersion.Major, versionRange.MaxVersion.Major)
+		return false
 	}
-	if currentVersion.Minor < minVersionSupported.Minor {
+	if currentVersion.Major == versionRange.MinVersion.Major && currentVersion.Minor < versionRange.MinVersion.Minor {
+		logrus.Infof("currentVersion.Minor < versionRange.MinVersion.Major: %v, %v", currentVersion.Minor, versionRange.MinVersion.Minor)
+		return false
+	}
+	if currentVersion.Major == versionRange.MaxVersion.Major && currentVersion.Minor > versionRange.MaxVersion.Minor {
+		logrus.Infof("currentVersion.Minor > versionRange.MaxVersion.Major: %v, %v", currentVersion.Minor, versionRange.MaxVersion.Minor)
 		return false
 	}
 	return true

--- a/hcn/hcnsupport_test.go
+++ b/hcn/hcnsupport_test.go
@@ -60,3 +60,188 @@ func TestDSRSupport(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestSlash32EndpointPrefixesSupport(t *testing.T) {
+	supportedFeatures := GetSupportedFeatures()
+	err := Slash32EndpointPrefixesSupported()
+	if supportedFeatures.Slash32EndpointPrefixes && err != nil {
+		t.Fatal(err)
+	}
+	if !supportedFeatures.Slash32EndpointPrefixes && err == nil {
+		t.Fatal(err)
+	}
+}
+
+func TestAclSupportForProtocol252Support(t *testing.T) {
+	supportedFeatures := GetSupportedFeatures()
+	err := AclSupportForProtocol252Supported()
+	if supportedFeatures.AclSupportForProtocol252 && err != nil {
+		t.Fatal(err)
+	}
+	if !supportedFeatures.AclSupportForProtocol252 && err == nil {
+		t.Fatal(err)
+	}
+}
+
+func TestIsFeatureSupported(t *testing.T) {
+	// HNSVersion1803 testing (single range tests)
+	if isFeatureSupported(Version{Major: 0, Minor: 0}, HNSVersion1803) {
+		t.Fatalf("HNSVersion1803 should NOT be supported on HNS version 0.0")
+	}
+
+	if isFeatureSupported(Version{Major: 7, Minor: 0}, HNSVersion1803) {
+		t.Fatalf("HNSVersion1803 should NOT be supported on HNS version 7.1")
+	}
+
+	if isFeatureSupported(Version{Major: 7, Minor: 1}, HNSVersion1803) {
+		t.Fatalf("HNSVersion1803 should NOT be supported on HNS version 7.1")
+	}
+
+	if !isFeatureSupported(Version{Major: 7, Minor: 2}, HNSVersion1803) {
+		t.Fatalf("HNSVersion1803 SHOULD be supported on HNS version 7.2")
+	}
+
+	if !isFeatureSupported(Version{Major: 7, Minor: 3}, HNSVersion1803) {
+		t.Fatalf("HNSVersion1803 SHOULD be supported on HNS version 7.3")
+	}
+
+	if !isFeatureSupported(Version{Major: 8, Minor: 0}, HNSVersion1803) {
+		t.Fatalf("HNSVersion1803 SHOULD be supported on HNS version 8.0")
+	}
+
+	if !isFeatureSupported(Version{Major: 8, Minor: 2}, HNSVersion1803) {
+		t.Fatalf("HNSVersion1803 SHOULD be supported on HNS version 8.2")
+	}
+
+	if !isFeatureSupported(Version{Major: 8, Minor: 3}, HNSVersion1803) {
+		t.Fatalf("HNSVersion1803 SHOULD be supported on HNS version 8.3")
+	}
+
+	if !isFeatureSupported(Version{Major: 255, Minor: 2}, HNSVersion1803) {
+		t.Fatalf("HNSVersion1803 SHOULD be supported on HNS version 255.2")
+	}
+
+	if !isFeatureSupported(Version{Major: 255, Minor: 0}, HNSVersion1803) {
+		t.Fatalf("HNSVersion1803 SHOULD be supported on HNS version 255.0")
+	}
+
+	if !isFeatureSupported(Version{Major: 255, Minor: 6}, HNSVersion1803) {
+		t.Fatalf("HNSVersion1803 SHOULD be supported on HNS version 255.6")
+	}
+
+	// Slash 32 endpoint prefix support testing (multi-ranges tests)
+	if isFeatureSupported(Version{Major: 8, Minor: 0}, Slash32EndpointPrefixesVersion) {
+		t.Fatalf("Slash32EndpointPrefixesVersion should NOT be supported on HNS version 8.0")
+	}
+
+	if isFeatureSupported(Version{Major: 8, Minor: 2}, Slash32EndpointPrefixesVersion) {
+		t.Fatalf("Slash32EndpointPrefixesVersion should NOT be supported on HNS version 8.2")
+	}
+
+	if isFeatureSupported(Version{Major: 8, Minor: 3}, Slash32EndpointPrefixesVersion) {
+		t.Fatalf("Slash32EndpointPrefixesVersion should NOT be supported on HNS version 8.3")
+	}
+
+	if isFeatureSupported(Version{Major: 8, Minor: 4}, Slash32EndpointPrefixesVersion) {
+		t.Fatalf("Slash32EndpointPrefixesVersion should NOT be supported on HNS version 8.4")
+	}
+
+	if isFeatureSupported(Version{Major: 8, Minor: 5}, Slash32EndpointPrefixesVersion) {
+		t.Fatalf("Slash32EndpointPrefixesVersion should NOT be supported on HNS version 8.5")
+	}
+
+	if isFeatureSupported(Version{Major: 9, Minor: 0}, Slash32EndpointPrefixesVersion) {
+		t.Fatalf("Slash32EndpointPrefixesVersion should NOT be supported on HNS version 9.0")
+	}
+
+	if isFeatureSupported(Version{Major: 9, Minor: 2}, Slash32EndpointPrefixesVersion) {
+		t.Fatalf("Slash32EndpointPrefixesVersion should NOT be supported on HNS version 9.2")
+	}
+
+	//// Beginning of supported range
+	if !isFeatureSupported(Version{Major: 9, Minor: 3}, Slash32EndpointPrefixesVersion) {
+		t.Fatalf("Slash32EndpointPrefixesVersion SHOULD be supported on HNS version 9.3")
+	}
+
+	if !isFeatureSupported(Version{Major: 9, Minor: 4}, Slash32EndpointPrefixesVersion) {
+		t.Fatalf("Slash32EndpointPrefixesVersion SHOULD be supported on HNS version 9.4")
+	}
+
+	if !isFeatureSupported(Version{Major: 9, Minor: 5}, Slash32EndpointPrefixesVersion) {
+		t.Fatalf("Slash32EndpointPrefixesVersion SHOULD be supported on HNS version 9.5")
+	}
+
+	if !isFeatureSupported(Version{Major: 9, Minor: 9}, Slash32EndpointPrefixesVersion) {
+		t.Fatalf("Slash32EndpointPrefixesVersion SHOULD be supported on HNS version 9.9")
+	}
+
+	if !isFeatureSupported(Version{Major: 9, Minor: 372}, Slash32EndpointPrefixesVersion) {
+		t.Fatalf("Slash32EndpointPrefixesVersion SHOULD be supported on HNS version 9.372")
+	}
+	//// End of supported range
+
+	if isFeatureSupported(Version{Major: 10, Minor: 0}, Slash32EndpointPrefixesVersion) {
+		t.Fatalf("Slash32EndpointPrefixesVersion should NOT be supported on HNS version 10.0")
+	}
+
+	if isFeatureSupported(Version{Major: 10, Minor: 1}, Slash32EndpointPrefixesVersion) {
+		t.Fatalf("Slash32EndpointPrefixesVersion should NOT be supported on HNS version 10.1")
+	}
+
+	if isFeatureSupported(Version{Major: 10, Minor: 2}, Slash32EndpointPrefixesVersion) {
+		t.Fatalf("Slash32EndpointPrefixesVersion should NOT be supported on HNS version 10.2")
+	}
+
+	if isFeatureSupported(Version{Major: 10, Minor: 3}, Slash32EndpointPrefixesVersion) {
+		t.Fatalf("Slash32EndpointPrefixesVersion should NOT be supported on HNS version 10.3")
+	}
+
+	//// Beginning of supported range (final range, no end)
+	if !isFeatureSupported(Version{Major: 10, Minor: 4}, Slash32EndpointPrefixesVersion) {
+		t.Fatalf("Slash32EndpointPrefixesVersion SHOULD be supported on HNS version 10.4")
+	}
+
+	if !isFeatureSupported(Version{Major: 10, Minor: 5}, Slash32EndpointPrefixesVersion) {
+		t.Fatalf("Slash32EndpointPrefixesVersion SHOULD be supported on HNS version 10.5")
+	}
+
+	if !isFeatureSupported(Version{Major: 10, Minor: 9}, Slash32EndpointPrefixesVersion) {
+		t.Fatalf("Slash32EndpointPrefixesVersion SHOULD be supported on HNS version 10.9")
+	}
+
+	if !isFeatureSupported(Version{Major: 10, Minor: 410}, Slash32EndpointPrefixesVersion) {
+		t.Fatalf("Slash32EndpointPrefixesVersion SHOULD be supported on HNS version 10.410")
+	}
+
+	if !isFeatureSupported(Version{Major: 11, Minor: 0}, Slash32EndpointPrefixesVersion) {
+		t.Fatalf("Slash32EndpointPrefixesVersion SHOULD be supported on HNS version 11.0")
+	}
+
+	if !isFeatureSupported(Version{Major: 11, Minor: 1}, Slash32EndpointPrefixesVersion) {
+		t.Fatalf("Slash32EndpointPrefixesVersion SHOULD be supported on HNS version 11.1")
+	}
+
+	if !isFeatureSupported(Version{Major: 11, Minor: 2}, Slash32EndpointPrefixesVersion) {
+		t.Fatalf("Slash32EndpointPrefixesVersion SHOULD be supported on HNS version 11.2")
+	}
+
+	if !isFeatureSupported(Version{Major: 11, Minor: 3}, Slash32EndpointPrefixesVersion) {
+		t.Fatalf("Slash32EndpointPrefixesVersion SHOULD be supported on HNS version 11.3")
+	}
+
+	if !isFeatureSupported(Version{Major: 11, Minor: 4}, Slash32EndpointPrefixesVersion) {
+		t.Fatalf("Slash32EndpointPrefixesVersion SHOULD be supported on HNS version 11.4")
+	}
+
+	if !isFeatureSupported(Version{Major: 11, Minor: 5}, Slash32EndpointPrefixesVersion) {
+		t.Fatalf("Slash32EndpointPrefixesVersion SHOULD be supported on HNS version 11.5")
+	}
+
+	if !isFeatureSupported(Version{Major: 11, Minor: 9}, Slash32EndpointPrefixesVersion) {
+		t.Fatalf("Slash32EndpointPrefixesVersion SHOULD be supported on HNS version 11.9")
+	}
+
+	if !isFeatureSupported(Version{Major: 255, Minor: 2}, Slash32EndpointPrefixesVersion) {
+		t.Fatalf("Slash32EndpointPrefixesVersion SHOULD be supported on HNS version 255.2")
+	}
+}


### PR DESCRIPTION
Adding Slash32EndpointPrefixes and AclSupportForProtocol252 feature detection logic.
- Introduced support for detecting features on disjoint HNS versions
- Added support for Slash32EndpointPrefixes and AclSupportForProtocol252
- Added unit-testing of version ranges to the go tests

