### PR TITLE
Fix issue in LCOW test with CPU set limit

### DIFF
--- a/test/cri-containerd/createcontainer_test.go
+++ b/test/cri-containerd/createcontainer_test.go
@@ -486,7 +486,7 @@ func Test_CreateContainer_CPUCount_LCOW(t *testing.T) {
 			},
 			Linux: &runtime.LinuxContainerConfig{
 				Resources: &runtime.LinuxContainerResources{
-					CpusetCpus: "0-3",
+					CpusetCpus: "0",
 				},
 			},
 		},


### PR DESCRIPTION
Now that we properly honor the CPU set limits the test starting failing because
it uses an invalid set of processors for a default 2 vCPU UVM.

Signed-off-by: Justin Terry (VM) <juterry@microsoft.com>