### PR TITLE
Fix a race condition in vPMEM layer addition fallback

### DIFF
--- a/internal/uvm/create_lcow.go
+++ b/internal/uvm/create_lcow.go
@@ -294,12 +294,11 @@ func CreateLCOW(ctx context.Context, opts *OptionsLCOW) (_ *UtilityVM, err error
 			},
 		}
 		// Add to our internal structure
-		uvm.vpmemDevices[0] = vpmemInfo{
+		uvm.vpmemDevices[0] = &vpmemInfo{
 			hostPath: opts.RootFSFile,
 			uvmPath:  "/",
 			refCount: 1,
 		}
-		uvm.vpmemNumDevices++
 	}
 
 	vmDebugging := false

--- a/internal/uvm/types.go
+++ b/internal/uvm/types.go
@@ -95,10 +95,9 @@ type UtilityVM struct {
 
 	// VPMEM devices that are mapped into a Linux UVM. These are used for read-only layers, or for
 	// booting from VHD.
-	vpmemDevices      [MaxVPMEMCount]vpmemInfo // Limited by ACPI size.
-	vpmemNumDevices   uint32                   // Current number of VPMem devices
-	vpmemMaxCount     uint32                   // Actual max number of VPMem devices
-	vpmemMaxSizeBytes uint64                   // Actual max size of VPMem devices
+	vpmemDevices      [MaxVPMEMCount]*vpmemInfo // Limited by ACPI size.
+	vpmemMaxCount     uint32                    // The max number of VPMem devices.
+	vpmemMaxSizeBytes uint64                    // The max size of the layer in bytes per vPMem device.
 
 	// SCSI devices that are mapped into a Windows or Linux utility VM
 	scsiLocations       [4][64]scsiInfo // Hyper-V supports 4 controllers, 64 slots per controller. Limited to 1 controller for now though.


### PR DESCRIPTION
1. Fixes a race condition between when the check for vPMEM layer space and the
actual addition takes place for parallel creates/removals.
2. Simplifies the fallback logic for LCOW when adding layers first to vPMEM and
if there is no space or the file is too large based on max vpmem layer size
settings falls back to SCSI.

Signed-off-by: Justin Terry (VM) <juterry@microsoft.com>