### PR TITLE
Simplify hcsoci.MountContainerLayers cleanup logic

### DIFF
--- a/test/functional/uvm_vpmem_test.go
+++ b/test/functional/uvm_vpmem_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/Microsoft/hcsshim/internal/uvm"
 	"github.com/Microsoft/hcsshim/osversion"
 	testutilities "github.com/Microsoft/hcsshim/test/functional/utilities"
-	"github.com/sirupsen/logrus"
 )
 
 // TestVPMEM tests adding/removing VPMem Read-Only layers from a v2 Linux utility VM
@@ -33,11 +32,11 @@ func TestVPMEM(t *testing.T) {
 	defer os.RemoveAll(tempDir)
 
 	for i := 0; i < int(iterations); i++ {
-		deviceNumber, uvmPath, err := u.AddVPMEM(context.Background(), filepath.Join(tempDir, "layer.vhd"), true)
+		uvmPath, err := u.AddVPMEM(context.Background(), filepath.Join(tempDir, "layer.vhd"))
 		if err != nil {
 			t.Fatalf("AddVPMEM failed: %s", err)
 		}
-		logrus.Debugf("exposed as %s on %d", uvmPath, deviceNumber)
+		t.Logf("exposed as %s", uvmPath)
 	}
 
 	// Remove them all


### PR DESCRIPTION
1. Simplifies the hcsoci.MountContainerLayers logic on failure to use defer
statements to avoid duplicate code.
2. Modified the uvm.AddSCSILayer to return the uvmpath since all callers
assumed its location.
3. Modified the uvm.AddPMEM to stop returning device number since all callers
ignored its response.

Signed-off-by: Justin Terry (VM) <juterry@microsoft.com>