### PR TITLE
move container files to be backed by writeable storage

### DIFF
--- a/internal/guestrequest/types.go
+++ b/internal/guestrequest/types.go
@@ -25,7 +25,7 @@ type CombinedLayers struct {
 
 // SCSI. Scratch space for remote file-system commands, or R/W layer for containers
 type LCOWMappedVirtualDisk struct {
-	MountPath  string `json:"MountPath,omitempty"` // /tmp/scratch for an LCOW utility VM being used as a service VM
+	MountPath  string `json:"MountPath,omitempty"`
 	Lun        uint8  `json:"Lun,omitempty"`
 	Controller uint8  `json:"Controller,omitempty"`
 	ReadOnly   bool   `json:"ReadOnly,omitempty"`
@@ -46,7 +46,7 @@ type LCOWMappedDirectory struct {
 // Read-only layers over VPMem
 type LCOWMappedVPMemDevice struct {
 	DeviceNumber uint32 `json:"DeviceNumber,omitempty"`
-	MountPath    string `json:"MountPath,omitempty"` // /tmp/pN
+	MountPath    string `json:"MountPath,omitempty"`
 }
 
 type LCOWNetworkAdapter struct {

--- a/internal/hcsoci/create.go
+++ b/internal/hcsoci/create.go
@@ -22,6 +22,11 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+var (
+	lcowRootInUVM = "/run/gcs/c/%s"
+	wcowRootInUVM = `C:\c\%s`
+)
+
 // CreateOptions are the set of fields used to call CreateContainer().
 // Note: In the spec, the LayerFolders must be arranged in the same way in which
 // moby configures them: layern, layern-1,...,layer2,layer1,scratch
@@ -109,9 +114,9 @@ func CreateContainer(ctx context.Context, createOptions *CreateOptions) (_ cow.C
 	if coi.HostingSystem != nil {
 		n := coi.HostingSystem.ContainerCounter()
 		if coi.Spec.Linux != nil {
-			resources.containerRootInUVM = "/run/gcs/c/" + strconv.FormatUint(n, 16)
+			resources.containerRootInUVM = fmt.Sprintf(lcowRootInUVM, createOptions.ID)
 		} else {
-			resources.containerRootInUVM = `C:\c\` + strconv.FormatUint(n, 16)
+			resources.containerRootInUVM = fmt.Sprintf(wcowRootInUVM, strconv.FormatUint(n, 16))
 		}
 	}
 

--- a/internal/hcsoci/layers.go
+++ b/internal/hcsoci/layers.go
@@ -141,7 +141,7 @@ func MountContainerLayers(ctx context.Context, layerFolders []string, guestRoot 
 	}
 
 	hostPath := filepath.Join(layerFolders[len(layerFolders)-1], "sandbox.vhdx")
-	containerScratchPathInUVM := ospath.Join(uvm.OS(), guestRoot, scratchPath)
+	containerScratchPathInUVM := ospath.Join(uvm.OS(), guestRoot)
 	_, _, err = uvm.AddSCSI(ctx, hostPath, containerScratchPathInUVM, false)
 	if err != nil {
 		return "", err

--- a/internal/hcsoci/resources_lcow.go
+++ b/internal/hcsoci/resources_lcow.go
@@ -11,14 +11,13 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"strconv"
 	"strings"
 
 	"github.com/Microsoft/hcsshim/internal/log"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 )
 
-const mountPathPrefix = "m"
+const lcowMountPathPrefix = "/mounts/m%d"
 
 func allocateLinuxResources(ctx context.Context, coi *createOptionsInternal, resources *Resources) error {
 	if coi.Spec.Root == nil {
@@ -67,7 +66,7 @@ func allocateLinuxResources(ctx context.Context, coi *createOptionsInternal, res
 
 		if coi.HostingSystem != nil {
 			hostPath := mount.Source
-			uvmPathForShare := path.Join(resources.containerRootInUVM, mountPathPrefix+strconv.Itoa(i))
+			uvmPathForShare := path.Join(resources.containerRootInUVM, fmt.Sprintf(lcowMountPathPrefix, i))
 			uvmPathForFile := uvmPathForShare
 
 			readOnly := false

--- a/internal/uvm/scsi.go
+++ b/internal/uvm/scsi.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	lcowSCSILayerFmt = "/tmp/S%d/%d"
+	lcowSCSILayerFmt = "/run/layers/S%d/%d"
 )
 
 var (

--- a/internal/uvm/vpmem.go
+++ b/internal/uvm/vpmem.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	lcowVPMEMLayerFmt = "/tmp/p%d"
+	lcowVPMEMLayerFmt = "/run/layers/p%d"
 )
 
 var (


### PR DESCRIPTION
* move layer files to /run/layers
* move container specific files to /run/gcs/c/id

Signed-off-by: Kathryn Baldauf <kabaldau@microsoft.com>