### PR TITLE
Fix race condition in legacy process stdio code

### DIFF
--- a/container.go
+++ b/container.go
@@ -196,7 +196,7 @@ func (container *container) MappedVirtualDisks() (map[int]MappedVirtualDiskContr
 
 // CreateProcess launches a new process within the container.
 func (container *container) CreateProcess(c *ProcessConfig) (Process, error) {
-	p, err := container.system.CreateProcessNoStdio(c)
+	p, err := container.system.CreateProcess(context.Background(), c)
 	if err != nil {
 		return nil, convertSystemError(err, container)
 	}


### PR DESCRIPTION
HcsCreateProcess returns a set of stdio handles for the newly created
process. A while ago, we used to cache these handles and return them
the first time stdio handles were requested for the process, and then
get new handles via HcsGetProcessInfo for each subsequent request. At
some point, this code was cleaned up to instead always return the
original set of handles as non-closable (for new callers) and always get
new handles via HcsGetProcessInfo (for legacy callers, who required
closable handles).

However, this change introduced a race condition for legacy callers,
where in the case of a short lived container process, the container
could have terminated between when it was started and when the
orchestrator requested stdio handles. This led to ERROR_NOT_FOUND
being returned from HcsGetProcessInfo.

This change addresses this by returning the original handles the first
time stdio handles are requested, and then calling HcsGetProcessInfo for
every subsequent request (just as it used to work a while ago).

Signed-off-by: Kevin Parsons <kevpar@microsoft.com>