### PR TITLE
Increase LCOW GCS memory limit to 50MB

### DIFF
--- a/internal/uvm/create_lcow.go
+++ b/internal/uvm/create_lcow.go
@@ -104,7 +104,10 @@ func NewDefaultOptionsLCOW(id, owner string) *OptionsLCOW {
 		ConsolePipe:           "",
 		SCSIControllerCount:   1,
 		UseGuestConnection:    true,
-		ExecCommandLine:       fmt.Sprintf("/bin/gcs -v4 -log-format json -loglevel %s", logrus.StandardLogger().Level.String()),
+		ExecCommandLine: fmt.Sprintf(
+			"/bin/gcs -v4 -log-format json -loglevel %s -gcs-mem-limit-bytes %d",
+			logrus.StandardLogger().Level.String(),
+			50*1024*1024),
 		ForwardStdout:         false,
 		ForwardStderr:         true,
 		OutputHandler:         parseLogrus(id),


### PR DESCRIPTION
Without passing the `gcs-mem-limit-bytes` argument, the default limit is
10MB for the GCS. We are currently seeing cases where we hit this limit,
especially when invoking runc. This change increases the limit to give
some additional breathing room.

At a later point, we will make another change to revamp the GCS limits
more drastically, as we probably just want to monitor the GCS usage,
rather than limiting it.

Signed-off-by: Kevin Parsons <kevpar@microsoft.com>