### PR TITLE
Fix NetworkNotFoundError and EndpointNotFoundError message strings

### DIFF
--- a/hcn/hcnerrors.go
+++ b/hcn/hcnerrors.go
@@ -50,10 +50,10 @@ type NetworkNotFoundError struct {
 }
 
 func (e NetworkNotFoundError) Error() string {
-	if e.NetworkName == "" {
-		return fmt.Sprintf("Network Name %s not found", e.NetworkName)
+	if e.NetworkName != "" {
+		return fmt.Sprintf("Network name %q not found", e.NetworkName)
 	}
-	return fmt.Sprintf("Network Id %s not found", e.NetworkID)
+	return fmt.Sprintf("Network ID %q not found", e.NetworkID)
 }
 
 // EndpointNotFoundError results from a failed seach for an endpoint by Id or Name
@@ -63,10 +63,10 @@ type EndpointNotFoundError struct {
 }
 
 func (e EndpointNotFoundError) Error() string {
-	if e.EndpointName == "" {
-		return fmt.Sprintf("Endpoint Name %s not found", e.EndpointName)
+	if e.EndpointName != "" {
+		return fmt.Sprintf("Endpoint name %q not found", e.EndpointName)
 	}
-	return fmt.Sprintf("Endpoint Id %s not found", e.EndpointID)
+	return fmt.Sprintf("Endpoint ID %q not found", e.EndpointID)
 }
 
 // NamespaceNotFoundError results from a failed seach for a namsepace by Id

--- a/hcn/hcnerrors_test.go
+++ b/hcn/hcnerrors_test.go
@@ -14,10 +14,13 @@ func TestMissingNetworkByName(t *testing.T) {
 		t.Fatal("Error was not thrown.")
 	}
 	if !IsNotFoundError(err) {
-		t.Fatal("Unrelated error was thrown.")
+		t.Fatal("Unrelated error was thrown.", err)
 	}
 	if _, ok := err.(NetworkNotFoundError); !ok {
-		t.Fatal("Wrong error type was thrown.")
+		t.Fatal("Wrong error type was thrown.", err)
+	}
+	if err.Error() != `Network name "Not found name" not found` {
+		t.Fatal("Wrong error message was returned", err.Error())
 	}
 }
 
@@ -28,10 +31,13 @@ func TestMissingNetworkById(t *testing.T) {
 		t.Fatal("Error was not thrown.")
 	}
 	if !IsNotFoundError(err) {
-		t.Fatal("Unrelated error was thrown.")
+		t.Fatal("Unrelated error was thrown.", err)
 	}
 	if _, ok := err.(NetworkNotFoundError); !ok {
-		t.Fatal("Wrong error type was thrown.")
+		t.Fatal("Wrong error type was thrown.", err)
+	}
+	if err.Error() != `Network ID "5f0b1190-63be-4e0c-b974-bd0f55675a42" not found` {
+		t.Fatal("Wrong error message was returned", err.Error())
 	}
 }
 
@@ -42,9 +48,9 @@ func TestMissingNamespaceById(t *testing.T) {
 		t.Fatal("Error was not thrown.")
 	}
 	if !IsNotFoundError(err) {
-		t.Fatal("Unrelated error was thrown.")
+		t.Fatal("Unrelated error was thrown.", err)
 	}
 	if _, ok := err.(*hcserror.HcsError); !ok {
-		t.Fatal("Wrong error type was thrown.")
+		t.Fatal("Wrong error type was thrown.", err)
 	}
 }


### PR DESCRIPTION
It looks like it had its logic backwards. Added some test coverage and tried to make the test failures more helpful as well.

Resubmission of #519 