### PR TITLE
HCS: Remove not anymore needed CGO dependency

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ clone_folder: c:\gopath\src\github.com\Microsoft\hcsshim
 
 environment:
   GOPATH: c:\gopath
-  PATH: C:\mingw-w64\x86_64-7.2.0-posix-seh-rt_v5-rev1\mingw64\bin;%GOPATH%\bin;C:\gometalinter-2.0.12-windows-amd64;%PATH%
+  PATH: "%GOPATH%\\bin;C:\\gometalinter-2.0.12-windows-amd64;%PATH%"
 
 stack: go 1.13.4
 

--- a/internal/hcs/cgo.go
+++ b/internal/hcs/cgo.go
@@ -1,7 +1,0 @@
-package hcs
-
-import "C"
-
-// This import is needed to make the library compile as CGO because HCSSHIM
-// only works with CGO due to callbacks from HCS comming back from a C thread
-// which is not supported without CGO. See https://github.com/golang/go/issues/10973


### PR DESCRIPTION
With https://github.com/golang/go/commit/bb0fae603bd19e096e38c3321d95bf114f40dcff this also 
works without CGO (>=Go 1.11).