### PR TITLE
Fix shim crash when cleaning up process-isolated containers

### DIFF
--- a/internal/hcsoci/resources.go
+++ b/internal/hcsoci/resources.go
@@ -108,7 +108,7 @@ func ReleaseResources(ctx context.Context, r *Resources, vm *uvm.UtilityVM, all 
 		r.createdNetNS = false
 	}
 
-	if all {
+	if vm != nil && all {
 		for len(r.vsmbMounts) != 0 {
 			mount := r.vsmbMounts[len(r.vsmbMounts)-1]
 			if err := vm.RemoveVSMB(ctx, mount); err != nil {
@@ -146,7 +146,7 @@ func ReleaseResources(ctx context.Context, r *Resources, vm *uvm.UtilityVM, all 
 		r.scsiMounts = nil
 	}
 
-	if vm.DeleteContainerStateSupported() {
+	if vm != nil && vm.DeleteContainerStateSupported() {
 		if err := vm.DeleteContainerState(ctx, r.id); err != nil {
 			log.G(ctx).WithError(err).Error("failed to delete container state")
 		}


### PR DESCRIPTION
The issue was observed while experimenting with Buildkit for Windows against containerd, and getting a 'ttrpc closed' error after the layer had completed its task successfully.

The null ptr access in `vm.DeleteContainerStateSupported` was killing the thread it was on, and hence the channel back to containerd was never given an answer before the shim cleaned up the container and terminated.