### PR TITLE
Cleanup usage of internal spans in shim

### DIFF
--- a/cmd/containerd-shim-runhcs-v1/events.go
+++ b/cmd/containerd-shim-runhcs-v1/events.go
@@ -2,12 +2,11 @@ package main
 
 import (
 	"context"
+	"fmt"
 
-	"github.com/Microsoft/hcsshim/internal/log"
 	"github.com/Microsoft/hcsshim/internal/oc"
 	"github.com/containerd/containerd/namespaces"
 	shim "github.com/containerd/containerd/runtime/v2/shim"
-	"github.com/sirupsen/logrus"
 	"go.opencensus.io/trace"
 )
 
@@ -39,12 +38,9 @@ func (e *eventPublisher) publishEvent(ctx context.Context, topic string, event i
 	ctx, span := trace.StartSpan(ctx, "publishEvent")
 	defer span.End()
 	defer func() { oc.SetSpanStatus(span, err) }()
-	span.AddAttributes(trace.StringAttribute("topic", topic))
-
-	log.G(ctx).WithFields(logrus.Fields{
-		"topic": topic,
-		"event": event,
-	}).Debug("Publishing event")
+	span.AddAttributes(
+		trace.StringAttribute("topic", topic),
+		trace.StringAttribute("event", fmt.Sprintf("%+v", event)))
 
 	if e == nil {
 		return nil

--- a/cmd/containerd-shim-runhcs-v1/task_wcow_podsandbox.go
+++ b/cmd/containerd-shim-runhcs-v1/task_wcow_podsandbox.go
@@ -28,9 +28,7 @@ import (
 // `parent`. When the fake WCOW `init` process exits via `Signal` `parent` will
 // be forcibly closed by this task.
 func newWcowPodSandboxTask(ctx context.Context, events publisher, id, bundle string, parent *uvm.UtilityVM) shimTask {
-	ctx, span := trace.StartSpan(ctx, "newWcowPodSandboxTask")
-	defer span.End()
-	span.AddAttributes(trace.StringAttribute("tid", id))
+	log.G(ctx).WithField("tid", id).Debug("newWcowPodSandboxTask")
 
 	wpst := &wcowPodSandboxTask{
 		events: events,
@@ -165,9 +163,7 @@ func (wpst *wcowPodSandboxTask) Wait() *task.StateResponse {
 // This call is idempotent and safe to call multiple times.
 func (wpst *wcowPodSandboxTask) close(ctx context.Context) {
 	wpst.closeOnce.Do(func() {
-		ctx, span := trace.StartSpan(ctx, "wcowPodSandboxTask::close")
-		defer span.End()
-		span.AddAttributes(trace.StringAttribute("tid", wpst.id))
+		log.G(ctx).Debug("wcowPodSandboxTask::closeOnce")
 
 		if wpst.host != nil {
 			if err := wpst.host.Close(); err != nil {


### PR DESCRIPTION
We decided long ago that only entry and exit methods should have spans
associated. Since the caller of all context methods will always have a span
removing these child spans makes it significantly easier to see a full log
chain.

Signed-off-by: Justin Terry (VM) <juterry@microsoft.com>