### PR TITLE
Use winio.DialPipeContext for upstream IO

### DIFF
--- a/cmd/containerd-shim-runhcs-v1/io_npipe.go
+++ b/cmd/containerd-shim-runhcs-v1/io_npipe.go
@@ -34,21 +34,21 @@ func newNpipeIO(ctx context.Context, stdin, stdout, stderr string, terminal bool
 		}
 	}()
 	if stdin != "" {
-		c, err := winio.DialPipe(stdin, nil)
+		c, err := winio.DialPipeContext(ctx, stdin)
 		if err != nil {
 			return nil, err
 		}
 		nio.sin = c
 	}
 	if stdout != "" {
-		c, err := winio.DialPipe(stdout, nil)
+		c, err := winio.DialPipeContext(ctx, stdout)
 		if err != nil {
 			return nil, err
 		}
 		nio.sout = c
 	}
 	if stderr != "" {
-		c, err := winio.DialPipe(stderr, nil)
+		c, err := winio.DialPipeContext(ctx, stderr)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
In order for the shim to support true cancellation we need to use contextual
pipe dial's when opening in/out/err pipes for container upstream IO.

Signed-off-by: Justin Terry (VM) <juterry@microsoft.com>