### PR TITLE
Add span around CopyFileW win32 call

### DIFF
--- a/internal/copyfile/copyfile.go
+++ b/internal/copyfile/copyfile.go
@@ -1,9 +1,13 @@
 package copyfile
 
 import (
+	"context"
 	"fmt"
 	"syscall"
 	"unsafe"
+
+	"github.com/Microsoft/hcsshim/internal/oc"
+	"go.opencensus.io/trace"
 )
 
 var (
@@ -11,9 +15,17 @@ var (
 	procCopyFileW = modkernel32.NewProc("CopyFileW")
 )
 
-// CopyFile is a utility for copying a file - used for the LCOW scratch cache.
-// Uses CopyFileW win32 API for performance.
-func CopyFile(srcFile, destFile string, overwrite bool) error {
+// CopyFile is a utility for copying a file using CopyFileW win32 API for
+// performance.
+func CopyFile(ctx context.Context, srcFile, destFile string, overwrite bool) (err error) {
+	ctx, span := trace.StartSpan(ctx, "copyfile::CopyFile")
+	defer span.End()
+	defer func() { oc.SetSpanStatus(span, err) }()
+	span.AddAttributes(
+		trace.StringAttribute("srcFile", srcFile),
+		trace.StringAttribute("destFile", destFile),
+		trace.BoolAttribute("overwrite", overwrite))
+
 	var bFailIfExists uint32 = 1
 	if overwrite {
 		bFailIfExists = 0

--- a/internal/lcow/scratch.go
+++ b/internal/lcow/scratch.go
@@ -50,7 +50,7 @@ func CreateScratch(ctx context.Context, lcowUVM *uvm.UtilityVM, destFile string,
 	// Retrieve from cache if the default size and already on disk
 	if cacheFile != "" && sizeGB == DefaultScratchSizeGB {
 		if _, err := os.Stat(cacheFile); err == nil {
-			if err := copyfile.CopyFile(cacheFile, destFile, false); err != nil {
+			if err := copyfile.CopyFile(ctx, cacheFile, destFile, false); err != nil {
 				return fmt.Errorf("failed to copy cached file '%s' to '%s': %s", cacheFile, destFile, err)
 			}
 			log.G(ctx).WithFields(logrus.Fields{
@@ -133,7 +133,7 @@ func CreateScratch(ctx context.Context, lcowUVM *uvm.UtilityVM, destFile string,
 
 	// Populate the cache.
 	if cacheFile != "" && (sizeGB == DefaultScratchSizeGB) {
-		if err := copyfile.CopyFile(destFile, cacheFile, true); err != nil {
+		if err := copyfile.CopyFile(ctx, destFile, cacheFile, true); err != nil {
 			return fmt.Errorf("failed to seed cache '%s' from '%s': %s", destFile, cacheFile, err)
 		}
 	}

--- a/internal/wcow/scratch.go
+++ b/internal/wcow/scratch.go
@@ -6,9 +6,7 @@ import (
 	"path/filepath"
 
 	"github.com/Microsoft/hcsshim/internal/copyfile"
-	"github.com/Microsoft/hcsshim/internal/log"
 	"github.com/Microsoft/hcsshim/internal/wclayer"
-	"github.com/sirupsen/logrus"
 )
 
 // CreateUVMScratch is a helper to create a scratch for a Windows utility VM
@@ -16,11 +14,7 @@ import (
 func CreateUVMScratch(ctx context.Context, imagePath, destDirectory, vmID string) error {
 	sourceScratch := filepath.Join(imagePath, `UtilityVM\SystemTemplate.vhdx`)
 	targetScratch := filepath.Join(destDirectory, "sandbox.vhdx")
-	log.G(ctx).WithFields(logrus.Fields{
-		"target": targetScratch,
-		"source": sourceScratch,
-	}).Debug("uvm::CreateUVMScratch")
-	if err := copyfile.CopyFile(sourceScratch, targetScratch, true); err != nil {
+	if err := copyfile.CopyFile(ctx, sourceScratch, targetScratch, true); err != nil {
 		return err
 	}
 	if err := wclayer.GrantVmAccess(vmID, targetScratch); err != nil {

--- a/test/functional/uvm_vpmem_test.go
+++ b/test/functional/uvm_vpmem_test.go
@@ -19,20 +19,21 @@ func TestVPMEM(t *testing.T) {
 	testutilities.RequiresBuild(t, osversion.RS5)
 	alpineLayers := testutilities.LayerFolders(t, "alpine")
 
-	u := testutilities.CreateLCOWUVM(context.Background(), t, t.Name())
+	ctx := context.Background()
+	u := testutilities.CreateLCOWUVM(ctx, t, t.Name())
 	defer u.Close()
 
 	var iterations uint32 = uvm.MaxVPMEMCount
 
 	// Use layer.vhd from the alpine image as something to add
 	tempDir := testutilities.CreateTempDir(t)
-	if err := copyfile.CopyFile(filepath.Join(alpineLayers[0], "layer.vhd"), filepath.Join(tempDir, "layer.vhd"), true); err != nil {
+	if err := copyfile.CopyFile(ctx, filepath.Join(alpineLayers[0], "layer.vhd"), filepath.Join(tempDir, "layer.vhd"), true); err != nil {
 		t.Fatal(err)
 	}
 	defer os.RemoveAll(tempDir)
 
 	for i := 0; i < int(iterations); i++ {
-		uvmPath, err := u.AddVPMEM(context.Background(), filepath.Join(tempDir, "layer.vhd"))
+		uvmPath, err := u.AddVPMEM(ctx, filepath.Join(tempDir, "layer.vhd"))
 		if err != nil {
 			t.Fatalf("AddVPMEM failed: %s", err)
 		}
@@ -41,7 +42,7 @@ func TestVPMEM(t *testing.T) {
 
 	// Remove them all
 	for i := 0; i < int(iterations); i++ {
-		if err := u.RemoveVPMEM(context.Background(), filepath.Join(tempDir, "layer.vhd")); err != nil {
+		if err := u.RemoveVPMEM(ctx, filepath.Join(tempDir, "layer.vhd")); err != nil {
 			t.Fatalf("RemoveVPMEM failed: %s", err)
 		}
 	}


### PR DESCRIPTION
CopyFileW is an external call from the shim and thus should have a span for
tracking reliability and duration.

Signed-off-by: Justin Terry (VM) <juterry@microsoft.com>