### PR TITLE
Encapsulate UVM Resources into types with Release functions 

### DIFF
--- a/internal/hcsoci/network.go
+++ b/internal/hcsoci/network.go
@@ -6,6 +6,7 @@ import (
 	"github.com/Microsoft/hcsshim/internal/hns"
 	"github.com/Microsoft/hcsshim/internal/log"
 	"github.com/Microsoft/hcsshim/internal/logfields"
+	"github.com/Microsoft/hcsshim/internal/uvm"
 	"github.com/sirupsen/logrus"
 )
 
@@ -27,6 +28,7 @@ func createNetworkNamespace(ctx context.Context, coi *createOptionsInternal, res
 	}).Info("created network namespace for container")
 	resources.netNS = netID
 	resources.createdNetNS = true
+	endpoints := make([]string, 0)
 	for _, endpointID := range coi.Spec.Windows.Network.EndpointList {
 		err = hns.AddNamespaceEndpoint(netID, endpointID)
 		if err != nil {
@@ -36,8 +38,9 @@ func createNetworkNamespace(ctx context.Context, coi *createOptionsInternal, res
 			"netID":      netID,
 			"endpointID": endpointID,
 		}).Info("added network endpoint to namespace")
-		resources.networkEndpoints = append(resources.networkEndpoints, endpointID)
+		endpoints = append(endpoints, endpointID)
 	}
+	resources.resources = append(resources.resources, &uvm.NetworkEndpoints{EndpointIDs: endpoints, Namespace: netID})
 	return nil
 }
 

--- a/internal/hcsoci/resources.go
+++ b/internal/hcsoci/resources.go
@@ -4,11 +4,9 @@ import (
 	"context"
 	"os"
 
-	"github.com/Microsoft/hcsshim/internal/hns"
 	"github.com/Microsoft/hcsshim/internal/log"
 	"github.com/Microsoft/hcsshim/internal/ospath"
 	"github.com/Microsoft/hcsshim/internal/uvm"
-	"github.com/sirupsen/logrus"
 )
 
 const (
@@ -23,7 +21,7 @@ func (r *Resources) NetNS() string {
 
 // Resources is the structure returned as part of creating a container. It holds
 // nothing useful to clients, hence everything is lowercased. A client would use
-// it in a call to ReleaseResource to ensure everything is cleaned up when a
+// it in a call to ReleaseResources to ensure everything is cleaned up when a
 // container exits.
 type Resources struct {
 	id string
@@ -34,151 +32,90 @@ type Resources struct {
 	// For WCOW, this will be under wcowRootInUVM. For LCOW, this will be under
 	// lcowRootInUVM, this will also be the "OCI Bundle Path".
 	containerRootInUVM string
-
-	// layers is an array of the layer folder paths which have been mounted either on
-	// the host in the case or a WCOW Argon, or in a utility VM for WCOW Xenon and LCOW.
-	layers []string
-
-	// vsmbMounts is an array of the host-paths mounted into a utility VM to support
-	// (bind-)mounts into a WCOW v2 Xenon.
-	vsmbMounts []string
-
-	// pipeMounts is an array of the host-paths of named pipes mounted into a utility
-	// VM.
-	pipeMounts []string
-
-	// plan9Mounts is an array of all the host paths which have been added to
-	// an LCOW utility VM
-	plan9Mounts []*uvm.Plan9Share
-
-	// netNS is the network namespace
-	netNS string
-
-	// networkEndpoints is the list of network endpoints used by the container
-	networkEndpoints []string
-
+	netNS              string
 	// createNetNS indicates if the network namespace has been created
 	createdNetNS bool
-
 	// addedNetNSToVM indicates if the network namespace has been added to the containers utility VM
 	addedNetNSToVM bool
-
-	// scsiMounts is an array of the vhd's mounted into a utility VM to support
-	// scsi device passthrough.
-	scsiMounts []scsiMount
-
-	// vpciDevices is an array of vpci device names
-	vpciDevices []string
+	// layers is a pointer to a struct of the layers paths of a container
+	layers *ImageLayers
+	// resources is an array of the resources associated with a container
+	resources []ResourceCloser
 }
 
-type scsiMount struct {
-	// path is the host path to the vhd that is mounted.
-	path string
-	// autoManage if `true` means that on cleanup, the runtime should
-	// automatically delete this vhd.
-	autoManage bool
+// ResourceCloser is a generic interface for the releasing of a resource. If a resource implements
+// this interface(which they all should), freeing of that resource should entail one call to
+// <resourceName>.Release(ctx)
+type ResourceCloser interface {
+	Release(context.Context) error
 }
 
-// TODO: Method on the resources?
+// AutoManagedVHD struct representing a VHD that will be cleaned up automatically.
+type AutoManagedVHD struct {
+	hostPath string
+}
+
+// Release removes the vhd.
+func (vhd *AutoManagedVHD) Release(ctx context.Context) error {
+	if err := os.Remove(vhd.hostPath); err != nil {
+		log.G(ctx).WithField("hostPath", vhd.hostPath).WithError(err).Error("failed to remove automanage-virtual-disk")
+	}
+	return nil
+}
+
+// ReleaseResources releases/frees all of the resources associated with a container. This includes
+// Plan9 shares, vsmb mounts, pipe mounts, network endpoints, scsi mounts, vpci devices and layers.
+// TODO: make method on Resources struct.
 func ReleaseResources(ctx context.Context, r *Resources, vm *uvm.UtilityVM, all bool) error {
-	if vm != nil && r.addedNetNSToVM {
-		if err := vm.RemoveNetNS(ctx, r.netNS); err != nil {
-			log.G(ctx).Warn(err)
+	if vm != nil {
+		if r.addedNetNSToVM {
+			if err := vm.RemoveNetNS(ctx, r.netNS); err != nil {
+				log.G(ctx).Warn(err)
+			}
+			r.addedNetNSToVM = false
 		}
-		r.addedNetNSToVM = false
 	}
 
-	if r.createdNetNS {
-		for len(r.networkEndpoints) != 0 {
-			endpoint := r.networkEndpoints[len(r.networkEndpoints)-1]
-			err := hns.RemoveNamespaceEndpoint(r.netNS, endpoint)
-			if err != nil {
-				if !os.IsNotExist(err) {
+	// Release resources in reverse order so that the most recently
+	// added are cleaned up first.
+	for i := len(r.resources) - 1; i >= 0; i-- {
+		switch r.resources[i].(type) {
+		case *uvm.NetworkEndpoints:
+			if r.createdNetNS {
+				if err := r.resources[i].Release(ctx); err != nil {
 					return err
 				}
-				log.G(ctx).WithFields(logrus.Fields{
-					"endpointID": endpoint,
-					"netID":      r.NetNS(),
-				}).Warn("removing endpoint from namespace: does not exist")
+				r.createdNetNS = false
 			}
-			r.networkEndpoints = r.networkEndpoints[:len(r.networkEndpoints)-1]
-		}
-		r.networkEndpoints = nil
-		err := hns.RemoveNamespace(r.netNS)
-		if err != nil && !os.IsNotExist(err) {
-			return err
-		}
-		r.createdNetNS = false
-	}
-
-	if vm != nil && all {
-		for len(r.vsmbMounts) != 0 {
-			mount := r.vsmbMounts[len(r.vsmbMounts)-1]
-			if err := vm.RemoveVSMB(ctx, mount); err != nil {
-				return err
-			}
-			r.vsmbMounts = r.vsmbMounts[:len(r.vsmbMounts)-1]
-		}
-
-		for len(r.pipeMounts) != 0 {
-			mount := r.pipeMounts[len(r.pipeMounts)-1]
-			if err := vm.RemovePipe(ctx, mount); err != nil {
-				return err
-			}
-			r.pipeMounts = r.pipeMounts[:len(r.pipeMounts)-1]
-		}
-
-		for len(r.plan9Mounts) != 0 {
-			mount := r.plan9Mounts[len(r.plan9Mounts)-1]
-			if err := vm.RemovePlan9(ctx, mount); err != nil {
-				return err
-			}
-			r.plan9Mounts = r.plan9Mounts[:len(r.plan9Mounts)-1]
-		}
-
-		for _, sm := range r.scsiMounts {
-			if err := vm.RemoveSCSI(ctx, sm.path); err != nil {
-				return err
-			}
-			if sm.autoManage {
-				if err := os.Remove(sm.path); err != nil {
-					log.G(ctx).WithError(err).Warnf("failed to remove automanage-virtual-disk at: %q", sm.path)
+		default:
+			// Don't need to check if vm != nil here anymore as they wouldnt
+			// have been added in the first place. All resources have embedded
+			// vm they belong to.
+			if all {
+				if err := r.resources[i].Release(ctx); err != nil {
+					return err
 				}
 			}
 		}
-		r.scsiMounts = nil
 	}
+	r.resources = nil
 
-	if vm != nil && vm.DeleteContainerStateSupported() {
-		if err := vm.DeleteContainerState(ctx, r.id); err != nil {
-			log.G(ctx).WithError(err).Error("failed to delete container state")
-		}
-	}
-
-	if len(r.layers) != 0 {
-		op := UnmountOperationSCSI
-		if vm == nil || all {
-			op = UnmountOperationAll
-		}
-		var crp string
-		if vm != nil {
-			crp = containerRootfsPath(vm, r.containerRootInUVM)
-		}
-		err := UnmountContainerLayers(ctx, r.layers, crp, vm, op)
-		if err != nil {
-			return err
-		}
-		r.layers = nil
-	}
-
+	// cleanup container state
 	if vm != nil {
-		for _, name := range r.vpciDevices {
-			if err := vm.RemoveDevice(ctx, name); err != nil {
-				log.G(ctx).WithError(err).Warn("failed to remove VPCI device")
+		if vm.DeleteContainerStateSupported() {
+			if err := vm.DeleteContainerState(ctx, r.id); err != nil {
+				log.G(ctx).WithError(err).Error("failed to delete container state")
 			}
 		}
 	}
 
+	if r.layers != nil {
+		// TODO dcantah: Either make it so layers doesn't rely on the all bool for cleanup logic
+		// or find a way to factor out the all bool in favor of something else.
+		if err := r.layers.Release(ctx, all); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/internal/hcsoci/resources_wcow.go
+++ b/internal/hcsoci/resources_wcow.go
@@ -21,7 +21,7 @@ import (
 
 const wcowGlobalMountPrefix = "C:\\mounts\\m%d"
 
-func allocateWindowsResources(ctx context.Context, coi *createOptionsInternal, resources *Resources) error {
+func allocateWindowsResources(ctx context.Context, coi *createOptionsInternal, r *Resources) error {
 	if coi.Spec == nil || coi.Spec.Windows == nil || coi.Spec.Windows.LayerFolders == nil {
 		return fmt.Errorf("field 'Spec.Windows.Layerfolders' is not populated")
 	}
@@ -50,7 +50,7 @@ func allocateWindowsResources(ctx context.Context, coi *createOptionsInternal, r
 
 	if coi.Spec.Root.Path == "" && (coi.HostingSystem != nil || coi.Spec.Windows.HyperV == nil) {
 		log.G(ctx).Debug("hcsshim::allocateWindowsResources mounting storage")
-		containerRootPath, err := MountContainerLayers(ctx, coi.Spec.Windows.LayerFolders, resources.containerRootInUVM, coi.HostingSystem)
+		containerRootPath, err := MountContainerLayers(ctx, coi.Spec.Windows.LayerFolders, r.containerRootInUVM, coi.HostingSystem)
 		if err != nil {
 			return fmt.Errorf("failed to mount container storage: %s", err)
 		}
@@ -59,7 +59,12 @@ func allocateWindowsResources(ctx context.Context, coi *createOptionsInternal, r
 		} else {
 			coi.Spec.Root.Path = containerRootPath // v2 Xenon WCOW
 		}
-		resources.layers = coi.Spec.Windows.LayerFolders
+		layers := &ImageLayers{
+			vm:                 coi.HostingSystem,
+			containerRootInUVM: r.containerRootInUVM,
+			layers:             coi.Spec.Windows.LayerFolders,
+		}
+		r.layers = layers
 	}
 
 	// Validate each of the mounts. If this is a V2 Xenon, we have to add them as
@@ -90,26 +95,30 @@ func allocateWindowsResources(ctx context.Context, coi *createOptionsInternal, r
 			l := log.G(ctx).WithField("mount", fmt.Sprintf("%+v", mount))
 			if mount.Type == "physical-disk" {
 				l.Debug("hcsshim::allocateWindowsResources Hot-adding SCSI physical disk for OCI mount")
-				_, _, _, err := coi.HostingSystem.AddSCSIPhysicalDisk(ctx, mount.Source, uvmPath, readOnly)
+				scsiMount, err := coi.HostingSystem.AddSCSIPhysicalDisk(ctx, mount.Source, uvmPath, readOnly)
 				if err != nil {
 					return fmt.Errorf("adding SCSI physical disk mount %+v: %s", mount, err)
 				}
 				coi.Spec.Mounts[i].Type = ""
-				resources.scsiMounts = append(resources.scsiMounts, scsiMount{path: mount.Source})
+				r.resources = append(r.resources, scsiMount)
 			} else if mount.Type == "virtual-disk" || mount.Type == "automanage-virtual-disk" {
 				l.Debug("hcsshim::allocateWindowsResources Hot-adding SCSI virtual disk for OCI mount")
-				_, _, _, err := coi.HostingSystem.AddSCSI(ctx, mount.Source, uvmPath, readOnly)
+				scsiMount, err := coi.HostingSystem.AddSCSI(ctx, mount.Source, uvmPath, readOnly)
 				if err != nil {
 					return fmt.Errorf("adding SCSI virtual disk mount %+v: %s", mount, err)
 				}
 				coi.Spec.Mounts[i].Type = ""
-				resources.scsiMounts = append(resources.scsiMounts, scsiMount{path: mount.Source, autoManage: mount.Type == "automanage-virtual-disk"})
+				if mount.Type == "automanage-virtual-disk" {
+					r.resources = append(r.resources, &AutoManagedVHD{hostPath: scsiMount.HostPath})
+				}
+				r.resources = append(r.resources, scsiMount)
 			} else {
 				if uvm.IsPipe(mount.Source) {
-					if err := coi.HostingSystem.AddPipe(ctx, mount.Source); err != nil {
+					pipe, err := coi.HostingSystem.AddPipe(ctx, mount.Source)
+					if err != nil {
 						return fmt.Errorf("failed to add named pipe to UVM: %s", err)
 					}
-					resources.pipeMounts = append(resources.pipeMounts, mount.Source)
+					r.resources = append(r.resources, pipe)
 				} else {
 					l.Debug("hcsshim::allocateWindowsResources Hot-adding VSMB share for OCI mount")
 					options := &hcsschema.VirtualSmbShareOptions{}
@@ -120,13 +129,12 @@ func allocateWindowsResources(ctx context.Context, coi *createOptionsInternal, r
 						options.ForceLevelIIOplocks = true
 						break
 					}
-
-					if err := coi.HostingSystem.AddVSMB(ctx, mount.Source, "", options); err != nil {
+					share, err := coi.HostingSystem.AddVSMB(ctx, mount.Source, "", options)
+					if err != nil {
 						return fmt.Errorf("failed to add VSMB share to utility VM for mount %+v: %s", mount, err)
 					}
-					resources.vsmbMounts = append(resources.vsmbMounts, mount.Source)
+					r.resources = append(r.resources, share)
 				}
-
 			}
 		}
 	}

--- a/internal/lcow/scratch.go
+++ b/internal/lcow/scratch.go
@@ -66,7 +66,7 @@ func CreateScratch(ctx context.Context, lcowUVM *uvm.UtilityVM, destFile string,
 		return fmt.Errorf("failed to create VHDx %s: %s", destFile, err)
 	}
 
-	controller, lun, _, err := lcowUVM.AddSCSI(ctx, destFile, "", false) // No destination as not formatted
+	scsi, err := lcowUVM.AddSCSI(ctx, destFile, "", false) // No destination as not formatted
 	if err != nil {
 		return err
 	}
@@ -79,12 +79,12 @@ func CreateScratch(ctx context.Context, lcowUVM *uvm.UtilityVM, destFile string,
 
 	log.G(ctx).WithFields(logrus.Fields{
 		"dest":       destFile,
-		"controller": controller,
-		"lun":        lun,
+		"controller": scsi.Controller,
+		"lun":        scsi.LUN,
 	}).Debug("lcow::CreateScratch device attached")
 
 	// Validate /sys/bus/scsi/devices/C:0:0:L exists as a directory
-	devicePath := fmt.Sprintf("/sys/bus/scsi/devices/%d:0:0:%d/block", controller, lun)
+	devicePath := fmt.Sprintf("/sys/bus/scsi/devices/%d:0:0:%d/block", scsi.Controller, scsi.LUN)
 	testdCtx, cancel := context.WithTimeout(ctx, timeout.TestDRetryLoop)
 	defer cancel()
 	for {

--- a/internal/uvm/create_lcow.go
+++ b/internal/uvm/create_lcow.go
@@ -28,7 +28,6 @@ type PreferredRootFSType int
 const (
 	PreferredRootFSTypeInitRd PreferredRootFSType = iota
 	PreferredRootFSTypeVHD
-
 	entropyVsockPort  = 1
 	linuxLogVsockPort = 109
 )

--- a/internal/uvm/create_wcow.go
+++ b/internal/uvm/create_wcow.go
@@ -66,8 +66,8 @@ func CreateWCOW(ctx context.Context, opts *OptionsWCOW) (_ *UtilityVM, err error
 		owner:               opts.Owner,
 		operatingSystem:     "windows",
 		scsiControllerCount: 1,
-		vsmbDirShares:       make(map[string]*vsmbShare),
-		vsmbFileShares:      make(map[string]*vsmbShare),
+		vsmbDirShares:       make(map[string]*VSMBShare),
+		vsmbFileShares:      make(map[string]*VSMBShare),
 	}
 	defer func() {
 		if err != nil {
@@ -194,7 +194,11 @@ func CreateWCOW(ctx context.Context, opts *OptionsWCOW) (_ *UtilityVM, err error
 		}
 	}
 
-	uvm.scsiLocations[0][0].hostPath = doc.VirtualMachine.Devices.Scsi["0"].Attachments["0"].Path
+	uvm.scsiLocations[0][0] = &SCSIMount{
+		vm:       uvm,
+		HostPath: doc.VirtualMachine.Devices.Scsi["0"].Attachments["0"].Path,
+		refCount: 1,
+	}
 
 	fullDoc, err := mergemaps.MergeJSON(doc, ([]byte)(opts.AdditionHCSDocumentJSON))
 	if err != nil {

--- a/internal/uvm/pipes.go
+++ b/internal/uvm/pipes.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/Microsoft/hcsshim/internal/log"
 	"github.com/Microsoft/hcsshim/internal/requesttype"
 	hcsschema "github.com/Microsoft/hcsshim/internal/schema2"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
@@ -12,16 +13,32 @@ import (
 
 const pipePrefix = `\\.\pipe\`
 
+// PipeMount contains the host path for pipe mount
+type PipeMount struct {
+	// UVM the resource belongs to
+	vm       *UtilityVM
+	HostPath string
+}
+
+// Release frees the resources of the corresponding pipe Mount
+func (pipe *PipeMount) Release(ctx context.Context) error {
+	if err := pipe.vm.RemovePipe(ctx, pipe.HostPath); err != nil {
+		log.G(ctx).WithError(err).Warn("failed to remove pipe mount")
+		return err
+	}
+	return nil
+}
+
 // AddPipe shares a named pipe into the UVM.
-func (uvm *UtilityVM) AddPipe(ctx context.Context, hostPath string) error {
+func (uvm *UtilityVM) AddPipe(ctx context.Context, hostPath string) (*PipeMount, error) {
 	modification := &hcsschema.ModifySettingRequest{
 		RequestType:  requesttype.Add,
 		ResourcePath: fmt.Sprintf(mappedPipeResourceFormat, hostPath),
 	}
 	if err := uvm.modify(ctx, modification); err != nil {
-		return err
+		return nil, err
 	}
-	return nil
+	return &PipeMount{uvm, hostPath}, nil
 }
 
 // RemovePipe removes a shared named pipe from the UVM.

--- a/internal/uvm/scsi.go
+++ b/internal/uvm/scsi.go
@@ -26,67 +26,150 @@ var (
 	ErrSCSILayerWCOWUnsupported = fmt.Errorf("SCSI attached layers are not supported for WCOW")
 )
 
+// Release frees the resources of the corresponding Scsi Mount
+func (sm *SCSIMount) Release(ctx context.Context) error {
+	if err := sm.vm.RemoveSCSI(ctx, sm.HostPath); err != nil {
+		log.G(ctx).WithError(err).Warn("failed to remove scsi device")
+		return err
+	}
+	return nil
+}
+
+// SCSIMount struct representing a SCSI mount point and the UVM
+// it belongs to.
+type SCSIMount struct {
+	// Utility VM the scsi mount belongs to
+	vm *UtilityVM
+	// path is the host path to the vhd that is mounted.
+	HostPath string
+	// path for the uvm
+	UVMPath string
+	// scsi controller
+	Controller int
+	// scsi logical unit number
+	LUN int32
+	// While most VHDs attached to SCSI are scratch spaces, in the case of LCOW
+	// when the size is over the size possible to attach to PMEM, we use SCSI for
+	// read-only layers. As RO layers are shared, we perform ref-counting.
+	isLayer  bool
+	refCount uint32
+}
+
+func (sm *SCSIMount) logFormat() logrus.Fields {
+	return logrus.Fields{
+		"HostPath":   sm.HostPath,
+		"UVMPath":    sm.UVMPath,
+		"isLayer":    sm.isLayer,
+		"refCount":   sm.refCount,
+		"Controller": sm.Controller,
+		"LUN":        sm.LUN,
+	}
+}
+
 // allocateSCSI finds the next available slot on the
 // SCSI controllers associated with a utility VM to use.
 // Lock must be held when calling this function
-func (uvm *UtilityVM) allocateSCSI(ctx context.Context, hostPath string, uvmPath string, isLayer bool) (int, int32, error) {
+func (uvm *UtilityVM) allocateSCSI(ctx context.Context, hostPath string, uvmPath string, isLayer bool) (*SCSIMount, error) {
 	for controller, luns := range uvm.scsiLocations {
-		for lun, si := range luns {
-			if si.hostPath == "" {
-				uvm.scsiLocations[controller][lun].hostPath = hostPath
-				uvm.scsiLocations[controller][lun].uvmPath = uvmPath
-				uvm.scsiLocations[controller][lun].isLayer = isLayer
-				uvm.scsiLocations[controller][lun].refCount = 1
-				log.G(ctx).WithFields(logrus.Fields{
-					"hostPath":   hostPath,
-					"uvmPath":    uvmPath,
-					"isLayer":    isLayer,
-					"refCount":   1,
-					"controller": controller,
-					"lun":        lun,
-				}).Debug("allocated SCSI location")
-				return controller, int32(lun), nil
+		for lun, sm := range luns {
+			// If sm is nil, we have found an open slot so we allocate a new SCSIMount
+			if sm == nil {
+				uvm.scsiLocations[controller][lun] = &SCSIMount{
+					vm:         uvm,
+					HostPath:   hostPath,
+					UVMPath:    uvmPath,
+					isLayer:    isLayer,
+					refCount:   1,
+					Controller: controller,
+					LUN:        int32(lun),
+				}
+				log.G(ctx).WithFields(uvm.scsiLocations[controller][lun].logFormat()).Debug("allocated SCSI mount")
+				return uvm.scsiLocations[controller][lun], nil
 			}
 		}
 	}
-	return -1, -1, ErrNoAvailableLocation
+	return nil, ErrNoAvailableLocation
 }
 
-func (uvm *UtilityVM) deallocateSCSI(ctx context.Context, controller int, lun int32) {
+func (uvm *UtilityVM) deallocateSCSI(ctx context.Context, sm *SCSIMount) {
 	uvm.m.Lock()
 	defer uvm.m.Unlock()
-	si := uvm.scsiLocations[controller][lun]
-	if si.hostPath != "" {
-		log.G(ctx).WithFields(logrus.Fields{
-			"hostPath":   si.hostPath,
-			"uvmPath":    si.uvmPath,
-			"isLayer":    si.isLayer,
-			"refCount":   si.refCount,
-			"controller": controller,
-			"lun":        lun,
-		}).Debug("removed SCSI location")
-		uvm.scsiLocations[controller][lun] = scsiInfo{}
+	if sm != nil {
+		log.G(ctx).WithFields(sm.logFormat()).Debug("removed SCSI location")
+		uvm.scsiLocations[sm.Controller][sm.LUN] = nil
 	}
 }
 
 // Lock must be held when calling this function.
-func (uvm *UtilityVM) findSCSIAttachment(ctx context.Context, findThisHostPath string) (int, int32, string, error) {
-	for controller, luns := range uvm.scsiLocations {
-		for lun, si := range luns {
-			if si.hostPath == findThisHostPath {
-				log.G(ctx).WithFields(logrus.Fields{
-					"hostPath":   si.hostPath,
-					"uvmPath":    si.uvmPath,
-					"isLayer":    si.isLayer,
-					"refCount":   si.refCount,
-					"controller": controller,
-					"lun":        lun,
-				}).Debug("found SCSI location")
-				return controller, int32(lun), si.uvmPath, nil
+func (uvm *UtilityVM) findSCSIAttachment(ctx context.Context, findThisHostPath string) (*SCSIMount, error) {
+	for _, luns := range uvm.scsiLocations {
+		for _, sm := range luns {
+			if sm != nil && sm.HostPath == findThisHostPath {
+				log.G(ctx).WithFields(sm.logFormat()).Debug("found SCSI location")
+				return sm, nil
 			}
 		}
 	}
-	return -1, -1, "", ErrNotAttached
+	return nil, ErrNotAttached
+}
+
+// RemoveSCSI removes a SCSI disk from a utility VM.
+func (uvm *UtilityVM) RemoveSCSI(ctx context.Context, hostPath string) error {
+	uvm.m.Lock()
+	defer uvm.m.Unlock()
+
+	if uvm.scsiControllerCount == 0 {
+		return ErrNoSCSIControllers
+	}
+
+	// Make sure it is actually attached
+	sm, err := uvm.findSCSIAttachment(ctx, hostPath)
+	if err != nil {
+		return err
+	}
+
+	sm.refCount--
+	if sm.refCount > 0 {
+		return nil
+	}
+
+	scsiModification := &hcsschema.ModifySettingRequest{
+		RequestType:  requesttype.Remove,
+		ResourcePath: fmt.Sprintf(scsiResourceFormat, strconv.Itoa(sm.Controller), sm.LUN),
+	}
+
+	// Include the GuestRequest so that the GCS ejects the disk cleanly if the
+	// disk was attached/mounted
+	//
+	// Note: We always send a guest eject even if there is no UVM path in lcow
+	// so that we synchronize the guest state. This seems to always avoid SCSI
+	// related errors if this index quickly reused by another container.
+	if uvm.operatingSystem == "windows" && sm.UVMPath != "" {
+		scsiModification.GuestRequest = guestrequest.GuestRequest{
+			ResourceType: guestrequest.ResourceTypeMappedVirtualDisk,
+			RequestType:  requesttype.Remove,
+			Settings: guestrequest.WCOWMappedVirtualDisk{
+				ContainerPath: sm.UVMPath,
+				Lun:           sm.LUN,
+			},
+		}
+	} else {
+		scsiModification.GuestRequest = guestrequest.GuestRequest{
+			ResourceType: guestrequest.ResourceTypeMappedVirtualDisk,
+			RequestType:  requesttype.Remove,
+			Settings: guestrequest.LCOWMappedVirtualDisk{
+				MountPath:  sm.UVMPath, // May be blank in attach-only
+				Lun:        uint8(sm.LUN),
+				Controller: uint8(sm.Controller),
+			},
+		}
+	}
+
+	if err := uvm.modify(ctx, scsiModification); err != nil {
+		return fmt.Errorf("failed to remove SCSI disk %s from container %s: %s", hostPath, uvm.id, err)
+	}
+	uvm.scsiLocations[sm.Controller][sm.LUN] = nil
+	return nil
 }
 
 // AddSCSI adds a SCSI disk to a utility VM at the next available location. This
@@ -99,7 +182,7 @@ func (uvm *UtilityVM) findSCSIAttachment(ctx context.Context, findThisHostPath s
 // `uvmPath` is optional.
 //
 // `readOnly` set to `true` if the vhd/vhdx should be attached read only.
-func (uvm *UtilityVM) AddSCSI(ctx context.Context, hostPath string, uvmPath string, readOnly bool) (int, int32, string, error) {
+func (uvm *UtilityVM) AddSCSI(ctx context.Context, hostPath string, uvmPath string, readOnly bool) (*SCSIMount, error) {
 	return uvm.addSCSIActual(ctx, hostPath, uvmPath, "VirtualDisk", false, readOnly)
 }
 
@@ -111,7 +194,7 @@ func (uvm *UtilityVM) AddSCSI(ctx context.Context, hostPath string, uvmPath stri
 // `uvmPath` is optional if a guest mount is not requested.
 //
 // `readOnly` set to `true` if the physical disk should be attached read only.
-func (uvm *UtilityVM) AddSCSIPhysicalDisk(ctx context.Context, hostPath, uvmPath string, readOnly bool) (int, int32, string, error) {
+func (uvm *UtilityVM) AddSCSIPhysicalDisk(ctx context.Context, hostPath, uvmPath string, readOnly bool) (*SCSIMount, error) {
 	return uvm.addSCSIActual(ctx, hostPath, uvmPath, "PassThru", false, readOnly)
 }
 
@@ -119,21 +202,21 @@ func (uvm *UtilityVM) AddSCSIPhysicalDisk(ctx context.Context, hostPath, uvmPath
 // available location and returns the path in the UVM where the layer was
 // mounted. This function is used by LCOW as an alternate to PMEM for large
 // layers.
-func (uvm *UtilityVM) AddSCSILayer(ctx context.Context, hostPath string) (string, error) {
+func (uvm *UtilityVM) AddSCSILayer(ctx context.Context, hostPath string) (*SCSIMount, error) {
 	if uvm.operatingSystem == "windows" {
-		return "", ErrSCSILayerWCOWUnsupported
+		return nil, ErrSCSILayerWCOWUnsupported
 	}
 
-	controller, lun, uvmPath, err := uvm.addSCSIActual(ctx, hostPath, "", "VirtualDisk", true, true)
+	sm, err := uvm.addSCSIActual(ctx, hostPath, "", "VirtualDisk", true, true)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
-	if uvmPath != "" {
-		return uvmPath, nil
+	if sm.UVMPath != "" {
+		return sm, nil
 	}
-
-	return fmt.Sprintf(lcowSCSILayerFmt, controller, lun), nil
+	sm.UVMPath = fmt.Sprintf(lcowSCSILayerFmt, sm.Controller, sm.LUN)
+	return sm, nil
 }
 
 // addSCSIActual is the implementation behind the external functions AddSCSI and
@@ -156,15 +239,15 @@ func (uvm *UtilityVM) AddSCSILayer(ctx context.Context, hostPath string) (string
 // `readOnly` indicates the attachment should be added read only.
 //
 // Returns the controller ID (0..3) and LUN (0..63) where the disk is attached.
-func (uvm *UtilityVM) addSCSIActual(ctx context.Context, hostPath, uvmPath, attachmentType string, isLayer, readOnly bool) (_ int, _ int32, _ string, err error) {
+func (uvm *UtilityVM) addSCSIActual(ctx context.Context, hostPath, uvmPath, attachmentType string, isLayer, readOnly bool) (*SCSIMount, error) {
 	if uvm.scsiControllerCount == 0 {
-		return -1, -1, "", ErrNoSCSIControllers
+		return nil, ErrNoSCSIControllers
 	}
 
 	// Ensure the utility VM has access
 	if !isLayer {
 		if err := wclayer.GrantVmAccess(ctx, uvm.id, hostPath); err != nil {
-			return -1, -1, "", err
+			return nil, err
 		}
 	}
 
@@ -174,37 +257,37 @@ func (uvm *UtilityVM) addSCSIActual(ctx context.Context, hostPath, uvmPath, atta
 	// these two operations. All failure paths between these two must release
 	// the lock.
 	uvm.m.Lock()
-	if controller, lun, uvmPath, err := uvm.findSCSIAttachment(ctx, hostPath); err == nil {
+	if sm, err := uvm.findSCSIAttachment(ctx, hostPath); err == nil {
 		// SCSI disk is already attached, Increment the refcount
-		uvm.scsiLocations[controller][lun].refCount++
+		sm.refCount++
 		uvm.m.Unlock()
-		return controller, lun, uvmPath, nil
+		return sm, nil
 	}
 
 	// At this point, we know it's not attached, regardless of whether it's a
 	// ref-counted layer VHD, or not.
-	controller, lun, err := uvm.allocateSCSI(ctx, hostPath, uvmPath, isLayer)
+	sm, err := uvm.allocateSCSI(ctx, hostPath, uvmPath, isLayer)
 	if err != nil {
 		uvm.m.Unlock()
-		return -1, -1, "", err
+		return nil, err
 	}
 	defer func() {
 		if err != nil {
-			uvm.deallocateSCSI(ctx, controller, lun)
+			uvm.deallocateSCSI(ctx, sm)
 		}
 	}()
 
 	// Auto-generate the UVM path for LCOW layers
 	if isLayer {
-		uvmPath = fmt.Sprintf(lcowSCSILayerFmt, controller, lun)
+		uvmPath = fmt.Sprintf(lcowSCSILayerFmt, sm.Controller, sm.LUN)
 	}
 
 	// See comment higher up. Now safe to release the lock.
 	uvm.m.Unlock()
 
 	// Note: Can remove this check post-RS5 if multiple controllers are supported
-	if controller > 0 {
-		return -1, -1, "", ErrTooManyAttachments
+	if sm.Controller > 0 {
+		return nil, ErrTooManyAttachments
 	}
 
 	SCSIModification := &hcsschema.ModifySettingRequest{
@@ -214,97 +297,35 @@ func (uvm *UtilityVM) addSCSIActual(ctx context.Context, hostPath, uvmPath, atta
 			Type_:    attachmentType,
 			ReadOnly: readOnly,
 		},
-		ResourcePath: fmt.Sprintf(scsiResourceFormat, strconv.Itoa(controller), lun),
+		ResourcePath: fmt.Sprintf(scsiResourceFormat, strconv.Itoa(sm.Controller), sm.LUN),
 	}
 
 	if uvmPath != "" {
+		guestReq := guestrequest.GuestRequest{
+			ResourceType: guestrequest.ResourceTypeMappedVirtualDisk,
+			RequestType:  requesttype.Add,
+		}
+
 		if uvm.operatingSystem == "windows" {
-			SCSIModification.GuestRequest = guestrequest.GuestRequest{
-				ResourceType: guestrequest.ResourceTypeMappedVirtualDisk,
-				RequestType:  requesttype.Add,
-				Settings: guestrequest.WCOWMappedVirtualDisk{
-					ContainerPath: uvmPath,
-					Lun:           lun,
-				},
+			guestReq.Settings = guestrequest.WCOWMappedVirtualDisk{
+				ContainerPath: uvmPath,
+				Lun:           sm.LUN,
 			}
 		} else {
-			SCSIModification.GuestRequest = guestrequest.GuestRequest{
-				ResourceType: guestrequest.ResourceTypeMappedVirtualDisk,
-				RequestType:  requesttype.Add,
-				Settings: guestrequest.LCOWMappedVirtualDisk{
-					MountPath:  uvmPath,
-					Lun:        uint8(lun),
-					Controller: uint8(controller),
-					ReadOnly:   readOnly,
-				},
+			guestReq.Settings = guestrequest.LCOWMappedVirtualDisk{
+				MountPath:  uvmPath,
+				Lun:        uint8(sm.LUN),
+				Controller: uint8(sm.Controller),
+				ReadOnly:   readOnly,
 			}
 		}
+		SCSIModification.GuestRequest = guestReq
 	}
 
 	if err := uvm.modify(ctx, SCSIModification); err != nil {
-		return -1, -1, "", fmt.Errorf("uvm::AddSCSI: failed to modify utility VM configuration: %s", err)
+		return nil, fmt.Errorf("uvm::AddSCSI: failed to modify utility VM configuration: %s", err)
 	}
-	return controller, lun, uvmPath, nil
-
-}
-
-// RemoveSCSI removes a SCSI disk from a utility VM.
-func (uvm *UtilityVM) RemoveSCSI(ctx context.Context, hostPath string) error {
-	uvm.m.Lock()
-	defer uvm.m.Unlock()
-
-	if uvm.scsiControllerCount == 0 {
-		return ErrNoSCSIControllers
-	}
-
-	// Make sure is actually attached
-	controller, lun, uvmPath, err := uvm.findSCSIAttachment(ctx, hostPath)
-	if err != nil {
-		return err
-	}
-
-	uvm.scsiLocations[controller][lun].refCount--
-	if uvm.scsiLocations[controller][lun].refCount > 0 {
-		return nil
-	}
-
-	scsiModification := &hcsschema.ModifySettingRequest{
-		RequestType:  requesttype.Remove,
-		ResourcePath: fmt.Sprintf(scsiResourceFormat, strconv.Itoa(controller), lun),
-	}
-
-	// Include the GuestRequest so that the GCS ejects the disk cleanly if the
-	// disk was attached/mounted
-	//
-	// Note: We always send a guest eject even if there is no UVM path in lcow
-	// so that we synchronize the guest state. This seems to always avoid SCSI
-	// related errors if this index quickly reused by another container.
-	if uvm.operatingSystem == "windows" && uvmPath != "" {
-		scsiModification.GuestRequest = guestrequest.GuestRequest{
-			ResourceType: guestrequest.ResourceTypeMappedVirtualDisk,
-			RequestType:  requesttype.Remove,
-			Settings: guestrequest.WCOWMappedVirtualDisk{
-				ContainerPath: uvmPath,
-				Lun:           lun,
-			},
-		}
-	} else {
-		scsiModification.GuestRequest = guestrequest.GuestRequest{
-			ResourceType: guestrequest.ResourceTypeMappedVirtualDisk,
-			RequestType:  requesttype.Remove,
-			Settings: guestrequest.LCOWMappedVirtualDisk{
-				MountPath:  uvmPath, // May be blank in attach-only
-				Lun:        uint8(lun),
-				Controller: uint8(controller),
-			},
-		}
-	}
-
-	if err := uvm.modify(ctx, scsiModification); err != nil {
-		return fmt.Errorf("failed to remove SCSI disk %s from container %s: %s", hostPath, uvm.id, err)
-	}
-	uvm.scsiLocations[controller][lun] = scsiInfo{}
-	return nil
+	return sm, nil
 }
 
 // GetScsiUvmPath returns the guest mounted path of a SCSI drive.
@@ -313,7 +334,9 @@ func (uvm *UtilityVM) RemoveSCSI(ctx context.Context, hostPath string) error {
 func (uvm *UtilityVM) GetScsiUvmPath(ctx context.Context, hostPath string) (string, error) {
 	uvm.m.Lock()
 	defer uvm.m.Unlock()
-
-	_, _, uvmPath, err := uvm.findSCSIAttachment(ctx, hostPath)
-	return uvmPath, err
+	sm, err := uvm.findSCSIAttachment(ctx, hostPath)
+	if err != nil {
+		return "", err
+	}
+	return sm.UVMPath, err
 }

--- a/internal/uvm/types.go
+++ b/internal/uvm/types.go
@@ -20,27 +20,6 @@ import (
 // Read-Only Layer    | VSMB | VPMEM
 // Mapped Directory   | VSMB | PLAN9
 
-// vsmbShare is an internal structure used for ref-counting VSMB shares mapped to a Windows utility VM.
-type vsmbShare struct {
-	refCount     uint32
-	name         string
-	guestRequest interface{}
-	allowedFiles []string
-}
-
-// scsiInfo is an internal structure used for determining what is mapped to a utility VM.
-// hostPath is required. uvmPath may be blank.
-type scsiInfo struct {
-	hostPath string
-	uvmPath  string
-
-	// While most VHDs attached to SCSI are scratch spaces, in the case of LCOW
-	// when the size is over the size possible to attach to PMEM, we use SCSI for
-	// read-only layers. As RO layers are shared, we perform ref-counting.
-	isLayer  bool
-	refCount uint32
-}
-
 // vpmemInfo is an internal structure used for determining VPMem devices mapped to
 // a Linux utility VM.
 type vpmemInfo struct {
@@ -89,8 +68,8 @@ type UtilityVM struct {
 	// unrestricted mappings of directories. `vsmbFileShares` tracks shares that
 	// are restricted to some subset of files in the directory. This is used as
 	// part of a temporary fix to allow WCOW single-file mapping to function.
-	vsmbDirShares  map[string]*vsmbShare
-	vsmbFileShares map[string]*vsmbShare
+	vsmbDirShares  map[string]*VSMBShare
+	vsmbFileShares map[string]*VSMBShare
 	vsmbCounter    uint64 // Counter to generate a unique share name for each VSMB share.
 
 	// VPMEM devices that are mapped into a Linux UVM. These are used for read-only layers, or for
@@ -100,8 +79,8 @@ type UtilityVM struct {
 	vpmemMaxSizeBytes uint64                    // The max size of the layer in bytes per vPMem device.
 
 	// SCSI devices that are mapped into a Windows or Linux utility VM
-	scsiLocations       [4][64]scsiInfo // Hyper-V supports 4 controllers, 64 slots per controller. Limited to 1 controller for now though.
-	scsiControllerCount uint32          // Number of SCSI controllers in the utility VM
+	scsiLocations       [4][64]*SCSIMount // Hyper-V supports 4 controllers, 64 slots per controller. Limited to 1 controller for now though.
+	scsiControllerCount uint32            // Number of SCSI controllers in the utility VM
 
 	// Plan9 are directories mapped into a Linux utility VM
 	plan9Counter uint64 // Each newly-added plan9 share has a counter used as its ID in the ResourceURI and for the name

--- a/internal/uvm/virtual_device.go
+++ b/internal/uvm/virtual_device.go
@@ -6,20 +6,38 @@ import (
 
 	"github.com/Microsoft/go-winio/pkg/guid"
 	"github.com/Microsoft/hcsshim/internal/guestrequest"
+	"github.com/Microsoft/hcsshim/internal/log"
 	"github.com/Microsoft/hcsshim/internal/requesttype"
 	hcsschema "github.com/Microsoft/hcsshim/internal/schema2"
 )
 
-func (uvm *UtilityVM) AssignDevice(ctx context.Context, device hcsschema.VirtualPciDevice) (string, error) {
+// VPCIDevice represents a vpci device. Holds its guid and a handle to the uvm it
+// belongs to.
+type VPCIDevice struct {
+	vm *UtilityVM
+	ID string
+}
+
+// Release frees the resources of the corresponding vpci device
+func (vpci *VPCIDevice) Release(ctx context.Context) error {
+	if err := vpci.vm.RemoveDevice(ctx, vpci.ID); err != nil {
+		log.G(ctx).WithError(err).Warn("failed to remove VPCI device")
+		return err
+	}
+	return nil
+}
+
+// AssignDevice assigns a new vpci device to the uvm
+func (uvm *UtilityVM) AssignDevice(ctx context.Context, device hcsschema.VirtualPciDevice) (*VPCIDevice, error) {
 	guid, err := guid.NewV4()
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	id := guid.String()
 
 	uvm.m.Lock()
 	defer uvm.m.Unlock()
-	return id, uvm.modify(ctx, &hcsschema.ModifySettingRequest{
+	if err := uvm.modify(ctx, &hcsschema.ModifySettingRequest{
 		ResourcePath: fmt.Sprintf(virtualPciResourceFormat, id),
 		RequestType:  requesttype.Add,
 		Settings:     device,
@@ -30,9 +48,16 @@ func (uvm *UtilityVM) AssignDevice(ctx context.Context, device hcsschema.Virtual
 				VMBusGUID: id,
 			},
 		},
-	})
+	}); err != nil {
+		return nil, err
+	}
+	return &VPCIDevice{
+		vm: uvm,
+		ID: id,
+	}, nil
 }
 
+// RemoveDevice removes a vpci device from the uvm
 func (uvm *UtilityVM) RemoveDevice(ctx context.Context, id string) error {
 	uvm.m.Lock()
 	defer uvm.m.Unlock()

--- a/test/functional/lcow_test.go
+++ b/test/functional/lcow_test.go
@@ -141,7 +141,7 @@ func TestLCOWSimplePodScenario(t *testing.T) {
 	if err := lcow.CreateScratch(context.Background(), lcowUVM, uvmScratchFile, lcow.DefaultScratchSizeGB, cacheFile); err != nil {
 		t.Fatal(err)
 	}
-	if _, _, _, err := lcowUVM.AddSCSI(context.Background(), uvmScratchFile, `/tmp/scratch`, false); err != nil {
+	if _, err := lcowUVM.AddSCSI(context.Background(), uvmScratchFile, `/tmp/scratch`, false); err != nil {
 		t.Fatal(err)
 	}
 

--- a/test/functional/uvm_scratch_test.go
+++ b/test/functional/uvm_scratch_test.go
@@ -44,11 +44,11 @@ func TestScratchCreateLCOW(t *testing.T) {
 	}
 
 	// Make sure it can be added (verifies it has access correctly)
-	c, l, _, err := targetUVM.AddSCSI(context.Background(), destTwo, "", false)
+	scsiMount, err := targetUVM.AddSCSI(context.Background(), destTwo, "", false)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if c != 0 && l != 0 {
+	if scsiMount.Controller != 0 && scsiMount.LUN != 0 {
 		t.Fatal(err)
 	}
 	// TODO Could consider giving it a host path and verifying it's contents somehow

--- a/test/functional/uvm_scsi_test.go
+++ b/test/functional/uvm_scsi_test.go
@@ -51,12 +51,12 @@ func testAddSCSI(u *uvm.UtilityVM, disks []string, pathPrefix string, usePath bo
 		if usePath {
 			uvmPath = fmt.Sprintf(`%s%d`, pathPrefix, i)
 		}
-		_, _, existingPath, err := u.AddSCSI(context.Background(), disks[i], uvmPath, false)
+		scsiMount, err := u.AddSCSI(context.Background(), disks[i], uvmPath, false)
 		if err != nil {
 			return err
 		}
-		if reAdd && existingPath != uvmPath {
-			return fmt.Errorf("expecting existing path to be %s but it is %s", uvmPath, existingPath)
+		if reAdd && scsiMount.UVMPath != uvmPath {
+			return fmt.Errorf("expecting existing path to be %s but it is %s", uvmPath, scsiMount.UVMPath)
 		}
 	}
 	return nil
@@ -274,7 +274,7 @@ func TestParallelScsiOps(t *testing.T) {
 					t.Errorf("failed to grantvmaccess for worker: %d, iteration: %d with err: %v", scsiIndex, iteration, err)
 					continue
 				}
-				_, _, _, err = u.AddSCSI(context.Background(), path, "", false)
+				_, err = u.AddSCSI(context.Background(), path, "", false)
 				if err != nil {
 					os.Remove(path)
 					t.Errorf("failed to AddSCSI for worker: %d, iteration: %d with err: %v", scsiIndex, iteration, err)
@@ -286,7 +286,7 @@ func TestParallelScsiOps(t *testing.T) {
 					// This worker cant continue because the index is dead. We have to stop
 					break
 				}
-				_, _, _, err = u.AddSCSI(context.Background(), path, fmt.Sprintf("/run/gcs/c/0/scsi/%d", iteration), false)
+				_, err = u.AddSCSI(context.Background(), path, fmt.Sprintf("/run/gcs/c/0/scsi/%d", iteration), false)
 				if err != nil {
 					os.Remove(path)
 					t.Errorf("failed to AddSCSI for worker: %d, iteration: %d with err: %v", scsiIndex, iteration, err)

--- a/test/functional/uvm_virtualdevice_test.go
+++ b/test/functional/uvm_virtualdevice_test.go
@@ -58,11 +58,11 @@ func TestVirtualDevice(t *testing.T) {
 			},
 		},
 	}
-	busGUID, err := vm.AssignDevice(ctx, dev)
+	vpci, err := vm.AssignDevice(ctx, dev)
 	if err != nil {
 		t.Fatalf("failed to assign device %s with %v", testDeviceInstanceID, err)
 	}
-	if err := vm.RemoveDevice(ctx, busGUID); err != nil {
+	if err := vm.RemoveDevice(ctx, vpci.ID); err != nil {
 		t.Fatalf("failed to remove device %s with %v", testDeviceInstanceID, err)
 	}
 }

--- a/test/functional/uvm_vsmb_test.go
+++ b/test/functional/uvm_vsmb_test.go
@@ -30,7 +30,7 @@ func TestVSMB(t *testing.T) {
 		ShareRead:           true,
 	}
 	for i := 0; i < int(iterations); i++ {
-		if err := uvm.AddVSMB(context.Background(), dir, "", options); err != nil {
+		if _, err := uvm.AddVSMB(context.Background(), dir, "", options); err != nil {
 			t.Fatalf("AddVSMB failed: %s", err)
 		}
 	}


### PR DESCRIPTION
* Changed all resources that were originally just a slice of strings(paths mostly) to be actual structs with the paths as fields. This allows the structs to implement how they are cleaned up/released now.
* Moved the logic of resource cleanup out of ReleaseResources and into the corresponding Release methods of the structs.
 * New interface to eventually have all resources implement so they can all be generically closed without worrying about what the resource is.
 * Move scsiInfo fields into ScsiMount so we can track the lifetime of a sci mount from one object instead of two.
 * Exported vsmbShare

Signed-off-by: Daniel Canter <dcanter@microsoft.com>