### PR TITLE
Allow a VHD to be mounted into multiple LCOW containers in the same pod

### DIFF
--- a/internal/hcsoci/layers.go
+++ b/internal/hcsoci/layers.go
@@ -127,7 +127,7 @@ func MountContainerLayers(ctx context.Context, layerFolders []string, guestRoot 
 
 	hostPath := filepath.Join(layerFolders[len(layerFolders)-1], "sandbox.vhdx")
 	containerScratchPathInUVM := ospath.Join(uvm.OS(), guestRoot)
-	_, _, err = uvm.AddSCSI(ctx, hostPath, containerScratchPathInUVM, false)
+	_, _, containerScratchPathInUVM, err = uvm.AddSCSI(ctx, hostPath, containerScratchPathInUVM, false)
 	if err != nil {
 		return "", err
 	}

--- a/internal/hcsoci/resources_lcow.go
+++ b/internal/hcsoci/resources_lcow.go
@@ -99,18 +99,29 @@ func allocateLinuxResources(ctx context.Context, coi *createOptionsInternal, res
 			l := log.G(ctx).WithField("mount", fmt.Sprintf("%+v", mount))
 			if mount.Type == "physical-disk" {
 				l.Debug("hcsshim::allocateLinuxResources Hot-adding SCSI physical disk for OCI mount")
-				_, _, err := coi.HostingSystem.AddSCSIPhysicalDisk(ctx, hostPath, uvmPathForShare, readOnly)
+				uvmPathForShare = fmt.Sprintf(lcowGlobalMountPrefix, i)
+				_, _, uvmPath, err := coi.HostingSystem.AddSCSIPhysicalDisk(ctx, hostPath, uvmPathForShare, readOnly)
 				if err != nil {
 					return fmt.Errorf("adding SCSI physical disk mount %+v: %s", mount, err)
 				}
+
+				uvmPathForFile = uvmPath
+				uvmPathForShare = uvmPath
 				resources.scsiMounts = append(resources.scsiMounts, scsiMount{path: hostPath})
 				coi.Spec.Mounts[i].Type = "none"
 			} else if mount.Type == "virtual-disk" || mount.Type == "automanage-virtual-disk" {
 				l.Debug("hcsshim::allocateLinuxResources Hot-adding SCSI virtual disk for OCI mount")
-				_, _, err := coi.HostingSystem.AddSCSI(ctx, hostPath, uvmPathForShare, readOnly)
+				uvmPathForShare = fmt.Sprintf(lcowGlobalMountPrefix, i)
+
+				// if the scsi device is already attached then we take the uvm path that the function below returns
+				// that is where it was previously mounted in UVM
+				_, _, uvmPath, err := coi.HostingSystem.AddSCSI(ctx, hostPath, uvmPathForShare, readOnly)
 				if err != nil {
 					return fmt.Errorf("adding SCSI virtual disk mount %+v: %s", mount, err)
 				}
+
+				uvmPathForFile = uvmPath
+				uvmPathForShare = uvmPath
 				resources.scsiMounts = append(resources.scsiMounts, scsiMount{path: hostPath, autoManage: mount.Type == "automanage-virtual-disk"})
 				coi.Spec.Mounts[i].Type = "none"
 			} else if strings.HasPrefix(mount.Source, "sandbox://") {
@@ -174,7 +185,7 @@ func allocateLinuxResources(ctx context.Context, coi *createOptionsInternal, res
 		}
 		// use lcowNvidiaMountPath since we only support nvidia gpus right now
 		// must use scsi here since DDA'ing a hyper-v pci device is not supported on VMs that have ANY virtual memory
-		_, _, err = coi.HostingSystem.AddSCSI(ctx, gpuSupportVhdPath, lcowNvidiaMountPath, true)
+		_, _, _, err = coi.HostingSystem.AddSCSI(ctx, gpuSupportVhdPath, lcowNvidiaMountPath, true)
 		if err != nil {
 			return errors.Wrapf(err, "failed to add scsi device %s in the UVM %s at %s", gpuSupportVhdPath, coi.HostingSystem.ID(), lcowNvidiaMountPath)
 		}

--- a/internal/hcsoci/resources_wcow.go
+++ b/internal/hcsoci/resources_wcow.go
@@ -89,7 +89,7 @@ func allocateWindowsResources(ctx context.Context, coi *createOptionsInternal, r
 			l := log.G(ctx).WithField("mount", fmt.Sprintf("%+v", mount))
 			if mount.Type == "physical-disk" {
 				l.Debug("hcsshim::allocateWindowsResources Hot-adding SCSI physical disk for OCI mount")
-				_, _, err := coi.HostingSystem.AddSCSIPhysicalDisk(ctx, mount.Source, uvmPath, readOnly)
+				_, _, _, err := coi.HostingSystem.AddSCSIPhysicalDisk(ctx, mount.Source, uvmPath, readOnly)
 				if err != nil {
 					return fmt.Errorf("adding SCSI physical disk mount %+v: %s", mount, err)
 				}
@@ -97,7 +97,7 @@ func allocateWindowsResources(ctx context.Context, coi *createOptionsInternal, r
 				resources.scsiMounts = append(resources.scsiMounts, scsiMount{path: mount.Source})
 			} else if mount.Type == "virtual-disk" || mount.Type == "automanage-virtual-disk" {
 				l.Debug("hcsshim::allocateWindowsResources Hot-adding SCSI virtual disk for OCI mount")
-				_, _, err := coi.HostingSystem.AddSCSI(ctx, mount.Source, uvmPath, readOnly)
+				_, _, _, err := coi.HostingSystem.AddSCSI(ctx, mount.Source, uvmPath, readOnly)
 				if err != nil {
 					return fmt.Errorf("adding SCSI virtual disk mount %+v: %s", mount, err)
 				}

--- a/internal/lcow/scratch.go
+++ b/internal/lcow/scratch.go
@@ -66,7 +66,7 @@ func CreateScratch(ctx context.Context, lcowUVM *uvm.UtilityVM, destFile string,
 		return fmt.Errorf("failed to create VHDx %s: %s", destFile, err)
 	}
 
-	controller, lun, err := lcowUVM.AddSCSI(ctx, destFile, "", false) // No destination as not formatted
+	controller, lun, _, err := lcowUVM.AddSCSI(ctx, destFile, "", false) // No destination as not formatted
 	if err != nil {
 		return err
 	}

--- a/internal/uvm/scsi.go
+++ b/internal/uvm/scsi.go
@@ -101,7 +101,7 @@ func (uvm *UtilityVM) findSCSIAttachment(ctx context.Context, findThisHostPath s
 // `uvmPath` is optional.
 //
 // `readOnly` set to `true` if the vhd/vhdx should be attached read only.
-func (uvm *UtilityVM) AddSCSI(ctx context.Context, hostPath string, uvmPath string, readOnly bool) (int, int32, error) {
+func (uvm *UtilityVM) AddSCSI(ctx context.Context, hostPath string, uvmPath string, readOnly bool) (int, int32, string, error) {
 	return uvm.addSCSIActual(ctx, hostPath, uvmPath, "VirtualDisk", false, readOnly)
 }
 
@@ -113,7 +113,7 @@ func (uvm *UtilityVM) AddSCSI(ctx context.Context, hostPath string, uvmPath stri
 // `uvmPath` is optional if a guest mount is not requested.
 //
 // `readOnly` set to `true` if the physical disk should be attached read only.
-func (uvm *UtilityVM) AddSCSIPhysicalDisk(ctx context.Context, hostPath, uvmPath string, readOnly bool) (int, int32, error) {
+func (uvm *UtilityVM) AddSCSIPhysicalDisk(ctx context.Context, hostPath, uvmPath string, readOnly bool) (int, int32, string, error) {
 	return uvm.addSCSIActual(ctx, hostPath, uvmPath, "PassThru", false, readOnly)
 }
 
@@ -126,10 +126,15 @@ func (uvm *UtilityVM) AddSCSILayer(ctx context.Context, hostPath string) (string
 		return "", ErrSCSILayerWCOWUnsupported
 	}
 
-	controller, lun, err := uvm.addSCSIActual(ctx, hostPath, "", "VirtualDisk", true, true)
+	controller, lun, uvmPath, err := uvm.addSCSIActual(ctx, hostPath, "", "VirtualDisk", true, true)
 	if err != nil {
 		return "", err
 	}
+
+	if uvmPath != "" {
+		return uvmPath, nil
+	}
+
 	return fmt.Sprintf(lcowSCSILayerFmt, controller, lun), nil
 }
 
@@ -153,15 +158,15 @@ func (uvm *UtilityVM) AddSCSILayer(ctx context.Context, hostPath string) (string
 // `readOnly` indicates the attachment should be added read only.
 //
 // Returns the controller ID (0..3) and LUN (0..63) where the disk is attached.
-func (uvm *UtilityVM) addSCSIActual(ctx context.Context, hostPath, uvmPath, attachmentType string, isLayer, readOnly bool) (_ int, _ int32, err error) {
+func (uvm *UtilityVM) addSCSIActual(ctx context.Context, hostPath, uvmPath, attachmentType string, isLayer, readOnly bool) (_ int, _ int32, _ string, err error) {
 	if uvm.scsiControllerCount == 0 {
-		return -1, -1, ErrNoSCSIControllers
+		return -1, -1, "", ErrNoSCSIControllers
 	}
 
 	// Ensure the utility VM has access
 	if !isLayer {
 		if err := wclayer.GrantVmAccess(ctx, uvm.id, hostPath); err != nil {
-			return -1, -1, err
+			return -1, -1, "", err
 		}
 	}
 
@@ -171,17 +176,11 @@ func (uvm *UtilityVM) addSCSIActual(ctx context.Context, hostPath, uvmPath, atta
 	// these two operations. All failure paths between these two must release
 	// the lock.
 	uvm.m.Lock()
-	if controller, lun, _, err := uvm.findSCSIAttachment(ctx, hostPath); err == nil {
-		// So is attached
-		if isLayer {
-			// Increment the refcount
-			uvm.scsiLocations[controller][lun].refCount++
-			uvm.m.Unlock()
-			return controller, lun, nil
-		}
-
+	if controller, lun, uvmPath, err := uvm.findSCSIAttachment(ctx, hostPath); err == nil {
+		// SCSI disk is already attached, Increment the refcount
+		uvm.scsiLocations[controller][lun].refCount++
 		uvm.m.Unlock()
-		return -1, -1, ErrAlreadyAttached
+		return controller, lun, uvmPath, nil
 	}
 
 	// At this point, we know it's not attached, regardless of whether it's a
@@ -189,7 +188,7 @@ func (uvm *UtilityVM) addSCSIActual(ctx context.Context, hostPath, uvmPath, atta
 	controller, lun, err := uvm.allocateSCSI(ctx, hostPath, uvmPath, isLayer)
 	if err != nil {
 		uvm.m.Unlock()
-		return -1, -1, err
+		return -1, -1, "", err
 	}
 	defer func() {
 		if err != nil {
@@ -207,7 +206,7 @@ func (uvm *UtilityVM) addSCSIActual(ctx context.Context, hostPath, uvmPath, atta
 
 	// Note: Can remove this check post-RS5 if multiple controllers are supported
 	if controller > 0 {
-		return -1, -1, ErrTooManyAttachments
+		return -1, -1, "", ErrTooManyAttachments
 	}
 
 	SCSIModification := &hcsschema.ModifySettingRequest{
@@ -245,9 +244,9 @@ func (uvm *UtilityVM) addSCSIActual(ctx context.Context, hostPath, uvmPath, atta
 	}
 
 	if err := uvm.modify(ctx, SCSIModification); err != nil {
-		return -1, -1, fmt.Errorf("uvm::AddSCSI: failed to modify utility VM configuration: %s", err)
+		return -1, -1, "", fmt.Errorf("uvm::AddSCSI: failed to modify utility VM configuration: %s", err)
 	}
-	return controller, lun, nil
+	return controller, lun, uvmPath, nil
 
 }
 
@@ -266,11 +265,9 @@ func (uvm *UtilityVM) RemoveSCSI(ctx context.Context, hostPath string) error {
 		return err
 	}
 
-	if uvm.scsiLocations[controller][lun].isLayer {
-		uvm.scsiLocations[controller][lun].refCount--
-		if uvm.scsiLocations[controller][lun].refCount > 0 {
-			return nil
-		}
+	uvm.scsiLocations[controller][lun].refCount--
+	if uvm.scsiLocations[controller][lun].refCount > 0 {
+		return nil
 	}
 
 	scsiModification := &hcsschema.ModifySettingRequest{

--- a/test/cri-containerd/main.go
+++ b/test/cri-containerd/main.go
@@ -54,7 +54,7 @@ func getWindowsNanoserverImage(build uint16) string {
 	case osversion.V19H1:
 		return "mcr.microsoft.com/windows/nanoserver:1903"
 	default:
-		panic("unspported build")
+		panic("unsupported build")
 	}
 }
 
@@ -65,7 +65,7 @@ func getWindowsServerCoreImage(build uint16) string {
 	case osversion.V19H1:
 		return "mcr.microsoft.com/windows/servercore:1903"
 	default:
-		panic("unspported build")
+		panic("unsupported build")
 	}
 }
 

--- a/test/functional/lcow_test.go
+++ b/test/functional/lcow_test.go
@@ -141,7 +141,7 @@ func TestLCOWSimplePodScenario(t *testing.T) {
 	if err := lcow.CreateScratch(context.Background(), lcowUVM, uvmScratchFile, lcow.DefaultScratchSizeGB, cacheFile); err != nil {
 		t.Fatal(err)
 	}
-	if _, _, err := lcowUVM.AddSCSI(context.Background(), uvmScratchFile, `/tmp/scratch`, false); err != nil {
+	if _, _, _, err := lcowUVM.AddSCSI(context.Background(), uvmScratchFile, `/tmp/scratch`, false); err != nil {
 		t.Fatal(err)
 	}
 

--- a/test/functional/uvm_scratch_test.go
+++ b/test/functional/uvm_scratch_test.go
@@ -44,7 +44,7 @@ func TestScratchCreateLCOW(t *testing.T) {
 	}
 
 	// Make sure it can be added (verifies it has access correctly)
-	c, l, err := targetUVM.AddSCSI(context.Background(), destTwo, "", false)
+	c, l, _, err := targetUVM.AddSCSI(context.Background(), destTwo, "", false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/functional/uvm_scsi_test.go
+++ b/test/functional/uvm_scsi_test.go
@@ -67,7 +67,7 @@ func testSCSIAddRemove(t *testing.T, u *uvm.UtilityVM, pathPrefix string, operat
 	// Add each of the disks to the utility VM. Attach-only, no container path
 	logrus.Debugln("First - adding in attach-only")
 	for i := 0; i < numDisks; i++ {
-		_, _, err := u.AddSCSI(context.Background(), disks[i], "", false)
+		_, _, _, err := u.AddSCSI(context.Background(), disks[i], "", false)
 		if err != nil {
 			t.Fatalf("failed to add scsi disk %d %s: %s", i, disks[i], err)
 		}
@@ -76,7 +76,7 @@ func testSCSIAddRemove(t *testing.T, u *uvm.UtilityVM, pathPrefix string, operat
 	// Try to re-add. These should all fail.
 	logrus.Debugln("Next - trying to re-add")
 	for i := 0; i < numDisks; i++ {
-		_, _, err := u.AddSCSI(context.Background(), disks[i], "", false)
+		_, _, _, err := u.AddSCSI(context.Background(), disks[i], "", false)
 		if err == nil {
 			t.Fatalf("should not be able to re-add the same SCSI disk!")
 		}
@@ -96,7 +96,7 @@ func testSCSIAddRemove(t *testing.T, u *uvm.UtilityVM, pathPrefix string, operat
 	// Now re-add but providing a container path
 	logrus.Debugln("Next - re-adding with a container path")
 	for i := 0; i < numDisks; i++ {
-		_, _, err := u.AddSCSI(context.Background(), disks[i], fmt.Sprintf(`%s%d`, pathPrefix, i), false)
+		_, _, _, err := u.AddSCSI(context.Background(), disks[i], fmt.Sprintf(`%s%d`, pathPrefix, i), false)
 		if err != nil {
 			t.Fatalf("failed to add scsi disk %d %s: %s", i, disks[i], err)
 		}
@@ -105,12 +105,10 @@ func testSCSIAddRemove(t *testing.T, u *uvm.UtilityVM, pathPrefix string, operat
 	// Try to re-add. These should all fail.
 	logrus.Debugln("Next - trying to re-add")
 	for i := 0; i < numDisks; i++ {
-		_, _, err := u.AddSCSI(context.Background(), disks[i], fmt.Sprintf(`%s%d`, pathPrefix, i), false)
-		if err == nil {
-			t.Fatalf("should not be able to re-add the same SCSI disk!")
-		}
-		if err != uvm.ErrAlreadyAttached {
-			t.Fatalf("expecting %s, got %s", uvm.ErrAlreadyAttached, err)
+		_, _, existingPath, err := u.AddSCSI(context.Background(), disks[i], fmt.Sprintf(`%s%d`, pathPrefix, i), false)
+
+		if existingPath == "" {
+			t.Fatalf("expecting existing path to not be empty but it is %s", err)
 		}
 	}
 
@@ -187,7 +185,7 @@ func TestParallelScsiOps(t *testing.T) {
 					t.Errorf("failed to grantvmaccess for worker: %d, iteration: %d with err: %v", scsiIndex, iteration, err)
 					continue
 				}
-				_, _, err = u.AddSCSI(context.Background(), path, "", false)
+				_, _, _, err = u.AddSCSI(context.Background(), path, "", false)
 				if err != nil {
 					os.Remove(path)
 					t.Errorf("failed to AddSCSI for worker: %d, iteration: %d with err: %v", scsiIndex, iteration, err)
@@ -199,7 +197,7 @@ func TestParallelScsiOps(t *testing.T) {
 					// This worker cant continue because the index is dead. We have to stop
 					break
 				}
-				_, _, err = u.AddSCSI(context.Background(), path, fmt.Sprintf("/run/gcs/c/0/scsi/%d", iteration), false)
+				_, _, _, err = u.AddSCSI(context.Background(), path, fmt.Sprintf("/run/gcs/c/0/scsi/%d", iteration), false)
 				if err != nil {
 					os.Remove(path)
 					t.Errorf("failed to AddSCSI for worker: %d, iteration: %d with err: %v", scsiIndex, iteration, err)


### PR DESCRIPTION
This is a re-visiting of the change made by abwah previously in commit
7f17353012eda1dbd8367135642ec24ebc88bd1d. That work was reverted due to
test failures with WCOW. With this new change, we no longer attempt to
support WCOW (we can look into that later if needed).

This change also differs from the original in that we now generate the
VHD dynamically at test time, rather than checking in a static VHD file.

Signed-off-by: Kevin Parsons <kevpar@microsoft.com>

@abwah FYI