### PR TITLE
always set newly allocated scsi device's ref count to 1

### DIFF
--- a/internal/uvm/scsi.go
+++ b/internal/uvm/scsi.go
@@ -36,14 +36,12 @@ func (uvm *UtilityVM) allocateSCSI(ctx context.Context, hostPath string, uvmPath
 				uvm.scsiLocations[controller][lun].hostPath = hostPath
 				uvm.scsiLocations[controller][lun].uvmPath = uvmPath
 				uvm.scsiLocations[controller][lun].isLayer = isLayer
-				if isLayer {
-					uvm.scsiLocations[controller][lun].refCount = 1
-				}
+				uvm.scsiLocations[controller][lun].refCount = 1
 				log.G(ctx).WithFields(logrus.Fields{
 					"hostPath":   hostPath,
 					"uvmPath":    uvmPath,
 					"isLayer":    isLayer,
-					"refCount":   0,
+					"refCount":   1,
 					"controller": controller,
 					"lun":        lun,
 				}).Debug("allocated SCSI location")


### PR DESCRIPTION
previously in the [work to support adding the same scsi device to multiple containers](https://github.com/microsoft/hcsshim/pull/773), ref count was only set to 1 if the device was a layer. This caused allocated non-layer scsi devices to never be removed as decrementing the ref count on removal would cause uint underflow.

Signed-off-by: Kathryn Baldauf <kabaldau@microsoft.com>