### PR TITLE
fix scsimount path for gpu vhd addition to allow proper clean up 

### DIFF
--- a/internal/hcsoci/resources_lcow.go
+++ b/internal/hcsoci/resources_lcow.go
@@ -189,7 +189,7 @@ func allocateLinuxResources(ctx context.Context, coi *createOptionsInternal, res
 		if err != nil {
 			return errors.Wrapf(err, "failed to add scsi device %s in the UVM %s at %s", gpuSupportVhdPath, coi.HostingSystem.ID(), lcowNvidiaMountPath)
 		}
-		resources.scsiMounts = append(resources.scsiMounts, scsiMount{path: lcowNvidiaMountPath})
+		resources.scsiMounts = append(resources.scsiMounts, scsiMount{path: gpuSupportVhdPath})
 	}
 
 	return nil

--- a/test/cri-containerd/container_test.go
+++ b/test/cri-containerd/container_test.go
@@ -250,6 +250,7 @@ func Test_RunContainer_VirtualDevice_GPU_LCOW(t *testing.T) {
 				// if a given gpu device needs more, this test will fail to create the container
 				// and may hang.
 				"io.microsoft.virtualmachine.computetopology.memory.highmmiogapinmb": "64000",
+				"io.microsoft.virtualmachine.lcow.bootfilesrootpath":                 testGPUBootFiles,
 			},
 		},
 		RuntimeHandler: lcowRuntimeHandler,
@@ -289,7 +290,6 @@ func Test_RunContainer_VirtualDevice_GPU_LCOW(t *testing.T) {
 	defer cancel()
 	containerID := createContainer(t, client, ctx, containerRequest)
 	defer removeContainer(t, client, ctx, containerID)
-
 	startContainer(t, client, ctx, containerID)
 	defer stopContainer(t, client, ctx, containerID)
 

--- a/test/cri-containerd/main.go
+++ b/test/cri-containerd/main.go
@@ -36,6 +36,7 @@ const (
 	imageLcowK8sPause                 = "k8s.gcr.io/pause:3.1"
 	imageLcowAlpine                   = "docker.io/library/alpine:latest"
 	imageLcowCosmos                   = "cosmosarno/spark-master:2.4.1_2019-04-18_8e864ce"
+	testGPUBootFiles                  = "C:\\ContainerPlat\\LinuxBootFiles\\nvidiagpu"
 )
 
 var (


### PR DESCRIPTION
* add necessary annotation to previous gpu test for linux boot files
* add additional check that after container has exited, gpu vhd is removed from uvm

Signed-off-by: Kathryn Baldauf <kabaldau@microsoft.com>