### PR TITLE
Fix multiple VHD overlapping mount bug LCOW

### DIFF
--- a/internal/hcsoci/resources_lcow.go
+++ b/internal/hcsoci/resources_lcow.go
@@ -99,7 +99,7 @@ func allocateLinuxResources(ctx context.Context, coi *createOptionsInternal, res
 			l := log.G(ctx).WithField("mount", fmt.Sprintf("%+v", mount))
 			if mount.Type == "physical-disk" {
 				l.Debug("hcsshim::allocateLinuxResources Hot-adding SCSI physical disk for OCI mount")
-				uvmPathForShare = fmt.Sprintf(lcowGlobalMountPrefix, i)
+				uvmPathForShare = fmt.Sprintf(lcowGlobalMountPrefix, coi.HostingSystem.UVMMountCounter())
 				_, _, uvmPath, err := coi.HostingSystem.AddSCSIPhysicalDisk(ctx, hostPath, uvmPathForShare, readOnly)
 				if err != nil {
 					return fmt.Errorf("adding SCSI physical disk mount %+v: %s", mount, err)
@@ -111,7 +111,7 @@ func allocateLinuxResources(ctx context.Context, coi *createOptionsInternal, res
 				coi.Spec.Mounts[i].Type = "none"
 			} else if mount.Type == "virtual-disk" || mount.Type == "automanage-virtual-disk" {
 				l.Debug("hcsshim::allocateLinuxResources Hot-adding SCSI virtual disk for OCI mount")
-				uvmPathForShare = fmt.Sprintf(lcowGlobalMountPrefix, i)
+				uvmPathForShare = fmt.Sprintf(lcowGlobalMountPrefix, coi.HostingSystem.UVMMountCounter())
 
 				// if the scsi device is already attached then we take the uvm path that the function below returns
 				// that is where it was previously mounted in UVM

--- a/internal/uvm/counter.go
+++ b/internal/uvm/counter.go
@@ -9,3 +9,9 @@ import (
 func (uvm *UtilityVM) ContainerCounter() uint64 {
 	return atomic.AddUint64(&uvm.containerCounter, 1)
 }
+
+// mountCounter is used for maintaining the number of mounts to the UVM.
+// This helps in generating unique mount paths for every mount.
+func (uvm *UtilityVM) UVMMountCounter() uint64 {
+	return atomic.AddUint64(&uvm.mountCounter, 1)
+}

--- a/internal/uvm/types.go
+++ b/internal/uvm/types.go
@@ -122,4 +122,9 @@ type UtilityVM struct {
 	// We only need to look up the vmmem process once, then we keep a handle
 	// open.
 	vmmemOnce sync.Once
+
+	// mountCounter is the number of mounts that have been added to the UVM
+	// This is used in generating unique mount path inside UVM for every mount.
+	// Access to this variable should be done atomically.
+	mountCounter uint64
 }


### PR DESCRIPTION
Every VHD that is mounted inside a container must be mounted in the UVM first. When different containers mount the different VHDs, a unique mount path (unique inside the UVM) should be generated for each such VHD. Existing mount code generates such unique paths but those paths are unique only across the container. Hence, two different VHDs mounted by two different containers will have unique path inside their own container world but can have the same path inside the UVM. Due to this the second mount will end up mounting over the existing mount of the first container.
This change fixes the bug to generate such unique mount paths across the UVM instead of just keeping them unique to the container.