### PR TITLE
Allow a VHD to be mounted into multiple WCOW containers in the same pod

### DIFF
--- a/internal/hcs/syscall.go
+++ b/internal/hcs/syscall.go
@@ -1,0 +1,5 @@
+package hcs
+
+//go:generate go run ../../mksyscall_windows.go -output zsyscall_windows.go syscall.go
+
+//sys hcsFormatWritableLayerVhd(handle uintptr) (hr error) = computestorage.HcsFormatWritableLayerVhd

--- a/internal/hcs/utils.go
+++ b/internal/hcs/utils.go
@@ -1,10 +1,14 @@
 package hcs
 
 import (
+	"context"
 	"io"
 	"syscall"
 
 	"github.com/Microsoft/go-winio"
+	diskutil "github.com/Microsoft/go-winio/vhd"
+	"github.com/pkg/errors"
+	"golang.org/x/sys/windows"
 )
 
 // makeOpenFiles calls winio.MakeOpenFile for each handle in a slice but closes all the handles
@@ -30,4 +34,28 @@ func makeOpenFiles(hs []syscall.Handle) (_ []io.ReadWriteCloser, err error) {
 		return nil, err
 	}
 	return fs, nil
+}
+
+// creates a VHD formatted with NTFS of size `sizeGB` at the given `vhdPath`.
+func CreateNTFSVHD(ctx context.Context, vhdPath string, sizeGB uint32) (err error) {
+	if err := diskutil.CreateVhdx(vhdPath, sizeGB, 1); err != nil {
+		return errors.Wrap(err, "failed to create VHD")
+	}
+
+	vhd, err := diskutil.OpenVirtualDisk(vhdPath, diskutil.VirtualDiskAccessNone, diskutil.OpenVirtualDiskFlagNone)
+	if err != nil {
+		return errors.Wrap(err, "failed to open VHD")
+	}
+	defer func() {
+		err2 := windows.CloseHandle(windows.Handle(vhd))
+		if err == nil {
+			err = errors.Wrap(err2, "failed to close VHD")
+		}
+	}()
+
+	if err := hcsFormatWritableLayerVhd(uintptr(vhd)); err != nil {
+		return errors.Wrap(err, "failed to format VHD")
+	}
+
+	return nil
 }

--- a/internal/hcs/zsyscall_windows.go
+++ b/internal/hcs/zsyscall_windows.go
@@ -1,0 +1,54 @@
+// Code generated mksyscall_windows.exe DO NOT EDIT
+
+package hcs
+
+import (
+	"syscall"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+var _ unsafe.Pointer
+
+// Do the interface allocations only once for common
+// Errno values.
+const (
+	errnoERROR_IO_PENDING = 997
+)
+
+var (
+	errERROR_IO_PENDING error = syscall.Errno(errnoERROR_IO_PENDING)
+)
+
+// errnoErr returns common boxed Errno values, to prevent
+// allocations at runtime.
+func errnoErr(e syscall.Errno) error {
+	switch e {
+	case 0:
+		return nil
+	case errnoERROR_IO_PENDING:
+		return errERROR_IO_PENDING
+	}
+	// TODO: add more here, after collecting data on the common
+	// error values see on Windows. (perhaps when running
+	// all.bat?)
+	return e
+}
+
+var (
+	modcomputestorage = windows.NewLazySystemDLL("computestorage.dll")
+
+	procHcsFormatWritableLayerVhd = modcomputestorage.NewProc("HcsFormatWritableLayerVhd")
+)
+
+func hcsFormatWritableLayerVhd(handle uintptr) (hr error) {
+	r0, _, _ := syscall.Syscall(procHcsFormatWritableLayerVhd.Addr(), 1, uintptr(handle), 0, 0)
+	if int32(r0) < 0 {
+		if r0&0x1fff0000 == 0x00070000 {
+			r0 &= 0xffff
+		}
+		hr = syscall.Errno(r0)
+	}
+	return
+}

--- a/internal/hcsoci/resources_wcow.go
+++ b/internal/hcsoci/resources_wcow.go
@@ -19,6 +19,8 @@ import (
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 )
 
+const wcowGlobalMountPrefix = "C:\\mounts\\m%d"
+
 func allocateWindowsResources(ctx context.Context, coi *createOptionsInternal, resources *Resources) error {
 	if coi.Spec == nil || coi.Spec.Windows == nil || coi.Spec.Windows.LayerFolders == nil {
 		return fmt.Errorf("field 'Spec.Windows.Layerfolders' is not populated")
@@ -77,8 +79,7 @@ func allocateWindowsResources(ctx context.Context, coi *createOptionsInternal, r
 		}
 
 		if coi.HostingSystem != nil && schemaversion.IsV21(coi.actualSchemaVersion) {
-			uvmPath := fmt.Sprintf("C:\\%s\\%d", coi.actualID, i)
-
+			uvmPath := fmt.Sprintf(wcowGlobalMountPrefix, coi.HostingSystem.UVMMountCounter())
 			readOnly := false
 			for _, o := range mount.Options {
 				if strings.ToLower(o) == "ro" {


### PR DESCRIPTION
In order to mount a VHD to a container, first it needs to be mounted inside the UVM.  We generate a unique mount point (inside UVM) for every such mount that is requested by a container. However, this
breaks when two containers try to mount the same VHD. Because then we generate two unique paths for the same VHD and try to mount it at two different locations inside the UVM. This change fixes that issue for WCOW containers. (corresponding LCOW change was done in #773 )