### PR TITLE
Implement early cloning for UVM

### DIFF
--- a/cmd/containerd-shim-runhcs-v1/pod.go
+++ b/cmd/containerd-shim-runhcs-v1/pod.go
@@ -2,10 +2,10 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"sync"
-	"fmt"
 
 	"github.com/Microsoft/hcsshim/internal/hcsoci"
 	"github.com/Microsoft/hcsshim/internal/log"

--- a/cmd/containerd-shim-runhcs-v1/service_internal.go
+++ b/cmd/containerd-shim-runhcs-v1/service_internal.go
@@ -36,7 +36,6 @@ func (s *service) getPod() (shimPod, error) {
 	return raw.(shimPod), nil
 }
 
-
 // getTask returns a task matching `tid` or else returns `nil`. This properly
 // handles a task in a pod or a singular task shim.
 //

--- a/internal/hcs/callback.go
+++ b/internal/hcs/callback.go
@@ -106,6 +106,7 @@ func newSystemChannels() notificationChannels {
 		hcsNotificationSystemStartCompleted,
 		hcsNotificationSystemPauseCompleted,
 		hcsNotificationSystemResumeCompleted,
+		hcsNotificationSystemSaveCompleted,
 	} {
 		channels[notif] = make(notificationChannel, 1)
 	}

--- a/internal/hcs/system.go
+++ b/internal/hcs/system.go
@@ -371,7 +371,6 @@ func (computeSystem *System) Pause(ctx context.Context) (err error) {
 	if computeSystem.handle == 0 {
 		return makeSystemError(computeSystem, operation, "", ErrAlreadyClosed, nil)
 	}
-
 	resultJSON, err := vmcompute.HcsPauseComputeSystem(ctx, computeSystem.handle, "")
 	events, err := processAsyncHcsResult(ctx, err, resultJSON, computeSystem.callbackNumber, hcsNotificationSystemPauseCompleted, &timeout.SystemPause)
 	if err != nil {
@@ -600,6 +599,33 @@ func (computeSystem *System) Modify(ctx context.Context, config interface{}) err
 	events := processHcsResult(ctx, resultJSON)
 	if err != nil {
 		return makeSystemError(computeSystem, operation, requestJSON, err, events)
+	}
+
+	return nil
+}
+
+// Save the compute system
+func (computeSystem *System) Save(ctx context.Context, options string) (err error) {
+	operation := "hcsshim::System::Save"
+
+	// hcsSaveComputeSystemContext is an async peration. Start the outer span
+	// here to measure the full save time.
+	ctx, span := trace.StartSpan(ctx, operation)
+	defer span.End()
+	defer func() { oc.SetSpanStatus(span, err) }()
+	span.AddAttributes(trace.StringAttribute("cid", computeSystem.id))
+
+	computeSystem.handleLock.RLock()
+	defer computeSystem.handleLock.RUnlock()
+
+	if computeSystem.handle == 0 {
+		return makeSystemError(computeSystem, operation, "", ErrAlreadyClosed, nil)
+	}
+
+	result, err := vmcompute.HcsSaveComputeSystem(ctx, computeSystem.handle, options)
+	events, err := processAsyncHcsResult(ctx, err, result, computeSystem.callbackNumber, hcsNotificationSystemSaveCompleted, &timeout.SystemSave)
+	if err != nil {
+		return makeSystemError(computeSystem, operation, "", err, events)
 	}
 
 	return nil

--- a/internal/hcs/system.go
+++ b/internal/hcs/system.go
@@ -371,6 +371,7 @@ func (computeSystem *System) Pause(ctx context.Context) (err error) {
 	if computeSystem.handle == 0 {
 		return makeSystemError(computeSystem, operation, "", ErrAlreadyClosed, nil)
 	}
+
 	resultJSON, err := vmcompute.HcsPauseComputeSystem(ctx, computeSystem.handle, "")
 	events, err := processAsyncHcsResult(ctx, err, resultJSON, computeSystem.callbackNumber, hcsNotificationSystemPauseCompleted, &timeout.SystemPause)
 	if err != nil {

--- a/internal/hcsoci/resources_wcow.go
+++ b/internal/hcsoci/resources_wcow.go
@@ -19,6 +19,8 @@ import (
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 )
 
+const wcowGlobalMountPrefix = "C:\\mounts\\m%d"
+
 func allocateWindowsResources(ctx context.Context, coi *createOptionsInternal, resources *Resources) error {
 	if coi.Spec == nil || coi.Spec.Windows == nil || coi.Spec.Windows.LayerFolders == nil {
 		return fmt.Errorf("field 'Spec.Windows.Layerfolders' is not populated")
@@ -77,8 +79,7 @@ func allocateWindowsResources(ctx context.Context, coi *createOptionsInternal, r
 		}
 
 		if coi.HostingSystem != nil && schemaversion.IsV21(coi.actualSchemaVersion) {
-			uvmPath := fmt.Sprintf("C:\\%s\\%d", coi.actualID, i)
-
+			uvmPath := fmt.Sprintf(wcowGlobalMountPrefix, coi.HostingSystem.UVMMountCounter())
 			readOnly := false
 			for _, o := range mount.Options {
 				if strings.ToLower(o) == "ro" {

--- a/internal/oci/uvm.go
+++ b/internal/oci/uvm.go
@@ -123,7 +123,6 @@ const (
 	annotationVPCIEnabled                = "io.microsoft.virtualmachine.lcow.vpcienabled"
 	annotationStorageQoSBandwidthMaximum = "io.microsoft.virtualmachine.storageqos.bandwidthmaximum"
 	annotationStorageQoSIopsMaximum      = "io.microsoft.virtualmachine.storageqos.iopsmaximum"
-
 	annotationSaveAsTemplate             = "io.microsoft.virtualmachine.saveastemplate"
 	annotationTemplateID                 = "io.microsoft.virtualmachine.templateid"
 )

--- a/internal/oci/uvm.go
+++ b/internal/oci/uvm.go
@@ -123,6 +123,9 @@ const (
 	annotationVPCIEnabled                = "io.microsoft.virtualmachine.lcow.vpcienabled"
 	annotationStorageQoSBandwidthMaximum = "io.microsoft.virtualmachine.storageqos.bandwidthmaximum"
 	annotationStorageQoSIopsMaximum      = "io.microsoft.virtualmachine.storageqos.iopsmaximum"
+
+	annotationSaveAsTemplate             = "io.microsoft.virtualmachine.saveastemplate"
+	annotationTemplateID                 = "io.microsoft.virtualmachine.templateid"
 )
 
 // parseAnnotationsBool searches `a` for `key` and if found verifies that the
@@ -348,6 +351,8 @@ func SpecToUVMCreateOpts(ctx context.Context, s *specs.Spec, id, owner string) (
 			lopts.KernelFile = uvm.KernelFile
 		}
 		lopts.BootFilesPath = parseAnnotationsString(s.Annotations, annotationBootFilesRootPath, lopts.BootFilesPath)
+		lopts.SaveAsTemplate = parseAnnotationsBool(ctx, s.Annotations, annotationSaveAsTemplate, false)
+		lopts.TemplateID = parseAnnotationsString(s.Annotations, annotationTemplateID, lopts.TemplateID)
 		return lopts, nil
 	} else if IsWCOW(s) {
 		wopts := uvm.NewDefaultOptionsWCOW(id, owner)
@@ -362,6 +367,8 @@ func SpecToUVMCreateOpts(ctx context.Context, s *specs.Spec, id, owner string) (
 		wopts.ProcessorWeight = ParseAnnotationsCPUWeight(ctx, s, annotationProcessorWeight, wopts.ProcessorWeight)
 		wopts.StorageQoSBandwidthMaximum = ParseAnnotationsStorageBps(ctx, s, annotationStorageQoSBandwidthMaximum, wopts.StorageQoSBandwidthMaximum)
 		wopts.StorageQoSIopsMaximum = ParseAnnotationsStorageIops(ctx, s, annotationStorageQoSIopsMaximum, wopts.StorageQoSIopsMaximum)
+		wopts.SaveAsTemplate = parseAnnotationsBool(ctx, s.Annotations, annotationSaveAsTemplate, false)
+		wopts.TemplateID = parseAnnotationsString(s.Annotations, annotationTemplateID, wopts.TemplateID)
 		return wopts, nil
 	}
 	return nil, errors.New("cannot create UVM opts spec is not LCOW or WCOW")

--- a/internal/timeout/timeout.go
+++ b/internal/timeout/timeout.go
@@ -29,6 +29,9 @@ var (
 	// SystemResume is the timeout for resuming a compute system
 	SystemResume time.Duration = defaultTimeout
 
+	// SystemSave is the timeout for saving a compute system
+	SystemSave time.Duration = defaultTimeout
+
 	// SyscallWatcher is the timeout before warning of a potential stuck platform syscall.
 	SyscallWatcher time.Duration = defaultTimeout
 
@@ -51,6 +54,7 @@ func init() {
 	SystemStart = durationFromEnvironment("HCSSHIM_TIMEOUT_SYSTEMSTART", SystemStart)
 	SystemPause = durationFromEnvironment("HCSSHIM_TIMEOUT_SYSTEMPAUSE", SystemPause)
 	SystemResume = durationFromEnvironment("HCSSHIM_TIMEOUT_SYSTEMRESUME", SystemResume)
+	SystemSave = durationFromEnvironment("HCSSHIM_TIMEOUT_SYSTEMSAVE", SystemSave)
 	SyscallWatcher = durationFromEnvironment("HCSSHIM_TIMEOUT_SYSCALLWATCHER", SyscallWatcher)
 	Tar2VHD = durationFromEnvironment("HCSSHIM_TIMEOUT_TAR2VHD", Tar2VHD)
 	ExternalCommandToStart = durationFromEnvironment("HCSSHIM_TIMEOUT_EXTERNALCOMMANDSTART", ExternalCommandToStart)

--- a/internal/uvm/clone.go
+++ b/internal/uvm/clone.go
@@ -1,0 +1,122 @@
+package uvm
+
+import (
+	"context"
+	"os"
+	// "io"
+
+	hcsschema "github.com/Microsoft/hcsshim/internal/schema2"
+	"github.com/Microsoft/hcsshim/internal/copyfile"
+	"github.com/Microsoft/go-winio/pkg/guid"
+	"github.com/Microsoft/go-winio/pkg/security"
+)
+
+var logFile *os.File
+var err error
+
+var hcsSaveOptions = "{\"SaveType\": \"AsTemplate\"}"
+
+func debuglog(msg string) {
+	if logFile == nil {
+		logFile, err = os.OpenFile("C:\\Users\\Amit\\Documents\\debuglog.txt", os.O_RDWR|os.O_CREATE|os.O_APPEND, 0755)
+		if err != nil {
+			return
+		}
+	}
+	logFile.WriteString(msg)
+}
+
+func createCloneConfigDoc(uvm *UtilityVM) (*hcsschema.ComputeSystem) {
+	cloneDoc := *uvm.configDoc
+	cloneDoc.VirtualMachine.RestoreState = &hcsschema.RestoreState {}
+	cloneDoc.VirtualMachine.RestoreState.TemplateSystemId = uvm.ID()
+	return &cloneDoc
+}
+
+func (uvm *UtilityVM) Clone(ctx context.Context) (*UtilityVM, error) {
+	err := uvm.hcsSystem.Pause(ctx)
+	if err != nil {
+		debuglog("1." + err.Error() + "\n")
+		return nil, err
+	}
+
+	err = uvm.hcsSystem.Save(ctx, hcsSaveOptions)
+	if err != nil {
+		debuglog("2." + err.Error() + "\n")
+		return nil, err
+	}
+
+	props, err := uvm.hcsSystem.PropertiesV2(ctx)
+	if err != nil {
+		debuglog("2.1." + err.Error() + "\n")
+		return nil, err
+	}
+	debuglog("properties: " + props.State)
+
+	cloneDoc := createCloneConfigDoc(uvm)
+
+	srcVhdPath := uvm.configDoc.VirtualMachine.Devices.Scsi["0"].Attachments["0"].Path
+	dstVhdPath := "C:\\Users\\Amit\\Documents\\sandbox.vhdx"
+
+	// copy the VHDX of source VM
+	err = copyfile.CopyFile(ctx, srcVhdPath, dstVhdPath, true)
+	if err != nil {
+		debuglog("3." + err.Error() + "\n")
+		return nil, err
+	}
+
+	// replace the VHD path in config
+	vhdAttachement := cloneDoc.VirtualMachine.Devices.Scsi["0"].Attachments["0"]
+	vhdAttachement.Path = dstVhdPath
+	cloneDoc.VirtualMachine.Devices.Scsi["0"].Attachments["0"] = vhdAttachement
+	// Guest connection will be done externally
+	cloneDoc.VirtualMachine.GuestConnection = &hcsschema.GuestConnection{}
+
+
+	err = security.GrantVmGroupAccess(dstVhdPath)
+	if err != nil {
+		debuglog("4." + err.Error() + "\n")
+		return nil, err
+	}
+
+	g, err := guid.NewV4()
+	if err != nil {
+		return nil, err
+	}
+
+	opts := NewDefaultOptionsWCOW(g.String(), uvm.owner)
+
+	cloneUvm := &UtilityVM{
+		id:                  g.String(),
+		owner:               uvm.owner,
+		operatingSystem:     "windows",
+		scsiControllerCount: 1,
+		vsmbDirShares:       make(map[string]*vsmbShare),
+		vsmbFileShares:      make(map[string]*vsmbShare),
+	}
+	defer func() {
+		if err != nil {
+			cloneUvm.Close()
+		}
+	}()
+
+	// To maintain compatability with Docker we need to automatically downgrade
+	// a user CPU count if the setting is not possible.
+	cloneUvm.normalizeProcessorCount(ctx, opts.ProcessorCount)
+	cloneUvm.scsiLocations[0][0].hostPath = dstVhdPath
+
+
+	err = cloneUvm.create(ctx, cloneDoc)
+	if err != nil {
+		debuglog("5." + err.Error() + "\n")
+		return nil, err
+	}
+
+	err = cloneUvm.hcsSystem.Start(ctx)
+	if err != nil {
+		debuglog("6." + err.Error() + "\n")
+		return nil, err
+	}
+
+	return cloneUvm, nil
+}

--- a/internal/uvm/clone.go
+++ b/internal/uvm/clone.go
@@ -13,19 +13,19 @@ var err error
 
 const (
 	hcsSaveOptions = "{\"SaveType\": \"AsTemplate\"}"
-	templateRoot = "troot"
-	templateKey = "tkey"
+	templateRoot   = "troot"
+	templateKey    = "tkey"
 )
 
 type PersistedUVMConfig struct {
-	ID              string
-	Stored          bool
-	Config          hcsschema.ComputeSystem
+	ID     string
+	Stored bool
+	Config hcsschema.ComputeSystem
 }
 
 func NewPersistedUVMConfig(ID string, config hcsschema.ComputeSystem) *PersistedUVMConfig {
 	return &PersistedUVMConfig{
-		ID: ID,
+		ID:     ID,
 		Stored: false,
 		Config: config,
 	}
@@ -121,9 +121,8 @@ func getUVMConfig(ctx context.Context, uvmID string) (*hcsschema.ComputeSystem, 
 	return &puc.Config, nil
 }
 
-
-func (uvm *UtilityVM) clone(ctx context.Context, doc *hcsschema.ComputeSystem, opts *OptionsWCOW) (error) {
-	doc.VirtualMachine.RestoreState = &hcsschema.RestoreState {}
+func (uvm *UtilityVM) clone(ctx context.Context, doc *hcsschema.ComputeSystem, opts *OptionsWCOW) error {
+	doc.VirtualMachine.RestoreState = &hcsschema.RestoreState{}
 	doc.VirtualMachine.RestoreState.TemplateSystemId = opts.TemplateID
 
 	templateConfig, err := getUVMConfig(ctx, opts.TemplateID)

--- a/internal/uvm/create.go
+++ b/internal/uvm/create.go
@@ -64,6 +64,13 @@ type Options struct {
 	// ExternalGuestConnection sets whether the guest RPC connection is performed
 	// internally by the OS platform or externally by this package.
 	ExternalGuestConnection bool
+
+	// SaveAsTemplate states if this pod should be created and saved as template
+	SaveAsTemplate bool
+
+	// TemplateID specifies the ID of the template from which this pod should
+	// be created
+	TemplateID string
 }
 
 // newDefaultOptions returns the default base options for WCOW and LCOW.

--- a/internal/uvm/create_wcow.go
+++ b/internal/uvm/create_wcow.go
@@ -75,7 +75,6 @@ func CreateWCOW(ctx context.Context, opts *OptionsWCOW) (_ *UtilityVM, err error
 		}
 	}()
 
-
 	// To maintain compatability with Docker we need to automatically downgrade
 	// a user CPU count if the setting is not possible.
 	uvm.normalizeProcessorCount(ctx, opts.ProcessorCount)

--- a/internal/uvm/create_wcow.go
+++ b/internal/uvm/create_wcow.go
@@ -75,10 +75,6 @@ func CreateWCOW(ctx context.Context, opts *OptionsWCOW) (_ *UtilityVM, err error
 		}
 	}()
 
-	logFile, err = os.OpenFile("C:\\Users\\Amit\\Documents\\debuglog.txt", os.O_RDWR|os.O_CREATE|os.O_APPEND, 0755)
-	for _, path := range opts.LayerFolders {
-		logFile.WriteString(path + "\n")
-	}
 
 	// To maintain compatability with Docker we need to automatically downgrade
 	// a user CPU count if the setting is not possible.
@@ -95,8 +91,6 @@ func CreateWCOW(ctx context.Context, opts *OptionsWCOW) (_ *UtilityVM, err error
 		return nil, fmt.Errorf("failed to locate utility VM folder from layer folders: %s", err)
 	}
 
-	logFile.WriteString("uvm folder: " + uvmFolder + "\n")
-
 	// TODO: BUGBUG Remove this. @jhowardmsft
 	//       It should be the responsiblity of the caller to do the creation and population.
 	//       - Update runhcs too (vm.go).
@@ -104,8 +98,6 @@ func CreateWCOW(ctx context.Context, opts *OptionsWCOW) (_ *UtilityVM, err error
 	//       - Update tests that rely on this current behaviour.
 	// Create the RW scratch in the top-most layer folder, creating the folder if it doesn't already exist.
 	scratchFolder := opts.LayerFolders[len(opts.LayerFolders)-1]
-
-	logFile.WriteString("scratch folder: " + scratchFolder + "\n")
 
 	// Create the directory if it doesn't exist
 	if _, err := os.Stat(scratchFolder); os.IsNotExist(err) {
@@ -121,8 +113,6 @@ func CreateWCOW(ctx context.Context, opts *OptionsWCOW) (_ *UtilityVM, err error
 			return nil, fmt.Errorf("failed to create scratch: %s", err)
 		}
 	}
-
-	logFile.WriteString("scratch path: " + scratchPath + "\n")
 
 	doc := &hcsschema.ComputeSystem{
 		Owner:                             uvm.owner,
@@ -206,7 +196,6 @@ func CreateWCOW(ctx context.Context, opts *OptionsWCOW) (_ *UtilityVM, err error
 			BandwidthMaximum: opts.StorageQoSBandwidthMaximum,
 		}
 	}
-
 	uvm.scsiLocations[0][0].hostPath = doc.VirtualMachine.Devices.Scsi["0"].Attachments["0"].Path
 
 	fullDoc, err := mergemaps.MergeJSON(doc, ([]byte)(opts.AdditionHCSDocumentJSON))
@@ -214,10 +203,15 @@ func CreateWCOW(ctx context.Context, opts *OptionsWCOW) (_ *UtilityVM, err error
 		return nil, fmt.Errorf("failed to merge additional JSON '%s': %s", opts.AdditionHCSDocumentJSON, err)
 	}
 
-	// TODO figure out a way to include the fullDoc
-	uvm.configDoc = doc
+	// Save the config doc of this UVM so that it can be used for cloning etc
+	uvm.configDoc = (fullDoc).(*hcsschema.ComputeSystem)
 
-	err = uvm.create(ctx, fullDoc)
+	if opts.Options.TemplateID != "" {
+		err = uvm.clone(ctx, (fullDoc).(*hcsschema.ComputeSystem), opts)
+	} else {
+		err = uvm.create(ctx, fullDoc)
+	}
+
 	if err != nil {
 		return nil, err
 	}

--- a/internal/uvm/types.go
+++ b/internal/uvm/types.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Microsoft/hcsshim/internal/hcs"
 	"github.com/Microsoft/hcsshim/internal/hns"
 	"github.com/Microsoft/hcsshim/internal/schema1"
+	hcsschema "github.com/Microsoft/hcsshim/internal/schema2"
 	"golang.org/x/sys/windows"
 )
 
@@ -127,4 +128,7 @@ type UtilityVM struct {
 	// This is used in generating unique mount path inside UVM for every mount.
 	// Access to this variable should be done atomically.
 	mountCounter uint64
+
+	// The configuration with which this UVM was created
+	configDoc *hcsschema.ComputeSystem
 }

--- a/internal/vmcompute/vmcompute.go
+++ b/internal/vmcompute/vmcompute.go
@@ -28,6 +28,8 @@ import (
 //sys hcsModifyComputeSystem(computeSystem HcsSystem, configuration string, result **uint16) (hr error) = vmcompute.HcsModifyComputeSystem?
 //sys hcsRegisterComputeSystemCallback(computeSystem HcsSystem, callback uintptr, context uintptr, callbackHandle *HcsCallback) (hr error) = vmcompute.HcsRegisterComputeSystemCallback?
 //sys hcsUnregisterComputeSystemCallback(callbackHandle HcsCallback) (hr error) = vmcompute.HcsUnregisterComputeSystemCallback?
+//sys hcsSaveComputeSystem(computeSystem HcsSystem, options string, result **uint16) (hr error) = vmcompute.HcsSaveComputeSystem?
+
 
 //sys hcsCreateProcess(computeSystem HcsSystem, processParameters string, processInformation *HcsProcessInformation, process *HcsProcess, result **uint16) (hr error) = vmcompute.HcsCreateProcess?
 //sys hcsOpenProcess(computeSystem HcsSystem, pid uint32, process *HcsProcess, result **uint16) (hr error) = vmcompute.HcsOpenProcess?
@@ -354,6 +356,28 @@ func HcsUnregisterComputeSystemCallback(ctx gcontext.Context, callbackHandle Hcs
 
 	return execute(ctx, timeout.SyscallWatcher, func() error {
 		return hcsUnregisterComputeSystemCallback(callbackHandle)
+	})
+}
+
+func HcsSaveComputeSystem(ctx gcontext.Context, computeSystem HcsSystem, options string) (result string, hr error) {
+	ctx, span := trace.StartSpan(ctx, "HcsSaveComputeSystem")
+	defer span.End()
+	defer func() {
+		if result != "" {
+			span.AddAttributes(trace.StringAttribute("result", result))
+		}
+		if hr != errVmcomputeOperationPending {
+			oc.SetSpanStatus(span, hr)
+		}
+	}()
+
+	return result, execute(ctx, timeout.SyscallWatcher, func() error {
+		var resultp *uint16
+		err := hcsSaveComputeSystem(computeSystem, options, &resultp)
+		if resultp != nil {
+			result = interop.ConvertAndFreeCoTaskMemString(resultp)
+		}
+		return err
 	})
 }
 

--- a/internal/vmcompute/vmcompute.go
+++ b/internal/vmcompute/vmcompute.go
@@ -30,7 +30,6 @@ import (
 //sys hcsUnregisterComputeSystemCallback(callbackHandle HcsCallback) (hr error) = vmcompute.HcsUnregisterComputeSystemCallback?
 //sys hcsSaveComputeSystem(computeSystem HcsSystem, options string, result **uint16) (hr error) = vmcompute.HcsSaveComputeSystem?
 
-
 //sys hcsCreateProcess(computeSystem HcsSystem, processParameters string, processInformation *HcsProcessInformation, process *HcsProcess, result **uint16) (hr error) = vmcompute.HcsCreateProcess?
 //sys hcsOpenProcess(computeSystem HcsSystem, pid uint32, process *HcsProcess, result **uint16) (hr error) = vmcompute.HcsOpenProcess?
 //sys hcsCloseProcess(process HcsProcess) (hr error) = vmcompute.HcsCloseProcess?

--- a/internal/vmcompute/zsyscall_windows.go
+++ b/internal/vmcompute/zsyscall_windows.go
@@ -52,6 +52,7 @@ var (
 	procHcsModifyComputeSystem             = modvmcompute.NewProc("HcsModifyComputeSystem")
 	procHcsRegisterComputeSystemCallback   = modvmcompute.NewProc("HcsRegisterComputeSystemCallback")
 	procHcsUnregisterComputeSystemCallback = modvmcompute.NewProc("HcsUnregisterComputeSystemCallback")
+	procHcsSaveComputeSystem               = modvmcompute.NewProc("HcsSaveComputeSystem")
 	procHcsCreateProcess                   = modvmcompute.NewProc("HcsCreateProcess")
 	procHcsOpenProcess                     = modvmcompute.NewProc("HcsOpenProcess")
 	procHcsCloseProcess                    = modvmcompute.NewProc("HcsCloseProcess")
@@ -333,6 +334,29 @@ func hcsUnregisterComputeSystemCallback(callbackHandle HcsCallback) (hr error) {
 		return
 	}
 	r0, _, _ := syscall.Syscall(procHcsUnregisterComputeSystemCallback.Addr(), 1, uintptr(callbackHandle), 0, 0)
+	if int32(r0) < 0 {
+		if r0&0x1fff0000 == 0x00070000 {
+			r0 &= 0xffff
+		}
+		hr = syscall.Errno(r0)
+	}
+	return
+}
+
+func hcsSaveComputeSystem(computeSystem HcsSystem, options string, result **uint16) (hr error) {
+	var _p0 *uint16
+	_p0, hr = syscall.UTF16PtrFromString(options)
+	if hr != nil {
+		return
+	}
+	return _hcsSaveComputeSystem(computeSystem, _p0, result)
+}
+
+func _hcsSaveComputeSystem(computeSystem HcsSystem, options *uint16, result **uint16) (hr error) {
+	if hr = procHcsSaveComputeSystem.Find(); hr != nil {
+		return
+	}
+	r0, _, _ := syscall.Syscall(procHcsSaveComputeSystem.Addr(), 3, uintptr(computeSystem), uintptr(unsafe.Pointer(options)), uintptr(unsafe.Pointer(result)))
 	if int32(r0) < 0 {
 		if r0&0x1fff0000 == 0x00070000 {
 			r0 &= 0xffff

--- a/internal/wcow/scratch.go
+++ b/internal/wcow/scratch.go
@@ -23,16 +23,3 @@ func CreateUVMScratch(ctx context.Context, imagePath, destDirectory, vmID string
 	}
 	return nil
 }
-
-
-// Copies the given VHD at a given destination path
-func CopyUVMVHD(ctx context.Context, srcVHDPath, dstVHDPath, vmID string) error {
-	if err := copyfile.CopyFile(ctx, srcVHDPath, dstVHDPath, true); err != nil {
-		return err
-	}
-	if err := wclayer.GrantVmAccess(ctx, dstVHDPath, vmID); err != nil {
-		os.Remove(dstVHDPath)
-		return err
-	}
-	return nil
-}

--- a/internal/wcow/scratch.go
+++ b/internal/wcow/scratch.go
@@ -23,3 +23,16 @@ func CreateUVMScratch(ctx context.Context, imagePath, destDirectory, vmID string
 	}
 	return nil
 }
+
+
+// Copies the given VHD at a given destination path
+func CopyUVMVHD(ctx context.Context, srcVHDPath, dstVHDPath, vmID string) error {
+	if err := copyfile.CopyFile(ctx, srcVHDPath, dstVHDPath, true); err != nil {
+		return err
+	}
+	if err := wclayer.GrantVmAccess(ctx, dstVHDPath, vmID); err != nil {
+		os.Remove(dstVHDPath)
+		return err
+	}
+	return nil
+}

--- a/test/cri-containerd/createcontainer_test.go
+++ b/test/cri-containerd/createcontainer_test.go
@@ -988,7 +988,7 @@ func Test_Create_Pod_FromTemplate(t *testing.T) {
 		RuntimeHandler: wcowHypervisorRuntimeHandler,
 	}
 
-	templateID := runPodSandbox(t, client, ctx, sandboxRequest)
+	templatePodID := runPodSandbox(t, client, ctx, sandboxRequest)
 	defer removePodSandbox(t, client, ctx, templatePodID)
 	defer stopPodSandbox(t, client, ctx, templatePodID)
 
@@ -1001,7 +1001,7 @@ func Test_Create_Pod_FromTemplate(t *testing.T) {
 				Namespace: testNamespace,
 			},
 			Annotations: map[string]string{
-				"io.microsoft.virtualmachine.templateid": templateID + "@vm",
+				"io.microsoft.virtualmachine.templateid": templatePodID + "@vm",
 			},
 		},
 		RuntimeHandler: wcowHypervisorRuntimeHandler,

--- a/test/cri-containerd/createcontainer_test.go
+++ b/test/cri-containerd/createcontainer_test.go
@@ -48,8 +48,6 @@ func runCreateContainerTestWithSandbox(t *testing.T, sandboxRequest *runtime.Run
 	stopContainer(t, client, ctx, containerID)
 }
 
-
-
 func Test_CreateContainer_WCOW_Process(t *testing.T) {
 	pullRequiredImages(t, []string{imageWindowsNanoserver})
 
@@ -963,8 +961,6 @@ func Test_CreateContainer_Mount_NamedPipe_WCOW(t *testing.T) {
 	}
 	runCreateContainerTest(t, wcowHypervisorRuntimeHandler, request)
 }
-
-
 
 // TODO(ambarve): This test doesn't work right now because start container command for template fails.
 // It seems that the pod directory is deleted if start pod command fails. So when the test creates a clone

--- a/test/cri-containerd/runpodsandbox_test.go
+++ b/test/cri-containerd/runpodsandbox_test.go
@@ -1081,16 +1081,12 @@ func Test_RunPodSandbox_MultipleContainersSameVhd_LCOW(t *testing.T) {
 		containerName := t.Name() + "-Container-" + strconv.Itoa(i)
 		containerId := createContainerInSandbox(t, client, ctx, podID, containerName, imageLcowAlpine, command, annotations, mounts, sbRequest.Config)
 		defer removeContainer(t, client, ctx, containerId)
-		t.Log("container ", i, " created")
 
 		startContainer(t, client, ctx, containerId)
 		defer stopContainer(t, client, ctx, containerId)
 
-		t.Log("container ", i, " started")
-
 		_, errorMsg, exitCode := execContainer(t, client, ctx, containerId, execCommand)
 
-		t.Log("container ", i, " exec done")
 		// For container 1 and 2 we should find the mounts
 		if exitCode != 0 {
 			t.Fatalf("Exec into container failed with: %v and exit code: %d, %s", errorMsg, exitCode, containerId)

--- a/test/cri-containerd/syscall.go
+++ b/test/cri-containerd/syscall.go
@@ -1,0 +1,7 @@
+// +build functional
+
+package cri_containerd
+
+//go:generate go run ../../mksyscall_windows.go -output zsyscall_windows.go syscall.go
+
+//sys hcsFormatWritableLayerVhd(handle uintptr) (hr error) = computestorage.HcsFormatWritableLayerVhd

--- a/test/cri-containerd/zsyscall_windows.go
+++ b/test/cri-containerd/zsyscall_windows.go
@@ -1,0 +1,54 @@
+// Code generated mksyscall_windows.exe DO NOT EDIT
+
+package cri_containerd
+
+import (
+	"syscall"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+var _ unsafe.Pointer
+
+// Do the interface allocations only once for common
+// Errno values.
+const (
+	errnoERROR_IO_PENDING = 997
+)
+
+var (
+	errERROR_IO_PENDING error = syscall.Errno(errnoERROR_IO_PENDING)
+)
+
+// errnoErr returns common boxed Errno values, to prevent
+// allocations at runtime.
+func errnoErr(e syscall.Errno) error {
+	switch e {
+	case 0:
+		return nil
+	case errnoERROR_IO_PENDING:
+		return errERROR_IO_PENDING
+	}
+	// TODO: add more here, after collecting data on the common
+	// error values see on Windows. (perhaps when running
+	// all.bat?)
+	return e
+}
+
+var (
+	modcomputestorage = windows.NewLazySystemDLL("computestorage.dll")
+
+	procHcsFormatWritableLayerVhd = modcomputestorage.NewProc("HcsFormatWritableLayerVhd")
+)
+
+func hcsFormatWritableLayerVhd(handle uintptr) (hr error) {
+	r0, _, _ := syscall.Syscall(procHcsFormatWritableLayerVhd.Addr(), 1, uintptr(handle), 0, 0)
+	if int32(r0) < 0 {
+		if r0&0x1fff0000 == 0x00070000 {
+			r0 &= 0xffff
+		}
+		hr = syscall.Errno(r0)
+	}
+	return
+}


### PR DESCRIPTION
This PR features a set of changes that implement early cloning for WCOW UVMs.

In order to support cloning of Pods with containers created inside them (late cloning) first we need to be able to clone the Pods (i.e the UVMs). This PR adds the set of functions required for creating a pod as a template which can be later used for creating clones. Currently we don't have any good way of reporting these template pods to cotainerd or CRI so the tests don't work well yet. 

(created this PR towards `fix_multivhd_wcow_bug` branch so that changes from that branch don't show up in the diff)