### PR TITLE
Refactor scsi layer addition

### DIFF
--- a/internal/hcsoci/layers.go
+++ b/internal/hcsoci/layers.go
@@ -140,11 +140,11 @@ func MountContainerLayers(ctx context.Context, layerFolders []string, guestRoot 
 			uvmPath, err = uvm.AddVPMEM(ctx, layerPath)
 			if err == uvmpkg.ErrNoAvailableLocation || err == uvmpkg.ErrMaxVPMEMLayerSize {
 				log.G(ctx).WithError(err).Debug("falling back to SCSI for LCOW layer addition")
-				sm, err := uvm.AddSCSILayer(ctx, layerPath)
+				uvmPath = fmt.Sprintf(lcowGlobalMountPrefix, uvm.UVMMountCounter())
+				_, err := uvm.AddSCSI(ctx, layerPath, uvmPath, true, uvmpkg.VMAccessTypeNoop)
 				if err != nil {
 					return "", fmt.Errorf("failed to add SCSI layer: %s", err)
 				}
-				uvmPath = sm.UVMPath
 			} else if err != nil {
 				return "", fmt.Errorf("failed to add VPMEM layer: %s", err)
 			}
@@ -156,7 +156,7 @@ func MountContainerLayers(ctx context.Context, layerFolders []string, guestRoot 
 	hostPath := filepath.Join(layerFolders[len(layerFolders)-1], "sandbox.vhdx")
 	containerScratchPathInUVM := ospath.Join(uvm.OS(), guestRoot)
 	log.G(ctx).WithField("hostPath", hostPath).Debug("mounting scratch VHD")
-	scsiMount, err := uvm.AddSCSI(ctx, hostPath, containerScratchPathInUVM, false)
+	scsiMount, err := uvm.AddSCSI(ctx, hostPath, containerScratchPathInUVM, false, uvmpkg.VMAccessTypeIndividual)
 	if err != nil {
 		return "", fmt.Errorf("failed to add SCSI scratch VHD: %s", err)
 	}

--- a/internal/hcsoci/resources_wcow.go
+++ b/internal/hcsoci/resources_wcow.go
@@ -103,7 +103,7 @@ func allocateWindowsResources(ctx context.Context, coi *createOptionsInternal, r
 				r.resources = append(r.resources, scsiMount)
 			} else if mount.Type == "virtual-disk" || mount.Type == "automanage-virtual-disk" {
 				l.Debug("hcsshim::allocateWindowsResources Hot-adding SCSI virtual disk for OCI mount")
-				scsiMount, err := coi.HostingSystem.AddSCSI(ctx, mount.Source, uvmPath, readOnly)
+				scsiMount, err := coi.HostingSystem.AddSCSI(ctx, mount.Source, uvmPath, readOnly, uvm.VMAccessTypeIndividual)
 				if err != nil {
 					return fmt.Errorf("adding SCSI virtual disk mount %+v: %s", mount, err)
 				}

--- a/internal/lcow/scratch.go
+++ b/internal/lcow/scratch.go
@@ -66,7 +66,7 @@ func CreateScratch(ctx context.Context, lcowUVM *uvm.UtilityVM, destFile string,
 		return fmt.Errorf("failed to create VHDx %s: %s", destFile, err)
 	}
 
-	scsi, err := lcowUVM.AddSCSI(ctx, destFile, "", false) // No destination as not formatted
+	scsi, err := lcowUVM.AddSCSI(ctx, destFile, "", false, uvm.VMAccessTypeIndividual) // No destination as not formatted
 	if err != nil {
 		return err
 	}

--- a/test/functional/lcow_test.go
+++ b/test/functional/lcow_test.go
@@ -141,7 +141,7 @@ func TestLCOWSimplePodScenario(t *testing.T) {
 	if err := lcow.CreateScratch(context.Background(), lcowUVM, uvmScratchFile, lcow.DefaultScratchSizeGB, cacheFile); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := lcowUVM.AddSCSI(context.Background(), uvmScratchFile, `/tmp/scratch`, false); err != nil {
+	if _, err := lcowUVM.AddSCSI(context.Background(), uvmScratchFile, `/tmp/scratch`, false, uvm.VMAccessTypeIndividual); err != nil {
 		t.Fatal(err)
 	}
 

--- a/test/functional/uvm_scratch_test.go
+++ b/test/functional/uvm_scratch_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/Microsoft/hcsshim/internal/lcow"
+	"github.com/Microsoft/hcsshim/internal/uvm"
 	"github.com/Microsoft/hcsshim/osversion"
 	testutilities "github.com/Microsoft/hcsshim/test/functional/utilities"
 )
@@ -44,7 +45,7 @@ func TestScratchCreateLCOW(t *testing.T) {
 	}
 
 	// Make sure it can be added (verifies it has access correctly)
-	scsiMount, err := targetUVM.AddSCSI(context.Background(), destTwo, "", false)
+	scsiMount, err := targetUVM.AddSCSI(context.Background(), destTwo, "", false, uvm.VMAccessTypeIndividual)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/functional/uvm_scsi_test.go
+++ b/test/functional/uvm_scsi_test.go
@@ -51,7 +51,7 @@ func testAddSCSI(u *uvm.UtilityVM, disks []string, pathPrefix string, usePath bo
 		if usePath {
 			uvmPath = fmt.Sprintf(`%s%d`, pathPrefix, i)
 		}
-		scsiMount, err := u.AddSCSI(context.Background(), disks[i], uvmPath, false)
+		scsiMount, err := u.AddSCSI(context.Background(), disks[i], uvmPath, false, uvm.VMAccessTypeIndividual)
 		if err != nil {
 			return err
 		}
@@ -274,7 +274,7 @@ func TestParallelScsiOps(t *testing.T) {
 					t.Errorf("failed to grantvmaccess for worker: %d, iteration: %d with err: %v", scsiIndex, iteration, err)
 					continue
 				}
-				_, err = u.AddSCSI(context.Background(), path, "", false)
+				_, err = u.AddSCSI(context.Background(), path, "", false, uvm.VMAccessTypeIndividual)
 				if err != nil {
 					os.Remove(path)
 					t.Errorf("failed to AddSCSI for worker: %d, iteration: %d with err: %v", scsiIndex, iteration, err)
@@ -286,7 +286,7 @@ func TestParallelScsiOps(t *testing.T) {
 					// This worker cant continue because the index is dead. We have to stop
 					break
 				}
-				_, err = u.AddSCSI(context.Background(), path, fmt.Sprintf("/run/gcs/c/0/scsi/%d", iteration), false)
+				_, err = u.AddSCSI(context.Background(), path, fmt.Sprintf("/run/gcs/c/0/scsi/%d", iteration), false, uvm.VMAccessTypeIndividual)
 				if err != nil {
 					os.Remove(path)
 					t.Errorf("failed to AddSCSI for worker: %d, iteration: %d with err: %v", scsiIndex, iteration, err)


### PR DESCRIPTION
* add counter of scsi layers to uvm struct
* move mount location of scsi layers
* add option for customizing vm granted access to scsi functions

This addresses the issue where calling GrantVmAccess on a given file (for example, the nvidia vhd) causes an `Incorrect Parameter` error after numerous calls. 

Signed-off-by: Kathryn Baldauf <kabaldau@microsoft.com>