### PR TITLE
Fix wrapped error missing when failing to add scratch VHD

### DIFF
--- a/internal/hcsoci/layers.go
+++ b/internal/hcsoci/layers.go
@@ -158,7 +158,7 @@ func MountContainerLayers(ctx context.Context, layerFolders []string, guestRoot 
 	log.G(ctx).WithField("hostPath", hostPath).Debug("mounting scratch VHD")
 	scsiMount, err := uvm.AddSCSI(ctx, hostPath, containerScratchPathInUVM, false)
 	if err != nil {
-		return "", fmt.Errorf("failed to add SCSI scratch VHD")
+		return "", fmt.Errorf("failed to add SCSI scratch VHD: %s", err)
 	}
 	containerScratchPathInUVM = scsiMount.UVMPath
 


### PR DESCRIPTION
Fixes an issue introduced in 298b1378aa39919c4a103c1e450c95bdace16d05.

Signed-off-by: Kevin Parsons <kevpar@microsoft.com>