### PR TITLE
Export execInUVM to allow for access to the tool outside cmd

### DIFF
--- a/cmd/containerd-shim-runhcs-v1/exec_hcs.go
+++ b/cmd/containerd-shim-runhcs-v1/exec_hcs.go
@@ -49,7 +49,7 @@ func newHcsExec(
 	id, bundle string,
 	isWCOW bool,
 	spec *specs.Process,
-	io upstreamIO) shimExec {
+	io hcsoci.UpstreamIO) shimExec {
 	log.G(ctx).WithFields(logrus.Fields{
 		"tid":    tid,
 		"eid":    id, // Init exec ID is always same as Task ID
@@ -118,7 +118,7 @@ type hcsExec struct {
 	// create time in order to be valid.
 	//
 	// This MUST be treated as read only in the lifetime of the exec.
-	io              upstreamIO
+	io              hcsoci.UpstreamIO
 	processDone     chan struct{}
 	processDoneOnce sync.Once
 

--- a/cmd/containerd-shim-runhcs-v1/task_hcs.go
+++ b/cmd/containerd-shim-runhcs-v1/task_hcs.go
@@ -120,7 +120,7 @@ func newHcsTask(
 
 	owner := filepath.Base(os.Args[0])
 
-	io, err := newNpipeIO(ctx, req.Stdin, req.Stdout, req.Stderr, req.Terminal)
+	io, err := hcsoci.NewNpipeIO(ctx, req.Stdin, req.Stdout, req.Stderr, req.Terminal)
 	if err != nil {
 		return nil, err
 	}
@@ -269,7 +269,7 @@ func (ht *hcsTask) CreateExec(ctx context.Context, req *task.ExecProcessRequest,
 		return errors.Wrapf(errdefs.ErrFailedPrecondition, "exec: '' in task: '%s' must be running to create additional execs", ht.id)
 	}
 
-	io, err := newNpipeIO(ctx, req.Stdin, req.Stdout, req.Stderr, req.Terminal)
+	io, err := hcsoci.NewNpipeIO(ctx, req.Stdin, req.Stdout, req.Stderr, req.Terminal)
 	if err != nil {
 		return err
 	}
@@ -581,7 +581,7 @@ func (ht *hcsTask) ExecInHost(ctx context.Context, req *shimdiag.ExecProcessRequ
 	if ht.host == nil {
 		return 0, errors.New("task is not isolated")
 	}
-	return execInUvm(ctx, ht.host, req)
+	return hcsoci.ExecInUvm(ctx, ht.host, req)
 }
 
 func (ht *hcsTask) DumpGuestStacks(ctx context.Context) string {

--- a/cmd/containerd-shim-runhcs-v1/task_wcow_podsandbox.go
+++ b/cmd/containerd-shim-runhcs-v1/task_wcow_podsandbox.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/Microsoft/hcsshim/cmd/containerd-shim-runhcs-v1/options"
 	"github.com/Microsoft/hcsshim/cmd/containerd-shim-runhcs-v1/stats"
+	"github.com/Microsoft/hcsshim/internal/hcsoci"
 	"github.com/Microsoft/hcsshim/internal/log"
 	"github.com/Microsoft/hcsshim/internal/shimdiag"
 	"github.com/Microsoft/hcsshim/internal/uvm"
@@ -220,7 +221,7 @@ func (wpst *wcowPodSandboxTask) ExecInHost(ctx context.Context, req *shimdiag.Ex
 	if wpst.host == nil {
 		return 0, errors.New("task is not isolated")
 	}
-	return execInUvm(ctx, wpst.host, req)
+	return hcsoci.ExecInUvm(ctx, wpst.host, req)
 }
 
 func (wpst *wcowPodSandboxTask) DumpGuestStacks(ctx context.Context) string {

--- a/internal/hcsoci/diag.go
+++ b/internal/hcsoci/diag.go
@@ -1,26 +1,25 @@
-package main
+package hcsoci
 
 import (
 	"context"
 	"errors"
 
-	"github.com/Microsoft/hcsshim/internal/hcsoci"
 	"github.com/Microsoft/hcsshim/internal/log"
 	"github.com/Microsoft/hcsshim/internal/logfields"
 	"github.com/Microsoft/hcsshim/internal/shimdiag"
 	"github.com/Microsoft/hcsshim/internal/uvm"
 )
 
-func execInUvm(ctx context.Context, vm *uvm.UtilityVM, req *shimdiag.ExecProcessRequest) (int, error) {
+func ExecInUvm(ctx context.Context, vm *uvm.UtilityVM, req *shimdiag.ExecProcessRequest) (int, error) {
 	if len(req.Args) == 0 {
 		return 0, errors.New("missing command")
 	}
-	np, err := newNpipeIO(ctx, req.Stdin, req.Stdout, req.Stderr, req.Terminal)
+	np, err := NewNpipeIO(ctx, req.Stdin, req.Stdout, req.Stderr, req.Terminal)
 	if err != nil {
 		return 0, err
 	}
 	defer np.Close(ctx)
-	cmd := hcsoci.CommandContext(ctx, vm, req.Args[0], req.Args[1:]...)
+	cmd := CommandContext(ctx, vm, req.Args[0], req.Args[1:]...)
 	if req.Workdir != "" {
 		cmd.Spec.Cwd = req.Workdir
 	}

--- a/internal/hcsoci/io.go
+++ b/internal/hcsoci/io.go
@@ -1,13 +1,13 @@
-package main
+package hcsoci
 
 import (
 	"context"
 	"io"
 )
 
-// upstreamIO is an interface describing the IO to connect to above the shim.
+// UpstreamIO is an interface describing the IO to connect to above the shim.
 // Depending on the callers settings there may be no opened IO.
-type upstreamIO interface {
+type UpstreamIO interface {
 	// Close closes all open io.
 	//
 	// This call is idempotent and safe to call multiple times.

--- a/internal/hcsoci/io_npipe.go
+++ b/internal/hcsoci/io_npipe.go
@@ -1,4 +1,4 @@
-package main
+package hcsoci
 
 import (
 	"context"
@@ -10,14 +10,14 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// newNpipeIO creates connected upstream io. It is the callers responsibility to
+// NewNpipeIO creates connected upstream io. It is the callers responsibility to
 // validate that `if terminal == true`, `stderr == ""`.
-func newNpipeIO(ctx context.Context, stdin, stdout, stderr string, terminal bool) (_ upstreamIO, err error) {
+func NewNpipeIO(ctx context.Context, stdin, stdout, stderr string, terminal bool) (_ UpstreamIO, err error) {
 	log.G(ctx).WithFields(logrus.Fields{
 		"stdin":    stdin,
 		"stdout":   stdout,
 		"stderr":   stderr,
-		"terminal": terminal}).Debug("newNpipeIO")
+		"terminal": terminal}).Debug("NewNpipeIO")
 
 	nio := &npipeio{
 		stdin:    stdin,
@@ -54,7 +54,7 @@ func newNpipeIO(ctx context.Context, stdin, stdout, stderr string, terminal bool
 	return nio, nil
 }
 
-var _ = (upstreamIO)(&npipeio{})
+var _ = (UpstreamIO)(&npipeio{})
 
 type npipeio struct {
 	// stdin, stdout, stderr are the original paths used to open the connections.
@@ -69,14 +69,14 @@ type npipeio struct {
 	// sin is the upstream `stdin` connection.
 	//
 	// `sin` MUST be treated as readonly in the lifetime of the pipe io after
-	// the return from `newNpipeIO`.
+	// the return from `NewNpipeIO`.
 	sin       io.ReadCloser
 	sinCloser sync.Once
 
 	// sout and serr are the upstream `stdout` and `stderr` connections.
 	//
 	// `sout` and `serr` MUST be treated as readonly in the lifetime of the pipe
-	// io after the return from `newNpipeIO`.
+	// io after the return from `NewNpipeIO`.
 	sout, serr   io.WriteCloser
 	outErrCloser sync.Once
 }


### PR DESCRIPTION
Intermediate PR for vpci assigned devices work. 

* This PR just exports the function `execInUVM` and moves around related files. Allows us to make calls to execute commands in the UVM from outside of the cmd/containerd-shim-runhcs-v1 package. 

Signed-off-by: Kathryn Baldauf <kabaldau@microsoft.com>