### PR TITLE
Update scsi layer's uvmPath

### DIFF
--- a/internal/hcsoci/layers.go
+++ b/internal/hcsoci/layers.go
@@ -141,7 +141,8 @@ func MountContainerLayers(ctx context.Context, layerFolders []string, guestRoot 
 			if err == uvmpkg.ErrNoAvailableLocation || err == uvmpkg.ErrMaxVPMEMLayerSize {
 				log.G(ctx).WithError(err).Debug("falling back to SCSI for LCOW layer addition")
 				uvmPath = fmt.Sprintf(lcowGlobalMountPrefix, uvm.UVMMountCounter())
-				_, err := uvm.AddSCSI(ctx, layerPath, uvmPath, true, uvmpkg.VMAccessTypeNoop)
+				sm, err := uvm.AddSCSI(ctx, layerPath, uvmPath, true, uvmpkg.VMAccessTypeNoop)
+				uvmPath = sm.UVMPath
 				if err != nil {
 					return "", fmt.Errorf("failed to add SCSI layer: %s", err)
 				}


### PR DESCRIPTION
This fixes a bug where a scsi layer added to two containers would fail on the second container due to trying to use an incorrect uvmPath that the second container had constructed instead of the correctly set up uvmPath created on the first container's creation. 

Adds a test to find this in the future by creating two containers that share base layers in a pod that does not allow for virtual pmem devices, therefore falling back to scsi for all layer additions. 

Signed-off-by: Kathryn Baldauf <kabaldau@microsoft.com>