### PR TITLE
Add ref counting of assigned devices

### DIFF
--- a/internal/hcsoci/resources_lcow.go
+++ b/internal/hcsoci/resources_lcow.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/Microsoft/hcsshim/internal/log"
 	"github.com/Microsoft/hcsshim/internal/oci"
-	hcsschema "github.com/Microsoft/hcsshim/internal/schema2"
 	"github.com/Microsoft/hcsshim/internal/uvm"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
@@ -165,21 +164,14 @@ func allocateLinuxResources(ctx context.Context, coi *createOptionsInternal, r *
 		switch d.IDType {
 		case "gpu":
 			addGPUVHD = true
-			v := hcsschema.VirtualPciDevice{
-				Functions: []hcsschema.VirtualPciFunction{
-					{
-						DeviceInstancePath: d.ID,
-					},
-				},
-			}
-			vpci, err := coi.HostingSystem.AssignDevice(ctx, v)
+			vpci, err := coi.HostingSystem.AssignDevice(ctx, d.ID)
 			if err != nil {
 				return errors.Wrapf(err, "failed to assign gpu device %s to pod %s", d.ID, coi.HostingSystem.ID())
 			}
 			r.resources = append(r.resources, vpci)
 			// update device ID on the spec to the assigned device's resulting vmbus guid so gcs knows which devices to
 			// map into the container
-			coi.Spec.Windows.Devices[i].ID = vpci.ID
+			coi.Spec.Windows.Devices[i].ID = vpci.VMBusGUID
 		}
 	}
 

--- a/internal/uvm/create_lcow.go
+++ b/internal/uvm/create_lcow.go
@@ -165,6 +165,7 @@ func CreateLCOW(ctx context.Context, opts *OptionsLCOW) (_ *UtilityVM, err error
 		scsiControllerCount:     opts.SCSIControllerCount,
 		vpmemMaxCount:           opts.VPMemDeviceCount,
 		vpmemMaxSizeBytes:       opts.VPMemSizeBytes,
+		vpciDevices:             make(map[string]*VPCIDevice),
 		devicesPhysicallyBacked: opts.FullyPhysicallyBacked,
 	}
 	defer func() {

--- a/internal/uvm/create_wcow.go
+++ b/internal/uvm/create_wcow.go
@@ -68,6 +68,7 @@ func CreateWCOW(ctx context.Context, opts *OptionsWCOW) (_ *UtilityVM, err error
 		scsiControllerCount:     1,
 		vsmbDirShares:           make(map[string]*VSMBShare),
 		vsmbFileShares:          make(map[string]*VSMBShare),
+		vpciDevices:             make(map[string]*VPCIDevice),
 		devicesPhysicallyBacked: opts.FullyPhysicallyBacked,
 	}
 	defer func() {

--- a/internal/uvm/types.go
+++ b/internal/uvm/types.go
@@ -86,6 +86,8 @@ type UtilityVM struct {
 	scsiLocations       [4][64]*SCSIMount // Hyper-V supports 4 controllers, 64 slots per controller. Limited to 1 controller for now though.
 	scsiControllerCount uint32            // Number of SCSI controllers in the utility VM
 
+	vpciDevices map[string]*VPCIDevice // map of device instance id to vpci device
+
 	// Plan9 are directories mapped into a Linux utility VM
 	plan9Counter uint64 // Each newly-added plan9 share has a counter used as its ID in the ResourceURI and for the name
 

--- a/internal/uvm/virtual_device.go
+++ b/internal/uvm/virtual_device.go
@@ -2,6 +2,7 @@ package uvm
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/Microsoft/go-winio/pkg/guid"
@@ -10,57 +11,112 @@ import (
 	hcsschema "github.com/Microsoft/hcsshim/internal/schema2"
 )
 
-// VPCIDevice represents a vpci device. Holds its guid and a handle to the uvm it
-// belongs to.
+// VPCIDevice represents a vpci device.
 type VPCIDevice struct {
+	// vm is the handle to the UVM that this device belongs to
 	vm *UtilityVM
-	ID string
+	// VMBusGUID is the instance ID for this device when it is exposed via VMBus
+	VMBusGUID string
+	// deviceInstanceID is the instance ID of the device on the host
+	deviceInstanceID string
+	// refCount stores the number of references to this device in the UVM
+	refCount uint32
 }
 
 // Release frees the resources of the corresponding vpci device
 func (vpci *VPCIDevice) Release(ctx context.Context) error {
-	if err := vpci.vm.RemoveDevice(ctx, vpci.ID); err != nil {
+	if err := vpci.vm.removeDevice(ctx, vpci.deviceInstanceID); err != nil {
 		return fmt.Errorf("failed to remove VPCI device: %s", err)
 	}
 	return nil
 }
 
-// AssignDevice assigns a new vpci device to the uvm
-func (uvm *UtilityVM) AssignDevice(ctx context.Context, device hcsschema.VirtualPciDevice) (*VPCIDevice, error) {
+// AssignDevice assigns a vpci device to the uvm
+// if the device already exists, the stored VPCIDevice's ref count is increased
+// and the VPCIDevice is returned.
+// Otherwise, a new request is made to assign the target device indicated by the deviceID
+// onto the UVM. A new VPCIDevice entry is made on the UVM and the VPCIDevice is returned
+// to the caller
+func (uvm *UtilityVM) AssignDevice(ctx context.Context, deviceID string) (*VPCIDevice, error) {
+	if uvm.operatingSystem == "windows" {
+		return nil, errors.New("assigned devices is not currently supported on wcow")
+	}
+
 	guid, err := guid.NewV4()
 	if err != nil {
 		return nil, err
 	}
-	id := guid.String()
+	vmBusGUID := guid.String()
 
 	uvm.m.Lock()
 	defer uvm.m.Unlock()
-	if err := uvm.modify(ctx, &hcsschema.ModifySettingRequest{
-		ResourcePath: fmt.Sprintf(virtualPciResourceFormat, id),
+
+	existingVPCIDevice := uvm.vpciDevices[deviceID]
+	if existingVPCIDevice != nil {
+		existingVPCIDevice.refCount++
+		return existingVPCIDevice, nil
+	}
+
+	targetDevice := hcsschema.VirtualPciDevice{
+		Functions: []hcsschema.VirtualPciFunction{
+			{
+				DeviceInstancePath: deviceID,
+			},
+		},
+	}
+
+	request := &hcsschema.ModifySettingRequest{
+		ResourcePath: fmt.Sprintf(virtualPciResourceFormat, vmBusGUID),
 		RequestType:  requesttype.Add,
-		Settings:     device,
-		GuestRequest: guestrequest.GuestRequest{
+		Settings:     targetDevice}
+
+	// WCOW (when supported) does not require a guest request as part of the
+	// device assignment
+	if uvm.operatingSystem != "windows" {
+		// for LCOW, we need to make sure that specific paths relating to the
+		// device exist so they are ready to be used by later
+		// work in openGCS
+		request.GuestRequest = guestrequest.GuestRequest{
 			ResourceType: guestrequest.ResourceTypeVPCIDevice,
 			RequestType:  requesttype.Add,
 			Settings: guestrequest.LCOWMappedVPCIDevice{
-				VMBusGUID: id,
+				VMBusGUID: vmBusGUID,
 			},
-		},
-	}); err != nil {
+		}
+	}
+
+	if err := uvm.modify(ctx, request); err != nil {
 		return nil, err
 	}
-	return &VPCIDevice{
-		vm: uvm,
-		ID: id,
-	}, nil
+	result := &VPCIDevice{
+		vm:               uvm,
+		VMBusGUID:        vmBusGUID,
+		deviceInstanceID: deviceID,
+		refCount:         1,
+	}
+	uvm.vpciDevices[deviceID] = result
+	return result, nil
 }
 
-// RemoveDevice removes a vpci device from the uvm
-func (uvm *UtilityVM) RemoveDevice(ctx context.Context, id string) error {
+// removeDevice removes a vpci device from a uvm when there are
+// no more references to a given VPCIDevice. Otherwise, decrements
+// the reference count of the stored VPCIDevice and returns nil.
+func (uvm *UtilityVM) removeDevice(ctx context.Context, deviceInstanceID string) error {
 	uvm.m.Lock()
 	defer uvm.m.Unlock()
-	return uvm.modify(ctx, &hcsschema.ModifySettingRequest{
-		ResourcePath: fmt.Sprintf(virtualPciResourceFormat, id),
-		RequestType:  requesttype.Remove,
-	})
+
+	vpci := uvm.vpciDevices[deviceInstanceID]
+	if vpci == nil {
+		return fmt.Errorf("no device with ID %s is present on the uvm %s", deviceInstanceID, uvm.ID())
+	}
+
+	vpci.refCount--
+	if vpci.refCount == 0 {
+		delete(uvm.vpciDevices, deviceInstanceID)
+		return uvm.modify(ctx, &hcsschema.ModifySettingRequest{
+			ResourcePath: fmt.Sprintf(virtualPciResourceFormat, vpci.VMBusGUID),
+			RequestType:  requesttype.Remove,
+		})
+	}
+	return nil
 }

--- a/test/cri-containerd/container_virtual_device_test.go
+++ b/test/cri-containerd/container_virtual_device_test.go
@@ -1,0 +1,323 @@
+// +build functional
+
+package cri_containerd
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Microsoft/hcsshim/osversion"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+)
+
+// makeGPUExecCommand constructs the container command to check for the
+// existence of a nvidia GPU device and returns the command in an
+// ExecSyncRequest
+func makeGPUExecCommand(containerID string) *runtime.ExecSyncRequest {
+	cmd := []string{"ls", "/dev/nvidia0"}
+	return &runtime.ExecSyncRequest{
+		ContainerId: containerID,
+		Cmd:         cmd,
+		Timeout:     20,
+	}
+}
+
+// verifyGPUIsPresent is a helper function that runs a command in the container
+// to verify the existence of a GPU and fails the running test is none are found
+func verifyGPUIsPresent(t *testing.T, client runtime.RuntimeServiceClient, ctx context.Context, containerID string) {
+	execReq := makeGPUExecCommand(containerID)
+	response := execSync(t, client, ctx, execReq)
+	if len(response.Stderr) != 0 {
+		t.Fatalf("expected to see no error, instead saw %s", string(response.Stderr))
+	}
+	if len(response.Stdout) == 0 {
+		t.Fatal("expected to see GPU device on container, not present")
+	}
+}
+
+// verifyGPUIsNotPresent is a helper function that runs a command in the container
+// to verify that there are no GPUs present in the container and fails the running test
+// if any are found
+func verifyGPUIsNotPresent(t *testing.T, client runtime.RuntimeServiceClient, ctx context.Context, containerID string) {
+	execReq := makeGPUExecCommand(containerID)
+	response := execSync(t, client, ctx, execReq)
+	if len(response.Stderr) == 0 {
+		t.Fatal("expected to see an error as file /dev/nvidia0 should not exist, instead saw none")
+	} else if len(response.Stdout) != 0 {
+		t.Fatal("expected to not see GPU device on container, but some are present")
+	}
+}
+
+// findTestDevices returns the first nvidia pcip device on the host
+func findTestNvidiaGPUDevice() (string, error) {
+	out, err := exec.Command(
+		"powershell",
+		`(Get-PnpDevice -presentOnly | where-object {$_.InstanceID -Match 'PCIP\\VEN_10DE.*'})[0].InstanceId`,
+	).Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func getGPUPodRequestLCOW(t *testing.T) *runtime.RunPodSandboxRequest {
+	return &runtime.RunPodSandboxRequest{
+		Config: &runtime.PodSandboxConfig{
+			Metadata: &runtime.PodSandboxMetadata{
+				Name:      t.Name(),
+				Namespace: testNamespace,
+			},
+			Annotations: map[string]string{
+				"io.microsoft.virtualmachine.lcow.kerneldirectboot":                  "false",
+				"io.microsoft.virtualmachine.computetopology.memory.allowovercommit": "false",
+				"io.microsoft.virtualmachine.lcow.preferredrootfstype":               "initrd",
+				"io.microsoft.virtualmachine.devices.virtualpmem.maximumcount":       "0",
+				"io.microsoft.virtualmachine.lcow.vpcienabled":                       "true",
+				// we believe this is a sufficiently large high MMIO space amount for this test.
+				// if a given gpu device needs more, this test will fail to create the container
+				// and may hang.
+				"io.microsoft.virtualmachine.computetopology.memory.highmmiogapinmb": "64000",
+				"io.microsoft.virtualmachine.lcow.bootfilesrootpath":                 testGPUBootFiles,
+			},
+		},
+		RuntimeHandler: lcowRuntimeHandler,
+	}
+}
+
+func getGPUContainerRequest(t *testing.T, podID string, podConfig *runtime.PodSandboxConfig, device *runtime.Device) *runtime.CreateContainerRequest {
+	return &runtime.CreateContainerRequest{
+		Config: &runtime.ContainerConfig{
+			Metadata: &runtime.ContainerMetadata{
+				Name: t.Name() + "-Container",
+			},
+			Image: &runtime.ImageSpec{
+				Image: imageLcowAlpine,
+			},
+			Command: []string{
+				"top",
+			},
+			Devices: []*runtime.Device{
+				device,
+			},
+			Linux: &runtime.LinuxContainerConfig{},
+			Annotations: map[string]string{
+				"io.microsoft.container.gpu.capabilities": "utility",
+			},
+		},
+		PodSandboxId:  podID,
+		SandboxConfig: podConfig,
+	}
+}
+
+func Test_RunContainer_VirtualDevice_GPU_LCOW(t *testing.T) {
+	requireFeatures(t, featureLCOW, featureGPU)
+
+	if osversion.Get().Build < 19566 {
+		t.Skip("Requires build +19566")
+	}
+
+	testDeviceInstanceID, err := findTestNvidiaGPUDevice()
+	if err != nil {
+		t.Skipf("skipping test, failed to find assignable nvidia gpu on host with: %v", err)
+	}
+	if testDeviceInstanceID == "" {
+		t.Skipf("skipping test, host has no assignable nvidia gpu devices")
+	}
+
+	pullRequiredLcowImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
+	client := newTestRuntimeClient(t)
+
+	podctx := context.Background()
+	sandboxRequest := getGPUPodRequestLCOW(t)
+
+	podID := runPodSandbox(t, client, podctx, sandboxRequest)
+	defer removePodSandbox(t, client, podctx, podID)
+	defer stopPodSandbox(t, client, podctx, podID)
+
+	device := &runtime.Device{
+		HostPath: "gpu://" + testDeviceInstanceID,
+	}
+
+	containerRequest := getGPUContainerRequest(t, podID, sandboxRequest.Config, device)
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	containerID := createContainer(t, client, ctx, containerRequest)
+	defer removeContainer(t, client, ctx, containerID)
+	startContainer(t, client, ctx, containerID)
+	defer stopContainer(t, client, ctx, containerID)
+
+	verifyGPUIsPresent(t, client, ctx, containerID)
+}
+
+func Test_RunContainer_VirtualDevice_GPU_Multiple_LCOW(t *testing.T) {
+	requireFeatures(t, featureLCOW, featureGPU)
+
+	if osversion.Get().Build < 19566 {
+		t.Skip("Requires build +19566")
+	}
+
+	numContainers := 2
+	testDeviceInstanceID, err := findTestNvidiaGPUDevice()
+	if err != nil {
+		t.Skipf("skipping test, failed to find assignable nvidia gpu on host with: %v", err)
+	}
+	if testDeviceInstanceID == "" {
+		t.Skipf("skipping test, host has no assignable nvidia gpu devices")
+	}
+
+	pullRequiredLcowImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
+	client := newTestRuntimeClient(t)
+
+	podctx := context.Background()
+	sandboxRequest := getGPUPodRequestLCOW(t)
+
+	podID := runPodSandbox(t, client, podctx, sandboxRequest)
+	defer removePodSandbox(t, client, podctx, podID)
+	defer stopPodSandbox(t, client, podctx, podID)
+
+	device := &runtime.Device{
+		HostPath: "gpu://" + testDeviceInstanceID,
+	}
+
+	containerRequest := getGPUContainerRequest(t, podID, sandboxRequest.Config, device)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	for i := 0; i < numContainers; i++ {
+
+		name := t.Name() + "-Container-" + fmt.Sprintf("%d", i)
+		containerRequest.Config.Metadata.Name = name
+
+		containerID := createContainer(t, client, ctx, containerRequest)
+		defer removeContainer(t, client, ctx, containerID)
+		startContainer(t, client, ctx, containerID)
+		defer stopContainer(t, client, ctx, containerID)
+
+		verifyGPUIsPresent(t, client, ctx, containerID)
+	}
+}
+
+func Test_RunContainer_VirtualDevice_GPU_and_NoGPU_LCOW(t *testing.T) {
+	requireFeatures(t, featureLCOW, featureGPU)
+
+	if osversion.Get().Build < 19566 {
+		t.Skip("Requires build +19566")
+	}
+
+	testDeviceInstanceID, err := findTestNvidiaGPUDevice()
+	if err != nil {
+		t.Skipf("skipping test, failed to find assignable nvidia gpu on host with: %v", err)
+	}
+	if testDeviceInstanceID == "" {
+		t.Skipf("skipping test, host has no assignable nvidia gpu devices")
+	}
+
+	pullRequiredLcowImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
+	client := newTestRuntimeClient(t)
+
+	podctx := context.Background()
+	sandboxRequest := getGPUPodRequestLCOW(t)
+
+	podID := runPodSandbox(t, client, podctx, sandboxRequest)
+	defer removePodSandbox(t, client, podctx, podID)
+	defer stopPodSandbox(t, client, podctx, podID)
+
+	device := &runtime.Device{
+		HostPath: "gpu://" + testDeviceInstanceID,
+	}
+
+	containerGPURequest := getGPUContainerRequest(t, podID, sandboxRequest.Config, device)
+
+	containerNoGPURequest := &runtime.CreateContainerRequest{
+		Config: &runtime.ContainerConfig{
+			Metadata: &runtime.ContainerMetadata{
+				Name: "No-GPU-Container",
+			},
+			Image: &runtime.ImageSpec{
+				Image: imageLcowAlpine,
+			},
+			Command: []string{
+				"top",
+			},
+			Linux: &runtime.LinuxContainerConfig{},
+		},
+		PodSandboxId:  podID,
+		SandboxConfig: sandboxRequest.Config,
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	// create container with a GPU present
+	gpuContainerID := createContainer(t, client, ctx, containerGPURequest)
+	defer removeContainer(t, client, ctx, gpuContainerID)
+	startContainer(t, client, ctx, gpuContainerID)
+	defer stopContainer(t, client, ctx, gpuContainerID)
+
+	// verify that we can access the GPU in the GPU-Container
+	verifyGPUIsPresent(t, client, ctx, gpuContainerID)
+
+	// create container without a GPU
+	noGPUContainerID := createContainer(t, client, ctx, containerNoGPURequest)
+	defer removeContainer(t, client, ctx, noGPUContainerID)
+	startContainer(t, client, ctx, noGPUContainerID)
+	defer stopContainer(t, client, ctx, noGPUContainerID)
+
+	// verify that we can't access the GPU in the No-GPU-Container
+	verifyGPUIsNotPresent(t, client, ctx, noGPUContainerID)
+
+}
+
+func Test_RunContainer_VirtualDevice_GPU_Multiple_Removal_LCOW(t *testing.T) {
+	requireFeatures(t, featureLCOW, featureGPU)
+
+	if osversion.Get().Build < 19566 {
+		t.Skip("Requires build +19566")
+	}
+
+	testDeviceInstanceID, err := findTestNvidiaGPUDevice()
+	if err != nil {
+		t.Skipf("skipping test, failed to find assignable nvidia gpu on host with: %v", err)
+	}
+	if testDeviceInstanceID == "" {
+		t.Skipf("skipping test, host has no assignable nvidia gpu devices")
+	}
+
+	pullRequiredLcowImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
+	client := newTestRuntimeClient(t)
+
+	podctx := context.Background()
+	sandboxRequest := getGPUPodRequestLCOW(t)
+
+	podID := runPodSandbox(t, client, podctx, sandboxRequest)
+	defer removePodSandbox(t, client, podctx, podID)
+	defer stopPodSandbox(t, client, podctx, podID)
+
+	device := &runtime.Device{
+		HostPath: "gpu://" + testDeviceInstanceID,
+	}
+
+	containerRequest := getGPUContainerRequest(t, podID, sandboxRequest.Config, device)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// create and start up first container with GPU
+	containerRequest.Config.Metadata.Name = t.Name() + "-Container-1"
+	containerOneID := createContainer(t, client, ctx, containerRequest)
+	defer removeContainer(t, client, ctx, containerOneID)
+	startContainer(t, client, ctx, containerOneID)
+	defer stopContainer(t, client, ctx, containerOneID)
+
+	// run full lifetime of second container with GPU
+	containerRequest.Config.Metadata.Name = t.Name() + "-Container-2"
+	containerTwoID := createContainer(t, client, ctx, containerRequest)
+	runContainerLifetime(t, client, ctx, containerTwoID)
+
+	// verify after removing second container that we can still see
+	// the GPU on the first container
+	verifyGPUIsPresent(t, client, ctx, containerOneID)
+}

--- a/test/cri-containerd/main.go
+++ b/test/cri-containerd/main.go
@@ -9,8 +9,6 @@ import (
 	"fmt"
 	"net"
 	"os"
-	"os/exec"
-	"strings"
 	"testing"
 	"time"
 
@@ -70,6 +68,7 @@ const (
 	featureWCOWProcess    = "WCOWProcess"
 	featureWCOWHypervisor = "WCOWHypervisor"
 	featureGMSA           = "GMSA"
+	featureGPU            = "GPU"
 )
 
 var allFeatures = []string{
@@ -77,6 +76,7 @@ var allFeatures = []string{
 	featureWCOWProcess,
 	featureWCOWHypervisor,
 	featureGMSA,
+	featureGPU,
 }
 
 func init() {
@@ -239,16 +239,4 @@ func pullRequiredImagesWithLabels(t *testing.T, images []string, labels map[stri
 			t.Fatalf("failed PullImage for image: %s, with error: %v", image, err)
 		}
 	}
-}
-
-// findTestDevices returns the first nvidia pcip device on the host
-func findTestNvidiaGPUDevice() (string, error) {
-	out, err := exec.Command(
-		"powershell",
-		`(Get-PnpDevice -presentOnly | where-object {$_.InstanceID -Match 'PCIP\\VEN_10DE.*'})[0].InstanceId`,
-	).Output()
-	if err != nil {
-		return "", err
-	}
-	return strings.TrimSpace(string(out)), nil
 }


### PR DESCRIPTION
This allows us to map given gpus or assigned devices into multiple containers. This can be used to adding sidecar containers to monitor assigned gpu devices. 

* add additional tests for GPU scenarios 

Signed-off-by: Kathryn Baldauf <kabaldau@microsoft.com>