### PR TITLE
Add annotation for UVMs to be fully physically backed

### DIFF
--- a/internal/hcsoci/resources_wcow.go
+++ b/internal/hcsoci/resources_wcow.go
@@ -128,6 +128,9 @@ func allocateWindowsResources(ctx context.Context, coi *createOptionsInternal, r
 						options.ShareRead = true
 						options.ForceLevelIIOplocks = true
 					}
+					if coi.HostingSystem.DevicesPhysicallyBacked() {
+						options.NoDirectmap = true
+					}
 					share, err := coi.HostingSystem.AddVSMB(ctx, mount.Source, "", options)
 					if err != nil {
 						return fmt.Errorf("failed to add VSMB share to utility VM for mount %+v: %s", mount, err)

--- a/internal/oci/uvm.go
+++ b/internal/oci/uvm.go
@@ -123,6 +123,7 @@ const (
 	annotationVPCIEnabled                = "io.microsoft.virtualmachine.lcow.vpcienabled"
 	annotationStorageQoSBandwidthMaximum = "io.microsoft.virtualmachine.storageqos.bandwidthmaximum"
 	annotationStorageQoSIopsMaximum      = "io.microsoft.virtualmachine.storageqos.iopsmaximum"
+	annotationFullyPhysicallyBacked      = "io.microsoft.virtualmachine.fullyphysicallybacked"
 )
 
 // parseAnnotationsBool searches `a` for `key` and if found verifies that the
@@ -313,6 +314,47 @@ func parseAnnotationsString(a map[string]string, key string, def string) string 
 	return def
 }
 
+// handleAnnotationKernelDirectBoot handles parsing annotationKernelDirectBoot and setting
+// implied annotations from the result.
+func handleAnnotationKernelDirectBoot(ctx context.Context, a map[string]string, lopts *uvm.OptionsLCOW) {
+	lopts.KernelDirect = parseAnnotationsBool(ctx, a, annotationKernelDirectBoot, lopts.KernelDirect)
+	if !lopts.KernelDirect {
+		lopts.KernelFile = uvm.KernelFile
+	}
+}
+
+// handleAnnotationPreferredRootFSType handles parsing annotationPreferredRootFSType and setting
+// implied annotations from the result
+func handleAnnotationPreferredRootFSType(ctx context.Context, a map[string]string, lopts *uvm.OptionsLCOW) {
+	lopts.PreferredRootFSType = parseAnnotationsPreferredRootFSType(ctx, a, annotationPreferredRootFSType, lopts.PreferredRootFSType)
+	switch lopts.PreferredRootFSType {
+	case uvm.PreferredRootFSTypeInitRd:
+		lopts.RootFSFile = uvm.InitrdFile
+	case uvm.PreferredRootFSTypeVHD:
+		lopts.RootFSFile = uvm.VhdFile
+	}
+}
+
+// handleAnnotationFullyPhysicallyBacked handles parsing annotationFullyPhysicallyBacked and setting
+// implied annotations from the result. For both LCOW and WCOW options.
+func handleAnnotationFullyPhysicallyBacked(ctx context.Context, a map[string]string, opts interface{}) {
+	switch options := opts.(type) {
+	case *uvm.OptionsLCOW:
+		options.FullyPhysicallyBacked = parseAnnotationsBool(ctx, a, annotationFullyPhysicallyBacked, options.FullyPhysicallyBacked)
+		if options.FullyPhysicallyBacked {
+			options.AllowOvercommit = false
+			options.PreferredRootFSType = uvm.PreferredRootFSTypeInitRd
+			options.RootFSFile = uvm.InitrdFile
+			options.VPMemDeviceCount = 0
+		}
+	case *uvm.OptionsWCOW:
+		options.FullyPhysicallyBacked = parseAnnotationsBool(ctx, a, annotationFullyPhysicallyBacked, options.FullyPhysicallyBacked)
+		if options.FullyPhysicallyBacked {
+			options.AllowOvercommit = false
+		}
+	}
+}
+
 // SpecToUVMCreateOpts parses `s` and returns either `*uvm.OptionsLCOW` or
 // `*uvm.OptionsWCOW`.
 func SpecToUVMCreateOpts(ctx context.Context, s *specs.Spec, id, owner string) (interface{}, error) {
@@ -335,19 +377,14 @@ func SpecToUVMCreateOpts(ctx context.Context, s *specs.Spec, id, owner string) (
 		lopts.VPMemSizeBytes = parseAnnotationsUint64(ctx, s.Annotations, annotationVPMemSize, lopts.VPMemSizeBytes)
 		lopts.StorageQoSBandwidthMaximum = ParseAnnotationsStorageBps(ctx, s, annotationStorageQoSBandwidthMaximum, lopts.StorageQoSBandwidthMaximum)
 		lopts.StorageQoSIopsMaximum = ParseAnnotationsStorageIops(ctx, s, annotationStorageQoSIopsMaximum, lopts.StorageQoSIopsMaximum)
-		lopts.PreferredRootFSType = parseAnnotationsPreferredRootFSType(ctx, s.Annotations, annotationPreferredRootFSType, lopts.PreferredRootFSType)
-		switch lopts.PreferredRootFSType {
-		case uvm.PreferredRootFSTypeInitRd:
-			lopts.RootFSFile = uvm.InitrdFile
-		case uvm.PreferredRootFSTypeVHD:
-			lopts.RootFSFile = uvm.VhdFile
-		}
 		lopts.VPCIEnabled = parseAnnotationsBool(ctx, s.Annotations, annotationVPCIEnabled, lopts.VPCIEnabled)
-		lopts.KernelDirect = parseAnnotationsBool(ctx, s.Annotations, annotationKernelDirectBoot, lopts.KernelDirect)
-		if !lopts.KernelDirect {
-			lopts.KernelFile = uvm.KernelFile
-		}
 		lopts.BootFilesPath = parseAnnotationsString(s.Annotations, annotationBootFilesRootPath, lopts.BootFilesPath)
+		handleAnnotationPreferredRootFSType(ctx, s.Annotations, lopts)
+		handleAnnotationKernelDirectBoot(ctx, s.Annotations, lopts)
+
+		// parsing of FullyPhysicallyBacked needs to go after handling kernel direct boot and
+		// preferred rootfs type since it may overwrite settings created by those
+		handleAnnotationFullyPhysicallyBacked(ctx, s.Annotations, lopts)
 		return lopts, nil
 	} else if IsWCOW(s) {
 		wopts := uvm.NewDefaultOptionsWCOW(id, owner)
@@ -362,6 +399,7 @@ func SpecToUVMCreateOpts(ctx context.Context, s *specs.Spec, id, owner string) (
 		wopts.ProcessorWeight = ParseAnnotationsCPUWeight(ctx, s, annotationProcessorWeight, wopts.ProcessorWeight)
 		wopts.StorageQoSBandwidthMaximum = ParseAnnotationsStorageBps(ctx, s, annotationStorageQoSBandwidthMaximum, wopts.StorageQoSBandwidthMaximum)
 		wopts.StorageQoSIopsMaximum = ParseAnnotationsStorageIops(ctx, s, annotationStorageQoSIopsMaximum, wopts.StorageQoSIopsMaximum)
+		handleAnnotationFullyPhysicallyBacked(ctx, s.Annotations, wopts)
 		return wopts, nil
 	}
 	return nil, errors.New("cannot create UVM opts spec is not LCOW or WCOW")

--- a/internal/uvm/create.go
+++ b/internal/uvm/create.go
@@ -37,6 +37,10 @@ type Options struct {
 	// false.
 	AllowOvercommit bool
 
+	// FullyPhysicallyBacked describes if a uvm should be entirely physically
+	// backed, including in any additional devices
+	FullyPhysicallyBacked bool
+
 	// Memory for UVM. Defaults to false. For virtual memory with deferred
 	// commit, set to true.
 	EnableDeferredCommit bool
@@ -73,12 +77,13 @@ type Options struct {
 // If `owner` is empty it will be set to the calling executables name.
 func newDefaultOptions(id, owner string) *Options {
 	opts := &Options{
-		ID:                   id,
-		Owner:                owner,
-		MemorySizeInMB:       1024,
-		AllowOvercommit:      true,
-		EnableDeferredCommit: false,
-		ProcessorCount:       defaultProcessorCount(),
+		ID:                    id,
+		Owner:                 owner,
+		MemorySizeInMB:        1024,
+		AllowOvercommit:       true,
+		EnableDeferredCommit:  false,
+		ProcessorCount:        defaultProcessorCount(),
+		FullyPhysicallyBacked: false,
 	}
 
 	if opts.Owner == "" {
@@ -246,4 +251,10 @@ func (uvm *UtilityVM) normalizeMemorySize(ctx context.Context, requested int32) 
 		}).Warn("Changing user requested MemorySizeInMB to align to 2MB")
 	}
 	return actual
+}
+
+// DevicesPhysicallyBacked describes if additional devices added to the UVM
+// should be physically backed
+func (uvm *UtilityVM) DevicesPhysicallyBacked() bool {
+	return uvm.devicesPhysicallyBacked
 }

--- a/internal/uvm/create_lcow.go
+++ b/internal/uvm/create_lcow.go
@@ -159,12 +159,13 @@ func CreateLCOW(ctx context.Context, opts *OptionsLCOW) (_ *UtilityVM, err error
 	}
 
 	uvm := &UtilityVM{
-		id:                  opts.ID,
-		owner:               opts.Owner,
-		operatingSystem:     "linux",
-		scsiControllerCount: opts.SCSIControllerCount,
-		vpmemMaxCount:       opts.VPMemDeviceCount,
-		vpmemMaxSizeBytes:   opts.VPMemSizeBytes,
+		id:                      opts.ID,
+		owner:                   opts.Owner,
+		operatingSystem:         "linux",
+		scsiControllerCount:     opts.SCSIControllerCount,
+		vpmemMaxCount:           opts.VPMemDeviceCount,
+		vpmemMaxSizeBytes:       opts.VPMemSizeBytes,
+		devicesPhysicallyBacked: opts.FullyPhysicallyBacked,
 	}
 	defer func() {
 		if err != nil {

--- a/internal/uvm/create_wcow.go
+++ b/internal/uvm/create_wcow.go
@@ -62,12 +62,13 @@ func CreateWCOW(ctx context.Context, opts *OptionsWCOW) (_ *UtilityVM, err error
 	log.G(ctx).WithField("options", fmt.Sprintf("%+v", opts)).Debug("uvm::CreateLCOW options")
 
 	uvm := &UtilityVM{
-		id:                  opts.ID,
-		owner:               opts.Owner,
-		operatingSystem:     "windows",
-		scsiControllerCount: 1,
-		vsmbDirShares:       make(map[string]*VSMBShare),
-		vsmbFileShares:      make(map[string]*VSMBShare),
+		id:                      opts.ID,
+		owner:                   opts.Owner,
+		operatingSystem:         "windows",
+		scsiControllerCount:     1,
+		vsmbDirShares:           make(map[string]*VSMBShare),
+		vsmbFileShares:          make(map[string]*VSMBShare),
+		devicesPhysicallyBacked: opts.FullyPhysicallyBacked,
 	}
 	defer func() {
 		if err != nil {
@@ -111,6 +112,24 @@ func CreateWCOW(ctx context.Context, opts *OptionsWCOW) (_ *UtilityVM, err error
 		if err := wcow.CreateUVMScratch(ctx, uvmFolder, scratchFolder, uvm.id); err != nil {
 			return nil, fmt.Errorf("failed to create scratch: %s", err)
 		}
+	}
+
+	virtualSMB := &hcsschema.VirtualSmb{
+		DirectFileMappingInMB: 1024, // Sensible default, but could be a tuning parameter somewhere
+		Shares: []hcsschema.VirtualSmbShare{
+			{
+				Name: "os",
+				Path: filepath.Join(uvmFolder, `UtilityVM\Files`),
+				Options: &hcsschema.VirtualSmbShareOptions{
+					ReadOnly:            true,
+					PseudoOplocks:       true,
+					TakeBackupPrivilege: true,
+					CacheIo:             true,
+					ShareRead:           true,
+					NoDirectmap:         uvm.devicesPhysicallyBacked,
+				},
+			},
+		},
 	}
 
 	doc := &hcsschema.ComputeSystem{
@@ -162,22 +181,7 @@ func CreateWCOW(ctx context.Context, opts *OptionsWCOW) (_ *UtilityVM, err error
 						DefaultBindSecurityDescriptor: "D:P(A;;FA;;;SY)(A;;FA;;;BA)",
 					},
 				},
-				VirtualSmb: &hcsschema.VirtualSmb{
-					DirectFileMappingInMB: 1024, // Sensible default, but could be a tuning parameter somewhere
-					Shares: []hcsschema.VirtualSmbShare{
-						{
-							Name: "os",
-							Path: filepath.Join(uvmFolder, `UtilityVM\Files`),
-							Options: &hcsschema.VirtualSmbShareOptions{
-								ReadOnly:            true,
-								PseudoOplocks:       true,
-								TakeBackupPrivilege: true,
-								CacheIo:             true,
-								ShareRead:           true,
-							},
-						},
-					},
-				},
+				VirtualSmb: virtualSMB,
 			},
 		},
 	}

--- a/internal/uvm/types.go
+++ b/internal/uvm/types.go
@@ -52,6 +52,10 @@ type UtilityVM struct {
 	exitErr error
 	exitCh  chan struct{}
 
+	// devicesPhysicallyBacked indicates if additional devices added to a uvm should be
+	// entirely physically backed
+	devicesPhysicallyBacked bool
+
 	// GCS bridge protocol and capabilities
 	protocol  uint32
 	guestCaps schema1.GuestDefinedCapabilities

--- a/test/cri-containerd/runpodsandbox_test.go
+++ b/test/cri-containerd/runpodsandbox_test.go
@@ -252,6 +252,26 @@ func Test_RunPodSandbox_PhysicalMemory_WCOW_Hypervisor(t *testing.T) {
 	runPodSandboxTest(t, request)
 }
 
+func Test_RunPodSandbox_FullyPhysicallyBacked_WCOW_Hypervisor(t *testing.T) {
+	requireFeatures(t, featureWCOWHypervisor)
+
+	pullRequiredImages(t, []string{imageWindowsNanoserver})
+
+	request := &runtime.RunPodSandboxRequest{
+		Config: &runtime.PodSandboxConfig{
+			Metadata: &runtime.PodSandboxMetadata{
+				Name:      t.Name(),
+				Namespace: testNamespace,
+			},
+			Annotations: map[string]string{
+				"io.microsoft.virtualmachine.fullyphysicallybacked": "true",
+			},
+		},
+		RuntimeHandler: wcowHypervisorRuntimeHandler,
+	}
+	runPodSandboxTest(t, request)
+}
+
 func Test_RunPodSandbox_PhysicalMemory_LCOW(t *testing.T) {
 	requireFeatures(t, featureLCOW)
 
@@ -266,6 +286,26 @@ func Test_RunPodSandbox_PhysicalMemory_LCOW(t *testing.T) {
 			},
 			Annotations: map[string]string{
 				"io.microsoft.virtualmachine.computetopology.memory.allowovercommit": "false",
+			},
+		},
+		RuntimeHandler: lcowRuntimeHandler,
+	}
+	runPodSandboxTest(t, request)
+}
+
+func Test_RunPodSandbox_FullyPhysicallyBacked_LCOW(t *testing.T) {
+	requireFeatures(t, featureLCOW)
+
+	pullRequiredLcowImages(t, []string{imageLcowK8sPause})
+
+	request := &runtime.RunPodSandboxRequest{
+		Config: &runtime.PodSandboxConfig{
+			Metadata: &runtime.PodSandboxMetadata{
+				Name:      t.Name(),
+				Namespace: testNamespace,
+			},
+			Annotations: map[string]string{
+				"io.microsoft.virtualmachine.fullyphysicallybacked": "true",
 			},
 		},
 		RuntimeHandler: lcowRuntimeHandler,


### PR DESCRIPTION
* Necessary for assigned devices work to allow WCOW vsmb devices to not use virtual memory, a requirement of using vpci to assign a device to a pod. 

* Adds functions to handle annotations that imply other annotations

* Adds testing for LCOW and WCOW scenarios with the new annotation

Signed-off-by: Kathryn Baldauf <kabaldau@microsoft.com>