### PR TITLE
Updating session affinity version check

### DIFF
--- a/hcn/hcnglobals.go
+++ b/hcn/hcnglobals.go
@@ -49,8 +49,8 @@ var (
 		VersionRange{MinVersion: Version{Major: 9, Minor: 3}, MaxVersion: Version{Major: 9, Minor: math.MaxInt32}},
 		VersionRange{MinVersion: Version{Major: 10, Minor: 4}, MaxVersion: Version{Major: math.MaxInt32, Minor: math.MaxInt32}},
 	}
-	// HNS 11.10 allows for session affinity for loadbalancing
-	SessionAffinityVersion = VersionRanges{VersionRange{MinVersion: Version{Major: 11, Minor: 10}, MaxVersion: Version{Major: math.MaxInt32, Minor: math.MaxInt32}}}
+	// HNS 12.0 allows for session affinity for loadbalancing
+	SessionAffinityVersion = VersionRanges{VersionRange{MinVersion: Version{Major: 12, Minor: 0}, MaxVersion: Version{Major: math.MaxInt32, Minor: math.MaxInt32}}}
 )
 
 // GetGlobals returns the global properties of the HCN Service.


### PR DESCRIPTION
When [session affinity support was added](https://github.com/microsoft/hcsshim/pull/730) to hcsshim via LoadBalancerDistribution field, an incorrect version check was established. This PR correctly lines up hcsshim with the release of the LoadBalancerDistribution platform work in HNS.