### PR TITLE
Fix 'WorkingSetBytes' memory metric for PA backed VMs

### DIFF
--- a/internal/uvm/constants.go
+++ b/internal/uvm/constants.go
@@ -1,6 +1,8 @@
 package uvm
 
-import "fmt"
+import (
+	"errors"
+)
 
 const (
 	// MaxVPMEMCount is the maximum number of VPMem devices that may be added to an LCOW
@@ -16,4 +18,7 @@ const (
 	DefaultVPMemSizeBytes = 4 * 1024 * 1024 * 1024 // 4GB
 )
 
-var errNotSupported = fmt.Errorf("not supported")
+var (
+	errNotSupported = errors.New("not supported")
+	errBadUVMOpts   = errors.New("UVM options incorrect")
+)

--- a/internal/uvm/create_test.go
+++ b/internal/uvm/create_test.go
@@ -2,6 +2,7 @@ package uvm
 
 import (
 	"context"
+	"fmt"
 	"testing"
 )
 
@@ -20,7 +21,8 @@ func TestCreateBadBootFilesPath(t *testing.T) {
 func TestCreateWCOWBadLayerFolders(t *testing.T) {
 	opts := NewDefaultOptionsWCOW(t.Name(), "")
 	_, err := CreateWCOW(context.Background(), opts)
-	if err == nil || (err != nil && err.Error() != `at least 2 LayerFolders must be supplied`) {
+	errMsg := fmt.Sprintf("%s: %s", errBadUVMOpts, "at least 2 LayerFolders must be supplied")
+	if err == nil || (err != nil && err.Error() != errMsg) {
 		t.Fatal(err)
 	}
 }

--- a/internal/uvm/types.go
+++ b/internal/uvm/types.go
@@ -39,15 +39,16 @@ type namespaceInfo struct {
 
 // UtilityVM is the object used by clients representing a utility VM
 type UtilityVM struct {
-	id              string               // Identifier for the utility VM (user supplied or generated)
-	runtimeID       guid.GUID            // Hyper-V VM ID
-	owner           string               // Owner for the utility VM (user supplied or generated)
-	operatingSystem string               // "windows" or "linux"
-	hcsSystem       *hcs.System          // The handle to the compute system
-	gcListener      net.Listener         // The GCS connection listener
-	gc              *gcs.GuestConnection // The GCS connection
-	processorCount  int32
-	m               sync.Mutex // Lock for adding/removing devices
+	id               string               // Identifier for the utility VM (user supplied or generated)
+	runtimeID        guid.GUID            // Hyper-V VM ID
+	owner            string               // Owner for the utility VM (user supplied or generated)
+	operatingSystem  string               // "windows" or "linux"
+	hcsSystem        *hcs.System          // The handle to the compute system
+	gcListener       net.Listener         // The GCS connection listener
+	gc               *gcs.GuestConnection // The GCS connection
+	processorCount   int32
+	physicallyBacked bool       // If the uvm is backed by physical memory and not virtual memory
+	m                sync.Mutex // Lock for adding/removing devices
 
 	exitErr error
 	exitCh  chan struct{}

--- a/internal/uvm/vpmem.go
+++ b/internal/uvm/vpmem.go
@@ -2,6 +2,7 @@ package uvm
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 
@@ -19,7 +20,7 @@ const (
 var (
 	// ErrMaxVPMEMLayerSize is the error returned when the size of `hostPath` is
 	// greater than the max vPMEM layer size set at create time.
-	ErrMaxVPMEMLayerSize = fmt.Errorf("layer size is to large for VPMEM max size")
+	ErrMaxVPMEMLayerSize = errors.New("layer size is to large for VPMEM max size")
 )
 
 // findNextVPMEM finds the next available VPMem slot.


### PR DESCRIPTION
* Added a field (physicallyBacked) to UtilityVM struct.
* Fix behavior of querying the UVMs vmmem process to get the working set
size for physical backed UVMs. Instead we assign the total memory assigned
to the UVM by using AssignedMemory * 4096 (is returned as number of 4kb pages)

Signed-off-by: Daniel Canter <dcanter@microsoft.com>