### PR TITLE
Skip test on Windows before 19H1

### DIFF
--- a/test/cri-containerd/runpodsandbox_test.go
+++ b/test/cri-containerd/runpodsandbox_test.go
@@ -1088,6 +1088,12 @@ func Test_RunPodSandbox_MultipleContainersSameVhd_LCOW(t *testing.T) {
 }
 
 func Test_RunPodSandbox_MultipleContainersSameVhd_WCOW(t *testing.T) {
+	// Prior to 19H1, we aren't able to easily create a formatted VHD, as
+	// HcsFormatWritableLayerVhd requires the VHD to be mounted prior the call.
+	if osversion.Get().Build < osversion.V19H1 {
+		t.Skip("Requires at least 19H1")
+	}
+
 	pullRequiredImages(t, []string{imageWindowsNanoserver})
 
 	client := newTestRuntimeClient(t)


### PR DESCRIPTION
The Test_RunPodSandbox_MultipleContainersSameVhd_WCOW test does not work
prior to 19H1. In those versions, HcsFormatWritableLayerVhd requires the
VHD to be mounted prior to calling, which we don't do currently. Because
of this, we are unable to create a VHD to use for the test.

This fixes the issue by simply skipping the test on the affected OS
versions. We could potentially resolve this in the future by adding
more code to do the VHD mount ourselves, but this is a quick fix for
moment.

We will still have test coverage of this functionality on 19H1, so this
shouldn't be a big issue.

Signed-off-by: Kevin Parsons <kevpar@microsoft.com>