### PR TITLE
Add feature flags to cri-containerd tests

### DIFF
--- a/test/cri-containerd/container_downlevel_test.go
+++ b/test/cri-containerd/container_downlevel_test.go
@@ -11,7 +11,9 @@ import (
 )
 
 func Test_CreateContainer_DownLevel_WCOW_Hypervisor(t *testing.T) {
+	requireFeatures(t, featureWCOWHypervisor)
 	testutilities.RequiresBuild(t, osversion.V19H1)
+
 	pullRequiredImages(t, []string{imageWindowsNanoserver17763})
 
 	sandboxRequest := &runtime.RunPodSandboxRequest{

--- a/test/cri-containerd/container_network_test.go
+++ b/test/cri-containerd/container_network_test.go
@@ -16,6 +16,8 @@ import (
 )
 
 func Test_Container_Network_LCOW(t *testing.T) {
+	requireFeatures(t, featureLCOW)
+
 	pullRequiredLcowImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
 
 	// create a directory and log file
@@ -99,39 +101,44 @@ func Test_Container_Network_LCOW(t *testing.T) {
 
 func Test_Container_Network_Hostname(t *testing.T) {
 	type config struct {
-		name string
-
-		runtimeHandler string
-		sandboxImage   string
-		containerImage string
-		cmd            []string
+		name             string
+		requiredFeatures []string
+		runtimeHandler   string
+		sandboxImage     string
+		containerImage   string
+		cmd              []string
 	}
 	tests := []config{
 		{
-			name:           "WCOW_Process",
-			runtimeHandler: wcowProcessRuntimeHandler,
-			sandboxImage:   imageWindowsNanoserver,
-			containerImage: imageWindowsNanoserver,
-			cmd:            []string{"cmd", "/c", "ping", "-t", "127.0.0.1"},
+			name:             "WCOW_Process",
+			requiredFeatures: []string{featureWCOWProcess},
+			runtimeHandler:   wcowProcessRuntimeHandler,
+			sandboxImage:     imageWindowsNanoserver,
+			containerImage:   imageWindowsNanoserver,
+			cmd:              []string{"cmd", "/c", "ping", "-t", "127.0.0.1"},
 		},
 		{
-			name:           "WCOW_Hypervisor",
-			runtimeHandler: wcowHypervisorRuntimeHandler,
-			sandboxImage:   imageWindowsNanoserver,
-			containerImage: imageWindowsNanoserver,
-			cmd:            []string{"cmd", "/c", "ping", "-t", "127.0.0.1"},
+			name:             "WCOW_Hypervisor",
+			requiredFeatures: []string{featureWCOWHypervisor},
+			runtimeHandler:   wcowHypervisorRuntimeHandler,
+			sandboxImage:     imageWindowsNanoserver,
+			containerImage:   imageWindowsNanoserver,
+			cmd:              []string{"cmd", "/c", "ping", "-t", "127.0.0.1"},
 		},
 		{
-			name:           "LCOW",
-			runtimeHandler: lcowRuntimeHandler,
-			sandboxImage:   imageLcowK8sPause,
-			containerImage: imageLcowAlpine,
-			cmd:            []string{"top"},
+			name:             "LCOW",
+			requiredFeatures: []string{featureLCOW},
+			runtimeHandler:   lcowRuntimeHandler,
+			sandboxImage:     imageLcowK8sPause,
+			containerImage:   imageLcowAlpine,
+			cmd:              []string{"top"},
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			requireFeatures(t, test.requiredFeatures...)
+
 			if test.runtimeHandler == lcowRuntimeHandler {
 				pullRequiredLcowImages(t, []string{test.sandboxImage, test.containerImage})
 			} else {

--- a/test/cri-containerd/container_test.go
+++ b/test/cri-containerd/container_test.go
@@ -63,6 +63,8 @@ func runContainerLifetime(t *testing.T, client runtime.RuntimeServiceClient, ctx
 }
 
 func Test_RotateLogs_LCOW(t *testing.T) {
+	requireFeatures(t, featureLCOW)
+
 	image := "alpine:latest"
 	dir, err := ioutil.TempDir("", "")
 	if err != nil {
@@ -140,6 +142,8 @@ func Test_RotateLogs_LCOW(t *testing.T) {
 }
 
 func Test_RunContainer_Events_LCOW(t *testing.T) {
+	requireFeatures(t, featureLCOW)
+
 	pullRequiredLcowImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
 	client := newTestRuntimeClient(t)
 
@@ -218,6 +222,8 @@ func Test_RunContainer_Events_LCOW(t *testing.T) {
 }
 
 func Test_RunContainer_VirtualDevice_GPU_LCOW(t *testing.T) {
+	requireFeatures(t, featureLCOW)
+
 	if osversion.Get().Build < 19566 {
 		t.Skip("Requires build +19566")
 	}
@@ -310,6 +316,8 @@ func Test_RunContainer_VirtualDevice_GPU_LCOW(t *testing.T) {
 }
 
 func Test_RunContainer_ForksThenExits_ShowsAsExited_LCOW(t *testing.T) {
+	requireFeatures(t, featureLCOW)
+
 	pullRequiredLcowImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
 	client := newTestRuntimeClient(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
@@ -367,6 +375,8 @@ func Test_RunContainer_ForksThenExits_ShowsAsExited_LCOW(t *testing.T) {
 }
 
 func Test_RunContainer_ZeroVPMEM_LCOW(t *testing.T) {
+	requireFeatures(t, featureLCOW)
+
 	pullRequiredLcowImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
 
 	client := newTestRuntimeClient(t)
@@ -412,6 +422,8 @@ func Test_RunContainer_ZeroVPMEM_LCOW(t *testing.T) {
 }
 
 func Test_RunContainer_ZeroVPMEM_Multiple_LCOW(t *testing.T) {
+	requireFeatures(t, featureLCOW)
+
 	pullRequiredLcowImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
 
 	client := newTestRuntimeClient(t)

--- a/test/cri-containerd/createcontainer_test.go
+++ b/test/cri-containerd/createcontainer_test.go
@@ -49,6 +49,8 @@ func runCreateContainerTestWithSandbox(t *testing.T, sandboxRequest *runtime.Run
 }
 
 func Test_CreateContainer_WCOW_Process(t *testing.T) {
+	requireFeatures(t, featureWCOWProcess)
+
 	pullRequiredImages(t, []string{imageWindowsNanoserver})
 
 	request := &runtime.CreateContainerRequest{
@@ -73,6 +75,8 @@ func Test_CreateContainer_WCOW_Process(t *testing.T) {
 }
 
 func Test_CreateContainer_WCOW_Hypervisor(t *testing.T) {
+	requireFeatures(t, featureWCOWHypervisor)
+
 	pullRequiredImages(t, []string{imageWindowsNanoserver})
 
 	request := &runtime.CreateContainerRequest{
@@ -97,6 +101,8 @@ func Test_CreateContainer_WCOW_Hypervisor(t *testing.T) {
 }
 
 func Test_CreateContainer_LCOW(t *testing.T) {
+	requireFeatures(t, featureLCOW)
+
 	pullRequiredLcowImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
 
 	request := &runtime.CreateContainerRequest{
@@ -117,6 +123,8 @@ func Test_CreateContainer_LCOW(t *testing.T) {
 }
 
 func Test_CreateContainer_WCOW_Process_Tty(t *testing.T) {
+	requireFeatures(t, featureWCOWProcess)
+
 	pullRequiredImages(t, []string{imageWindowsNanoserver})
 
 	request := &runtime.CreateContainerRequest{
@@ -138,6 +146,8 @@ func Test_CreateContainer_WCOW_Process_Tty(t *testing.T) {
 }
 
 func Test_CreateContainer_WCOW_Hypervisor_Tty(t *testing.T) {
+	requireFeatures(t, featureWCOWHypervisor)
+
 	pullRequiredImages(t, []string{imageWindowsNanoserver})
 
 	request := &runtime.CreateContainerRequest{
@@ -159,6 +169,8 @@ func Test_CreateContainer_WCOW_Hypervisor_Tty(t *testing.T) {
 }
 
 func Test_CreateContainer_LCOW_Tty(t *testing.T) {
+	requireFeatures(t, featureLCOW)
+
 	pullRequiredLcowImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
 
 	request := &runtime.CreateContainerRequest{
@@ -180,6 +192,8 @@ func Test_CreateContainer_LCOW_Tty(t *testing.T) {
 }
 
 func Test_CreateContainer_LCOW_Privileged(t *testing.T) {
+	requireFeatures(t, featureLCOW)
+
 	pullRequiredLcowImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
 
 	sandboxRequest := &runtime.RunPodSandboxRequest{
@@ -221,6 +235,8 @@ func Test_CreateContainer_LCOW_Privileged(t *testing.T) {
 }
 
 func Test_CreateContainer_MemorySize_Config_WCOW_Process(t *testing.T) {
+	requireFeatures(t, featureWCOWProcess)
+
 	pullRequiredImages(t, []string{imageWindowsNanoserver})
 
 	request := &runtime.CreateContainerRequest{
@@ -250,6 +266,8 @@ func Test_CreateContainer_MemorySize_Config_WCOW_Process(t *testing.T) {
 }
 
 func Test_CreateContainer_MemorySize_Annotation_WCOW_Process(t *testing.T) {
+	requireFeatures(t, featureWCOWProcess)
+
 	pullRequiredImages(t, []string{imageWindowsNanoserver})
 
 	request := &runtime.CreateContainerRequest{
@@ -277,6 +295,8 @@ func Test_CreateContainer_MemorySize_Annotation_WCOW_Process(t *testing.T) {
 }
 
 func Test_CreateContainer_MemorySize_Config_WCOW_Hypervisor(t *testing.T) {
+	requireFeatures(t, featureWCOWHypervisor)
+
 	pullRequiredImages(t, []string{imageWindowsNanoserver})
 
 	request := &runtime.CreateContainerRequest{
@@ -306,6 +326,8 @@ func Test_CreateContainer_MemorySize_Config_WCOW_Hypervisor(t *testing.T) {
 }
 
 func Test_CreateContainer_MemorySize_Annotation_WCOW_Hypervisor(t *testing.T) {
+	requireFeatures(t, featureWCOWHypervisor)
+
 	pullRequiredImages(t, []string{imageWindowsNanoserver})
 
 	request := &runtime.CreateContainerRequest{
@@ -333,6 +355,8 @@ func Test_CreateContainer_MemorySize_Annotation_WCOW_Hypervisor(t *testing.T) {
 }
 
 func Test_CreateContainer_MemorySize_LCOW(t *testing.T) {
+	requireFeatures(t, featureLCOW)
+
 	pullRequiredLcowImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
 
 	request := &runtime.CreateContainerRequest{
@@ -358,6 +382,8 @@ func Test_CreateContainer_MemorySize_LCOW(t *testing.T) {
 }
 
 func Test_CreateContainer_CPUCount_Config_WCOW_Process(t *testing.T) {
+	requireFeatures(t, featureWCOWProcess)
+
 	pullRequiredImages(t, []string{imageWindowsNanoserver})
 
 	request := &runtime.CreateContainerRequest{
@@ -387,6 +413,8 @@ func Test_CreateContainer_CPUCount_Config_WCOW_Process(t *testing.T) {
 }
 
 func Test_CreateContainer_CPUCount_Annotation_WCOW_Process(t *testing.T) {
+	requireFeatures(t, featureWCOWProcess)
+
 	pullRequiredImages(t, []string{imageWindowsNanoserver})
 
 	request := &runtime.CreateContainerRequest{
@@ -414,6 +442,8 @@ func Test_CreateContainer_CPUCount_Annotation_WCOW_Process(t *testing.T) {
 }
 
 func Test_CreateContainer_CPUCount_Config_WCOW_Hypervisor(t *testing.T) {
+	requireFeatures(t, featureWCOWHypervisor)
+
 	pullRequiredImages(t, []string{imageWindowsNanoserver})
 
 	request := &runtime.CreateContainerRequest{
@@ -443,6 +473,8 @@ func Test_CreateContainer_CPUCount_Config_WCOW_Hypervisor(t *testing.T) {
 }
 
 func Test_CreateContainer_CPUCount_Annotation_WCOW_Hypervisor(t *testing.T) {
+	requireFeatures(t, featureWCOWHypervisor)
+
 	pullRequiredImages(t, []string{imageWindowsNanoserver})
 
 	request := &runtime.CreateContainerRequest{
@@ -470,6 +502,8 @@ func Test_CreateContainer_CPUCount_Annotation_WCOW_Hypervisor(t *testing.T) {
 }
 
 func Test_CreateContainer_CPUCount_LCOW(t *testing.T) {
+	requireFeatures(t, featureLCOW)
+
 	pullRequiredLcowImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
 
 	request := &runtime.CreateContainerRequest{
@@ -495,6 +529,8 @@ func Test_CreateContainer_CPUCount_LCOW(t *testing.T) {
 }
 
 func Test_CreateContainer_CPULimit_Config_WCOW_Process(t *testing.T) {
+	requireFeatures(t, featureWCOWProcess)
+
 	pullRequiredImages(t, []string{imageWindowsNanoserver})
 
 	request := &runtime.CreateContainerRequest{
@@ -524,6 +560,8 @@ func Test_CreateContainer_CPULimit_Config_WCOW_Process(t *testing.T) {
 }
 
 func Test_CreateContainer_CPULimit_Annotation_WCOW_Process(t *testing.T) {
+	requireFeatures(t, featureWCOWProcess)
+
 	pullRequiredImages(t, []string{imageWindowsNanoserver})
 
 	request := &runtime.CreateContainerRequest{
@@ -551,6 +589,8 @@ func Test_CreateContainer_CPULimit_Annotation_WCOW_Process(t *testing.T) {
 }
 
 func Test_CreateContainer_CPULimit_Config_WCOW_Hypervisor(t *testing.T) {
+	requireFeatures(t, featureWCOWHypervisor)
+
 	pullRequiredImages(t, []string{imageWindowsNanoserver})
 
 	request := &runtime.CreateContainerRequest{
@@ -580,6 +620,8 @@ func Test_CreateContainer_CPULimit_Config_WCOW_Hypervisor(t *testing.T) {
 }
 
 func Test_CreateContainer_CPULimit_Annotation_WCOW_Hypervisor(t *testing.T) {
+	requireFeatures(t, featureWCOWHypervisor)
+
 	pullRequiredImages(t, []string{imageWindowsNanoserver})
 
 	request := &runtime.CreateContainerRequest{
@@ -607,6 +649,8 @@ func Test_CreateContainer_CPULimit_Annotation_WCOW_Hypervisor(t *testing.T) {
 }
 
 func Test_CreateContainer_CPUQuota_LCOW(t *testing.T) {
+	requireFeatures(t, featureLCOW)
+
 	pullRequiredLcowImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
 
 	request := &runtime.CreateContainerRequest{
@@ -633,6 +677,8 @@ func Test_CreateContainer_CPUQuota_LCOW(t *testing.T) {
 }
 
 func Test_CreateContainer_CPUWeight_Config_WCOW_Process(t *testing.T) {
+	requireFeatures(t, featureWCOWProcess)
+
 	pullRequiredImages(t, []string{imageWindowsNanoserver})
 
 	request := &runtime.CreateContainerRequest{
@@ -662,6 +708,8 @@ func Test_CreateContainer_CPUWeight_Config_WCOW_Process(t *testing.T) {
 }
 
 func Test_CreateContainer_CPUWeight_Annotation_WCOW_Process(t *testing.T) {
+	requireFeatures(t, featureWCOWProcess)
+
 	pullRequiredImages(t, []string{imageWindowsNanoserver})
 
 	request := &runtime.CreateContainerRequest{
@@ -689,6 +737,8 @@ func Test_CreateContainer_CPUWeight_Annotation_WCOW_Process(t *testing.T) {
 }
 
 func Test_CreateContainer_CPUWeight_Config_WCOW_Hypervisor(t *testing.T) {
+	requireFeatures(t, featureWCOWHypervisor)
+
 	pullRequiredImages(t, []string{imageWindowsNanoserver})
 
 	request := &runtime.CreateContainerRequest{
@@ -718,6 +768,8 @@ func Test_CreateContainer_CPUWeight_Config_WCOW_Hypervisor(t *testing.T) {
 }
 
 func Test_CreateContainer_CPUWeight_Annotation_WCOW_Hypervisor(t *testing.T) {
+	requireFeatures(t, featureWCOWHypervisor)
+
 	pullRequiredImages(t, []string{imageWindowsNanoserver})
 
 	request := &runtime.CreateContainerRequest{
@@ -745,6 +797,8 @@ func Test_CreateContainer_CPUWeight_Annotation_WCOW_Hypervisor(t *testing.T) {
 }
 
 func Test_CreateContainer_CPUShares_LCOW(t *testing.T) {
+	requireFeatures(t, featureLCOW)
+
 	pullRequiredLcowImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
 
 	request := &runtime.CreateContainerRequest{
@@ -770,7 +824,9 @@ func Test_CreateContainer_CPUShares_LCOW(t *testing.T) {
 }
 
 func Test_CreateContainer_Mount_File_LCOW(t *testing.T) {
+	requireFeatures(t, featureLCOW)
 	testutilities.RequiresBuild(t, osversion.V19H1)
+
 	pullRequiredLcowImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
 
 	tempFile, err := ioutil.TempFile("", "test")
@@ -813,7 +869,9 @@ func Test_CreateContainer_Mount_File_LCOW(t *testing.T) {
 }
 
 func Test_CreateContainer_Mount_ReadOnlyFile_LCOW(t *testing.T) {
+	requireFeatures(t, featureLCOW)
 	testutilities.RequiresBuild(t, osversion.V19H1)
+
 	pullRequiredLcowImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
 
 	tempFile, err := ioutil.TempFile("", "test")
@@ -857,6 +915,8 @@ func Test_CreateContainer_Mount_ReadOnlyFile_LCOW(t *testing.T) {
 }
 
 func Test_CreateContainer_Mount_Dir_LCOW(t *testing.T) {
+	requireFeatures(t, featureLCOW)
+
 	pullRequiredLcowImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
 
 	tempDir, err := ioutil.TempDir("", "")
@@ -891,6 +951,8 @@ func Test_CreateContainer_Mount_Dir_LCOW(t *testing.T) {
 }
 
 func Test_CreateContainer_Mount_ReadOnlyDir_LCOW(t *testing.T) {
+	requireFeatures(t, featureLCOW)
+
 	pullRequiredLcowImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
 
 	tempDir, err := ioutil.TempDir("", "")
@@ -926,6 +988,7 @@ func Test_CreateContainer_Mount_ReadOnlyDir_LCOW(t *testing.T) {
 }
 
 func Test_CreateContainer_Mount_File_WCOW(t *testing.T) {
+	requireFeatures(t, featureWCOWHypervisor)
 	pullRequiredImages(t, []string{imageWindowsNanoserver})
 
 	tempFile, err := ioutil.TempFile("", "test")
@@ -969,6 +1032,8 @@ func Test_CreateContainer_Mount_File_WCOW(t *testing.T) {
 }
 
 func Test_CreateContainer_Mount_ReadOnlyFile_WCOW(t *testing.T) {
+	requireFeatures(t, featureWCOWHypervisor)
+
 	pullRequiredImages(t, []string{imageWindowsNanoserver})
 
 	tempFile, err := ioutil.TempFile("", "test")
@@ -1013,6 +1078,8 @@ func Test_CreateContainer_Mount_ReadOnlyFile_WCOW(t *testing.T) {
 }
 
 func Test_CreateContainer_Mount_Dir_WCOW(t *testing.T) {
+	requireFeatures(t, featureWCOWHypervisor)
+
 	pullRequiredImages(t, []string{imageWindowsNanoserver})
 
 	tempDir, err := ioutil.TempDir("", "")
@@ -1048,6 +1115,8 @@ func Test_CreateContainer_Mount_Dir_WCOW(t *testing.T) {
 }
 
 func Test_CreateContainer_Mount_ReadOnlyDir_WCOW(t *testing.T) {
+	requireFeatures(t, featureWCOWHypervisor)
+
 	pullRequiredImages(t, []string{imageWindowsNanoserver})
 
 	tempDir, err := ioutil.TempDir("", "")
@@ -1084,6 +1153,8 @@ func Test_CreateContainer_Mount_ReadOnlyDir_WCOW(t *testing.T) {
 }
 
 func Test_CreateContainer_Mount_NamedPipe_WCOW(t *testing.T) {
+	requireFeatures(t, featureWCOWHypervisor)
+
 	pullRequiredImages(t, []string{imageWindowsNanoserver})
 
 	path := `\\.\pipe\testpipe`

--- a/test/cri-containerd/execcontainer_test.go
+++ b/test/cri-containerd/execcontainer_test.go
@@ -94,6 +94,8 @@ func execContainerLCOW(t *testing.T, uid int64, cmd []string) *runtime.ExecSyncR
 }
 
 func Test_ExecContainer_RunAs_LCOW(t *testing.T) {
+	requireFeatures(t, featureLCOW)
+
 	// this is just saying 'give me the UID of the process with pid = 1; ignore headers'
 	r := execContainerLCOW(t,
 		9000, // cosmosarno user
@@ -123,6 +125,8 @@ func Test_ExecContainer_RunAs_LCOW(t *testing.T) {
 }
 
 func Test_ExecContainer_LCOW_HasEntropy(t *testing.T) {
+	requireFeatures(t, featureLCOW)
+
 	r := execContainerLCOW(t, 9000, []string{"cat", "/proc/sys/kernel/random/entropy_avail"})
 	if r.ExitCode != 0 {
 		t.Fatalf("failed with exit code %d to cat entropy_avail: %s", r.ExitCode, r.Stderr)

--- a/test/cri-containerd/runpodsandbox_test.go
+++ b/test/cri-containerd/runpodsandbox_test.go
@@ -32,6 +32,8 @@ func runPodSandboxTest(t *testing.T, request *runtime.RunPodSandboxRequest) {
 }
 
 func Test_RunPodSandbox_WCOW_Process(t *testing.T) {
+	requireFeatures(t, featureWCOWProcess)
+
 	pullRequiredImages(t, []string{imageWindowsNanoserver})
 
 	request := &runtime.RunPodSandboxRequest{
@@ -48,6 +50,8 @@ func Test_RunPodSandbox_WCOW_Process(t *testing.T) {
 }
 
 func Test_RunPodSandbox_WCOW_Hypervisor(t *testing.T) {
+	requireFeatures(t, featureWCOWHypervisor)
+
 	pullRequiredImages(t, []string{imageWindowsNanoserver})
 
 	request := &runtime.RunPodSandboxRequest{
@@ -64,6 +68,8 @@ func Test_RunPodSandbox_WCOW_Hypervisor(t *testing.T) {
 }
 
 func Test_RunPodSandbox_LCOW(t *testing.T) {
+	requireFeatures(t, featureLCOW)
+
 	pullRequiredLcowImages(t, []string{imageLcowK8sPause})
 
 	request := &runtime.RunPodSandboxRequest{
@@ -80,6 +86,8 @@ func Test_RunPodSandbox_LCOW(t *testing.T) {
 }
 
 func Test_RunPodSandbox_Events_LCOW(t *testing.T) {
+	requireFeatures(t, featureLCOW)
+
 	client := newTestRuntimeClient(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
@@ -138,6 +146,8 @@ func Test_RunPodSandbox_Events_LCOW(t *testing.T) {
 }
 
 func Test_RunPodSandbox_VirtualMemory_WCOW_Hypervisor(t *testing.T) {
+	requireFeatures(t, featureWCOWHypervisor)
+
 	pullRequiredImages(t, []string{imageWindowsNanoserver})
 
 	request := &runtime.RunPodSandboxRequest{
@@ -157,6 +167,8 @@ func Test_RunPodSandbox_VirtualMemory_WCOW_Hypervisor(t *testing.T) {
 }
 
 func Test_RunPodSandbox_VirtualMemory_LCOW(t *testing.T) {
+	requireFeatures(t, featureLCOW)
+
 	pullRequiredLcowImages(t, []string{imageLcowK8sPause})
 
 	request := &runtime.RunPodSandboxRequest{
@@ -176,6 +188,8 @@ func Test_RunPodSandbox_VirtualMemory_LCOW(t *testing.T) {
 }
 
 func Test_RunPodSandbox_VirtualMemory_DeferredCommit_WCOW_Hypervisor(t *testing.T) {
+	requireFeatures(t, featureWCOWHypervisor)
+
 	pullRequiredImages(t, []string{imageWindowsNanoserver})
 
 	request := &runtime.RunPodSandboxRequest{
@@ -196,6 +210,8 @@ func Test_RunPodSandbox_VirtualMemory_DeferredCommit_WCOW_Hypervisor(t *testing.
 }
 
 func Test_RunPodSandbox_VirtualMemory_DeferredCommit_LCOW(t *testing.T) {
+	requireFeatures(t, featureLCOW)
+
 	pullRequiredLcowImages(t, []string{imageLcowK8sPause})
 
 	request := &runtime.RunPodSandboxRequest{
@@ -216,6 +232,8 @@ func Test_RunPodSandbox_VirtualMemory_DeferredCommit_LCOW(t *testing.T) {
 }
 
 func Test_RunPodSandbox_PhysicalMemory_WCOW_Hypervisor(t *testing.T) {
+	requireFeatures(t, featureWCOWHypervisor)
+
 	pullRequiredImages(t, []string{imageWindowsNanoserver})
 
 	request := &runtime.RunPodSandboxRequest{
@@ -235,6 +253,8 @@ func Test_RunPodSandbox_PhysicalMemory_WCOW_Hypervisor(t *testing.T) {
 }
 
 func Test_RunPodSandbox_PhysicalMemory_LCOW(t *testing.T) {
+	requireFeatures(t, featureLCOW)
+
 	pullRequiredLcowImages(t, []string{imageLcowK8sPause})
 
 	request := &runtime.RunPodSandboxRequest{
@@ -254,6 +274,8 @@ func Test_RunPodSandbox_PhysicalMemory_LCOW(t *testing.T) {
 }
 
 func Test_RunPodSandbox_MemorySize_WCOW_Process(t *testing.T) {
+	requireFeatures(t, featureWCOWProcess)
+
 	pullRequiredImages(t, []string{imageWindowsNanoserver})
 
 	request := &runtime.RunPodSandboxRequest{
@@ -273,6 +295,8 @@ func Test_RunPodSandbox_MemorySize_WCOW_Process(t *testing.T) {
 }
 
 func Test_RunPodSandbox_MemorySize_WCOW_Hypervisor(t *testing.T) {
+	requireFeatures(t, featureWCOWHypervisor)
+
 	pullRequiredImages(t, []string{imageWindowsNanoserver})
 
 	request := &runtime.RunPodSandboxRequest{
@@ -292,6 +316,8 @@ func Test_RunPodSandbox_MemorySize_WCOW_Hypervisor(t *testing.T) {
 }
 
 func Test_RunPodSandbox_MemorySize_LCOW(t *testing.T) {
+	requireFeatures(t, featureLCOW)
+
 	pullRequiredLcowImages(t, []string{imageLcowK8sPause})
 
 	request := &runtime.RunPodSandboxRequest{
@@ -311,6 +337,8 @@ func Test_RunPodSandbox_MemorySize_LCOW(t *testing.T) {
 }
 
 func Test_RunPodSandbox_MMIO_WCOW_Process(t *testing.T) {
+	requireFeatures(t, featureWCOWProcess)
+
 	if osversion.Get().Build < 19566 {
 		t.Skip("Requires build +19566")
 	}
@@ -334,6 +362,8 @@ func Test_RunPodSandbox_MMIO_WCOW_Process(t *testing.T) {
 }
 
 func Test_RunPodSandbox_MMIO_WCOW_Hypervisor(t *testing.T) {
+	requireFeatures(t, featureWCOWHypervisor)
+
 	if osversion.Get().Build < 19566 {
 		t.Skip("Requires build +19566")
 	}
@@ -357,6 +387,8 @@ func Test_RunPodSandbox_MMIO_WCOW_Hypervisor(t *testing.T) {
 }
 
 func Test_RunPodSandbox_MMIO_LCOW(t *testing.T) {
+	requireFeatures(t, featureLCOW)
+
 	if osversion.Get().Build < 19566 {
 		t.Skip("Requires build +19566")
 	}
@@ -380,6 +412,8 @@ func Test_RunPodSandbox_MMIO_LCOW(t *testing.T) {
 }
 
 func Test_RunPodSandbox_CPUCount_WCOW_Process(t *testing.T) {
+	requireFeatures(t, featureWCOWProcess)
+
 	pullRequiredImages(t, []string{imageWindowsNanoserver})
 
 	request := &runtime.RunPodSandboxRequest{
@@ -399,6 +433,8 @@ func Test_RunPodSandbox_CPUCount_WCOW_Process(t *testing.T) {
 }
 
 func Test_RunPodSandbox_CPUCount_WCOW_Hypervisor(t *testing.T) {
+	requireFeatures(t, featureWCOWHypervisor)
+
 	pullRequiredImages(t, []string{imageWindowsNanoserver})
 
 	request := &runtime.RunPodSandboxRequest{
@@ -418,6 +454,8 @@ func Test_RunPodSandbox_CPUCount_WCOW_Hypervisor(t *testing.T) {
 }
 
 func Test_RunPodSandbox_CPUCount_LCOW(t *testing.T) {
+	requireFeatures(t, featureLCOW)
+
 	pullRequiredLcowImages(t, []string{imageLcowK8sPause})
 
 	request := &runtime.RunPodSandboxRequest{
@@ -437,6 +475,8 @@ func Test_RunPodSandbox_CPUCount_LCOW(t *testing.T) {
 }
 
 func Test_RunPodSandbox_CPULimit_WCOW_Process(t *testing.T) {
+	requireFeatures(t, featureWCOWProcess)
+
 	pullRequiredImages(t, []string{imageWindowsNanoserver})
 
 	request := &runtime.RunPodSandboxRequest{
@@ -456,6 +496,8 @@ func Test_RunPodSandbox_CPULimit_WCOW_Process(t *testing.T) {
 }
 
 func Test_RunPodSandbox_CPULimit_WCOW_Hypervisor(t *testing.T) {
+	requireFeatures(t, featureWCOWHypervisor)
+
 	pullRequiredImages(t, []string{imageWindowsNanoserver})
 
 	request := &runtime.RunPodSandboxRequest{
@@ -475,6 +517,8 @@ func Test_RunPodSandbox_CPULimit_WCOW_Hypervisor(t *testing.T) {
 }
 
 func Test_RunPodSandbox_CPULimit_LCOW(t *testing.T) {
+	requireFeatures(t, featureLCOW)
+
 	pullRequiredLcowImages(t, []string{imageLcowK8sPause})
 
 	request := &runtime.RunPodSandboxRequest{
@@ -494,6 +538,8 @@ func Test_RunPodSandbox_CPULimit_LCOW(t *testing.T) {
 }
 
 func Test_RunPodSandbox_CPUWeight_WCOW_Process(t *testing.T) {
+	requireFeatures(t, featureWCOWProcess)
+
 	pullRequiredImages(t, []string{imageWindowsNanoserver})
 
 	request := &runtime.RunPodSandboxRequest{
@@ -513,6 +559,8 @@ func Test_RunPodSandbox_CPUWeight_WCOW_Process(t *testing.T) {
 }
 
 func Test_RunPodSandbox_CPUWeight_WCOW_Hypervisor(t *testing.T) {
+	requireFeatures(t, featureWCOWHypervisor)
+
 	pullRequiredImages(t, []string{imageWindowsNanoserver})
 
 	request := &runtime.RunPodSandboxRequest{
@@ -532,6 +580,8 @@ func Test_RunPodSandbox_CPUWeight_WCOW_Hypervisor(t *testing.T) {
 }
 
 func Test_RunPodSandbox_CPUWeight_LCOW(t *testing.T) {
+	requireFeatures(t, featureLCOW)
+
 	pullRequiredLcowImages(t, []string{imageLcowK8sPause})
 
 	request := &runtime.RunPodSandboxRequest{
@@ -551,6 +601,8 @@ func Test_RunPodSandbox_CPUWeight_LCOW(t *testing.T) {
 }
 
 func Test_RunPodSandbox_StorageQoSBandwithMax_WCOW_Process(t *testing.T) {
+	requireFeatures(t, featureWCOWProcess)
+
 	pullRequiredImages(t, []string{imageWindowsNanoserver})
 
 	request := &runtime.RunPodSandboxRequest{
@@ -570,6 +622,8 @@ func Test_RunPodSandbox_StorageQoSBandwithMax_WCOW_Process(t *testing.T) {
 }
 
 func Test_RunPodSandbox_StorageQoSBandwithMax_WCOW_Hypervisor(t *testing.T) {
+	requireFeatures(t, featureWCOWHypervisor)
+
 	pullRequiredImages(t, []string{imageWindowsNanoserver})
 
 	request := &runtime.RunPodSandboxRequest{
@@ -589,6 +643,8 @@ func Test_RunPodSandbox_StorageQoSBandwithMax_WCOW_Hypervisor(t *testing.T) {
 }
 
 func Test_RunPodSandbox_StorageQoSBandwithMax_LCOW(t *testing.T) {
+	requireFeatures(t, featureLCOW)
+
 	pullRequiredLcowImages(t, []string{imageLcowK8sPause})
 
 	request := &runtime.RunPodSandboxRequest{
@@ -608,6 +664,8 @@ func Test_RunPodSandbox_StorageQoSBandwithMax_LCOW(t *testing.T) {
 }
 
 func Test_RunPodSandbox_StorageQoSIopsMax_WCOW_Process(t *testing.T) {
+	requireFeatures(t, featureWCOWProcess)
+
 	pullRequiredImages(t, []string{imageWindowsNanoserver})
 
 	request := &runtime.RunPodSandboxRequest{
@@ -627,6 +685,8 @@ func Test_RunPodSandbox_StorageQoSIopsMax_WCOW_Process(t *testing.T) {
 }
 
 func Test_RunPodSandbox_StorageQoSIopsMax_WCOW_Hypervisor(t *testing.T) {
+	requireFeatures(t, featureWCOWHypervisor)
+
 	pullRequiredImages(t, []string{imageWindowsNanoserver})
 
 	request := &runtime.RunPodSandboxRequest{
@@ -646,6 +706,8 @@ func Test_RunPodSandbox_StorageQoSIopsMax_WCOW_Hypervisor(t *testing.T) {
 }
 
 func Test_RunPodSandbox_StorageQoSIopsMax_LCOW(t *testing.T) {
+	requireFeatures(t, featureLCOW)
+
 	pullRequiredLcowImages(t, []string{imageLcowK8sPause})
 
 	request := &runtime.RunPodSandboxRequest{
@@ -665,6 +727,8 @@ func Test_RunPodSandbox_StorageQoSIopsMax_LCOW(t *testing.T) {
 }
 
 func Test_RunPodSandbox_InitrdBoot_LCOW(t *testing.T) {
+	requireFeatures(t, featureLCOW)
+
 	pullRequiredLcowImages(t, []string{imageLcowK8sPause})
 
 	request := &runtime.RunPodSandboxRequest{
@@ -684,6 +748,8 @@ func Test_RunPodSandbox_InitrdBoot_LCOW(t *testing.T) {
 }
 
 func Test_RunPodSandbox_RootfsVhdBoot_LCOW(t *testing.T) {
+	requireFeatures(t, featureLCOW)
+
 	pullRequiredLcowImages(t, []string{imageLcowK8sPause})
 
 	request := &runtime.RunPodSandboxRequest{
@@ -703,6 +769,8 @@ func Test_RunPodSandbox_RootfsVhdBoot_LCOW(t *testing.T) {
 }
 
 func Test_RunPodSandbox_VPCIEnabled_LCOW(t *testing.T) {
+	requireFeatures(t, featureLCOW)
+
 	pullRequiredLcowImages(t, []string{imageLcowK8sPause})
 
 	request := &runtime.RunPodSandboxRequest{
@@ -721,6 +789,8 @@ func Test_RunPodSandbox_VPCIEnabled_LCOW(t *testing.T) {
 }
 
 func Test_RunPodSandbox_UEFIBoot_LCOW(t *testing.T) {
+	requireFeatures(t, featureLCOW)
+
 	pullRequiredLcowImages(t, []string{imageLcowK8sPause})
 
 	request := &runtime.RunPodSandboxRequest{
@@ -739,6 +809,8 @@ func Test_RunPodSandbox_UEFIBoot_LCOW(t *testing.T) {
 }
 
 func Test_RunPodSandbox_DnsConfig_WCOW_Process(t *testing.T) {
+	requireFeatures(t, featureWCOWProcess)
+
 	pullRequiredImages(t, []string{imageWindowsNanoserver})
 
 	request := &runtime.RunPodSandboxRequest{
@@ -761,6 +833,8 @@ func Test_RunPodSandbox_DnsConfig_WCOW_Process(t *testing.T) {
 }
 
 func Test_RunPodSandbox_DnsConfig_WCOW_Hypervisor(t *testing.T) {
+	requireFeatures(t, featureWCOWHypervisor)
+
 	pullRequiredImages(t, []string{imageWindowsNanoserver})
 
 	request := &runtime.RunPodSandboxRequest{
@@ -783,6 +857,8 @@ func Test_RunPodSandbox_DnsConfig_WCOW_Hypervisor(t *testing.T) {
 }
 
 func Test_RunPodSandbox_DnsConfig_LCOW(t *testing.T) {
+	requireFeatures(t, featureLCOW)
+
 	pullRequiredLcowImages(t, []string{imageLcowK8sPause})
 
 	request := &runtime.RunPodSandboxRequest{
@@ -805,6 +881,8 @@ func Test_RunPodSandbox_DnsConfig_LCOW(t *testing.T) {
 }
 
 func Test_RunPodSandbox_PortMappings_WCOW_Process(t *testing.T) {
+	requireFeatures(t, featureWCOWProcess)
+
 	pullRequiredImages(t, []string{imageWindowsNanoserver})
 
 	request := &runtime.RunPodSandboxRequest{
@@ -828,6 +906,8 @@ func Test_RunPodSandbox_PortMappings_WCOW_Process(t *testing.T) {
 }
 
 func Test_RunPodSandbox_PortMappings_WCOW_Hypervisor(t *testing.T) {
+	requireFeatures(t, featureWCOWHypervisor)
+
 	pullRequiredImages(t, []string{imageWindowsNanoserver})
 
 	request := &runtime.RunPodSandboxRequest{
@@ -851,6 +931,8 @@ func Test_RunPodSandbox_PortMappings_WCOW_Hypervisor(t *testing.T) {
 }
 
 func Test_RunPodSandbox_PortMappings_LCOW(t *testing.T) {
+	requireFeatures(t, featureLCOW)
+
 	pullRequiredLcowImages(t, []string{imageLcowK8sPause})
 
 	request := &runtime.RunPodSandboxRequest{
@@ -874,6 +956,8 @@ func Test_RunPodSandbox_PortMappings_LCOW(t *testing.T) {
 }
 
 func Test_RunPodSandbox_CustomizableScratchDefaultSize_LCOW(t *testing.T) {
+	requireFeatures(t, featureLCOW)
+
 	pullRequiredLcowImages(t, []string{imageLcowK8sPause})
 
 	annotations := map[string]string{
@@ -916,6 +1000,8 @@ func Test_RunPodSandbox_CustomizableScratchDefaultSize_LCOW(t *testing.T) {
 }
 
 func Test_RunPodSandbox_CustomizableScratchCustomSize_LCOW(t *testing.T) {
+	requireFeatures(t, featureLCOW)
+
 	pullRequiredLcowImages(t, []string{imageLcowK8sPause})
 
 	annotations := map[string]string{
@@ -961,6 +1047,8 @@ func Test_RunPodSandbox_CustomizableScratchCustomSize_LCOW(t *testing.T) {
 }
 
 func Test_RunPodSandbox_Mount_SandboxDir_LCOW(t *testing.T) {
+	requireFeatures(t, featureLCOW)
+
 	pullRequiredLcowImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
 
 	annotations := map[string]string{
@@ -998,6 +1086,8 @@ func createExt4VHD(ctx context.Context, t *testing.T, path string) {
 }
 
 func Test_RunPodSandbox_MultipleContainersSameVhd_LCOW(t *testing.T) {
+	requireFeatures(t, featureLCOW)
+
 	pullRequiredLcowImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
 
 	client := newTestRuntimeClient(t)
@@ -1088,6 +1178,7 @@ func Test_RunPodSandbox_MultipleContainersSameVhd_LCOW(t *testing.T) {
 }
 
 func Test_RunPodSandbox_MultipleContainersSameVhd_WCOW(t *testing.T) {
+	requireFeatures(t, featureWCOWHypervisor)
 	// Prior to 19H1, we aren't able to easily create a formatted VHD, as
 	// HcsFormatWritableLayerVhd requires the VHD to be mounted prior the call.
 	if osversion.Get().Build < osversion.V19H1 {

--- a/test/cri-containerd/stats_test.go
+++ b/test/cri-containerd/stats_test.go
@@ -71,6 +71,8 @@ func verifyStatsContent(t *testing.T, stat *runtime.ContainerStats) {
 }
 
 func Test_SandboxStats_Single_LCOW(t *testing.T) {
+	requireFeatures(t, featureLCOW)
+
 	pullRequiredLcowImages(t, []string{imageLcowK8sPause})
 
 	request := &runtime.RunPodSandboxRequest{
@@ -105,6 +107,8 @@ func Test_SandboxStats_Single_LCOW(t *testing.T) {
 }
 
 func Test_SandboxStats_List_ContainerID_LCOW(t *testing.T) {
+	requireFeatures(t, featureLCOW)
+
 	pullRequiredLcowImages(t, []string{imageLcowK8sPause})
 
 	request := &runtime.RunPodSandboxRequest{
@@ -144,6 +148,8 @@ func Test_SandboxStats_List_ContainerID_LCOW(t *testing.T) {
 }
 
 func Test_SandboxStats_List_PodID_LCOW(t *testing.T) {
+	requireFeatures(t, featureLCOW)
+
 	pullRequiredLcowImages(t, []string{imageLcowK8sPause})
 
 	request := &runtime.RunPodSandboxRequest{
@@ -184,39 +190,44 @@ func Test_SandboxStats_List_PodID_LCOW(t *testing.T) {
 
 func Test_ContainerStats_ContainerID(t *testing.T) {
 	type config struct {
-		name string
-
-		runtimeHandler string
-		sandboxImage   string
-		containerImage string
-		cmd            []string
+		name             string
+		requiredFeatures []string
+		runtimeHandler   string
+		sandboxImage     string
+		containerImage   string
+		cmd              []string
 	}
 	tests := []config{
 		{
-			name:           "WCOW_Process",
-			runtimeHandler: wcowProcessRuntimeHandler,
-			sandboxImage:   imageWindowsNanoserver,
-			containerImage: imageWindowsNanoserver,
-			cmd:            []string{"cmd", "/c", "ping", "-t", "127.0.0.1"},
+			name:             "WCOW_Process",
+			requiredFeatures: []string{featureWCOWProcess},
+			runtimeHandler:   wcowProcessRuntimeHandler,
+			sandboxImage:     imageWindowsNanoserver,
+			containerImage:   imageWindowsNanoserver,
+			cmd:              []string{"cmd", "/c", "ping", "-t", "127.0.0.1"},
 		},
 		{
-			name:           "WCOW_Hypervisor",
-			runtimeHandler: wcowHypervisorRuntimeHandler,
-			sandboxImage:   imageWindowsNanoserver,
-			containerImage: imageWindowsNanoserver,
-			cmd:            []string{"cmd", "/c", "ping", "-t", "127.0.0.1"},
+			name:             "WCOW_Hypervisor",
+			requiredFeatures: []string{featureWCOWHypervisor},
+			runtimeHandler:   wcowHypervisorRuntimeHandler,
+			sandboxImage:     imageWindowsNanoserver,
+			containerImage:   imageWindowsNanoserver,
+			cmd:              []string{"cmd", "/c", "ping", "-t", "127.0.0.1"},
 		},
 		{
-			name:           "LCOW",
-			runtimeHandler: lcowRuntimeHandler,
-			sandboxImage:   imageLcowK8sPause,
-			containerImage: imageLcowAlpine,
-			cmd:            []string{"top"},
+			name:             "LCOW",
+			requiredFeatures: []string{featureLCOW},
+			runtimeHandler:   lcowRuntimeHandler,
+			sandboxImage:     imageLcowK8sPause,
+			containerImage:   imageLcowAlpine,
+			cmd:              []string{"top"},
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			requireFeatures(t, test.requiredFeatures...)
+
 			if test.runtimeHandler == lcowRuntimeHandler {
 				pullRequiredLcowImages(t, []string{test.sandboxImage, test.containerImage})
 			} else {
@@ -263,39 +274,44 @@ func Test_ContainerStats_ContainerID(t *testing.T) {
 
 func Test_ContainerStats_List_ContainerID(t *testing.T) {
 	type config struct {
-		name string
-
-		runtimeHandler string
-		sandboxImage   string
-		containerImage string
-		cmd            []string
+		name             string
+		requiredFeatures []string
+		runtimeHandler   string
+		sandboxImage     string
+		containerImage   string
+		cmd              []string
 	}
 	tests := []config{
 		{
-			name:           "WCOW_Process",
-			runtimeHandler: wcowProcessRuntimeHandler,
-			sandboxImage:   imageWindowsNanoserver,
-			containerImage: imageWindowsNanoserver,
-			cmd:            []string{"cmd", "/c", "ping", "-t", "127.0.0.1"},
+			name:             "WCOW_Process",
+			requiredFeatures: []string{featureWCOWProcess},
+			runtimeHandler:   wcowProcessRuntimeHandler,
+			sandboxImage:     imageWindowsNanoserver,
+			containerImage:   imageWindowsNanoserver,
+			cmd:              []string{"cmd", "/c", "ping", "-t", "127.0.0.1"},
 		},
 		{
-			name:           "WCOW_Hypervisor",
-			runtimeHandler: wcowHypervisorRuntimeHandler,
-			sandboxImage:   imageWindowsNanoserver,
-			containerImage: imageWindowsNanoserver,
-			cmd:            []string{"cmd", "/c", "ping", "-t", "127.0.0.1"},
+			name:             "WCOW_Hypervisor",
+			requiredFeatures: []string{featureWCOWHypervisor},
+			runtimeHandler:   wcowHypervisorRuntimeHandler,
+			sandboxImage:     imageWindowsNanoserver,
+			containerImage:   imageWindowsNanoserver,
+			cmd:              []string{"cmd", "/c", "ping", "-t", "127.0.0.1"},
 		},
 		{
-			name:           "LCOW",
-			runtimeHandler: lcowRuntimeHandler,
-			sandboxImage:   imageLcowK8sPause,
-			containerImage: imageLcowAlpine,
-			cmd:            []string{"top"},
+			name:             "LCOW",
+			requiredFeatures: []string{featureLCOW},
+			runtimeHandler:   lcowRuntimeHandler,
+			sandboxImage:     imageLcowK8sPause,
+			containerImage:   imageLcowAlpine,
+			cmd:              []string{"top"},
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			requireFeatures(t, test.requiredFeatures...)
+
 			if test.runtimeHandler == lcowRuntimeHandler {
 				pullRequiredLcowImages(t, []string{test.sandboxImage, test.containerImage})
 			} else {

--- a/test/cri-containerd/stopcontainer_test.go
+++ b/test/cri-containerd/stopcontainer_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 func Test_StopContainer_LCOW(t *testing.T) {
+	requireFeatures(t, featureLCOW)
+
 	pullRequiredLcowImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
 
 	client := newTestRuntimeClient(t)
@@ -54,6 +56,8 @@ func Test_StopContainer_LCOW(t *testing.T) {
 }
 
 func Test_StopContainer_WithTimeout_LCOW(t *testing.T) {
+	requireFeatures(t, featureLCOW)
+
 	pullRequiredLcowImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
 
 	client := newTestRuntimeClient(t)
@@ -98,6 +102,8 @@ func Test_StopContainer_WithTimeout_LCOW(t *testing.T) {
 }
 
 func Test_StopContainer_WithExec_LCOW(t *testing.T) {
+	requireFeatures(t, featureLCOW)
+
 	pullRequiredLcowImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
 
 	client := newTestRuntimeClient(t)
@@ -150,6 +156,8 @@ func Test_StopContainer_WithExec_LCOW(t *testing.T) {
 }
 
 func Test_StopContainer_ReusePod_LCOW(t *testing.T) {
+	requireFeatures(t, featureLCOW)
+
 	pullRequiredLcowImages(t, []string{alpineAspNet, alpineAspnetUpgrade})
 
 	client := newTestRuntimeClient(t)

--- a/test/functional/utilities/stringsetflag.go
+++ b/test/functional/utilities/stringsetflag.go
@@ -1,0 +1,41 @@
+package testutilities
+
+// StringSetFlag is a type to be used with the standard library's flag.Var
+// function as a custom flag value. It accumulates the arguments passed each
+// time the flag is used into a set.
+type StringSetFlag struct {
+	set map[string]struct{}
+}
+
+// NewStringSetFlag returns a new StringSetFlag with an empty set.
+func NewStringSetFlag() StringSetFlag {
+	return StringSetFlag{
+		set: make(map[string]struct{}),
+	}
+}
+
+func (ssf StringSetFlag) String() string {
+	b := "["
+	i := 0
+	for k := range ssf.set {
+		if i > 0 {
+			b = b + ", "
+		}
+		b = b + k
+		i++
+	}
+	b = b + "]"
+	return b
+}
+
+// Set is called by `flag` each time the flag is seen when parsing the
+// command line.
+func (ssf StringSetFlag) Set(s string) error {
+	ssf.set[s] = struct{}{}
+	return nil
+}
+
+// ValueSet returns the internal set of what values have been seen.
+func (ssf StringSetFlag) ValueSet() map[string]struct{} {
+	return ssf.set
+}


### PR DESCRIPTION
This change adds support to the cri-containerd test suite to pass
feature flags on the command line to control what sets of functionality
are tested. The flags are passed as "-feature <feature>", and multiple
flags can be passed to a single invocation. This change also adds a
helper function that can be used to test if a given set of features are
enabled. If any of the required features are not enabled, the current
test is skipped. If no feature flags were passed, the helper function
treats all features as enabled.

This change is needed to support environments where we only want to run
subsets of the tests. For instance, in some cases we don't want to test
LCOW at all.

The -run test command parameter offers similar functionality through
specifying a regex to filter tests. However, it does not seem feasible
to write a regex that could detect the presence of e.g. "LCOW" in both
a top-level test name, or a subtest name. Therefore, this approach is
unsuitable.

Signed-off-by: Kevin Parsons <kevpar@microsoft.com>