### PR TITLE
Change to use GetActiveProcessorCount for logical processor count

### DIFF
--- a/internal/processorinfo/processor_count.go
+++ b/internal/processorinfo/processor_count.go
@@ -6,7 +6,7 @@ import "runtime"
 // to get the total number of logical processors on the system. If this
 // fails it will fall back to runtime.NumCPU
 func ProcessorCount() int32 {
-	if amount := getMaximumProcessorCount(ALL_PROCESSOR_GROUPS); amount != 0 {
+	if amount := getActiveProcessorCount(ALL_PROCESSOR_GROUPS); amount != 0 {
 		return int32(amount)
 	}
 	return int32(runtime.NumCPU())

--- a/internal/processorinfo/syscall.go
+++ b/internal/processorinfo/syscall.go
@@ -2,7 +2,7 @@ package processorinfo
 
 //go:generate go run ../../mksyscall_windows.go -output zsyscall_windows.go syscall.go
 
-//sys getMaximumProcessorCount(groupNumber uint16) (amount uint32) = kernel32.GetMaximumProcessorCount
+//sys getActiveProcessorCount(groupNumber uint16) (amount uint32) = kernel32.GetActiveProcessorCount
 
 // Get count from all processor groups.
 // https://docs.microsoft.com/en-us/windows/win32/procthread/processor-groups

--- a/internal/processorinfo/zsyscall_windows.go
+++ b/internal/processorinfo/zsyscall_windows.go
@@ -39,11 +39,11 @@ func errnoErr(e syscall.Errno) error {
 var (
 	modkernel32 = windows.NewLazySystemDLL("kernel32.dll")
 
-	procGetMaximumProcessorCount = modkernel32.NewProc("GetMaximumProcessorCount")
+	procGetActiveProcessorCount = modkernel32.NewProc("GetActiveProcessorCount")
 )
 
-func getMaximumProcessorCount(groupNumber uint16) (amount uint32) {
-	r0, _, _ := syscall.Syscall(procGetMaximumProcessorCount.Addr(), 1, uintptr(groupNumber), 0, 0)
+func getActiveProcessorCount(groupNumber uint16) (amount uint32) {
+	r0, _, _ := syscall.Syscall(procGetActiveProcessorCount.Addr(), 1, uintptr(groupNumber), 0, 0)
 	amount = uint32(r0)
 	return
 }


### PR DESCRIPTION
* Change to use GetActiveProcessorCount instead of GetMaximumProcessorCount
as the latter takes into account hot addable CPUs.

Signed-off-by: Daniel Canter <dcanter@microsoft.com>