### PR TITLE
Fix RootVpIndex type mistake

### DIFF
--- a/internal/schema2/logical_processor.go
+++ b/internal/schema2/logical_processor.go
@@ -14,5 +14,5 @@ type LogicalProcessor struct {
 	NodeNumber  uint8  `json:"NodeNumber, omitempty"`
 	PackageId   uint32 `json:"PackageId, omitempty"`
 	CoreId      uint32 `json:"CoreId, omitempty"`
-	RootVpIndex uint32 `json:"RootVpIndex, omitempty"`
+	RootVpIndex int32  `json:"RootVpIndex, omitempty"`
 }


### PR DESCRIPTION
* In a minroot configuration, everything assigned to the VM > the hosts logical processors will return -1 for RootVpIndex so unmarshaling into an unsigned integer will fail if the virtual processor count assigned to the UVM is greater than the hosts amount, i.e if the host sees 64 LPs and 65 was assigned to the UVM the last LogicalProcessor entry would have -1 for RootVpIndex. This was an 
oversight as our schema generates uints as regular ints and when manually changing them I missed that RootVpIndex was not also a uint.

Signed-off-by: Daniel Canter <dcanter@microsoft.com>