### PR TITLE
Add DefaultVSMBOptions function and remove guestrequest parameter

### DIFF
--- a/internal/hcsoci/layers.go
+++ b/internal/hcsoci/layers.go
@@ -118,15 +118,9 @@ func MountContainerLayers(ctx context.Context, layerFolders []string, guestRoot 
 	for _, layerPath := range layerFolders[:len(layerFolders)-1] {
 		log.G(ctx).WithField("layerPath", layerPath).Debug("mounting layer")
 		if uvm.OS() == "windows" {
-			options := &hcsschema.VirtualSmbShareOptions{
-				ReadOnly:            true,
-				PseudoOplocks:       true,
-				TakeBackupPrivilege: true,
-				CacheIo:             true,
-				ShareRead:           true,
-				NoDirectmap:         uvm.DevicesPhysicallyBacked(),
-			}
-			if _, err := uvm.AddVSMB(ctx, layerPath, "", options); err != nil {
+			options := uvm.DefaultVSMBOptions(true)
+			options.TakeBackupPrivilege = true
+			if _, err := uvm.AddVSMB(ctx, layerPath, options); err != nil {
 				return "", fmt.Errorf("failed to add VSMB layer: %s", err)
 			}
 			layersAdded = append(layersAdded, layerPath)

--- a/internal/hcsoci/resources_wcow.go
+++ b/internal/hcsoci/resources_wcow.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 
 	"github.com/Microsoft/hcsshim/internal/log"
-	hcsschema "github.com/Microsoft/hcsshim/internal/schema2"
 	"github.com/Microsoft/hcsshim/internal/schemaversion"
 	"github.com/Microsoft/hcsshim/internal/uvm"
 	"github.com/Microsoft/hcsshim/internal/wclayer"
@@ -121,17 +120,8 @@ func allocateWindowsResources(ctx context.Context, coi *createOptionsInternal, r
 					r.resources = append(r.resources, pipe)
 				} else {
 					l.Debug("hcsshim::allocateWindowsResources Hot-adding VSMB share for OCI mount")
-					options := &hcsschema.VirtualSmbShareOptions{}
-					if readOnly {
-						options.ReadOnly = true
-						options.CacheIo = true
-						options.ShareRead = true
-						options.ForceLevelIIOplocks = true
-					}
-					if coi.HostingSystem.DevicesPhysicallyBacked() {
-						options.NoDirectmap = true
-					}
-					share, err := coi.HostingSystem.AddVSMB(ctx, mount.Source, "", options)
+					options := coi.HostingSystem.DefaultVSMBOptions(readOnly)
+					share, err := coi.HostingSystem.AddVSMB(ctx, mount.Source, options)
 					if err != nil {
 						return fmt.Errorf("failed to add VSMB share to utility VM for mount %+v: %s", mount, err)
 					}

--- a/internal/uvm/create_wcow.go
+++ b/internal/uvm/create_wcow.go
@@ -124,20 +124,16 @@ func CreateWCOW(ctx context.Context, opts *OptionsWCOW) (_ *UtilityVM, err error
 	// Align the requested memory size.
 	memorySizeInMB := uvm.normalizeMemorySize(ctx, opts.MemorySizeInMB)
 
+	// UVM rootfs share is readonly.
+	vsmbOpts := uvm.DefaultVSMBOptions(true)
+	vsmbOpts.TakeBackupPrivilege = true
 	virtualSMB := &hcsschema.VirtualSmb{
 		DirectFileMappingInMB: 1024, // Sensible default, but could be a tuning parameter somewhere
 		Shares: []hcsschema.VirtualSmbShare{
 			{
-				Name: "os",
-				Path: filepath.Join(uvmFolder, `UtilityVM\Files`),
-				Options: &hcsschema.VirtualSmbShareOptions{
-					ReadOnly:            true,
-					PseudoOplocks:       true,
-					TakeBackupPrivilege: true,
-					CacheIo:             true,
-					ShareRead:           true,
-					NoDirectmap:         uvm.devicesPhysicallyBacked,
-				},
+				Name:    "os",
+				Path:    filepath.Join(uvmFolder, `UtilityVM\Files`),
+				Options: vsmbOpts,
 			},
 		},
 	}

--- a/test/functional/uvm_vsmb_test.go
+++ b/test/functional/uvm_vsmb_test.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"testing"
 
-	hcsschema "github.com/Microsoft/hcsshim/internal/schema2"
 	"github.com/Microsoft/hcsshim/osversion"
 	testutilities "github.com/Microsoft/hcsshim/test/functional/utilities"
 )
@@ -22,15 +21,10 @@ func TestVSMB(t *testing.T) {
 	dir := testutilities.CreateTempDir(t)
 	defer os.RemoveAll(dir)
 	var iterations uint32 = 64
-	options := &hcsschema.VirtualSmbShareOptions{
-		ReadOnly:            true,
-		PseudoOplocks:       true,
-		TakeBackupPrivilege: true,
-		CacheIo:             true,
-		ShareRead:           true,
-	}
+	options := uvm.DefaultVSMBOptions(true)
+	options.TakeBackupPrivilege = true
 	for i := 0; i < int(iterations); i++ {
-		if _, err := uvm.AddVSMB(context.Background(), dir, "", options); err != nil {
+		if _, err := uvm.AddVSMB(context.Background(), dir, options); err != nil {
 			t.Fatalf("AddVSMB failed: %s", err)
 		}
 	}


### PR DESCRIPTION
* As we use almost the same set of VSMB options throughout the codebase,
this consolidates the settings into a single function instead of having to
set them manually each time.
* Remove guestrequest object from VSMBShare struct and AddVSMB as it isnt used
anywhere.

Signed-off-by: Daniel Canter <dcanter@microsoft.com>