### PR TITLE
Add uvmPath string arg to AddVSMB

### DIFF
--- a/internal/hcsoci/layers.go
+++ b/internal/hcsoci/layers.go
@@ -120,7 +120,7 @@ func MountContainerLayers(ctx context.Context, layerFolders []string, guestRoot 
 		if uvm.OS() == "windows" {
 			options := uvm.DefaultVSMBOptions(true)
 			options.TakeBackupPrivilege = true
-			if _, err := uvm.AddVSMB(ctx, layerPath, options); err != nil {
+			if _, err := uvm.AddVSMB(ctx, layerPath, "", options); err != nil {
 				return "", fmt.Errorf("failed to add VSMB layer: %s", err)
 			}
 			layersAdded = append(layersAdded, layerPath)

--- a/internal/hcsoci/resources_wcow.go
+++ b/internal/hcsoci/resources_wcow.go
@@ -121,7 +121,7 @@ func allocateWindowsResources(ctx context.Context, coi *createOptionsInternal, r
 				} else {
 					l.Debug("hcsshim::allocateWindowsResources Hot-adding VSMB share for OCI mount")
 					options := coi.HostingSystem.DefaultVSMBOptions(readOnly)
-					share, err := coi.HostingSystem.AddVSMB(ctx, mount.Source, options)
+					share, err := coi.HostingSystem.AddVSMB(ctx, mount.Source, "", options)
 					if err != nil {
 						return fmt.Errorf("failed to add VSMB share to utility VM for mount %+v: %s", mount, err)
 					}

--- a/test/functional/uvm_vsmb_test.go
+++ b/test/functional/uvm_vsmb_test.go
@@ -24,7 +24,7 @@ func TestVSMB(t *testing.T) {
 	options := uvm.DefaultVSMBOptions(true)
 	options.TakeBackupPrivilege = true
 	for i := 0; i < int(iterations); i++ {
-		if _, err := uvm.AddVSMB(context.Background(), dir, options); err != nil {
+		if _, err := uvm.AddVSMB(context.Background(), dir, "", options); err != nil {
 			t.Fatalf("AddVSMB failed: %s", err)
 		}
 	}


### PR DESCRIPTION
* To follow in line with other mounts, and to replace the guest request
argument that used to be in its place and was never used, added a uvmPath argument that if not
an empty string will be used for a MappedDirectory guest request.

Signed-off-by: Daniel Canter <dcanter@microsoft.com>