### PR TITLE
Remove VSMB GuestPath func

### DIFF
--- a/internal/uvm/vsmb.go
+++ b/internal/uvm/vsmb.go
@@ -32,12 +32,6 @@ func (vsmb *VSMBShare) Release(ctx context.Context) error {
 	return nil
 }
 
-// GuestPath returns the location of the vsmb share in the UVM. This avoids having to
-// call GetVSMBUvmPath if you already have a share object and not just a hostpath.
-func (vsmb *VSMBShare) GuestPath() string {
-	return vsmb.guestPath
-}
-
 // DefaultVSMBOptions returns the default VSMB options. If readOnly is specified,
 // returns the default VSMB options for a readonly share.
 func (uvm *UtilityVM) DefaultVSMBOptions(readOnly bool) *hcsschema.VirtualSmbShareOptions {


### PR DESCRIPTION
This was recently added with https://github.com/microsoft/hcsshim/pull/829. 

However, in the case of the single file mount case for VSMB, this function will only return the path to the directory containing the single file in the UVM. Therefore, the caller would either need to construct the full path with the single file's name or we would need to update this function to take a hostpath, neither of which are desirable. Since we already have functionality to handle getting the full UVM path for both single files and mounted directories, `GetVSMBUvmPath`, just remove the unnecessary `GuestPath` function. 

Signed-off-by: Kathryn Baldauf <kabaldau@microsoft.com>