### PR TITLE
Update codeowners to proper format for hcn directory

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,3 @@
 * @microsoft/containerplat
 
-/hcn/* @nagiesek
+/hcn/ @nagiesek


### PR DESCRIPTION
Recent PRs for /hcn have not added anyone as automatic reviewers despite our codeowners file. This PR attempts to fix that issue, following docs [here](https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax)

Signed-off-by: Kathryn Baldauf <kabaldau@microsoft.com>