### PR TITLE
AppVeyor: test with Go 1.15.2

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,7 @@ environment:
   GOPATH: c:\gopath
   PATH: "%GOPATH%\\bin;C:\\gometalinter-2.0.12-windows-amd64;%PATH%"
 
-stack: go 1.13.4
+stack: go 1.15.2
 
 build_script:
   - appveyor DownloadFile https://github.com/alecthomas/gometalinter/releases/download/v2.0.12/gometalinter-2.0.12-windows-amd64.zip


### PR DESCRIPTION
I noticed that this failed to compile on the containerd repository (https://github.com/containerd/containerd/pull/4050#issuecomment-648796901);

```
HEAD is now at 5bc557d Added Version support for IPv6 Dual stack support in HNS
+ GO111MODULE=on
+ go build -mod=vendor -o /d/a/containerd/containerd/src/github.com/containerd/containerd/containerd-shim-runhcs-v1.exe ./cmd/containerd-shim-runhcs-v1
# github.com/Microsoft/hcsshim/cmd/containerd-shim-runhcs-v1
panic: runtime error: slice bounds out of range [128:0]

goroutine 1 [running]:
cmd/link/internal/ld.addpersrc(0xc00008d500)
	c:/go/src/cmd/link/internal/ld/pe.go:1490 +0x33d
cmd/link/internal/ld.Asmbpe(0xc00008d500)
	c:/go/src/cmd/link/internal/ld/pe.go:1568 +0x253
cmd/link/internal/amd64.asmb2(0xc00008d500)
	c:/go/src/cmd/link/internal/amd64/asm.go:842 +0xfa
cmd/link/internal/ld.Main(0x135f860, 0x20, 0x20, 0x1, 0x7, 0x10, 0x0, 0x0, 0x11bf875, 0x1b, ...)
	c:/go/src/cmd/link/internal/ld/main.go:349 +0x1509
main.main()
	c:/go/src/cmd/link/main.go:68 +0x1fc
##[error]Process completed with exit code 2.
```


Opening a draft PR here to see if the problem reproduces in this repository (and if it's a bug in this code, or if there's a bug in Golang)

/cc @kevpar @jterry75