### PR TITLE
Remove block on processor weight/maximum for WCOW process-isolated

### DIFF
--- a/internal/hcsoci/hcsdoc_wcow.go
+++ b/internal/hcsoci/hcsdoc_wcow.go
@@ -108,25 +108,10 @@ func createWindowsContainerDocument(ctx context.Context, coi *createOptionsInter
 		v1.ProcessorMaximum = int64(cpuLimit)
 		v1.ProcessorWeight = uint64(cpuWeight)
 
-		if cpuCount == 0 {
-			// TODO: JTERRY75 - There is a Windows platform bug (VSO#20891779)
-			// for V2 that we cannot set Maximum or Weight. We have to silently
-			// ignore here until its fixed. When the bug is fixed fully remove
-			// this if/else and always assign the v2Container.Processor field.
-			l := log.G(ctx).WithField(logfields.ContainerID, coi.ID)
-			if coi.HostingSystem != nil {
-				l.Data[logfields.UVMID] = coi.HostingSystem.ID()
-			}
-			l.WithFields(logrus.Fields{
-				"limit":  cpuLimit,
-				"weight": cpuWeight,
-			}).Warning("silently ignoring Windows Process Container QoS for limit or weight until bug fix")
-		} else {
-			v2Container.Processor = &hcsschema.Processor{
-				Count: cpuCount,
-				// Maximum: cpuLimit, // TODO: JTERRY75 - When the above bug is fixed remove this if/else and set this value.
-				// Weight:  cpuWeight, // TODO: JTERRY75 - When the above bug is fixed remove this if/else and set this value.
-			}
+		v2Container.Processor = &hcsschema.Processor{
+			Count:   cpuCount,
+			Maximum: cpuLimit,
+			Weight:  cpuWeight,
 		}
 	}
 


### PR DESCRIPTION
Previously there was an OS bug that prevented processor weight/maximum
from working properly. This has now been fixed and backported to 1809+,
so it is safe to remove this block.

Signed-off-by: Kevin Parsons <kevpar@microsoft.com>

@jterry75 FYI