### PR TITLE
Change image timestamp test to use 19H1 runtime class

### DIFF
--- a/test/cri-containerd/pullimage_test.go
+++ b/test/cri-containerd/pullimage_test.go
@@ -54,7 +54,7 @@ func Test_PullImageTimestamps(t *testing.T) {
 				Namespace: testNamespace,
 			},
 		},
-		RuntimeHandler: wcowHypervisorRuntimeHandler,
+		RuntimeHandler: wcowHypervisor18362RuntimeHandler,
 	}
 
 	podID := runPodSandbox(t, client, ctx, sandboxRequest)


### PR DESCRIPTION
This test involves running a 19H1-based image, and previously used
the wcow-hypervisor runtime class which uses the host OS version. This
caused the test to fail to run on RS5. This change fixes this by
explicitly using the 19H1 runtime class.

Signed-off-by: Kevin Parsons <kevpar@microsoft.com>