### PR TITLE
Fix comment on CreateScratchLayer

### DIFF
--- a/internal/wclayer/createscratchlayer.go
+++ b/internal/wclayer/createscratchlayer.go
@@ -10,9 +10,7 @@ import (
 )
 
 // CreateScratchLayer creates and populates new read-write layer for use by a container.
-// This requires both the id of the direct parent layer, as well as the full list
-// of paths to all parent layers up to the base (and including the direct parent
-// whose id was provided).
+// This requires the full list of paths to all parent layers up to the base
 func CreateScratchLayer(ctx context.Context, path string, parentLayerPaths []string) (err error) {
 	title := "hcsshim::CreateScratchLayer"
 	ctx, span := trace.StartSpan(ctx, title)


### PR DESCRIPTION
CreateScratchLayer doesn't take a parent id anymore, just the list of parent layer paths, since #183 in 0.7.0