### PR TITLE
Add Windows V19H2 (1909) to builds list

### DIFF
--- a/osversion/windowsbuilds.go
+++ b/osversion/windowsbuilds.go
@@ -25,6 +25,10 @@ const (
 	// channel).
 	V19H1 = 18362
 
+	// V19H2 (version 1909) corresponds to Windows Server 1909 (semi-annual
+	// channel).
+	V19H2 = 18363
+
 	// V20H1 (version 2004) corresponds to Windows Server 2004 (semi-annual
 	// channel).
 	V20H1 = 19041


### PR DESCRIPTION
It's not "semi-annual" if you're 12 months apart.

Mainly useful for vendoring, no tests currently distinguish V19H2 behaviour.