### PR TITLE
Fix VSMB to not mix up rw/ro shares

### DIFF
--- a/cmd/containerd-shim-runhcs-v1/task_wcow_podsandbox.go
+++ b/cmd/containerd-shim-runhcs-v1/task_wcow_podsandbox.go
@@ -248,7 +248,7 @@ func (wpst *wcowPodSandboxTask) Share(ctx context.Context, req *shimdiag.ShareRe
 	if err != nil {
 		return err
 	}
-	sharePath, err := wpst.host.GetVSMBUvmPath(ctx, req.HostPath)
+	sharePath, err := wpst.host.GetVSMBUvmPath(ctx, req.HostPath, req.ReadOnly)
 	if err != nil {
 		return err
 	}

--- a/internal/hcsoci/hcsdoc_wcow.go
+++ b/internal/hcsoci/hcsdoc_wcow.go
@@ -255,7 +255,7 @@ func createWindowsContainerDocument(ctx context.Context, coi *createOptionsInter
 			if coi.HostingSystem == nil {
 				mdv2.HostPath = mount.Source
 			} else {
-				uvmPath, err := coi.HostingSystem.GetVSMBUvmPath(ctx, mount.Source)
+				uvmPath, err := coi.HostingSystem.GetVSMBUvmPath(ctx, mount.Source, readOnly)
 				if err != nil {
 					if err == uvm.ErrNotAttached {
 						// It could also be a scsi mount.

--- a/internal/hcsoci/layers.go
+++ b/internal/hcsoci/layers.go
@@ -96,7 +96,7 @@ func MountContainerLayers(ctx context.Context, layerFolders []string, guestRoot 
 		if err != nil {
 			if uvm.OS() == "windows" {
 				for _, l := range layersAdded {
-					if err := uvm.RemoveVSMB(ctx, l); err != nil {
+					if err := uvm.RemoveVSMB(ctx, l, true); err != nil {
 						log.G(ctx).WithError(err).Warn("failed to remove wcow layer on cleanup")
 					}
 				}
@@ -265,7 +265,7 @@ func UnmountContainerLayers(ctx context.Context, layerFolders []string, containe
 	// to share layers.
 	if uvm.OS() == "windows" && (op&UnmountOperationVSMB) == UnmountOperationVSMB {
 		for _, layerPath := range layerFolders[:len(layerFolders)-1] {
-			if e := uvm.RemoveVSMB(ctx, layerPath); e != nil {
+			if e := uvm.RemoveVSMB(ctx, layerPath, true); e != nil {
 				log.G(ctx).WithError(e).Warn("remove VSMB failed")
 				if retError == nil {
 					retError = e
@@ -304,7 +304,7 @@ func UnmountContainerLayers(ctx context.Context, layerFolders []string, containe
 
 func computeV2Layers(ctx context.Context, vm *uvm.UtilityVM, paths []string) (layers []hcsschema.Layer, err error) {
 	for _, path := range paths {
-		uvmPath, err := vm.GetVSMBUvmPath(ctx, path)
+		uvmPath, err := vm.GetVSMBUvmPath(ctx, path, true)
 		if err != nil {
 			return nil, err
 		}

--- a/test/cri-containerd/createcontainer_test.go
+++ b/test/cri-containerd/createcontainer_test.go
@@ -1168,7 +1168,7 @@ func Test_CreateContainer_Mount_EmptyDir_WCOW(t *testing.T) {
 		t.Fatalf("Failed to create kubernetes.io~empty-dir volume path: %s", err)
 	}
 
-	containerFilePath := "C:\\foo"
+	containerFilePath := `C:\foo`
 
 	request := &runtime.CreateContainerRequest{
 		Config: &runtime.ContainerConfig{
@@ -1192,6 +1192,91 @@ func Test_CreateContainer_Mount_EmptyDir_WCOW(t *testing.T) {
 		},
 	}
 	runCreateContainerTest(t, wcowHypervisorRuntimeHandler, request)
+}
+
+func Test_Mount_ReadOnlyDirReuse_WCOW(t *testing.T) {
+	requireFeatures(t, featureWCOWHypervisor)
+
+	client := newTestRuntimeClient(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	pullRequiredImages(t, []string{imageWindowsNanoserver})
+
+	containerPath := `C:\foo`
+
+	tempDir, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %s", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	sandboxRequest := &runtime.RunPodSandboxRequest{
+		Config: &runtime.PodSandboxConfig{
+			Metadata: &runtime.PodSandboxMetadata{
+				Name:      t.Name() + "-Sandbox",
+				Namespace: testNamespace,
+			},
+		},
+		RuntimeHandler: wcowHypervisorRuntimeHandler,
+	}
+
+	podID := runPodSandbox(t, client, ctx, sandboxRequest)
+	defer removePodSandbox(t, client, ctx, podID)
+	defer stopPodSandbox(t, client, ctx, podID)
+
+	request := &runtime.CreateContainerRequest{
+		PodSandboxId: podID,
+		Config: &runtime.ContainerConfig{
+			Metadata: &runtime.ContainerMetadata{},
+			Image: &runtime.ImageSpec{
+				Image: imageWindowsNanoserver,
+			},
+			Command: []string{
+				"ping",
+				"-t",
+				"127.0.0.1",
+			},
+			Mounts: []*runtime.Mount{
+				{
+					HostPath:      tempDir,
+					ContainerPath: containerPath,
+				},
+			},
+		},
+		SandboxConfig: sandboxRequest.Config,
+	}
+
+	request.Config.Metadata.Name = request.Config.Metadata.Name + "-ro"
+	request.Config.Mounts[0].Readonly = true
+	c_ro := createContainer(t, client, ctx, request)
+	defer removeContainer(t, client, ctx, c_ro)
+	startContainer(t, client, ctx, c_ro)
+	defer stopContainer(t, client, ctx, c_ro)
+
+	request.Config.Metadata.Name = request.Config.Metadata.Name + "-rw"
+	request.Config.Mounts[0].Readonly = false
+	c_rw := createContainer(t, client, ctx, request)
+	defer removeContainer(t, client, ctx, c_rw)
+	startContainer(t, client, ctx, c_rw)
+	defer stopContainer(t, client, ctx, c_rw)
+
+	filePath := containerPath + `\tmp.txt`
+	execCommand := []string{"cmd", "/c", "echo foo", ">", filePath}
+
+	_, errorMsg, exitCode := execContainer(t, client, ctx, c_rw, execCommand)
+
+	// Writing a file to the rw container mount should succeed.
+	if exitCode != 0 || len(errorMsg) > 0 {
+		t.Fatalf("Failed to write file to rw container mount: %s, exitcode: %v\n", errorMsg, exitCode)
+	}
+
+	_, errorMsg, exitCode = execContainer(t, client, ctx, c_ro, execCommand)
+
+	// Writing a file to the ro container mount should fail.
+	if exitCode == 0 && len(errorMsg) == 0 {
+		t.Fatalf("Wrote file to ro container mount, should have failed: %s, exitcode: %v\n", errorMsg, exitCode)
+	}
 }
 
 func Test_CreateContainer_Mount_NamedPipe_WCOW(t *testing.T) {

--- a/test/functional/uvm_vsmb_test.go
+++ b/test/functional/uvm_vsmb_test.go
@@ -31,7 +31,7 @@ func TestVSMB(t *testing.T) {
 
 	// Remove them all
 	for i := 0; i < int(iterations); i++ {
-		if err := uvm.RemoveVSMB(context.Background(), dir); err != nil {
+		if err := uvm.RemoveVSMB(context.Background(), dir, true); err != nil {
 			t.Fatalf("RemoveVSMB failed: %s", err)
 		}
 	}


### PR DESCRIPTION
The VSMB code attempts to create as few actual shares as possible. This
is done by ref-counting existing shares so that if the same directory is
shared again, the old share is used instead. However, the mechanism for
looking up an existing share currently only keys off of the share path.
This has the unfortunate affect that a read-only share can be repurposed
as a read-write share.

I first looked at fixing this by more broadly refactoring the VSMB code,
with the aim of not only fixing this bug, but also removing some of the
hacks that were put in place to support single-file mapping. However,
that work ended up complicating things a lot, so I think other cleanup
work will need to be done first before that broader refactoring can
be merged.

As a more immediate and tactical fix, I have now simply changed the way
we create keys to look for an existing VSMB share. The key now includes
both the host path and the rw/ro state of the share. This should allow
for read-only and read-write shares of the same directory to coexist.

One consequence of this change is that operations like RemoveVSMB and
GetVSMBUvmPath now need to know the rw/ro state of the share, so they
can operate on the correct share. To resolve this, I have added a
readOnly parameter to the signatures of these functions, and updated the
callers to pass the correct value in.

Signed-off-by: Kevin Parsons <kevpar@microsoft.com>