### PR TITLE
Refactor code in hcsoci into logical packages

### DIFF
--- a/cmd/containerd-shim-runhcs-v1/exec_hcs.go
+++ b/cmd/containerd-shim-runhcs-v1/exec_hcs.go
@@ -6,9 +6,9 @@ import (
 	"sync"
 	"time"
 
+	"github.com/Microsoft/hcsshim/internal/cmd"
 	"github.com/Microsoft/hcsshim/internal/cow"
 	"github.com/Microsoft/hcsshim/internal/guestrequest"
-	"github.com/Microsoft/hcsshim/internal/hcsoci"
 	"github.com/Microsoft/hcsshim/internal/log"
 	"github.com/Microsoft/hcsshim/internal/signals"
 	"github.com/Microsoft/hcsshim/internal/uvm"
@@ -49,7 +49,7 @@ func newHcsExec(
 	id, bundle string,
 	isWCOW bool,
 	spec *specs.Process,
-	io hcsoci.UpstreamIO) shimExec {
+	io cmd.UpstreamIO) shimExec {
 	log.G(ctx).WithFields(logrus.Fields{
 		"tid":    tid,
 		"eid":    id, // Init exec ID is always same as Task ID
@@ -118,7 +118,7 @@ type hcsExec struct {
 	// create time in order to be valid.
 	//
 	// This MUST be treated as read only in the lifetime of the exec.
-	io              hcsoci.UpstreamIO
+	io              cmd.UpstreamIO
 	processDone     chan struct{}
 	processDoneOnce sync.Once
 
@@ -129,7 +129,7 @@ type hcsExec struct {
 	pid        int
 	exitStatus uint32
 	exitedAt   time.Time
-	p          *hcsoci.Cmd
+	p          *cmd.Cmd
 
 	// exited is a wait block which waits async for the process to exit.
 	exited     chan struct{}
@@ -205,7 +205,7 @@ func (he *hcsExec) Start(ctx context.Context) (err error) {
 			}
 		}()
 	}
-	cmd := &hcsoci.Cmd{
+	cmd := &cmd.Cmd{
 		Host:   he.c,
 		Stdin:  he.io.Stdin(),
 		Stdout: he.io.Stdout(),

--- a/cmd/containerd-shim-runhcs-v1/task_wcow_podsandbox.go
+++ b/cmd/containerd-shim-runhcs-v1/task_wcow_podsandbox.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/Microsoft/hcsshim/cmd/containerd-shim-runhcs-v1/options"
 	"github.com/Microsoft/hcsshim/cmd/containerd-shim-runhcs-v1/stats"
+	"github.com/Microsoft/hcsshim/internal/cmd"
 	"github.com/Microsoft/hcsshim/internal/guestrequest"
-	"github.com/Microsoft/hcsshim/internal/hcsoci"
 	"github.com/Microsoft/hcsshim/internal/log"
 	"github.com/Microsoft/hcsshim/internal/requesttype"
 	hcsschema "github.com/Microsoft/hcsshim/internal/schema2"
@@ -224,7 +224,7 @@ func (wpst *wcowPodSandboxTask) ExecInHost(ctx context.Context, req *shimdiag.Ex
 	if wpst.host == nil {
 		return 0, errors.New("task is not isolated")
 	}
-	return hcsoci.ExecInUvm(ctx, wpst.host, req)
+	return cmd.ExecInUvm(ctx, wpst.host, req)
 }
 
 func (wpst *wcowPodSandboxTask) DumpGuestStacks(ctx context.Context) string {

--- a/cmd/runhcs/shim.go
+++ b/cmd/runhcs/shim.go
@@ -13,8 +13,8 @@ import (
 
 	winio "github.com/Microsoft/go-winio"
 	"github.com/Microsoft/hcsshim/internal/appargs"
+	cmdpkg "github.com/Microsoft/hcsshim/internal/cmd"
 	"github.com/Microsoft/hcsshim/internal/hcs"
-	"github.com/Microsoft/hcsshim/internal/hcsoci"
 	"github.com/Microsoft/hcsshim/internal/runhcs"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/sirupsen/logrus"
@@ -162,7 +162,7 @@ var shimCommand = cli.Command{
 		}
 
 		// Create the process in the container.
-		cmd := &hcsoci.Cmd{
+		cmd := &cmdpkg.Cmd{
 			Host:   c.hc,
 			Stdin:  stdin,
 			Stdout: stdout,

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -1,4 +1,6 @@
-package hcsoci
+// Package cmd provides functionality used to execute commands inside of containers
+// or UVMs, and to connect an upstream client to those commands for handling in/out/err IO.
+package cmd
 
 import (
 	"bytes"

--- a/internal/cmd/cmd_test.go
+++ b/internal/cmd/cmd_test.go
@@ -1,6 +1,6 @@
 // build +windows
 
-package hcsoci
+package cmd
 
 import (
 	"bytes"

--- a/internal/cmd/diag.go
+++ b/internal/cmd/diag.go
@@ -1,4 +1,4 @@
-package hcsoci
+package cmd
 
 import (
 	"context"

--- a/internal/cmd/io.go
+++ b/internal/cmd/io.go
@@ -1,4 +1,4 @@
-package hcsoci
+package cmd
 
 import (
 	"context"

--- a/internal/cmd/io_npipe.go
+++ b/internal/cmd/io_npipe.go
@@ -1,4 +1,4 @@
-package hcsoci
+package cmd
 
 import (
 	"context"

--- a/internal/credentials/credentials.go
+++ b/internal/credentials/credentials.go
@@ -1,6 +1,9 @@
 // +build windows
 
-package hcsoci
+// Package credentials holds the necessary structs and functions for adding
+// and removing Container Credential Guard instances (shortened to CCG
+// normally) for V2 HCS schema containers.
+package credentials
 
 import (
 	"context"
@@ -13,9 +16,7 @@ import (
 	hcsschema "github.com/Microsoft/hcsshim/internal/schema2"
 )
 
-// This file holds the necessary structs and functions for adding and removing Container
-// Credential Guard instances (shortened to CCG normally) for V2 HCS schema
-// containers. Container Credential Guard is in HCS's own words "The solution to
+// Container Credential Guard is in HCS's own words "The solution to
 // allowing windows containers to have access to domain credentials for the
 // applications running in their corresponding guest." It essentially acts as
 // a way to temporarily Active Directory join a given container with a Group

--- a/internal/hcsoci/create.go
+++ b/internal/hcsoci/create.go
@@ -15,6 +15,7 @@ import (
 	"github.com/Microsoft/hcsshim/internal/hcs"
 	"github.com/Microsoft/hcsshim/internal/log"
 	"github.com/Microsoft/hcsshim/internal/oci"
+	"github.com/Microsoft/hcsshim/internal/resources"
 	hcsschema "github.com/Microsoft/hcsshim/internal/schema2"
 	"github.com/Microsoft/hcsshim/internal/schemaversion"
 	"github.com/Microsoft/hcsshim/internal/uvm"
@@ -68,7 +69,7 @@ type createOptionsInternal struct {
 // case of an error. This provides support for the debugging option not to
 // release the resources on failure, so that the client can make the necessary
 // call to release resources that have been allocated as part of calling this function.
-func CreateContainer(ctx context.Context, createOptions *CreateOptions) (_ cow.Container, _ *Resources, err error) {
+func CreateContainer(ctx context.Context, createOptions *CreateOptions) (_ cow.Container, _ *resources.Resources, err error) {
 	coi := &createOptionsInternal{
 		CreateOptions: createOptions,
 		actualID:      createOptions.ID,
@@ -103,13 +104,11 @@ func CreateContainer(ctx context.Context, createOptions *CreateOptions) (_ cow.C
 		"schema":  coi.actualSchemaVersion,
 	}).Debug("hcsshim::CreateContainer")
 
-	resources := &Resources{
-		id: createOptions.ID,
-	}
+	r := resources.NewContainerResources(createOptions.ID)
 	defer func() {
 		if err != nil {
 			if !coi.DoNotReleaseResourcesOnFailure {
-				ReleaseResources(ctx, resources, coi.HostingSystem, true)
+				resources.ReleaseResources(ctx, r, coi.HostingSystem, true)
 			}
 		}
 	}()
@@ -117,9 +116,9 @@ func CreateContainer(ctx context.Context, createOptions *CreateOptions) (_ cow.C
 	if coi.HostingSystem != nil {
 		n := coi.HostingSystem.ContainerCounter()
 		if coi.Spec.Linux != nil {
-			resources.containerRootInUVM = fmt.Sprintf(lcowRootInUVM, createOptions.ID)
+			r.SetContainerRootInUVM(fmt.Sprintf(lcowRootInUVM, createOptions.ID))
 		} else {
-			resources.containerRootInUVM = fmt.Sprintf(wcowRootInUVM, strconv.FormatUint(n, 16))
+			r.SetContainerRootInUVM(fmt.Sprintf(wcowRootInUVM, strconv.FormatUint(n, 16)))
 		}
 	}
 
@@ -129,18 +128,18 @@ func CreateContainer(ctx context.Context, createOptions *CreateOptions) (_ cow.C
 		schemaversion.IsV21(coi.actualSchemaVersion) {
 
 		if coi.NetworkNamespace != "" {
-			resources.netNS = coi.NetworkNamespace
+			r.SetNetNS(coi.NetworkNamespace)
 		} else {
-			err := createNetworkNamespace(ctx, coi, resources)
+			err := createNetworkNamespace(ctx, coi, r)
 			if err != nil {
-				return nil, resources, err
+				return nil, r, err
 			}
 		}
-		coi.actualNetworkNamespace = resources.netNS
+		coi.actualNetworkNamespace = r.NetNS()
 		if coi.HostingSystem != nil {
 			ct, _, err := oci.GetSandboxTypeAndID(coi.Spec.Annotations)
 			if err != nil {
-				return nil, resources, err
+				return nil, r, err
 			}
 			// Only add the network namespace to a standalone or sandbox
 			// container but not a workload container in a sandbox that inherits
@@ -148,19 +147,19 @@ func CreateContainer(ctx context.Context, createOptions *CreateOptions) (_ cow.C
 			if ct == oci.KubernetesContainerTypeNone || ct == oci.KubernetesContainerTypeSandbox {
 				endpoints, err := GetNamespaceEndpoints(ctx, coi.actualNetworkNamespace)
 				if err != nil {
-					return nil, resources, err
+					return nil, r, err
 				}
 				err = coi.HostingSystem.AddNetNS(ctx, coi.actualNetworkNamespace)
 				if err != nil {
-					return nil, resources, err
+					return nil, r, err
 				}
 				err = coi.HostingSystem.AddEndpointsToNS(ctx, coi.actualNetworkNamespace, endpoints)
 				if err != nil {
 					// Best effort clean up the NS
 					coi.HostingSystem.RemoveNetNS(ctx, coi.actualNetworkNamespace)
-					return nil, resources, err
+					return nil, r, err
 				}
-				resources.addedNetNSToVM = true
+				r.SetAddedNetNSToVM(true)
 			}
 		}
 	}
@@ -169,30 +168,30 @@ func CreateContainer(ctx context.Context, createOptions *CreateOptions) (_ cow.C
 	log.G(ctx).Debug("hcsshim::CreateContainer allocating resources")
 	if coi.Spec.Linux != nil {
 		if schemaversion.IsV10(coi.actualSchemaVersion) {
-			return nil, resources, errors.New("LCOW v1 not supported")
+			return nil, r, errors.New("LCOW v1 not supported")
 		}
 		log.G(ctx).Debug("hcsshim::CreateContainer allocateLinuxResources")
-		err = allocateLinuxResources(ctx, coi, resources)
+		err = allocateLinuxResources(ctx, coi, r)
 		if err != nil {
 			log.G(ctx).WithError(err).Debug("failed to allocateLinuxResources")
-			return nil, resources, err
+			return nil, r, err
 		}
-		gcsDocument, err = createLinuxContainerDocument(ctx, coi, resources.containerRootInUVM)
+		gcsDocument, err = createLinuxContainerDocument(ctx, coi, r.ContainerRootInUVM())
 		if err != nil {
 			log.G(ctx).WithError(err).Debug("failed createHCSContainerDocument")
-			return nil, resources, err
+			return nil, r, err
 		}
 	} else {
-		err = allocateWindowsResources(ctx, coi, resources)
+		err = allocateWindowsResources(ctx, coi, r)
 		if err != nil {
 			log.G(ctx).WithError(err).Debug("failed to allocateWindowsResources")
-			return nil, resources, err
+			return nil, r, err
 		}
 		log.G(ctx).Debug("hcsshim::CreateContainer creating container document")
 		v1, v2, err := createWindowsContainerDocument(ctx, coi)
 		if err != nil {
 			log.G(ctx).WithError(err).Debug("failed createHCSContainerDocument")
-			return nil, resources, err
+			return nil, r, err
 		}
 
 		if schemaversion.IsV10(coi.actualSchemaVersion) {
@@ -219,16 +218,16 @@ func CreateContainer(ctx context.Context, createOptions *CreateOptions) (_ cow.C
 	if gcsDocument != nil {
 		c, err := coi.HostingSystem.CreateContainer(ctx, coi.actualID, gcsDocument)
 		if err != nil {
-			return nil, resources, err
+			return nil, r, err
 		}
-		return c, resources, nil
+		return c, r, nil
 	}
 
 	system, err := hcs.CreateComputeSystem(ctx, coi.actualID, hcsDocument)
 	if err != nil {
-		return nil, resources, err
+		return nil, r, err
 	}
-	return system, resources, nil
+	return system, r, nil
 }
 
 // isV2Xenon returns true if the create options are for a HCS schema V2 xenon container

--- a/internal/hcsoci/hcsdoc_wcow.go
+++ b/internal/hcsoci/hcsdoc_wcow.go
@@ -10,11 +10,11 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/Microsoft/hcsshim/internal/processorinfo"
-
+	"github.com/Microsoft/hcsshim/internal/layers"
 	"github.com/Microsoft/hcsshim/internal/log"
 	"github.com/Microsoft/hcsshim/internal/logfields"
 	"github.com/Microsoft/hcsshim/internal/oci"
+	"github.com/Microsoft/hcsshim/internal/processorinfo"
 	"github.com/Microsoft/hcsshim/internal/schema1"
 	hcsschema "github.com/Microsoft/hcsshim/internal/schema2"
 	"github.com/Microsoft/hcsshim/internal/uvm"
@@ -208,7 +208,7 @@ func createWindowsContainerDocument(ctx context.Context, coi *createOptionsInter
 		// Hosting system was supplied, so is v2 Xenon.
 		v2Container.Storage.Path = coi.Spec.Root.Path
 		if coi.HostingSystem.OS() == "windows" {
-			layers, err := computeV2Layers(ctx, coi.HostingSystem, coi.Spec.Windows.LayerFolders[:len(coi.Spec.Windows.LayerFolders)-1])
+			layers, err := layers.GetHCSLayers(ctx, coi.HostingSystem, coi.Spec.Windows.LayerFolders[:len(coi.Spec.Windows.LayerFolders)-1])
 			if err != nil {
 				return nil, nil, err
 			}

--- a/internal/hcsoci/network.go
+++ b/internal/hcsoci/network.go
@@ -6,11 +6,12 @@ import (
 	"github.com/Microsoft/hcsshim/internal/hns"
 	"github.com/Microsoft/hcsshim/internal/log"
 	"github.com/Microsoft/hcsshim/internal/logfields"
+	"github.com/Microsoft/hcsshim/internal/resources"
 	"github.com/Microsoft/hcsshim/internal/uvm"
 	"github.com/sirupsen/logrus"
 )
 
-func createNetworkNamespace(ctx context.Context, coi *createOptionsInternal, resources *Resources) error {
+func createNetworkNamespace(ctx context.Context, coi *createOptionsInternal, r *resources.Resources) error {
 	op := "hcsoci::createNetworkNamespace"
 	l := log.G(ctx).WithField(logfields.ContainerID, coi.ID)
 	l.Debug(op + " - Begin")
@@ -26,8 +27,8 @@ func createNetworkNamespace(ctx context.Context, coi *createOptionsInternal, res
 		"netID":               netID,
 		logfields.ContainerID: coi.ID,
 	}).Info("created network namespace for container")
-	resources.netNS = netID
-	resources.createdNetNS = true
+	r.SetNetNS(netID)
+	r.SetCreatedNetNS(true)
 	endpoints := make([]string, 0)
 	for _, endpointID := range coi.Spec.Windows.Network.EndpointList {
 		err = hns.AddNamespaceEndpoint(netID, endpointID)
@@ -40,7 +41,7 @@ func createNetworkNamespace(ctx context.Context, coi *createOptionsInternal, res
 		}).Info("added network endpoint to namespace")
 		endpoints = append(endpoints, endpointID)
 	}
-	resources.resources = append(resources.resources, &uvm.NetworkEndpoints{EndpointIDs: endpoints, Namespace: netID})
+	r.Add(&uvm.NetworkEndpoints{EndpointIDs: endpoints, Namespace: netID})
 	return nil
 }
 

--- a/internal/hcsoci/resources_lcow.go
+++ b/internal/hcsoci/resources_lcow.go
@@ -12,18 +12,14 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/Microsoft/hcsshim/internal/layers"
 	"github.com/Microsoft/hcsshim/internal/log"
 	"github.com/Microsoft/hcsshim/internal/oci"
+	"github.com/Microsoft/hcsshim/internal/resources"
 	"github.com/Microsoft/hcsshim/internal/uvm"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
 )
-
-const lcowMountPathPrefix = "/mounts/m%d"
-const lcowGlobalMountPrefix = "/run/mounts/m%d"
-
-// keep lcowNvidiaMountPath value in sync with opengcs
-const lcowNvidiaMountPath = "/run/nvidia"
 
 // getGPUVHDPath gets the gpu vhd path from the shim options or uses the default if no
 // shim option is set. Right now we only support Nvidia gpus, so this will default to
@@ -39,34 +35,31 @@ func getGPUVHDPath(coi *createOptionsInternal) (string, error) {
 	return gpuVHDPath, nil
 }
 
-func allocateLinuxResources(ctx context.Context, coi *createOptionsInternal, r *Resources) error {
+func allocateLinuxResources(ctx context.Context, coi *createOptionsInternal, r *resources.Resources) error {
 	if coi.Spec.Root == nil {
 		coi.Spec.Root = &specs.Root{}
 	}
+	containerRootInUVM := r.ContainerRootInUVM()
 	if coi.Spec.Windows != nil && len(coi.Spec.Windows.LayerFolders) > 0 {
 		log.G(ctx).Debug("hcsshim::allocateLinuxResources mounting storage")
-		rootPath, err := MountContainerLayers(ctx, coi.Spec.Windows.LayerFolders, r.containerRootInUVM, coi.HostingSystem)
+		rootPath, err := layers.MountContainerLayers(ctx, coi.Spec.Windows.LayerFolders, containerRootInUVM, coi.HostingSystem)
 		if err != nil {
 			return fmt.Errorf("failed to mount container storage: %s", err)
 		}
 		coi.Spec.Root.Path = rootPath
-		layers := &ImageLayers{
-			vm:                 coi.HostingSystem,
-			containerRootInUVM: r.containerRootInUVM,
-			layers:             coi.Spec.Windows.LayerFolders,
-		}
-		r.layers = layers
+		layers := layers.NewImageLayers(coi.HostingSystem, containerRootInUVM, coi.Spec.Windows.LayerFolders)
+		r.SetLayers(layers)
 	} else if coi.Spec.Root.Path != "" {
 		// This is the "Plan 9" root filesystem.
 		// TODO: We need a test for this. Ask @jstarks how you can even lay this out on Windows.
 		hostPath := coi.Spec.Root.Path
-		uvmPathForContainersFileSystem := path.Join(r.containerRootInUVM, rootfsPath)
+		uvmPathForContainersFileSystem := path.Join(r.ContainerRootInUVM(), uvm.RootfsPath)
 		share, err := coi.HostingSystem.AddPlan9(ctx, hostPath, uvmPathForContainersFileSystem, coi.Spec.Root.Readonly, false, nil)
 		if err != nil {
 			return fmt.Errorf("adding plan9 root: %s", err)
 		}
 		coi.Spec.Root.Path = uvmPathForContainersFileSystem
-		r.resources = append(r.resources, share)
+		r.Add(share)
 	} else {
 		return errors.New("must provide either Windows.LayerFolders or Root.Path")
 	}
@@ -87,7 +80,7 @@ func allocateLinuxResources(ctx context.Context, coi *createOptionsInternal, r *
 
 		if coi.HostingSystem != nil {
 			hostPath := mount.Source
-			uvmPathForShare := path.Join(r.containerRootInUVM, fmt.Sprintf(lcowMountPathPrefix, i))
+			uvmPathForShare := path.Join(containerRootInUVM, fmt.Sprintf(uvm.LCOWMountPathPrefix, i))
 			uvmPathForFile := uvmPathForShare
 
 			readOnly := false
@@ -100,7 +93,7 @@ func allocateLinuxResources(ctx context.Context, coi *createOptionsInternal, r *
 			l := log.G(ctx).WithField("mount", fmt.Sprintf("%+v", mount))
 			if mount.Type == "physical-disk" {
 				l.Debug("hcsshim::allocateLinuxResources Hot-adding SCSI physical disk for OCI mount")
-				uvmPathForShare = fmt.Sprintf(lcowGlobalMountPrefix, coi.HostingSystem.UVMMountCounter())
+				uvmPathForShare = fmt.Sprintf(uvm.LCOWGlobalMountPrefix, coi.HostingSystem.UVMMountCounter())
 				scsiMount, err := coi.HostingSystem.AddSCSIPhysicalDisk(ctx, hostPath, uvmPathForShare, readOnly)
 				if err != nil {
 					return fmt.Errorf("adding SCSI physical disk mount %+v: %s", mount, err)
@@ -108,11 +101,11 @@ func allocateLinuxResources(ctx context.Context, coi *createOptionsInternal, r *
 
 				uvmPathForFile = scsiMount.UVMPath
 				uvmPathForShare = scsiMount.UVMPath
-				r.resources = append(r.resources, scsiMount)
+				r.Add(scsiMount)
 				coi.Spec.Mounts[i].Type = "none"
 			} else if mount.Type == "virtual-disk" || mount.Type == "automanage-virtual-disk" {
 				l.Debug("hcsshim::allocateLinuxResources Hot-adding SCSI virtual disk for OCI mount")
-				uvmPathForShare = fmt.Sprintf(lcowGlobalMountPrefix, coi.HostingSystem.UVMMountCounter())
+				uvmPathForShare = fmt.Sprintf(uvm.LCOWGlobalMountPrefix, coi.HostingSystem.UVMMountCounter())
 
 				// if the scsi device is already attached then we take the uvm path that the function below returns
 				// that is where it was previously mounted in UVM
@@ -124,9 +117,9 @@ func allocateLinuxResources(ctx context.Context, coi *createOptionsInternal, r *
 				uvmPathForFile = scsiMount.UVMPath
 				uvmPathForShare = scsiMount.UVMPath
 				if mount.Type == "automanage-virtual-disk" {
-					r.resources = append(r.resources, &AutoManagedVHD{hostPath: scsiMount.HostPath})
+					r.Add(uvm.NewAutoManagedVHD(scsiMount.HostPath))
 				}
-				r.resources = append(r.resources, scsiMount)
+				r.Add(scsiMount)
 				coi.Spec.Mounts[i].Type = "none"
 			} else if strings.HasPrefix(mount.Source, "sandbox://") {
 				// Mounts that map to a path in UVM are specified with 'sandbox://' prefix.
@@ -153,7 +146,7 @@ func allocateLinuxResources(ctx context.Context, coi *createOptionsInternal, r *
 				if err != nil {
 					return fmt.Errorf("adding plan9 mount %+v: %s", mount, err)
 				}
-				r.resources = append(r.resources, share)
+				r.Add(share)
 			}
 			coi.Spec.Mounts[i].Source = uvmPathForFile
 		}
@@ -168,7 +161,7 @@ func allocateLinuxResources(ctx context.Context, coi *createOptionsInternal, r *
 			if err != nil {
 				return errors.Wrapf(err, "failed to assign gpu device %s to pod %s", d.ID, coi.HostingSystem.ID())
 			}
-			r.resources = append(r.resources, vpci)
+			r.Add(vpci)
 			// update device ID on the spec to the assigned device's resulting vmbus guid so gcs knows which devices to
 			// map into the container
 			coi.Spec.Windows.Devices[i].ID = vpci.VMBusGUID
@@ -185,11 +178,11 @@ func allocateLinuxResources(ctx context.Context, coi *createOptionsInternal, r *
 		// use lcowNvidiaMountPath since we only support nvidia gpus right now
 		// must use scsi here since DDA'ing a hyper-v pci device is not supported on VMs that have ANY virtual memory
 		// gpuvhd must be granted VM Group access.
-		scsiMount, err := coi.HostingSystem.AddSCSI(ctx, gpuSupportVhdPath, lcowNvidiaMountPath, true, uvm.VMAccessTypeNoop)
+		scsiMount, err := coi.HostingSystem.AddSCSI(ctx, gpuSupportVhdPath, uvm.LCOWNvidiaMountPath, true, uvm.VMAccessTypeNoop)
 		if err != nil {
-			return errors.Wrapf(err, "failed to add scsi device %s in the UVM %s at %s", gpuSupportVhdPath, coi.HostingSystem.ID(), lcowNvidiaMountPath)
+			return errors.Wrapf(err, "failed to add scsi device %s in the UVM %s at %s", gpuSupportVhdPath, coi.HostingSystem.ID(), uvm.LCOWNvidiaMountPath)
 		}
-		r.resources = append(r.resources, scsiMount)
+		r.Add(scsiMount)
 	}
 	return nil
 }

--- a/internal/hcsoci/resources_wcow.go
+++ b/internal/hcsoci/resources_wcow.go
@@ -11,16 +11,17 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/Microsoft/hcsshim/internal/credentials"
+	"github.com/Microsoft/hcsshim/internal/layers"
 	"github.com/Microsoft/hcsshim/internal/log"
+	"github.com/Microsoft/hcsshim/internal/resources"
 	"github.com/Microsoft/hcsshim/internal/schemaversion"
 	"github.com/Microsoft/hcsshim/internal/uvm"
 	"github.com/Microsoft/hcsshim/internal/wclayer"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 )
 
-const wcowGlobalMountPrefix = "C:\\mounts\\m%d"
-
-func allocateWindowsResources(ctx context.Context, coi *createOptionsInternal, r *Resources) error {
+func allocateWindowsResources(ctx context.Context, coi *createOptionsInternal, r *resources.Resources) error {
 	if coi.Spec == nil || coi.Spec.Windows == nil || coi.Spec.Windows.LayerFolders == nil {
 		return fmt.Errorf("field 'Spec.Windows.Layerfolders' is not populated")
 	}
@@ -49,17 +50,14 @@ func allocateWindowsResources(ctx context.Context, coi *createOptionsInternal, r
 
 	if coi.Spec.Root.Path == "" && (coi.HostingSystem != nil || coi.Spec.Windows.HyperV == nil) {
 		log.G(ctx).Debug("hcsshim::allocateWindowsResources mounting storage")
-		containerRootPath, err := MountContainerLayers(ctx, coi.Spec.Windows.LayerFolders, r.containerRootInUVM, coi.HostingSystem)
+		containerRootInUVM := r.ContainerRootInUVM()
+		containerRootPath, err := layers.MountContainerLayers(ctx, coi.Spec.Windows.LayerFolders, containerRootInUVM, coi.HostingSystem)
 		if err != nil {
 			return fmt.Errorf("failed to mount container storage: %s", err)
 		}
 		coi.Spec.Root.Path = containerRootPath
-		layers := &ImageLayers{
-			vm:                 coi.HostingSystem,
-			containerRootInUVM: r.containerRootInUVM,
-			layers:             coi.Spec.Windows.LayerFolders,
-		}
-		r.layers = layers
+		layers := layers.NewImageLayers(coi.HostingSystem, containerRootInUVM, coi.Spec.Windows.LayerFolders)
+		r.SetLayers(layers)
 	}
 
 	// Validate each of the mounts. If this is a V2 Xenon, we have to add them as
@@ -79,7 +77,7 @@ func allocateWindowsResources(ctx context.Context, coi *createOptionsInternal, r
 		}
 
 		if coi.HostingSystem != nil && schemaversion.IsV21(coi.actualSchemaVersion) {
-			uvmPath := fmt.Sprintf(wcowGlobalMountPrefix, coi.HostingSystem.UVMMountCounter())
+			uvmPath := fmt.Sprintf(uvm.WCOWGlobalMountPrefix, coi.HostingSystem.UVMMountCounter())
 			readOnly := false
 			for _, o := range mount.Options {
 				if strings.ToLower(o) == "ro" {
@@ -95,7 +93,7 @@ func allocateWindowsResources(ctx context.Context, coi *createOptionsInternal, r
 					return fmt.Errorf("adding SCSI physical disk mount %+v: %s", mount, err)
 				}
 				coi.Spec.Mounts[i].Type = ""
-				r.resources = append(r.resources, scsiMount)
+				r.Add(scsiMount)
 			} else if mount.Type == "virtual-disk" || mount.Type == "automanage-virtual-disk" {
 				l.Debug("hcsshim::allocateWindowsResources Hot-adding SCSI virtual disk for OCI mount")
 				scsiMount, err := coi.HostingSystem.AddSCSI(ctx, mount.Source, uvmPath, readOnly, uvm.VMAccessTypeIndividual)
@@ -104,16 +102,16 @@ func allocateWindowsResources(ctx context.Context, coi *createOptionsInternal, r
 				}
 				coi.Spec.Mounts[i].Type = ""
 				if mount.Type == "automanage-virtual-disk" {
-					r.resources = append(r.resources, &AutoManagedVHD{hostPath: scsiMount.HostPath})
+					r.Add(uvm.NewAutoManagedVHD(scsiMount.HostPath))
 				}
-				r.resources = append(r.resources, scsiMount)
+				r.Add(scsiMount)
 			} else {
 				if uvm.IsPipe(mount.Source) {
 					pipe, err := coi.HostingSystem.AddPipe(ctx, mount.Source)
 					if err != nil {
 						return fmt.Errorf("failed to add named pipe to UVM: %s", err)
 					}
-					r.resources = append(r.resources, pipe)
+					r.Add(pipe)
 				} else {
 					l.Debug("hcsshim::allocateWindowsResources Hot-adding VSMB share for OCI mount")
 					options := coi.HostingSystem.DefaultVSMBOptions(readOnly)
@@ -121,7 +119,7 @@ func allocateWindowsResources(ctx context.Context, coi *createOptionsInternal, r
 					if err != nil {
 						return fmt.Errorf("failed to add VSMB share to utility VM for mount %+v: %s", mount, err)
 					}
-					r.resources = append(r.resources, share)
+					r.Add(share)
 				}
 			}
 		}
@@ -131,12 +129,12 @@ func allocateWindowsResources(ctx context.Context, coi *createOptionsInternal, r
 		// Only need to create a CCG instance for v2 containers
 		if schemaversion.IsV21(coi.actualSchemaVersion) {
 			hypervisorIsolated := coi.HostingSystem != nil
-			ccgState, ccgInstance, err := CreateCredentialGuard(ctx, coi.actualID, cs, hypervisorIsolated)
+			ccgState, ccgInstance, err := credentials.CreateCredentialGuard(ctx, coi.actualID, cs, hypervisorIsolated)
 			if err != nil {
 				return err
 			}
 			coi.ccgState = ccgState
-			r.resources = append(r.resources, ccgInstance)
+			r.Add(ccgInstance)
 			//TODO dcantah: If/when dynamic service table entries is supported register the RpcEndpoint with hvsocket here
 		}
 	}

--- a/internal/tools/uvmboot/lcow.go
+++ b/internal/tools/uvmboot/lcow.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/Microsoft/hcsshim/internal/hcsoci"
+	"github.com/Microsoft/hcsshim/internal/cmd"
 	"github.com/Microsoft/hcsshim/internal/uvm"
 	"github.com/containerd/console"
 	"github.com/sirupsen/logrus"
@@ -168,7 +168,7 @@ func runLCOW(ctx context.Context, options *uvm.OptionsLCOW, c *cli.Context) erro
 }
 
 func execViaGcs(vm *uvm.UtilityVM, c *cli.Context) error {
-	cmd := hcsoci.Command(vm, "/bin/sh", "-c", c.String(execCommandLineArgName))
+	cmd := cmd.Command(vm, "/bin/sh", "-c", c.String(execCommandLineArgName))
 	cmd.Log = logrus.NewEntry(logrus.StandardLogger())
 	if lcowUseTerminal {
 		cmd.Spec.Terminal = true

--- a/internal/tools/uvmboot/wcow.go
+++ b/internal/tools/uvmboot/wcow.go
@@ -10,7 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/Microsoft/hcsshim/internal/hcsoci"
+	"github.com/Microsoft/hcsshim/internal/cmd"
 	"github.com/Microsoft/hcsshim/internal/uvm"
 	"github.com/containerd/console"
 	"github.com/sirupsen/logrus"
@@ -85,7 +85,7 @@ var wcowCommand = cli.Command{
 				return err
 			}
 			if wcowCommandLine != "" {
-				cmd := hcsoci.Command(vm, "cmd.exe", "/c", wcowCommandLine)
+				cmd := cmd.Command(vm, "cmd.exe", "/c", wcowCommandLine)
 				cmd.Spec.User.Username = `NT AUTHORITY\SYSTEM`
 				cmd.Log = logrus.NewEntry(logrus.StandardLogger())
 				if wcowUseTerminal {

--- a/internal/uvm/automanagedvhd.go
+++ b/internal/uvm/automanagedvhd.go
@@ -1,0 +1,27 @@
+package uvm
+
+import (
+	"context"
+	"os"
+
+	"github.com/Microsoft/hcsshim/internal/log"
+)
+
+// AutoManagedVHD struct representing a VHD that will be cleaned up automatically.
+type AutoManagedVHD struct {
+	hostPath string
+}
+
+func NewAutoManagedVHD(hostPath string) *AutoManagedVHD {
+	return &AutoManagedVHD{
+		hostPath: hostPath,
+	}
+}
+
+// Release removes the vhd.
+func (vhd *AutoManagedVHD) Release(ctx context.Context) error {
+	if err := os.Remove(vhd.hostPath); err != nil {
+		log.G(ctx).WithField("hostPath", vhd.hostPath).WithError(err).Error("failed to remove automanage-virtual-disk")
+	}
+	return nil
+}

--- a/internal/uvm/constants.go
+++ b/internal/uvm/constants.go
@@ -16,6 +16,19 @@ const (
 	// DefaultVPMemSizeBytes is the default size of a VPMem device if the create request
 	// doesn't specify.
 	DefaultVPMemSizeBytes = 4 * 1024 * 1024 * 1024 // 4GB
+
+	// LCOWMountPathPrefix is the path format in the LCOW UVM where non global mounts, such
+	// as Plan9 mounts are added
+	LCOWMountPathPrefix = "/mounts/m%d"
+	// LCOWGlobalMountPrefix is the path format in the LCOW UVM where global mounts are added
+	LCOWGlobalMountPrefix = "/run/mounts/m%d"
+	// LCOWNvidiaMountPath is the path format in LCOW UVM where nvidia tools are mounted
+	// keep this value in sync with opengcs
+	LCOWNvidiaMountPath = "/run/nvidia"
+	// WCOWGlobalMountPrefix is the path prefix format in the WCOW UVM where mounts are added
+	WCOWGlobalMountPrefix = "C:\\mounts\\m%d"
+	// RootfsPath is part of the container's rootfs path
+	RootfsPath = "rootfs"
 )
 
 var (

--- a/internal/wclayer/wclayer.go
+++ b/internal/wclayer/wclayer.go
@@ -1,3 +1,6 @@
+// Package wclayer provides bindings to HCS's legacy layer management API and
+// provides a higher level interface around these calls for container layer
+// management.
 package wclayer
 
 import "github.com/Microsoft/go-winio/pkg/guid"

--- a/test/functional/lcow_test.go
+++ b/test/functional/lcow_test.go
@@ -13,9 +13,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Microsoft/hcsshim/internal/cmd"
 	"github.com/Microsoft/hcsshim/internal/cow"
 	"github.com/Microsoft/hcsshim/internal/hcsoci"
 	"github.com/Microsoft/hcsshim/internal/lcow"
+	"github.com/Microsoft/hcsshim/internal/resources"
 	"github.com/Microsoft/hcsshim/internal/uvm"
 	"github.com/Microsoft/hcsshim/osversion"
 	testutilities "github.com/Microsoft/hcsshim/test/functional/utilities"
@@ -189,12 +191,12 @@ func TestLCOWSimplePodScenario(t *testing.T) {
 	if err := c1hcsSystem.Start(context.Background()); err != nil {
 		t.Fatal(err)
 	}
-	defer hcsoci.ReleaseResources(context.Background(), c1Resources, lcowUVM, true)
+	defer resources.ReleaseResources(context.Background(), c1Resources, lcowUVM, true)
 
 	if err := c2hcsSystem.Start(context.Background()); err != nil {
 		t.Fatal(err)
 	}
-	defer hcsoci.ReleaseResources(context.Background(), c2Resources, lcowUVM, true)
+	defer resources.ReleaseResources(context.Background(), c2Resources, lcowUVM, true)
 
 	// Start the init process in each container and grab it's stdout comparing to expected
 	runInitProcess(t, c1hcsSystem, "hello lcow container one")
@@ -208,7 +210,7 @@ func runInitProcess(t *testing.T, s cow.Container, expected string) {
 	var errB bytes.Buffer
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
-	cmd := &hcsoci.Cmd{
+	cmd := &cmd.Cmd{
 		Host:    s,
 		Stderr:  &errB,
 		Context: ctx,

--- a/test/functional/test.go
+++ b/test/functional/test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/Microsoft/hcsshim/internal/cow"
 	"github.com/Microsoft/hcsshim/internal/hcsoci"
+	"github.com/Microsoft/hcsshim/internal/resources"
 	"github.com/sirupsen/logrus"
 )
 
@@ -34,7 +35,7 @@ func init() {
 
 }
 
-func CreateContainerTestWrapper(ctx context.Context, options *hcsoci.CreateOptions) (cow.Container, *hcsoci.Resources, error) {
+func CreateContainerTestWrapper(ctx context.Context, options *hcsoci.CreateOptions) (cow.Container, *resources.Resources, error) {
 	if pauseDurationOnCreateContainerFailure != 0 {
 		options.DoNotReleaseResourcesOnFailure = true
 	}
@@ -42,7 +43,7 @@ func CreateContainerTestWrapper(ctx context.Context, options *hcsoci.CreateOptio
 	if err != nil {
 		logrus.Warnf("Test is pausing for %s for debugging CreateContainer failure", pauseDurationOnCreateContainerFailure)
 		time.Sleep(pauseDurationOnCreateContainerFailure)
-		hcsoci.ReleaseResources(ctx, r, options.HostingSystem, true)
+		resources.ReleaseResources(ctx, r, options.HostingSystem, true)
 	}
 	return s, r, err
 }

--- a/test/functional/wcow_test.go
+++ b/test/functional/wcow_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/Microsoft/hcsshim"
 	"github.com/Microsoft/hcsshim/internal/cow"
 	"github.com/Microsoft/hcsshim/internal/hcsoci"
+	layerspkg "github.com/Microsoft/hcsshim/internal/layers"
+	"github.com/Microsoft/hcsshim/internal/resources"
 	"github.com/Microsoft/hcsshim/internal/schema1"
 	"github.com/Microsoft/hcsshim/internal/schemaversion"
 	"github.com/Microsoft/hcsshim/internal/uvm"
@@ -378,12 +380,12 @@ func TestWCOWArgonShim(t *testing.T) {
 	// For cleanup on failure
 	defer func() {
 		if argonShimMounted {
-			hcsoci.UnmountContainerLayers(context.Background(), append(imageLayers, argonShimScratchDir), "", nil, hcsoci.UnmountOperationAll)
+			layerspkg.UnmountContainerLayers(context.Background(), append(imageLayers, argonShimScratchDir), "", nil, layerspkg.UnmountOperationAll)
 		}
 	}()
 
 	// This is a cheat but stops us re-writing exactly the same code just for test
-	argonShimLocalMountPath, err := hcsoci.MountContainerLayers(context.Background(), append(imageLayers, argonShimScratchDir), "", nil)
+	argonShimLocalMountPath, err := layerspkg.MountContainerLayers(context.Background(), append(imageLayers, argonShimScratchDir), "", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -416,7 +418,7 @@ func TestWCOWArgonShim(t *testing.T) {
 	}
 	runShimCommands(t, argonShim)
 	stopContainer(t, argonShim)
-	if err := hcsoci.UnmountContainerLayers(context.Background(), append(imageLayers, argonShimScratchDir), "", nil, hcsoci.UnmountOperationAll); err != nil {
+	if err := layerspkg.UnmountContainerLayers(context.Background(), append(imageLayers, argonShimScratchDir), "", nil, layerspkg.UnmountOperationAll); err != nil {
 		t.Fatal(err)
 	}
 	argonShimMounted = false
@@ -508,11 +510,11 @@ func TestWCOWArgonOciV1(t *testing.T) {
 	defer os.RemoveAll(hostROSharedDirectory)
 
 	// For cleanup on failure
-	var argonOci1Resources *hcsoci.Resources
+	var argonOci1Resources *resources.Resources
 	var argonOci1 cow.Container
 	defer func() {
 		if argonOci1Mounted {
-			hcsoci.ReleaseResources(context.Background(), argonOci1Resources, nil, true)
+			resources.ReleaseResources(context.Background(), argonOci1Resources, nil, true)
 		}
 	}()
 
@@ -535,7 +537,7 @@ func TestWCOWArgonOciV1(t *testing.T) {
 	}
 	runHcsCommands(t, argonOci1)
 	stopContainer(t, argonOci1)
-	if err := hcsoci.ReleaseResources(context.Background(), argonOci1Resources, nil, true); err != nil {
+	if err := resources.ReleaseResources(context.Background(), argonOci1Resources, nil, true); err != nil {
 		t.Fatal(err)
 	}
 	argonOci1Mounted = false
@@ -563,11 +565,11 @@ func TestWCOWXenonOciV1(t *testing.T) {
 	//	}
 
 	// For cleanup on failure
-	var xenonOci1Resources *hcsoci.Resources
+	var xenonOci1Resources *resources.Resources
 	var xenonOci1 cow.Container
 	defer func() {
 		if xenonOci1Mounted {
-			hcsoci.ReleaseResources(context.Background(), xenonOci1Resources, nil, true)
+			resources.ReleaseResources(context.Background(), xenonOci1Resources, nil, true)
 		}
 	}()
 
@@ -591,7 +593,7 @@ func TestWCOWXenonOciV1(t *testing.T) {
 	}
 	runHcsCommands(t, xenonOci1)
 	stopContainer(t, xenonOci1)
-	if err := hcsoci.ReleaseResources(context.Background(), xenonOci1Resources, nil, true); err != nil {
+	if err := resources.ReleaseResources(context.Background(), xenonOci1Resources, nil, true); err != nil {
 		t.Fatal(err)
 	}
 	xenonOci1Mounted = false
@@ -614,11 +616,11 @@ func TestWCOWArgonOciV2(t *testing.T) {
 	defer os.RemoveAll(hostROSharedDirectory)
 
 	// For cleanup on failure
-	var argonOci2Resources *hcsoci.Resources
+	var argonOci2Resources *resources.Resources
 	var argonOci2 cow.Container
 	defer func() {
 		if argonOci2Mounted {
-			hcsoci.ReleaseResources(context.Background(), argonOci2Resources, nil, true)
+			resources.ReleaseResources(context.Background(), argonOci2Resources, nil, true)
 		}
 	}()
 
@@ -641,7 +643,7 @@ func TestWCOWArgonOciV2(t *testing.T) {
 	}
 	runHcsCommands(t, argonOci2)
 	stopContainer(t, argonOci2)
-	if err := hcsoci.ReleaseResources(context.Background(), argonOci2Resources, nil, true); err != nil {
+	if err := resources.ReleaseResources(context.Background(), argonOci2Resources, nil, true); err != nil {
 		t.Fatal(err)
 	}
 	argonOci2Mounted = false
@@ -670,12 +672,12 @@ func TestWCOWXenonOciV2(t *testing.T) {
 		t.Fatalf("LocateUVMFolder failed %s", err)
 	}
 
-	var xenonOci2Resources *hcsoci.Resources
+	var xenonOci2Resources *resources.Resources
 	var xenonOci2 cow.Container
 	var xenonOci2UVM *uvm.UtilityVM
 	defer func() {
 		if xenonOci2Mounted {
-			hcsoci.ReleaseResources(context.Background(), xenonOci2Resources, xenonOci2UVM, true)
+			resources.ReleaseResources(context.Background(), xenonOci2Resources, xenonOci2UVM, true)
 		}
 		if xenonOci2UVMCreated {
 			xenonOci2UVM.Close()
@@ -721,7 +723,7 @@ func TestWCOWXenonOciV2(t *testing.T) {
 	}
 	runHcsCommands(t, xenonOci2)
 	stopContainer(t, xenonOci2)
-	if err := hcsoci.ReleaseResources(context.Background(), xenonOci2Resources, xenonOci2UVM, true); err != nil {
+	if err := resources.ReleaseResources(context.Background(), xenonOci2Resources, xenonOci2UVM, true); err != nil {
 		t.Fatal(err)
 	}
 	xenonOci2Mounted = false


### PR DESCRIPTION
This PR refactors logical units of code that were previously in the hcsoci package into their own packages. This allows us to better scope our packages and avoid circular dependencies later on. Some of the code that was moved was that relating to ImageLayers, Resource, ResourceCloser, and others. 

Signed-off-by: Kathryn Baldauf <kabaldau@microsoft.com>