### PR TITLE
Fix flaky cri-containerd LCOW events test

### DIFF
--- a/test/cri-containerd/container_test.go
+++ b/test/cri-containerd/container_test.go
@@ -148,9 +148,6 @@ func Test_RunContainer_Events_LCOW(t *testing.T) {
 
 	podctx, podcancel := context.WithCancel(context.Background())
 	defer podcancel()
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-
 	targetNamespace := "k8s.io"
 
 	sandboxRequest := &runtime.RunPodSandboxRequest{
@@ -184,6 +181,9 @@ func Test_RunContainer_Events_LCOW(t *testing.T) {
 		PodSandboxId:  podID,
 		SandboxConfig: sandboxRequest.Config,
 	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
 
 	topicNames, filters := getTargetRunTopics()
 	eventService := newTestEventService(t)


### PR DESCRIPTION
* Move the context.WithTimeout after the setup/launch of the sandbox/uvm
to avoid hitting the timeout and failing the test.

Signed-off-by: Daniel Canter <dcanter@microsoft.com>