### PR TITLE
Fix LpIndex JSON annotation

### DIFF
--- a/internal/schema2/logical_processor.go
+++ b/internal/schema2/logical_processor.go
@@ -10,7 +10,7 @@
 package hcsschema
 
 type LogicalProcessor struct {
-	LpIndex     uint32 `json:"LogicalProcessorCount,omitempty"`
+	LpIndex     uint32 `json:"LpIndex,omitempty"`
 	NodeNumber  uint8  `json:"NodeNumber, omitempty"`
 	PackageId   uint32 `json:"PackageId, omitempty"`
 	CoreId      uint32 `json:"CoreId, omitempty"`


### PR DESCRIPTION
* Fix the LpIndex JSON annotation in the LogicalProcessor v2 HCS schema
from being the wrong value.

Signed-off-by: Daniel Canter <dcanter@microsoft.com>