### PR TITLE
Add prepare-disk command.

### DIFF
--- a/cmd/runhcs/main.go
+++ b/cmd/runhcs/main.go
@@ -108,6 +108,7 @@ func main() {
 		killCommand,
 		listCommand,
 		pauseCommand,
+		prepareDiskCommand,
 		psCommand,
 		resizeTtyCommand,
 		resumeCommand,

--- a/cmd/runhcs/prepare-disk.go
+++ b/cmd/runhcs/prepare-disk.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	gcontext "context"
+
+	"github.com/Microsoft/hcsshim/internal/appargs"
+	"github.com/Microsoft/hcsshim/internal/lcow"
+	"github.com/Microsoft/hcsshim/internal/oc"
+	"github.com/Microsoft/hcsshim/internal/uvm"
+	"github.com/Microsoft/hcsshim/osversion"
+	"github.com/pkg/errors"
+	"github.com/urfave/cli"
+	"go.opencensus.io/trace"
+)
+
+const (
+	// prepareDiskStr string used to name the command and identity in the logs
+	prepareDiskStr = "prepare-disk"
+)
+
+var prepareDiskCommand = cli.Command{
+	Name:        prepareDiskStr,
+	Usage:       "format a disk with ext4",
+	Description: "Format a disk with ext4. To be used prior to exposing a pass-through disk. Prerequisite is that disk should be offline ('Get-Disk -Number <disk num> | Set-Disk -IsOffline $true').",
+	Flags: []cli.Flag{
+		cli.StringFlag{
+			Name:  "destpath",
+			Usage: "Required: describes the destination disk path",
+		},
+	},
+	Before: appargs.Validate(),
+	Action: func(context *cli.Context) (err error) {
+		ctx, span := trace.StartSpan(gcontext.Background(), prepareDiskStr)
+		defer span.End()
+		defer func() { oc.SetSpanStatus(span, err) }()
+
+		dest := context.String("destpath")
+		if dest == "" {
+			return errors.New("'destpath' is required")
+		}
+
+		if osversion.Get().Build < osversion.RS5 {
+			return errors.New("LCOW is not supported pre-RS5")
+		}
+
+		opts := uvm.NewDefaultOptionsLCOW("preparedisk-uvm", context.GlobalString("owner"))
+
+		preparediskUVM, err := uvm.CreateLCOW(ctx, opts)
+		if err != nil {
+			return errors.Wrapf(err, "failed to create '%s'", opts.ID)
+		}
+		defer preparediskUVM.Close()
+		if err := preparediskUVM.Start(ctx); err != nil {
+			return errors.Wrapf(err, "failed to start '%s'", opts.ID)
+		}
+
+		if err := lcow.FormatDisk(ctx, preparediskUVM, dest); err != nil {
+			return errors.Wrapf(err, "failed to format disk '%s' with ext4", opts.ID)
+		}
+
+		return nil
+	},
+}

--- a/internal/lcow/common.go
+++ b/internal/lcow/common.go
@@ -1,0 +1,64 @@
+package lcow
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"time"
+
+	cmdpkg "github.com/Microsoft/hcsshim/internal/cmd"
+	"github.com/Microsoft/hcsshim/internal/log"
+	"github.com/Microsoft/hcsshim/internal/timeout"
+	"github.com/Microsoft/hcsshim/internal/uvm"
+	"github.com/sirupsen/logrus"
+)
+
+// formatDiskUvm creates a utility vm, mounts the disk as a scsi disk onto to the VM
+// and then formats it with ext4.
+func formatDiskUvm(ctx context.Context, lcowUVM *uvm.UtilityVM, controller int, lun int32, destPath string) error {
+	// Validate /sys/bus/scsi/devices/C:0:0:L exists as a directory
+	devicePath := fmt.Sprintf("/sys/bus/scsi/devices/%d:0:0:%d/block", controller, lun)
+	testdCtx, cancel := context.WithTimeout(ctx, timeout.TestDRetryLoop)
+	defer cancel()
+	for {
+		cmd := cmdpkg.CommandContext(testdCtx, lcowUVM, "test", "-d", devicePath)
+		err := cmd.Run()
+		if err == nil {
+			break
+		}
+		if _, ok := err.(*cmdpkg.ExitError); !ok {
+			return fmt.Errorf("failed to run %+v following hot-add %s to utility VM: %s", cmd.Spec.Args, destPath, err)
+		}
+		time.Sleep(time.Millisecond * 10)
+	}
+	cancel()
+
+	// Get the device from under the block subdirectory by doing a simple ls. This will come back as (eg) `sda`
+	lsCtx, cancel := context.WithTimeout(ctx, timeout.ExternalCommandToStart)
+	cmd := cmdpkg.CommandContext(lsCtx, lcowUVM, "ls", devicePath)
+	lsOutput, err := cmd.Output()
+	cancel()
+	if err != nil {
+		return fmt.Errorf("failed to `%+v` following hot-add %s to utility VM: %s", cmd.Spec.Args, destPath, err)
+	}
+	device := fmt.Sprintf(`/dev/%s`, bytes.TrimSpace(lsOutput))
+	log.G(ctx).WithFields(logrus.Fields{
+		"dest":   destPath,
+		"device": device,
+	}).Debug("lcow::FormatDisk device guest location")
+
+	// Format it ext4
+	mkfsCtx, cancel := context.WithTimeout(ctx, timeout.ExternalCommandToStart)
+	cmd = cmdpkg.CommandContext(mkfsCtx, lcowUVM, "mkfs.ext4", "-q", "-E", "lazy_itable_init=0,nodiscard", "-O", `^has_journal,sparse_super2,^resize_inode`, device)
+	var mkfsStderr bytes.Buffer
+	cmd.Stderr = &mkfsStderr
+	err = cmd.Run()
+	cancel()
+	if err != nil {
+		return fmt.Errorf("failed to `%+v` following hot-add %s to utility VM: %s. detailed error: %s", cmd.Spec.Args, destPath, err, mkfsStderr.String())
+	}
+
+	log.G(ctx).WithField("dest", destPath).Debug("lcow::FormatDisk complete")
+
+	return nil
+}

--- a/internal/lcow/disk.go
+++ b/internal/lcow/disk.go
@@ -1,0 +1,52 @@
+package lcow
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/Microsoft/hcsshim/internal/log"
+	"github.com/Microsoft/hcsshim/internal/uvm"
+	"github.com/sirupsen/logrus"
+)
+
+// FormatDisk creates a utility vm, mounts the disk as a scsi disk onto to the VM
+// and then formats it with ext4. Disk is expected to be made offline before this
+// command is run. The following powershell commands:
+// 'Get-Disk -Number <disk num> | Set-Disk -IsOffline $true'
+// can be used to offline the disk.
+func FormatDisk(ctx context.Context, lcowUVM *uvm.UtilityVM, destPath string) error {
+	if lcowUVM == nil {
+		return fmt.Errorf("no uvm")
+	}
+
+	if lcowUVM.OS() != "linux" {
+		return errors.New("lcow::FormatDisk requires a linux utility VM to operate")
+	}
+
+	log.G(ctx).WithFields(logrus.Fields{
+		"dest": destPath,
+	}).Debug("lcow::FormatDisk opts")
+
+	scsi, err := lcowUVM.AddSCSIPhysicalDisk(ctx, destPath, "", false) // No destination as not formatted
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		scsi.Release(ctx)
+	}()
+
+	log.G(ctx).WithFields(logrus.Fields{
+		"dest":       destPath,
+		"controller": scsi.Controller,
+		"lun":        scsi.LUN,
+	}).Debug("lcow::FormatDisk device attached")
+
+	if err := formatDiskUvm(ctx, lcowUVM, scsi.Controller, scsi.LUN, destPath); err != nil {
+		return err
+	}
+	log.G(ctx).WithField("dest", destPath).Debug("lcow::FormatDisk complete")
+
+	return nil
+}


### PR DESCRIPTION
Prepare-disk command formats a given disk with ext4. This is required for a disk(as passthrough) to be made available within a container. Here is an excerpt from a configuration for such a scenario.

"mounts": [
     {
       "host_path": "\\\\.\\PHYSICALDRIVE2",
       "container_path": "/disk"
     }

The gcs/runc combo expects the pass-through disk to be formatted and tries to mount it on a local path within
the uvm. Prepare-disk ensures that this restriction is met.

Note: Full disk is formatted with ext4 without any partitioning. TODO: add options to allow partitioning and then formatting.