### PR TITLE
Add calls to modify UVM memory size and tests

### DIFF
--- a/internal/uvm/memory_update.go
+++ b/internal/uvm/memory_update.go
@@ -1,0 +1,46 @@
+package uvm
+
+import (
+	"context"
+	"fmt"
+
+	hcsschema "github.com/Microsoft/hcsshim/internal/schema2"
+)
+
+const (
+	bytesPerPage = 4096
+	bytesPerMB   = 1024 * 1024
+)
+
+// UpdateMemory makes a call to the VM's orchestrator to update the VM's size in MB
+// Internally, HCS will get the number of pages this corresponds to and attempt to assign
+// pages to numa nodes evenly
+func (uvm *UtilityVM) UpdateMemory(ctx context.Context, sizeInBytes uint64) error {
+	requestedSizeInMB := sizeInBytes / bytesPerMB
+	actual := uvm.normalizeMemorySize(ctx, requestedSizeInMB)
+	req := &hcsschema.ModifySettingRequest{
+		ResourcePath: memoryResourcePath,
+		Settings:     actual,
+	}
+	return uvm.modify(ctx, req)
+}
+
+// GetAssignedMemoryInBytes returns the amount of assigned memory for the UVM in bytes
+func (uvm *UtilityVM) GetAssignedMemoryInBytes(ctx context.Context) (uint64, error) {
+	props, err := uvm.hcsSystem.PropertiesV2(ctx, hcsschema.PTMemory)
+	if err != nil {
+		return 0, err
+	}
+	if props.Memory == nil {
+		return 0, fmt.Errorf("no memory properties returned for system %s", uvm.id)
+	}
+	if props.Memory.VirtualMachineMemory == nil {
+		return 0, fmt.Errorf("no virtual memory properties returned for system %s", uvm.id)
+	}
+	pages := props.Memory.VirtualMachineMemory.AssignedMemory
+	if pages == 0 {
+		return 0, fmt.Errorf("assigned memory returned should not be 0 for system %s", uvm.id)
+	}
+	memInBytes := pages * bytesPerPage
+	return memInBytes, nil
+}

--- a/test/functional/test.go
+++ b/test/functional/test.go
@@ -13,6 +13,11 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+const (
+	bytesPerMB   = 1024 * 1024
+	bytesPerPage = 4096
+)
+
 var pauseDurationOnCreateContainerFailure time.Duration
 
 func init() {

--- a/test/functional/uvm_memory_test.go
+++ b/test/functional/uvm_memory_test.go
@@ -1,0 +1,63 @@
+package functional
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/Microsoft/hcsshim/internal/uvm"
+	"github.com/Microsoft/hcsshim/osversion"
+	testutilities "github.com/Microsoft/hcsshim/test/functional/utilities"
+)
+
+func TestUVMMemoryUpdateLCOW(t *testing.T) {
+	testutilities.RequiresBuild(t, osversion.RS5)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 40*time.Second)
+	defer cancel()
+
+	opts := uvm.NewDefaultOptionsLCOW(t.Name(), "")
+	opts.MemorySizeInMB = 1024 * 2
+	u := testutilities.CreateLCOWUVMFromOpts(ctx, t, opts)
+	defer u.Close()
+
+	newMemorySize := uint64(opts.MemorySizeInMB/2) * bytesPerMB
+
+	if err := u.UpdateMemory(ctx, newMemorySize); err != nil {
+		t.Fatalf("failed to make call to modify UVM memory size in MB with: %v", err)
+	}
+	memInBytes, err := u.GetAssignedMemoryInBytes(ctx)
+	if err != nil {
+		t.Fatalf("failed to verified assigned UVM memory size")
+	}
+	if memInBytes != newMemorySize {
+		t.Fatalf("incorrect memory size returned, expected %d but got %d", newMemorySize, memInBytes)
+	}
+}
+
+func TestUVMMemoryUpdateWCOW(t *testing.T) {
+	testutilities.RequiresBuild(t, osversion.RS5)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 40*time.Second)
+	defer cancel()
+
+	opts := uvm.NewDefaultOptionsWCOW(t.Name(), "")
+	opts.MemorySizeInMB = 1024 * 2
+
+	u, _, uvmScratchDir := testutilities.CreateWCOWUVMFromOptsWithImage(ctx, t, opts, "mcr.microsoft.com/windows/nanoserver:1909")
+	defer os.RemoveAll(uvmScratchDir)
+	defer u.Close()
+
+	newMemoryInBytes := uint64(opts.MemorySizeInMB/2) * bytesPerMB
+	if err := u.UpdateMemory(ctx, newMemoryInBytes); err != nil {
+		t.Fatalf("failed to make call to modify UVM memory size in MB with: %v", err)
+	}
+	memInBytes, err := u.GetAssignedMemoryInBytes(ctx)
+	if err != nil {
+		t.Fatalf("failed to verified assigned UVM memory size")
+	}
+	if memInBytes != newMemoryInBytes {
+		t.Fatalf("incorrect memory size returned, expected %d but got %d", newMemoryInBytes, memInBytes)
+	}
+}


### PR DESCRIPTION
This PR is part of the work to support dynamically updating resources. The work in this PR adds a call that will update the memory size (in MBs) of a UVM. This PR serves as an intermediate PR and therefore the new call is not used outside of testing. 

Signed-off-by: Kathryn Baldauf <kabaldau@microsoft.com>