### PR TITLE
Fix schema memory size field type

### DIFF
--- a/internal/oci/uvm.go
+++ b/internal/oci/uvm.go
@@ -246,16 +246,16 @@ func ParseAnnotationsStorageBps(ctx context.Context, s *specs.Spec, annotation s
 // returns `def`.
 //
 // Note: The returned value is in `MB`.
-func ParseAnnotationsMemory(ctx context.Context, s *specs.Spec, annotation string, def int32) int32 {
+func ParseAnnotationsMemory(ctx context.Context, s *specs.Spec, annotation string, def uint64) uint64 {
 	if m := parseAnnotationsUint64(ctx, s.Annotations, annotation, 0); m != 0 {
-		return int32(m)
+		return m
 	}
 	if s.Windows != nil &&
 		s.Windows.Resources != nil &&
 		s.Windows.Resources.Memory != nil &&
 		s.Windows.Resources.Memory.Limit != nil &&
 		*s.Windows.Resources.Memory.Limit > 0 {
-		return int32(*s.Windows.Resources.Memory.Limit / 1024 / 1024)
+		return (*s.Windows.Resources.Memory.Limit / 1024 / 1024)
 	}
 	return def
 }

--- a/internal/schema2/memory.go
+++ b/internal/schema2/memory.go
@@ -10,5 +10,5 @@
 package hcsschema
 
 type Memory struct {
-	SizeInMB int32 `json:"SizeInMB,omitempty"`
+	SizeInMB uint64 `json:"SizeInMB,omitempty"`
 }

--- a/internal/schema2/memory_2.go
+++ b/internal/schema2/memory_2.go
@@ -10,7 +10,7 @@
 package hcsschema
 
 type Memory2 struct {
-	SizeInMB int32 `json:"SizeInMB,omitempty"`
+	SizeInMB uint64 `json:"SizeInMB,omitempty"`
 
 	AllowOvercommit bool `json:"AllowOvercommit,omitempty"`
 

--- a/internal/tools/uvmboot/main.go
+++ b/internal/tools/uvmboot/main.go
@@ -101,7 +101,7 @@ func setGlobalOptions(c *cli.Context, options *uvm.Options) {
 		options.ProcessorCount = int32(c.GlobalUint64(cpusArgName))
 	}
 	if c.GlobalIsSet(memoryArgName) {
-		options.MemorySizeInMB = int32(c.GlobalUint64(memoryArgName))
+		options.MemorySizeInMB = c.GlobalUint64(memoryArgName)
 	}
 	if c.GlobalIsSet(allowOvercommitArgName) {
 		options.AllowOvercommit = c.GlobalBool(allowOvercommitArgName)

--- a/internal/uvm/create.go
+++ b/internal/uvm/create.go
@@ -29,7 +29,7 @@ type Options struct {
 
 	// MemorySizeInMB sets the UVM memory. If `0` will default to platform
 	// default.
-	MemorySizeInMB int32
+	MemorySizeInMB uint64
 
 	LowMMIOGapInMB   uint64
 	HighMMIOBaseInMB uint64
@@ -298,7 +298,7 @@ func (uvm *UtilityVM) PhysicallyBacked() bool {
 	return uvm.physicallyBacked
 }
 
-func (uvm *UtilityVM) normalizeMemorySize(ctx context.Context, requested int32) int32 {
+func (uvm *UtilityVM) normalizeMemorySize(ctx context.Context, requested uint64) uint64 {
 	actual := (requested + 1) &^ 1 // align up to an even number
 	if requested != actual {
 		log.G(ctx).WithFields(logrus.Fields{


### PR DESCRIPTION
The internal schema files have these values as uint64 but we previously used int32 due to an issue with the schema generation. 

Signed-off-by: Kathryn Baldauf <kabaldau@microsoft.com>