### PR TITLE
Add regkey to WCOW to deal with containment for GNS compartment changes

### DIFF
--- a/internal/oci/uvm.go
+++ b/internal/oci/uvm.go
@@ -120,16 +120,17 @@ const (
 	//
 	// Note: Unlike Windows process isolated container QoS Count/Limt/Weight on
 	// the UVM are not mutually exclusive and can be set together.
-	annotationProcessorWeight            = "io.microsoft.virtualmachine.computetopology.processor.weight"
-	annotationVPMemCount                 = "io.microsoft.virtualmachine.devices.virtualpmem.maximumcount"
-	annotationVPMemSize                  = "io.microsoft.virtualmachine.devices.virtualpmem.maximumsizebytes"
-	annotationPreferredRootFSType        = "io.microsoft.virtualmachine.lcow.preferredrootfstype"
-	annotationBootFilesRootPath          = "io.microsoft.virtualmachine.lcow.bootfilesrootpath"
-	annotationKernelDirectBoot           = "io.microsoft.virtualmachine.lcow.kerneldirectboot"
-	annotationVPCIEnabled                = "io.microsoft.virtualmachine.lcow.vpcienabled"
-	annotationStorageQoSBandwidthMaximum = "io.microsoft.virtualmachine.storageqos.bandwidthmaximum"
-	annotationStorageQoSIopsMaximum      = "io.microsoft.virtualmachine.storageqos.iopsmaximum"
-	annotationFullyPhysicallyBacked      = "io.microsoft.virtualmachine.fullyphysicallybacked"
+	annotationProcessorWeight             = "io.microsoft.virtualmachine.computetopology.processor.weight"
+	annotationVPMemCount                  = "io.microsoft.virtualmachine.devices.virtualpmem.maximumcount"
+	annotationVPMemSize                   = "io.microsoft.virtualmachine.devices.virtualpmem.maximumsizebytes"
+	annotationPreferredRootFSType         = "io.microsoft.virtualmachine.lcow.preferredrootfstype"
+	annotationBootFilesRootPath           = "io.microsoft.virtualmachine.lcow.bootfilesrootpath"
+	annotationKernelDirectBoot            = "io.microsoft.virtualmachine.lcow.kerneldirectboot"
+	annotationVPCIEnabled                 = "io.microsoft.virtualmachine.lcow.vpcienabled"
+	annotationStorageQoSBandwidthMaximum  = "io.microsoft.virtualmachine.storageqos.bandwidthmaximum"
+	annotationStorageQoSIopsMaximum       = "io.microsoft.virtualmachine.storageqos.iopsmaximum"
+	annotationFullyPhysicallyBacked       = "io.microsoft.virtualmachine.fullyphysicallybacked"
+	annotationDisableCompartmentNamespace = "io.microsoft.virtualmachine.disablecompartmentnamespace"
 	// A boolean annotation to control whether to use an external bridge or the
 	// HCS-GCS bridge. Default value is true which means external bridge will be used
 	// by default.
@@ -411,6 +412,7 @@ func SpecToUVMCreateOpts(ctx context.Context, s *specs.Spec, id, owner string) (
 		wopts.StorageQoSBandwidthMaximum = ParseAnnotationsStorageBps(ctx, s, annotationStorageQoSBandwidthMaximum, wopts.StorageQoSBandwidthMaximum)
 		wopts.StorageQoSIopsMaximum = ParseAnnotationsStorageIops(ctx, s, annotationStorageQoSIopsMaximum, wopts.StorageQoSIopsMaximum)
 		wopts.ExternalGuestConnection = parseAnnotationsBool(ctx, s.Annotations, annotationUseExternalGCSBridge, wopts.ExternalGuestConnection)
+		wopts.DisableCompartmentNamespace = parseAnnotationsBool(ctx, s.Annotations, annotationDisableCompartmentNamespace, wopts.DisableCompartmentNamespace)
 		handleAnnotationFullyPhysicallyBacked(ctx, s.Annotations, wopts)
 		return wopts, nil
 	}

--- a/internal/uvm/create.go
+++ b/internal/uvm/create.go
@@ -70,6 +70,17 @@ type Options struct {
 	// ExternalGuestConnection sets whether the guest RPC connection is performed
 	// internally by the OS platform or externally by this package.
 	ExternalGuestConnection bool
+
+	// DisableCompartmentNamespace sets whether to disable namespacing the network compartment in the UVM
+	// for WCOW. Namespacing makes it so the compartment created for a container is essentially no longer
+	// aware or able to see any of the other compartments on the host (in this case the UVM).
+	// The compartment that the container is added to now behaves as the default compartment as
+	// far as the container is concerned and it is only able to view the NICs in the compartment it's assigned to.
+	// This is the compartment setup (and behavior) that is followed for V1 HCS schema containers (docker) so
+	// this change brings parity as well. This behavior is gated behind a registry key currently to avoid any
+	// unneccessary behavior and once this restriction is removed then we can remove the need for this variable
+	// and the associated annotation as well.
+	DisableCompartmentNamespace bool
 }
 
 // Verifies that the final UVM options are correct and supported.


### PR DESCRIPTION
* A change was added recently to GNS that will be backported to Vb and possibly 19H1 and RS5 that changes how network compartments are created to fix an issue with accessing smb shares in hypervisor isolated containers. To ease the worries
of this breaking anything the change will be put behind a registry key (that is only set by us) so that the change won't impact docker and can be optionally toggled off by us through this annotation.

Signed-off-by: Daniel Canter <dcanter@microsoft.com>