### PR TITLE
Add SetJobCompartmentId function from iphlpapi.dll

### DIFF
--- a/internal/hns/namespace.go
+++ b/internal/hns/namespace.go
@@ -27,9 +27,10 @@ type namespaceResourceRequest struct {
 }
 
 type Namespace struct {
-	ID           string
-	IsDefault    bool                `json:",omitempty"`
-	ResourceList []NamespaceResource `json:",omitempty"`
+	ID            string
+	IsDefault     bool                `json:",omitempty"`
+	ResourceList  []NamespaceResource `json:",omitempty"`
+	CompartmentId uint32              `json:",omitempty"`
 }
 
 func issueNamespaceRequest(id *string, method, subpath string, request interface{}) (*Namespace, error) {

--- a/internal/winapi/net.go
+++ b/internal/winapi/net.go
@@ -1,0 +1,3 @@
+package winapi
+
+//sys SetJobCompartmentId(handle windows.Handle, compartmentId uint32) (hr error) = iphlpapi.SetJobCompartmentId

--- a/internal/winapi/winapi.go
+++ b/internal/winapi/winapi.go
@@ -2,4 +2,4 @@
 // be thought of as an extension to golang.org/x/sys/windows.
 package winapi
 
-//go:generate go run ..\..\mksyscall_windows.go -output zsyscall_windows.go jobobject.go path.go logon.go memory.go processor.go devices.go filesystem.go errors.go
+//go:generate go run ..\..\mksyscall_windows.go -output zsyscall_windows.go net.go jobobject.go path.go logon.go memory.go processor.go devices.go filesystem.go errors.go


### PR DESCRIPTION
* For future work to be able to run a job container in a network namespace
that isn't the hosts, added the SetJobCompartmentId function from iphlpapi.

Signed-off-by: Daniel Canter <dcanter@microsoft.com>