### PR TITLE
Change SetJobCompartmentId to use win32 error code semantics

### DIFF
--- a/internal/winapi/net.go
+++ b/internal/winapi/net.go
@@ -1,3 +1,3 @@
 package winapi
 
-//sys SetJobCompartmentId(handle windows.Handle, compartmentId uint32) (hr error) = iphlpapi.SetJobCompartmentId
+//sys SetJobCompartmentId(handle windows.Handle, compartmentId uint32) (win32Err error) = iphlpapi.SetJobCompartmentId

--- a/internal/winapi/zsyscall_windows.go
+++ b/internal/winapi/zsyscall_windows.go
@@ -65,13 +65,10 @@ var (
 	procRtlNtStatusToDosError                = modntdll.NewProc("RtlNtStatusToDosError")
 )
 
-func SetJobCompartmentId(handle windows.Handle, compartmentId uint32) (hr error) {
+func SetJobCompartmentId(handle windows.Handle, compartmentId uint32) (win32Err error) {
 	r0, _, _ := syscall.Syscall(procSetJobCompartmentId.Addr(), 2, uintptr(handle), uintptr(compartmentId), 0)
-	if int32(r0) < 0 {
-		if r0&0x1fff0000 == 0x00070000 {
-			r0 &= 0xffff
-		}
-		hr = syscall.Errno(r0)
+	if r0 != 0 {
+		win32Err = syscall.Errno(r0)
 	}
 	return
 }


### PR DESCRIPTION
* Binding currently has the return value checked against HRESULT semantics when
this shouldn't be the case as it doesn't return an HRESULT

Signed-off-by: Daniel Canter <dcanter@microsoft.com>