### PR TITLE
Add new function to exec cmds in host for process isolated containers

### DIFF
--- a/cmd/containerd-shim-runhcs-v1/task.go
+++ b/cmd/containerd-shim-runhcs-v1/task.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/Microsoft/hcsshim/cmd/containerd-shim-runhcs-v1/options"
@@ -10,6 +11,8 @@ import (
 	"github.com/containerd/containerd/runtime/v2/task"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 )
+
+var errTaskNotIsolated = errors.New("task is not isolated")
 
 // shimTaskPidPair groups a process pid to its execID if it was user generated.
 type shimTaskPidPair struct {

--- a/cmd/containerd-shim-runhcs-v1/task_hcs.go
+++ b/cmd/containerd-shim-runhcs-v1/task_hcs.go
@@ -594,7 +594,7 @@ func (ht *hcsTask) closeHost(ctx context.Context) {
 
 func (ht *hcsTask) ExecInHost(ctx context.Context, req *shimdiag.ExecProcessRequest) (int, error) {
 	if ht.host == nil {
-		return 0, errors.New("task is not isolated")
+		return cmd.ExecInShimHost(ctx, req)
 	}
 	return cmd.ExecInUvm(ctx, ht.host, req)
 }
@@ -613,7 +613,7 @@ func (ht *hcsTask) DumpGuestStacks(ctx context.Context) string {
 
 func (ht *hcsTask) Share(ctx context.Context, req *shimdiag.ShareRequest) error {
 	if ht.host == nil {
-		return errors.New("task is not isolated")
+		return errTaskNotIsolated
 	}
 	// For hyper-v isolated WCOW the task used isn't the standard hcsTask so we
 	// only have to deal with the LCOW case here.

--- a/cmd/containerd-shim-runhcs-v1/task_wcow_podsandbox.go
+++ b/cmd/containerd-shim-runhcs-v1/task_wcow_podsandbox.go
@@ -222,7 +222,7 @@ func (wpst *wcowPodSandboxTask) waitParentExit() {
 
 func (wpst *wcowPodSandboxTask) ExecInHost(ctx context.Context, req *shimdiag.ExecProcessRequest) (int, error) {
 	if wpst.host == nil {
-		return 0, errors.New("task is not isolated")
+		return 0, errTaskNotIsolated
 	}
 	return cmd.ExecInUvm(ctx, wpst.host, req)
 }
@@ -241,7 +241,7 @@ func (wpst *wcowPodSandboxTask) DumpGuestStacks(ctx context.Context) string {
 
 func (wpst *wcowPodSandboxTask) Share(ctx context.Context, req *shimdiag.ShareRequest) error {
 	if wpst.host == nil {
-		return errors.New("task is not isolated")
+		return errTaskNotIsolated
 	}
 	options := wpst.host.DefaultVSMBOptions(req.ReadOnly)
 	_, err := wpst.host.AddVSMB(ctx, req.HostPath, options)

--- a/internal/cmd/diag.go
+++ b/internal/cmd/diag.go
@@ -3,13 +3,16 @@ package cmd
 import (
 	"context"
 	"errors"
+	"os/exec"
 
 	"github.com/Microsoft/hcsshim/internal/log"
 	"github.com/Microsoft/hcsshim/internal/logfields"
 	"github.com/Microsoft/hcsshim/internal/shimdiag"
 	"github.com/Microsoft/hcsshim/internal/uvm"
+	errorspkg "github.com/pkg/errors"
 )
 
+// ExecInUvm is a helper function used to execute commands specified in `req` inside the given UVM.
 func ExecInUvm(ctx context.Context, vm *uvm.UtilityVM, req *shimdiag.ExecProcessRequest) (int, error) {
 	if len(req.Args) == 0 {
 		return 0, errors.New("missing command")
@@ -33,4 +36,25 @@ func ExecInUvm(ctx context.Context, vm *uvm.UtilityVM, req *shimdiag.ExecProcess
 	cmd.Log = log.G(ctx).WithField(logfields.UVMID, vm.ID())
 	err = cmd.Run()
 	return cmd.ExitState.ExitCode(), err
+}
+
+// ExecInShimHost is a helper function used to execute commands specified in `req` in the shim's
+// hosting system.
+func ExecInShimHost(ctx context.Context, req *shimdiag.ExecProcessRequest) (int, error) {
+	if len(req.Args) == 0 {
+		return 0, errors.New("missing command")
+	}
+	cmdArgsWithoutName := []string{""}
+	if len(req.Args) > 1 {
+		cmdArgsWithoutName = req.Args[1:]
+	}
+	cmd := exec.Command(req.Args[0], cmdArgsWithoutName...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		if exiterr, ok := err.(*exec.ExitError); ok {
+			return exiterr.ExitCode(), errorspkg.Wrapf(exiterr, "command output: %v", string(output))
+		}
+		return -1, errorspkg.Wrapf(err, "command output: %v", string(output))
+	}
+	return 0, nil
 }


### PR DESCRIPTION
This PR adds a new function that allows us to exec commands on the container host of process isolated containers. This will be used in subsequent PRs to support resource modification of process isolated containers. 

Signed-off-by: Kathryn Baldauf <kabaldau@microsoft.com>