### PR TITLE
Add virtdisk bindings and helper functions to computestorage

### DIFF
--- a/computestorage/helper.go
+++ b/computestorage/helper.go
@@ -1,0 +1,160 @@
+package computestorage
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/Microsoft/go-winio/pkg/security"
+	"github.com/Microsoft/hcsshim/internal/virtdisk"
+	"golang.org/x/sys/windows"
+)
+
+// SetupContainerBaseLayer is a helper function to setup a containers base layer. The size of
+// the template VHDs is configurable with the sizeInGB parameter.
+func SetupContainerBaseLayer(ctx context.Context, layerPath, vhdName string, sizeInGB uint64) error {
+	var (
+		baseVhdPath = filepath.Join(layerPath, vhdName+"-base.vhdx")
+		diffVhdPath = filepath.Join(layerPath, vhdName+".vhdx")
+		hivesPath   = filepath.Join(layerPath, "Hives")
+		layoutPath  = filepath.Join(layerPath, "Layout")
+	)
+
+	if _, err := os.Stat(hivesPath); err == nil {
+		os.RemoveAll(hivesPath)
+	}
+	if _, err := os.Stat(layoutPath); err == nil {
+		os.RemoveAll(layoutPath)
+	}
+	if _, err := os.Stat(baseVhdPath); err == nil {
+		os.RemoveAll(baseVhdPath)
+	}
+	if _, err := os.Stat(diffVhdPath); err == nil {
+		os.RemoveAll(diffVhdPath)
+	}
+
+	createParams := &virtdisk.CreateVirtualDiskParameters{
+		Version: 2,
+		Version2: virtdisk.CreateVersion2{
+			MaximumSize:      sizeInGB * 1024 * 1024 * 1024,
+			BlockSizeInBytes: 1 * 1024 * 1024,
+		},
+	}
+
+	handle, err := virtdisk.CreateVirtualDisk(ctx, baseVhdPath, virtdisk.VirtualDiskAccessFlagNone, virtdisk.CreateVirtualDiskFlagNone, createParams)
+	if err != nil {
+		return fmt.Errorf("failed to create VHD: %s", err)
+	}
+
+	defer func() {
+		if err != nil {
+			windows.CloseHandle(handle)
+		}
+	}()
+
+	if err := FormatWritableLayerVhd(ctx, handle); err != nil {
+		return err
+	}
+
+	if err = windows.CloseHandle(handle); err != nil {
+		return fmt.Errorf("failed to close VHD handle : %s", err)
+	}
+
+	options := OsLayerOptions{
+		Type: OsLayerTypeContainer,
+	}
+
+	// SetupBaseOSLayer expects an empty vhd handle for a container layer and will
+	// error out otherwise.
+	if err = SetupBaseOSLayer(ctx, layerPath, 0, options); err != nil {
+		return err
+	}
+
+	if err = virtdisk.CreateDiffVhd(ctx, diffVhdPath, baseVhdPath); err != nil {
+		return err
+	}
+
+	if err = security.GrantVmGroupAccess(baseVhdPath); err != nil {
+		return fmt.Errorf("failed to grant vm group access to %s: %s", baseVhdPath, err)
+	}
+
+	if err = security.GrantVmGroupAccess(diffVhdPath); err != nil {
+		return fmt.Errorf("failed to grant vm group access to %s: %s", diffVhdPath, err)
+	}
+	return nil
+}
+
+// SetupUtilityVMBaseLayer is a helper function to setup a UVMs base layer. The size of
+// the template VHDs is configurable with the sizeInGB parameter.
+func SetupUtilityVMBaseLayer(ctx context.Context, uvmPath string, vhdName string, sizeInGB uint64) error {
+	baseVhdPath := filepath.Join(uvmPath, vhdName+"Base.vhdx")
+	diffVhdPath := filepath.Join(uvmPath, vhdName+".vhdx")
+
+	if _, err := os.Stat(baseVhdPath); err == nil {
+		os.RemoveAll(baseVhdPath)
+	}
+	if _, err := os.Stat(diffVhdPath); err == nil {
+		os.RemoveAll(diffVhdPath)
+	}
+
+	// Just create the vhd for utilityVM layer, no need to format it.
+	createParams := &virtdisk.CreateVirtualDiskParameters{
+		Version: 2,
+		Version2: virtdisk.CreateVersion2{
+			MaximumSize:      sizeInGB * 1024 * 1024 * 1024,
+			BlockSizeInBytes: 1 * 1024 * 1024,
+		},
+	}
+
+	handle, err := virtdisk.CreateVirtualDisk(ctx, baseVhdPath, virtdisk.VirtualDiskAccessFlagNone, virtdisk.CreateVirtualDiskFlagNone, createParams)
+	if err != nil {
+		return fmt.Errorf("failed to create VHD: %s", err)
+	}
+
+	defer func() {
+		if err != nil {
+			windows.CloseHandle(handle)
+		}
+	}()
+
+	// If it is a utilityVM layer then the base vhd must be attached when calling
+	// SetupBaseOSLayer
+	attachParams := &virtdisk.AttachVirtualDiskParameters{
+		Version: 2,
+	}
+
+	if err := virtdisk.AttachVirtualDisk(ctx, handle, virtdisk.AttachVirtualDiskFlagNone, attachParams); err != nil {
+		return err
+	}
+
+	options := OsLayerOptions{
+		Type: OsLayerTypeVM,
+	}
+
+	if err = SetupBaseOSLayer(ctx, uvmPath, handle, options); err != nil {
+		return err
+	}
+
+	if err = virtdisk.DetachVirtualDisk(ctx, handle); err != nil {
+		return fmt.Errorf("failed to detach VHD: %s", err)
+	}
+
+	if err = windows.CloseHandle(handle); err != nil {
+		return fmt.Errorf("failed to close VHD handle: %s", err)
+	}
+
+	if err = virtdisk.CreateDiffVhd(ctx, diffVhdPath, baseVhdPath); err != nil {
+		return err
+	}
+
+	if err = security.GrantVmGroupAccess(baseVhdPath); err != nil {
+		return fmt.Errorf("failed to grant vm group access to %s: %s", baseVhdPath, err)
+	}
+
+	if err = security.GrantVmGroupAccess(diffVhdPath); err != nil {
+		return fmt.Errorf("failed to grant vm group access to %s: %s", diffVhdPath, err)
+	}
+
+	return nil
+}

--- a/internal/virtdisk/syscall.go
+++ b/internal/virtdisk/syscall.go
@@ -1,0 +1,74 @@
+package virtdisk
+
+import (
+	"context"
+	"fmt"
+
+	"golang.org/x/sys/windows"
+)
+
+// OpenVirtualDisk opens a virtual disk in either vhd or vhdx format and returns a handle to the
+// disk.
+func OpenVirtualDisk(ctx context.Context, vhdPath string, virtualDiskAccessMask VirtualDiskAccessMask, openVirtualDiskFlags OpenVirtualDiskFlag, parameters *OpenVirtualDiskParameters) (_ windows.Handle, err error) {
+	var handle windows.Handle
+	if parameters.Version != 2 {
+		return handle, fmt.Errorf("only version 2 VHDs are supported, found version: %d", parameters.Version)
+	}
+
+	err = openVirtualDisk(&vhdxVirtualStorageType, vhdPath, uint32(virtualDiskAccessMask), uint32(openVirtualDiskFlags), parameters, &handle)
+	if err != nil {
+		return handle, fmt.Errorf("failed to open virtual disk: %s", err)
+	}
+	return handle, nil
+}
+
+// CreateVirtualDisk creates a virtual harddisk and returns a handle to the disk.
+func CreateVirtualDisk(ctx context.Context, path string, virtualDiskAccessMask VirtualDiskAccessMask, createVirtualDiskFlags CreateVirtualDiskFlag, parameters *CreateVirtualDiskParameters) (_ windows.Handle, err error) {
+	var handle windows.Handle
+	if parameters.Version != 2 {
+		return handle, fmt.Errorf("only version 2 VHDs are supported, found version: %d", parameters.Version)
+	}
+
+	err = createVirtualDisk(&vhdxVirtualStorageType, path, uint32(virtualDiskAccessMask), 0, uint32(createVirtualDiskFlags), 0, parameters, nil, &handle)
+	if err != nil {
+		return handle, fmt.Errorf("failed to create virtual disk: %s", err)
+	}
+	return handle, nil
+}
+
+// GetVirtualDiskPhysicalPath takes a handle to a virtual hard disk and returns the physical
+// path of the disk on the machine.
+func GetVirtualDiskPhysicalPath(ctx context.Context, handle windows.Handle) (_ string, err error) {
+	var (
+		diskPathSizeInBytes uint32 = 256 * 2 // max path length 256 wide chars
+		diskPhysicalPathBuf [256]uint16
+	)
+
+	err = getVirtualDiskPhysicalPath(handle, &diskPathSizeInBytes, &diskPhysicalPathBuf[0])
+	if err != nil {
+		return "", fmt.Errorf("failed to get disk physical path: %s", err)
+	}
+	return windows.UTF16ToString(diskPhysicalPathBuf[:]), nil
+}
+
+// AttachVirtualDisk attaches a virtual hard disk for use.
+func AttachVirtualDisk(ctx context.Context, handle windows.Handle, attachVirtualDiskFlag AttachVirtualDiskFlag, parameters *AttachVirtualDiskParameters) (err error) {
+	if parameters.Version != 2 {
+		return fmt.Errorf("only version 2 VHDs are supported, found version: %d", parameters.Version)
+	}
+
+	err = attachVirtualDisk(handle, 0, uint32(attachVirtualDiskFlag), 0, parameters, nil)
+	if err != nil {
+		return fmt.Errorf("failed to attach virtual disk: %s", err)
+	}
+	return nil
+}
+
+// DetachVirtualDisk detaches a virtual hard disk.
+func DetachVirtualDisk(ctx context.Context, handle windows.Handle) (err error) {
+	err = detachVirtualDisk(handle, 0, 0)
+	if err != nil {
+		return fmt.Errorf("failed to detach virtual disk: %s", err)
+	}
+	return nil
+}

--- a/internal/virtdisk/virtdisk.go
+++ b/internal/virtdisk/virtdisk.go
@@ -1,0 +1,160 @@
+// Package virtdisk is a wrapper around the APIs exported by virtdisk.dll
+package virtdisk
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Microsoft/go-winio/pkg/guid"
+	"golang.org/x/sys/windows"
+)
+
+//go:generate go run ../../mksyscall_windows.go -output zsyscall_windows.go virtdisk.go
+
+// CreateDiffVhd creates a differencing virtual disk.
+func CreateDiffVhd(ctx context.Context, diffVhdPath, baseVhdPath string) error {
+	// Setting `ParentPath` is how to signal to create a differencing disk.
+	createParams := &CreateVirtualDiskParameters{
+		Version: 2,
+		Version2: CreateVersion2{
+			ParentPath:       windows.StringToUTF16Ptr(baseVhdPath),
+			BlockSizeInBytes: 1 * 1024 * 1024,
+			OpenFlags:        uint32(OpenVirtualDiskFlagCachedIO),
+		},
+	}
+
+	vhdHandle, err := CreateVirtualDisk(ctx, diffVhdPath, VirtualDiskAccessFlagNone, CreateVirtualDiskFlagNone, createParams)
+	if err != nil {
+		return fmt.Errorf("failed to create differencing vhd: %s", err)
+	}
+	if err := windows.CloseHandle(vhdHandle); err != nil {
+		return fmt.Errorf("failed to close differencing vhd handle: %s", err)
+	}
+	return nil
+}
+
+type (
+	CreateVirtualDiskFlag uint32
+	OpenVirtualDiskFlag   uint32
+	AttachVirtualDiskFlag uint32
+	DetachVirtualDiskFlag uint32
+	VirtualDiskAccessMask uint32
+)
+
+type VirtualStorageType struct {
+	DeviceID uint32
+	VendorID guid.GUID
+}
+
+type CreateVersion2 struct {
+	UniqueID                 guid.GUID
+	MaximumSize              uint64
+	BlockSizeInBytes         uint32
+	SectorSizeInBytes        uint32
+	PhysicalSectorSizeInByte uint32
+	ParentPath               *uint16 // string
+	SourcePath               *uint16 // string
+	OpenFlags                uint32
+	ParentVirtualStorageType VirtualStorageType
+	SourceVirtualStorageType VirtualStorageType
+	ResiliencyGUID           guid.GUID
+}
+
+type CreateVirtualDiskParameters struct {
+	Version  uint32 // Must always be set to 2
+	Version2 CreateVersion2
+}
+
+type OpenVersion2 struct {
+	GetInfoOnly    bool
+	ReadOnly       bool
+	ResiliencyGUID guid.GUID
+}
+
+type OpenVirtualDiskParameters struct {
+	Version  uint32 // Must always be set to 2
+	Version2 OpenVersion2
+}
+
+type AttachVersion2 struct {
+	RestrictedOffset uint64
+	RestrictedLength uint64
+}
+
+type AttachVirtualDiskParameters struct {
+	Version  uint32 // Must always be set to 2
+	Version2 AttachVersion2
+}
+
+const (
+	VIRTUAL_STORAGE_TYPE_DEVICE_VHDX = 0x3
+
+	VirtualDiskAccessFlagNone     VirtualDiskAccessMask = 0x00000000
+	VirtualDiskAccessFlagAttachRO VirtualDiskAccessMask = 0x00010000
+	VirtualDiskAccessFlagAttachRW VirtualDiskAccessMask = 0x00020000
+	VirtualDiskAccessFlagDetach   VirtualDiskAccessMask = 0x00040000
+	VirtualDiskAccessFlagGetInfo  VirtualDiskAccessMask = 0x00080000
+	VirtualDiskAccessFlagCreate   VirtualDiskAccessMask = 0x00100000
+	VirtualDiskAccessFlagMetaOps  VirtualDiskAccessMask = 0x00200000
+	VirtualDiskAccessFlagRead     VirtualDiskAccessMask = 0x000d0000
+	VirtualDiskAccessFlagAll      VirtualDiskAccessMask = 0x003f0000
+	VirtualDiskAccessFlagWritable VirtualDiskAccessMask = 0x00320000
+
+	CreateVirtualDiskFlagNone                              CreateVirtualDiskFlag = 0x0
+	CreateVirtualDiskFlagFullPhysicalAllocation            CreateVirtualDiskFlag = 0x1
+	CreateVirtualDiskFlagPreventWritesToSourceDisk         CreateVirtualDiskFlag = 0x2
+	CreateVirtualDiskFlagDoNotCopyMetadataFromParent       CreateVirtualDiskFlag = 0x4
+	CreateVirtualDiskFlagCreateBackingStorage              CreateVirtualDiskFlag = 0x8
+	CreateVirtualDiskFlagUseChangeTrackingSourceLimit      CreateVirtualDiskFlag = 0x10
+	CreateVirtualDiskFlagPreserveParentChangeTrackingState CreateVirtualDiskFlag = 0x20
+	CreateVirtualDiskFlagVhdSetUseOriginalBackingStorage   CreateVirtualDiskFlag = 0x40
+	CreateVirtualDiskFlagSparseFile                        CreateVirtualDiskFlag = 0x80
+	CreateVirtualDiskFlagPmemCompatible                    CreateVirtualDiskFlag = 0x100
+	CreateVirtualDiskFlagSupportCompressedVolumes          CreateVirtualDiskFlag = 0x200
+
+	OpenVirtualDiskFlagNone                        OpenVirtualDiskFlag = 0x00000000
+	OpenVirtualDiskFlagNoParents                   OpenVirtualDiskFlag = 0x00000001
+	OpenVirtualDiskFlagBlankFile                   OpenVirtualDiskFlag = 0x00000002
+	OpenVirtualDiskFlagBootDrive                   OpenVirtualDiskFlag = 0x00000004
+	OpenVirtualDiskFlagCachedIO                    OpenVirtualDiskFlag = 0x00000008
+	OpenVirtualDiskFlagCustomDiffChain             OpenVirtualDiskFlag = 0x00000010
+	OpenVirtualDiskFlagParentCachedIO              OpenVirtualDiskFlag = 0x00000020
+	OpenVirtualDiskFlagVhdsetFileOnly              OpenVirtualDiskFlag = 0x00000040
+	OpenVirtualDiskFlagIgnoreRelativeParentLocator OpenVirtualDiskFlag = 0x00000080
+	OpenVirtualDiskFlagNoWriteHardening            OpenVirtualDiskFlag = 0x00000100
+	OpenVirtualDiskFlagSupportCompressedVolumes    OpenVirtualDiskFlag = 0x00000200
+
+	AttachVirtualDiskFlagNone                          AttachVirtualDiskFlag = 0x00000000
+	AttachVirtualDiskFlagReadOnly                      AttachVirtualDiskFlag = 0x00000001
+	AttachVirtualDiskFlagNoDriveLetter                 AttachVirtualDiskFlag = 0x00000002
+	AttachVirtualDiskFlagPermanentLifetime             AttachVirtualDiskFlag = 0x00000004
+	AttachVirtualDiskFlagNoLocalHost                   AttachVirtualDiskFlag = 0x00000008
+	AttachVirtualDiskFlagNoSecurityDescriptor          AttachVirtualDiskFlag = 0x00000010
+	AttachVirtualDiskFlagBypassDefaultEncryptionPolicy AttachVirtualDiskFlag = 0x00000020
+	AttachVirtualDiskFlagNonPnp                        AttachVirtualDiskFlag = 0x00000040
+	AttachVirtualDiskFlagRestrictedRange               AttachVirtualDiskFlag = 0x00000080
+	AttachVirtualDiskFlagSinglePartition               AttachVirtualDiskFlag = 0x00000100
+	AttachVirtualDiskFlagRegisterVolume                AttachVirtualDiskFlag = 0x00000200
+
+	DetachVirtualDiskFlagNone DetachVirtualDiskFlag = 0x0
+)
+
+var (
+	VIRTUAL_STORAGE_TYPE_VENDOR_MICROSOFT = guid.GUID{
+		Data1: 0xec984aec,
+		Data2: 0xa0f9,
+		Data3: 0x47e9,
+		Data4: [8]byte{0x90, 0x1f, 0x71, 0x41, 0x5a, 0x66, 0x34, 0x5b},
+	}
+
+	vhdxVirtualStorageType = VirtualStorageType{
+		DeviceID: VIRTUAL_STORAGE_TYPE_DEVICE_VHDX,
+		VendorID: VIRTUAL_STORAGE_TYPE_VENDOR_MICROSOFT,
+	}
+)
+
+//sys createVirtualDisk(virtualStorageType *VirtualStorageType, path string, virtualDiskAccessMask uint32, securityDescriptor uintptr, createVirtualDiskFlags uint32, providerSpecificFlags uint32, parameters *CreateVirtualDiskParameters, overlapped *windows.Overlapped, handle *windows.Handle) (err error) [failretval != 0] = virtdisk.CreateVirtualDisk
+//sys openVirtualDisk(virtualStorageType *VirtualStorageType, path string, virtualDiskAccessMask uint32, openVirtualDiskFlags uint32, parameters *OpenVirtualDiskParameters, handle *windows.Handle) (err error) [failretval != 0] = virtdisk.OpenVirtualDisk
+//sys attachVirtualDisk(handle windows.Handle, securityDescriptor uintptr, attachVirtualDiskFlag uint32, providerSpecificFlags uint32, parameters *AttachVirtualDiskParameters, overlapped *windows.Overlapped) (err error) [failretval != 0] = virtdisk.AttachVirtualDisk
+//sys detachVirtualDisk(handle windows.Handle, detachVirtualDiskFlags uint32, providerSpecificFlags uint32) (err error) [failretval != 0] = virtdisk.DetachVirtualDisk
+//sys getVirtualDiskPhysicalPath(handle windows.Handle, diskPathSizeInBytes *uint32, buffer *uint16) (err error) [failretval != 0] = virtdisk.GetVirtualDiskPhysicalPath

--- a/internal/virtdisk/zsyscall_windows.go
+++ b/internal/virtdisk/zsyscall_windows.go
@@ -1,0 +1,125 @@
+// Code generated mksyscall_windows.exe DO NOT EDIT
+
+package virtdisk
+
+import (
+	"syscall"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+var _ unsafe.Pointer
+
+// Do the interface allocations only once for common
+// Errno values.
+const (
+	errnoERROR_IO_PENDING = 997
+)
+
+var (
+	errERROR_IO_PENDING error = syscall.Errno(errnoERROR_IO_PENDING)
+)
+
+// errnoErr returns common boxed Errno values, to prevent
+// allocations at runtime.
+func errnoErr(e syscall.Errno) error {
+	switch e {
+	case 0:
+		return nil
+	case errnoERROR_IO_PENDING:
+		return errERROR_IO_PENDING
+	}
+	// TODO: add more here, after collecting data on the common
+	// error values see on Windows. (perhaps when running
+	// all.bat?)
+	return e
+}
+
+var (
+	modvirtdisk = windows.NewLazySystemDLL("virtdisk.dll")
+
+	procCreateVirtualDisk          = modvirtdisk.NewProc("CreateVirtualDisk")
+	procOpenVirtualDisk            = modvirtdisk.NewProc("OpenVirtualDisk")
+	procAttachVirtualDisk          = modvirtdisk.NewProc("AttachVirtualDisk")
+	procDetachVirtualDisk          = modvirtdisk.NewProc("DetachVirtualDisk")
+	procGetVirtualDiskPhysicalPath = modvirtdisk.NewProc("GetVirtualDiskPhysicalPath")
+)
+
+func createVirtualDisk(virtualStorageType *VirtualStorageType, path string, virtualDiskAccessMask uint32, securityDescriptor uintptr, createVirtualDiskFlags uint32, providerSpecificFlags uint32, parameters *CreateVirtualDiskParameters, overlapped *windows.Overlapped, handle *windows.Handle) (err error) {
+	var _p0 *uint16
+	_p0, err = syscall.UTF16PtrFromString(path)
+	if err != nil {
+		return
+	}
+	return _createVirtualDisk(virtualStorageType, _p0, virtualDiskAccessMask, securityDescriptor, createVirtualDiskFlags, providerSpecificFlags, parameters, overlapped, handle)
+}
+
+func _createVirtualDisk(virtualStorageType *VirtualStorageType, path *uint16, virtualDiskAccessMask uint32, securityDescriptor uintptr, createVirtualDiskFlags uint32, providerSpecificFlags uint32, parameters *CreateVirtualDiskParameters, overlapped *windows.Overlapped, handle *windows.Handle) (err error) {
+	r1, _, e1 := syscall.Syscall9(procCreateVirtualDisk.Addr(), 9, uintptr(unsafe.Pointer(virtualStorageType)), uintptr(unsafe.Pointer(path)), uintptr(virtualDiskAccessMask), uintptr(securityDescriptor), uintptr(createVirtualDiskFlags), uintptr(providerSpecificFlags), uintptr(unsafe.Pointer(parameters)), uintptr(unsafe.Pointer(overlapped)), uintptr(unsafe.Pointer(handle)))
+	if r1 != 0 {
+		if e1 != 0 {
+			err = errnoErr(e1)
+		} else {
+			err = syscall.EINVAL
+		}
+	}
+	return
+}
+
+func openVirtualDisk(virtualStorageType *VirtualStorageType, path string, virtualDiskAccessMask uint32, openVirtualDiskFlags uint32, parameters *OpenVirtualDiskParameters, handle *windows.Handle) (err error) {
+	var _p0 *uint16
+	_p0, err = syscall.UTF16PtrFromString(path)
+	if err != nil {
+		return
+	}
+	return _openVirtualDisk(virtualStorageType, _p0, virtualDiskAccessMask, openVirtualDiskFlags, parameters, handle)
+}
+
+func _openVirtualDisk(virtualStorageType *VirtualStorageType, path *uint16, virtualDiskAccessMask uint32, openVirtualDiskFlags uint32, parameters *OpenVirtualDiskParameters, handle *windows.Handle) (err error) {
+	r1, _, e1 := syscall.Syscall6(procOpenVirtualDisk.Addr(), 6, uintptr(unsafe.Pointer(virtualStorageType)), uintptr(unsafe.Pointer(path)), uintptr(virtualDiskAccessMask), uintptr(openVirtualDiskFlags), uintptr(unsafe.Pointer(parameters)), uintptr(unsafe.Pointer(handle)))
+	if r1 != 0 {
+		if e1 != 0 {
+			err = errnoErr(e1)
+		} else {
+			err = syscall.EINVAL
+		}
+	}
+	return
+}
+
+func attachVirtualDisk(handle windows.Handle, securityDescriptor uintptr, attachVirtualDiskFlag uint32, providerSpecificFlags uint32, parameters *AttachVirtualDiskParameters, overlapped *windows.Overlapped) (err error) {
+	r1, _, e1 := syscall.Syscall6(procAttachVirtualDisk.Addr(), 6, uintptr(handle), uintptr(securityDescriptor), uintptr(attachVirtualDiskFlag), uintptr(providerSpecificFlags), uintptr(unsafe.Pointer(parameters)), uintptr(unsafe.Pointer(overlapped)))
+	if r1 != 0 {
+		if e1 != 0 {
+			err = errnoErr(e1)
+		} else {
+			err = syscall.EINVAL
+		}
+	}
+	return
+}
+
+func detachVirtualDisk(handle windows.Handle, detachVirtualDiskFlags uint32, providerSpecificFlags uint32) (err error) {
+	r1, _, e1 := syscall.Syscall(procDetachVirtualDisk.Addr(), 3, uintptr(handle), uintptr(detachVirtualDiskFlags), uintptr(providerSpecificFlags))
+	if r1 != 0 {
+		if e1 != 0 {
+			err = errnoErr(e1)
+		} else {
+			err = syscall.EINVAL
+		}
+	}
+	return
+}
+
+func getVirtualDiskPhysicalPath(handle windows.Handle, diskPathSizeInBytes *uint32, buffer *uint16) (err error) {
+	r1, _, e1 := syscall.Syscall(procGetVirtualDiskPhysicalPath.Addr(), 3, uintptr(handle), uintptr(unsafe.Pointer(diskPathSizeInBytes)), uintptr(unsafe.Pointer(buffer)))
+	if r1 != 0 {
+		if e1 != 0 {
+			err = errnoErr(e1)
+		} else {
+			err = syscall.EINVAL
+		}
+	}
+	return
+}


### PR DESCRIPTION
* Add necessary virtdisk bindings to be used for computestorage calls/cimfs
work.

Signed-off-by: Daniel Canter <dcanter@microsoft.com>