### PR TITLE
Force disable VSMB direct map when the volume does not support it

### DIFF
--- a/internal/winapi/filesystem.go
+++ b/internal/winapi/filesystem.go
@@ -31,6 +31,43 @@ const (
 	STATUS_NO_MORE_ENTRIES = 0x8000001a
 )
 
+// Select entries from FILE_INFO_BY_HANDLE_CLASS.
+//
+// C declaration:
+//   typedef enum _FILE_INFO_BY_HANDLE_CLASS {
+//       FileBasicInfo,
+//       FileStandardInfo,
+//       FileNameInfo,
+//       FileRenameInfo,
+//       FileDispositionInfo,
+//       FileAllocationInfo,
+//       FileEndOfFileInfo,
+//       FileStreamInfo,
+//       FileCompressionInfo,
+//       FileAttributeTagInfo,
+//       FileIdBothDirectoryInfo,
+//       FileIdBothDirectoryRestartInfo,
+//       FileIoPriorityHintInfo,
+//       FileRemoteProtocolInfo,
+//       FileFullDirectoryInfo,
+//       FileFullDirectoryRestartInfo,
+//       FileStorageInfo,
+//       FileAlignmentInfo,
+//       FileIdInfo,
+//       FileIdExtdDirectoryInfo,
+//       FileIdExtdDirectoryRestartInfo,
+//       FileDispositionInfoEx,
+//       FileRenameInfoEx,
+//       FileCaseSensitiveInfo,
+//       FileNormalizedNameInfo,
+//       MaximumFileInfoByHandleClass
+//   } FILE_INFO_BY_HANDLE_CLASS, *PFILE_INFO_BY_HANDLE_CLASS;
+//
+// Documentation: https://docs.microsoft.com/en-us/windows/win32/api/minwinbase/ne-minwinbase-file_info_by_handle_class
+const (
+	FileIdInfo = 18
+)
+
 type FileDispositionInformationEx struct {
 	Flags uintptr
 }
@@ -58,4 +95,16 @@ type FileLinkInformation struct {
 	RootDirectory   uintptr
 	FileNameLength  uint32
 	FileName        [1]uint16
+}
+
+// C declaration:
+//   typedef struct _FILE_ID_INFO {
+//       ULONGLONG   VolumeSerialNumber;
+//       FILE_ID_128 FileId;
+//   } FILE_ID_INFO, *PFILE_ID_INFO;
+//
+// Documentation: https://docs.microsoft.com/en-us/windows/win32/api/winbase/ns-winbase-file_id_info
+type FILE_ID_INFO struct {
+	VolumeSerialNumber uint64
+	FileID             [16]byte
 }

--- a/osversion/windowsbuilds.go
+++ b/osversion/windowsbuilds.go
@@ -32,4 +32,7 @@ const (
 	// V20H1 (version 2004) corresponds to Windows Server 2004 (semi-annual
 	// channel).
 	V20H1 = 19041
+
+	// V20H2 corresponds to Windows Server 20H2 (semi-annual channel).
+	V20H2 = 19042
 )


### PR DESCRIPTION
VSMB direct map requires support for querying FileIdInfo from the
backing volume. There is a bug in certain Windows versions where instead
of falling back to non-direct map when FileIdInfo is not supported, VSMB
instead causes errors whenever files on the share are accessed.

To work around this until the issue is fixed, we will query FileIdInfo
ourselves when setting up a VSMB share, and force disable direct map if
the query fails.

Signed-off-by: Kevin Parsons <kevpar@microsoft.com>