### PR TITLE
Change redundant test config declarations

### DIFF
--- a/test/cri-containerd/container_network_test.go
+++ b/test/cri-containerd/container_network_test.go
@@ -100,14 +100,6 @@ func Test_Container_Network_LCOW(t *testing.T) {
 }
 
 func Test_Container_Network_Hostname(t *testing.T) {
-	type config struct {
-		name             string
-		requiredFeatures []string
-		runtimeHandler   string
-		sandboxImage     string
-		containerImage   string
-		cmd              []string
-	}
 	tests := []config{
 		{
 			name:             "WCOW_Process",

--- a/test/cri-containerd/main.go
+++ b/test/cri-containerd/main.go
@@ -87,6 +87,15 @@ var allFeatures = []string{
 	featureGPU,
 }
 
+type config struct {
+	name             string
+	requiredFeatures []string
+	runtimeHandler   string
+	sandboxImage     string
+	containerImage   string
+	cmd              []string
+}
+
 func init() {
 	// Flag definitions must be in init rather than TestMain, as TestMain isn't
 	// called if -help is passed, but we want the feature usage to show up.

--- a/test/cri-containerd/stats_test.go
+++ b/test/cri-containerd/stats_test.go
@@ -202,14 +202,6 @@ func Test_SandboxStats_List_PodID_LCOW(t *testing.T) {
 }
 
 func Test_ContainerStats_ContainerID(t *testing.T) {
-	type config struct {
-		name             string
-		requiredFeatures []string
-		runtimeHandler   string
-		sandboxImage     string
-		containerImage   string
-		cmd              []string
-	}
 	tests := []config{
 		{
 			name:             "WCOW_Process",
@@ -286,14 +278,6 @@ func Test_ContainerStats_ContainerID(t *testing.T) {
 }
 
 func Test_ContainerStats_List_ContainerID(t *testing.T) {
-	type config struct {
-		name             string
-		requiredFeatures []string
-		runtimeHandler   string
-		sandboxImage     string
-		containerImage   string
-		cmd              []string
-	}
 	tests := []config{
 		{
 			name:             "WCOW_Process",
@@ -369,12 +353,6 @@ func Test_ContainerStats_List_ContainerID(t *testing.T) {
 }
 
 func Test_SandboxStats_WorkingSet_PhysicallyBacked(t *testing.T) {
-	type config struct {
-		name             string
-		requiredFeatures []string
-		runtimeHandler   string
-		sandboxImage     string
-	}
 	tests := []config{
 		{
 			name:             "WCOW_Hypervisor",


### PR DESCRIPTION
* We were declaring pretty much the same test config struct in multiple tests as a
function local definition. This just changes it so it's declared at package scope.

Signed-off-by: Daniel Canter <dcanter@microsoft.com>