### PR TITLE
Fix potential panic in createLCOWSpec when no network ns is set

### DIFF
--- a/internal/hcsoci/hcsdoc_lcow.go
+++ b/internal/hcsoci/hcsdoc_lcow.go
@@ -29,7 +29,7 @@ func createLCOWSpec(coi *createOptionsInternal) (*specs.Spec, error) {
 	spec.Windows = nil
 	if coi.Spec.Windows != nil {
 		setWindowsNetworkNamespace(coi, spec)
-		spec.Windows.Devices = coi.Spec.Windows.Devices
+		setWindowsDevices(coi, spec)
 	}
 
 	// Hooks are not supported (they should be run in the host)
@@ -52,11 +52,21 @@ func createLCOWSpec(coi *createOptionsInternal) (*specs.Spec, error) {
 func setWindowsNetworkNamespace(coi *createOptionsInternal, spec *specs.Spec) {
 	if coi.Spec.Windows.Network != nil &&
 		coi.Spec.Windows.Network.NetworkNamespace != "" {
-		spec.Windows = &specs.Windows{
-			Network: &specs.WindowsNetwork{
-				NetworkNamespace: coi.Spec.Windows.Network.NetworkNamespace,
-			},
+		if spec.Windows == nil {
+			spec.Windows = &specs.Windows{}
 		}
+		spec.Windows.Network = &specs.WindowsNetwork{
+			NetworkNamespace: coi.Spec.Windows.Network.NetworkNamespace,
+		}
+	}
+}
+
+func setWindowsDevices(coi *createOptionsInternal, spec *specs.Spec) {
+	if coi.Spec.Windows.Devices != nil {
+		if spec.Windows == nil {
+			spec.Windows = &specs.Windows{}
+		}
+		spec.Windows.Devices = coi.Spec.Windows.Devices
 	}
 }
 


### PR DESCRIPTION
Previously,  if no network information was set on the given spec, we would hit a panic trying to set the new spec's windows devices since we relied on `setWindowsNetworkNamespace` to create the windows field. This PR fixes that by checking if the windows field is nil and creating it if so. 

Signed-off-by: Kathryn Baldauf <kabaldau@microsoft.com>