### PR TITLE
Updating L4WfpProxyPolicy struct

### DIFF
--- a/hcn/hcnpolicy.go
+++ b/hcn/hcnpolicy.go
@@ -154,9 +154,10 @@ type FiveTuple struct {
 
 // L4WfpProxyPolicySetting sets Layer-4 Proxy on an endpoint.
 type L4WfpProxyPolicySetting struct {
-	Port        string    `json:",omitempty"`
-	FilterTuple FiveTuple `json:",omitempty"`
-	UserSID     string    `json:",omitempty"`
+	InboundProxyPort  string    `json:",omitempty"`
+	OutboundProxyPort string    `json:",omitempty"`
+	FilterTuple       FiveTuple `json:",omitempty"`
+	UserSID           string    `json:",omitempty"`
 }
 
 // PortnameEndpointPolicySetting sets the port name for an endpoint.

--- a/hcn/hcnutils_test.go
+++ b/hcn/hcnutils_test.go
@@ -235,7 +235,8 @@ func HcnCreateAcls() (*PolicyEndpointRequest, error) {
 
 func HcnCreateWfpProxyPolicyRequest() (*PolicyEndpointRequest, error) {
 	policySetting := L4WfpProxyPolicySetting{
-		Port: "80",
+		InboundProxyPort:  "80",
+		OutboundProxyPort: "80",
 		FilterTuple: FiveTuple{
 			Protocols:       "6",
 			RemoteAddresses: "10.0.0.4",


### PR DESCRIPTION
This PR reflects the HNS L4WfpProxyPolicy change to allow the caller to distinguish the inbound and outbound proxy ports 