### PR TITLE
Destroy the temporary export layer before removing it

### DIFF
--- a/internal/wclayer/exportlayer.go
+++ b/internal/wclayer/exportlayer.go
@@ -89,6 +89,10 @@ func (r *legacyLayerReaderWrapper) Close() (err error) {
 	defer func() { oc.SetSpanStatus(r.s, err) }()
 
 	err = r.legacyLayerReader.Close()
+	// if the layer is not Destroyed at hcs level before removing
+	// we might enter in a race-condition for large containers
+	// which end-up in a hang of the os.RemoveAll() call
+	DestroyLayer(r.ctx, r.root)
 	os.RemoveAll(r.root)
 	return err
 }


### PR DESCRIPTION
Fix: #696

This is an attempt to restart discussion on #696 

Several people have reproduced this issue, and provided example on how to reproduce (building images with lots of small files). There has been very few feedback from MS maintainers.

Like I report in a bug, my gut feeling is that there is a race condition in the windows kernel. My patch is only workarounding this. So this would be a problem that can only be resolved by MS team collaborating with their kernel team.

Open-source contributors like me can only help on what is open source..
