### PR TITLE
Wrap errors from computestorage package

### DIFF
--- a/computestorage/attach.go
+++ b/computestorage/attach.go
@@ -3,9 +3,9 @@ package computestorage
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 
 	"github.com/Microsoft/hcsshim/internal/oc"
+	"github.com/pkg/errors"
 	"go.opencensus.io/trace"
 )
 
@@ -32,7 +32,7 @@ func AttachLayerStorageFilter(ctx context.Context, layerPath string, layerData L
 
 	err = hcsAttachLayerStorageFilter(layerPath, string(bytes))
 	if err != nil {
-		return fmt.Errorf("failed to attach layer storage filter: %s", err)
+		return errors.Wrap(err, "failed to attach layer storage filter")
 	}
 	return nil
 }

--- a/computestorage/destroy.go
+++ b/computestorage/destroy.go
@@ -2,9 +2,9 @@ package computestorage
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/Microsoft/hcsshim/internal/oc"
+	"github.com/pkg/errors"
 	"go.opencensus.io/trace"
 )
 
@@ -20,7 +20,7 @@ func DestroyLayer(ctx context.Context, layerPath string) (err error) {
 
 	err = hcsDestroyLayer(layerPath)
 	if err != nil {
-		return fmt.Errorf("failed to destroy layer: %s", err)
+		return errors.Wrap(err, "failed to destroy layer")
 	}
 	return nil
 }

--- a/computestorage/detach.go
+++ b/computestorage/detach.go
@@ -2,9 +2,9 @@ package computestorage
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/Microsoft/hcsshim/internal/oc"
+	"github.com/pkg/errors"
 	"go.opencensus.io/trace"
 )
 
@@ -20,7 +20,7 @@ func DetachLayerStorageFilter(ctx context.Context, layerPath string) (err error)
 
 	err = hcsDetachLayerStorageFilter(layerPath)
 	if err != nil {
-		return fmt.Errorf("failed to detach layer storage filter: %s", err)
+		return errors.Wrap(err, "failed to detach layer storage filter")
 	}
 	return nil
 }

--- a/computestorage/export.go
+++ b/computestorage/export.go
@@ -3,9 +3,9 @@ package computestorage
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 
 	"github.com/Microsoft/hcsshim/internal/oc"
+	"github.com/pkg/errors"
 	"go.opencensus.io/trace"
 )
 
@@ -40,7 +40,7 @@ func ExportLayer(ctx context.Context, layerPath, exportFolderPath string, layerD
 
 	err = hcsExportLayer(layerPath, exportFolderPath, string(ldbytes), string(obytes))
 	if err != nil {
-		return fmt.Errorf("failed to export layer: %s", err)
+		return errors.Wrap(err, "failed to export layer")
 	}
 	return nil
 }

--- a/computestorage/format.go
+++ b/computestorage/format.go
@@ -2,9 +2,9 @@ package computestorage
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/Microsoft/hcsshim/internal/oc"
+	"github.com/pkg/errors"
 	"go.opencensus.io/trace"
 	"golang.org/x/sys/windows"
 )
@@ -20,7 +20,7 @@ func FormatWritableLayerVhd(ctx context.Context, vhdHandle windows.Handle) (err 
 
 	err = hcsFormatWritableLayerVhd(vhdHandle)
 	if err != nil {
-		return fmt.Errorf("failed to format writable layer vhd: %s", err)
+		return errors.Wrap(err, "failed to format writable layer vhd")
 	}
 	return nil
 }

--- a/computestorage/import.go
+++ b/computestorage/import.go
@@ -3,9 +3,9 @@ package computestorage
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 
 	"github.com/Microsoft/hcsshim/internal/oc"
+	"github.com/pkg/errors"
 	"go.opencensus.io/trace"
 )
 
@@ -35,7 +35,7 @@ func ImportLayer(ctx context.Context, layerPath, sourceFolderPath string, layerD
 
 	err = hcsImportLayer(layerPath, sourceFolderPath, string(bytes))
 	if err != nil {
-		return fmt.Errorf("failed to import layer: %s", err)
+		return errors.Wrap(err, "failed to import layer")
 	}
 	return nil
 }

--- a/computestorage/initialize.go
+++ b/computestorage/initialize.go
@@ -3,9 +3,9 @@ package computestorage
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 
 	"github.com/Microsoft/hcsshim/internal/oc"
+	"github.com/pkg/errors"
 	"go.opencensus.io/trace"
 )
 
@@ -32,7 +32,7 @@ func InitializeWritableLayer(ctx context.Context, layerPath string, layerData La
 	// Options are not used in the platform as of RS5
 	err = hcsInitializeWritableLayer(layerPath, string(bytes), "")
 	if err != nil {
-		return fmt.Errorf("failed to intitialize container layer: %s", err)
+		return errors.Wrap(err, "failed to intitialize container layer")
 	}
 	return nil
 }

--- a/computestorage/mount.go
+++ b/computestorage/mount.go
@@ -2,10 +2,10 @@ package computestorage
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/Microsoft/hcsshim/internal/interop"
 	"github.com/Microsoft/hcsshim/internal/oc"
+	"github.com/pkg/errors"
 	"go.opencensus.io/trace"
 	"golang.org/x/sys/windows"
 )
@@ -20,7 +20,7 @@ func GetLayerVhdMountPath(ctx context.Context, vhdHandle windows.Handle) (path s
 	var mountPath *uint16
 	err = hcsGetLayerVhdMountPath(vhdHandle, &mountPath)
 	if err != nil {
-		return "", fmt.Errorf("failed to get vhd mount path: %s", err)
+		return "", errors.Wrap(err, "failed to get vhd mount path")
 	}
 	path = interop.ConvertAndFreeCoTaskMemString(mountPath)
 	return path, nil

--- a/computestorage/setup.go
+++ b/computestorage/setup.go
@@ -3,11 +3,10 @@ package computestorage
 import (
 	"context"
 	"encoding/json"
-	"errors"
-	"fmt"
 
 	"github.com/Microsoft/hcsshim/internal/oc"
 	"github.com/Microsoft/hcsshim/osversion"
+	"github.com/pkg/errors"
 	"go.opencensus.io/trace"
 	"golang.org/x/sys/windows"
 )
@@ -37,7 +36,7 @@ func SetupBaseOSLayer(ctx context.Context, layerPath string, vhdHandle windows.H
 
 	err = hcsSetupBaseOSLayer(layerPath, vhdHandle, string(bytes))
 	if err != nil {
-		return fmt.Errorf("failed to setup base OS layer: %s", err)
+		return errors.Wrap(err, "failed to setup base OS layer")
 	}
 	return nil
 }
@@ -69,7 +68,7 @@ func SetupBaseOSVolume(ctx context.Context, layerPath, volumePath string, option
 
 	err = hcsSetupBaseOSVolume(layerPath, volumePath, string(bytes))
 	if err != nil {
-		return fmt.Errorf("failed to setup base OS layer: %s", err)
+		return errors.Wrap(err, "failed to setup base OS layer")
 	}
 	return nil
 }


### PR DESCRIPTION
* Change from stringifying errors with fmt.Errorf to errors.Wrap everywhere

Fixes: https://github.com/microsoft/hcsshim/issues/924

Signed-off-by: Daniel Canter <dcanter@microsoft.com>