### PR TITLE
Ignore NotFound errors when getting task stats

### DIFF
--- a/cmd/containerd-shim-runhcs-v1/task.go
+++ b/cmd/containerd-shim-runhcs-v1/task.go
@@ -7,7 +7,10 @@ import (
 
 	"github.com/Microsoft/hcsshim/cmd/containerd-shim-runhcs-v1/options"
 	"github.com/Microsoft/hcsshim/cmd/containerd-shim-runhcs-v1/stats"
+	"github.com/Microsoft/hcsshim/internal/gcs"
+	"github.com/Microsoft/hcsshim/internal/hcs"
 	"github.com/Microsoft/hcsshim/internal/shimdiag"
+	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/runtime/v2/task"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 )
@@ -92,4 +95,13 @@ type shimTask interface {
 	// If the host is hypervisor isolated and this task owns the host additional
 	// metrics on the UVM may be returned as well.
 	Stats(ctx context.Context) (*stats.Statistics, error)
+}
+
+// isStatsNotFound returns true if the err corresponds to a scenario
+// where statistics cannot be retrieved or found
+func isStatsNotFound(err error) bool {
+	return errdefs.IsNotFound(err) ||
+		hcs.IsNotExist(err) ||
+		hcs.IsOperationInvalidState(err) ||
+		gcs.IsNotExist(err)
 }

--- a/cmd/containerd-shim-runhcs-v1/task_wcow_podsandbox.go
+++ b/cmd/containerd-shim-runhcs-v1/task_wcow_podsandbox.go
@@ -244,11 +244,11 @@ func (wpst *wcowPodSandboxTask) Share(ctx context.Context, req *shimdiag.ShareRe
 }
 
 func (wpst *wcowPodSandboxTask) Stats(ctx context.Context) (*stats.Statistics, error) {
+	stats := &stats.Statistics{}
 	vmStats, err := wpst.host.Stats(ctx)
-	if err != nil {
+	if err != nil && !isStatsNotFound(err) {
 		return nil, err
 	}
-	stats := &stats.Statistics{}
 	stats.VM = vmStats
 	return stats, nil
 }

--- a/internal/gcs/bridge.go
+++ b/internal/gcs/bridge.go
@@ -182,6 +182,15 @@ func (err *rpcError) Error() string {
 	return "guest RPC failure: " + msg
 }
 
+// IsNotExist is a helper function to determine if the inner rpc error is Not Exist
+func IsNotExist(err error) bool {
+	switch rerr := err.(type) {
+	case *rpcError:
+		return uint32(rerr.result) == hrComputeSystemDoesNotExist
+	}
+	return false
+}
+
 // Err returns the RPC's result. This may be a transport error or an error from
 // the message response.
 func (call *rpc) Err() error {


### PR DESCRIPTION
This PR updates the code path in hcsshim when querying for stats to handle errors in a similar way [to upstream linux containers](https://github.com/containerd/containerd/blob/master/runtime/v2/runc/v2/service.go#L694). This behavior ignores errors from stats queries if the error is `Not Found`, `Does Not Exists`, or `Invalid State`. 

Signed-off-by: Kathryn Baldauf <kabaldau@microsoft.com>