### PR TITLE
Skip unmounting layers for sandbox container.

### DIFF
--- a/internal/hcsoci/resources_wcow.go
+++ b/internal/hcsoci/resources_wcow.go
@@ -19,11 +19,12 @@ import (
 	"github.com/Microsoft/hcsshim/internal/uvm"
 	"github.com/Microsoft/hcsshim/internal/wclayer"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/pkg/errors"
 )
 
-func allocateWindowsResources(ctx context.Context, coi *createOptionsInternal, r *resources.Resources) error {
+func allocateWindowsResources(ctx context.Context, coi *createOptionsInternal, r *resources.Resources, isSandbox bool) error {
 	if coi.Spec == nil || coi.Spec.Windows == nil || coi.Spec.Windows.LayerFolders == nil {
-		return fmt.Errorf("field 'Spec.Windows.Layerfolders' is not populated")
+		return errors.New("field 'Spec.Windows.Layerfolders' is not populated")
 	}
 
 	scratchFolder := coi.Spec.Windows.LayerFolders[len(coi.Spec.Windows.LayerFolders)-1]
@@ -32,7 +33,7 @@ func allocateWindowsResources(ctx context.Context, coi *createOptionsInternal, r
 	// Create the directory for the RW scratch layer if it doesn't exist
 	if _, err := os.Stat(scratchFolder); os.IsNotExist(err) {
 		if err := os.MkdirAll(scratchFolder, 0777); err != nil {
-			return fmt.Errorf("failed to auto-create container scratch folder %s: %s", scratchFolder, err)
+			return errors.Wrapf(err, "failed to auto-create container scratch folder %s", scratchFolder)
 		}
 	}
 
@@ -40,7 +41,7 @@ func allocateWindowsResources(ctx context.Context, coi *createOptionsInternal, r
 	// rather than scratch.vhdx as in the v1 schema, it's hard-coded in HCS.
 	if _, err := os.Stat(filepath.Join(scratchFolder, "sandbox.vhdx")); os.IsNotExist(err) {
 		if err := wclayer.CreateScratchLayer(ctx, scratchFolder, coi.Spec.Windows.LayerFolders[:len(coi.Spec.Windows.LayerFolders)-1]); err != nil {
-			return fmt.Errorf("failed to CreateSandboxLayer %s", err)
+			return errors.Wrap(err, "failed to CreateSandboxLayer")
 		}
 	}
 
@@ -53,10 +54,10 @@ func allocateWindowsResources(ctx context.Context, coi *createOptionsInternal, r
 		containerRootInUVM := r.ContainerRootInUVM()
 		containerRootPath, err := layers.MountContainerLayers(ctx, coi.Spec.Windows.LayerFolders, containerRootInUVM, coi.HostingSystem)
 		if err != nil {
-			return fmt.Errorf("failed to mount container storage: %s", err)
+			return errors.Wrap(err, "failed to mount container storage")
 		}
 		coi.Spec.Root.Path = containerRootPath
-		layers := layers.NewImageLayers(coi.HostingSystem, containerRootInUVM, coi.Spec.Windows.LayerFolders)
+		layers := layers.NewImageLayers(coi.HostingSystem, containerRootInUVM, coi.Spec.Windows.LayerFolders, isSandbox)
 		r.SetLayers(layers)
 	}
 
@@ -136,7 +137,7 @@ func setupMounts(ctx context.Context, coi *createOptionsInternal, r *resources.R
 				l.Debug("hcsshim::allocateWindowsResources Hot-adding SCSI physical disk for OCI mount")
 				scsiMount, err := coi.HostingSystem.AddSCSIPhysicalDisk(ctx, mount.Source, uvmPath, readOnly)
 				if err != nil {
-					return fmt.Errorf("adding SCSI physical disk mount %+v: %s", mount, err)
+					return errors.Wrapf(err, "adding SCSI physical disk mount %+v", mount)
 				}
 				coi.Spec.Mounts[i].Type = ""
 				r.Add(scsiMount)
@@ -144,7 +145,7 @@ func setupMounts(ctx context.Context, coi *createOptionsInternal, r *resources.R
 				l.Debug("hcsshim::allocateWindowsResources Hot-adding SCSI virtual disk for OCI mount")
 				scsiMount, err := coi.HostingSystem.AddSCSI(ctx, mount.Source, uvmPath, readOnly, uvm.VMAccessTypeIndividual)
 				if err != nil {
-					return fmt.Errorf("adding SCSI virtual disk mount %+v: %s", mount, err)
+					return errors.Wrapf(err, "adding SCSI virtual disk mount %+v", mount)
 				}
 				coi.Spec.Mounts[i].Type = ""
 				r.Add(scsiMount)
@@ -152,7 +153,7 @@ func setupMounts(ctx context.Context, coi *createOptionsInternal, r *resources.R
 				if uvm.IsPipe(mount.Source) {
 					pipe, err := coi.HostingSystem.AddPipe(ctx, mount.Source)
 					if err != nil {
-						return fmt.Errorf("failed to add named pipe to UVM: %s", err)
+						return errors.Wrap(err, "failed to add named pipe to UVM")
 					}
 					r.Add(pipe)
 				} else {
@@ -160,12 +161,49 @@ func setupMounts(ctx context.Context, coi *createOptionsInternal, r *resources.R
 					options := coi.HostingSystem.DefaultVSMBOptions(readOnly)
 					share, err := coi.HostingSystem.AddVSMB(ctx, mount.Source, options)
 					if err != nil {
-						return fmt.Errorf("failed to add VSMB share to utility VM for mount %+v: %s", mount, err)
+						return errors.Wrapf(err, "failed to add VSMB share to utility VM for mount %+v", mount)
 					}
 					r.Add(share)
 				}
 			}
 		}
+	}
+
+	if cs, ok := coi.Spec.Windows.CredentialSpec.(string); ok {
+		// Only need to create a CCG instance for v2 containers
+		if schemaversion.IsV21(coi.actualSchemaVersion) {
+			hypervisorIsolated := coi.HostingSystem != nil
+			ccgInstance, ccgResource, err := credentials.CreateCredentialGuard(ctx, coi.actualID, cs, hypervisorIsolated)
+			if err != nil {
+				return err
+			}
+			coi.ccgState = ccgInstance.CredentialGuard
+			r.Add(ccgResource)
+			if hypervisorIsolated {
+				// If hypervisor isolated we need to add an hvsocket service table entry
+				// By default HVSocket won't allow something inside the VM to connect
+				// back to a process on the host. We need to update the HVSocket service table
+				// to allow a connection to CCG.exe on the host, so that GMSA can function.
+				// We need to hot add this here because at UVM creation time we don't know what containers
+				// will be launched in the UVM, nonetheless if they will ask for GMSA. This is a workaround
+				// for the previous design requirement for CCG V2 where the service entry
+				// must be present in the UVM'S HCS document before being sent over as hot adding
+				// an HvSocket service was not possible.
+				hvSockConfig := ccgInstance.HvSocketConfig
+				if err := coi.HostingSystem.UpdateHvSocketService(ctx, hvSockConfig.ServiceId, hvSockConfig.ServiceConfig); err != nil {
+					return errors.Wrap(err, "failed to update hvsocket service")
+				}
+			}
+		}
+	}
+
+	if coi.HostingSystem != nil && coi.hasWindowsAssignedDevices() {
+		windowsDevices, closers, err := handleAssignedDevicesWindows(ctx, coi.HostingSystem, coi.Spec.Annotations, coi.Spec.Windows.Devices)
+		if err != nil {
+			return err
+		}
+		r.Add(closers...)
+		coi.Spec.Windows.Devices = windowsDevices
 	}
 
 	return nil


### PR DESCRIPTION
* Skip unmounting the layers for the sandbox container as we know the UVM gets torn down shortly afterwards.

Signed-off-by: Daniel Canter <dcanter@microsoft.com>