### PR TITLE
Expose more internal errors via hscshim api

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -230,6 +230,18 @@ func IsNotSupported(err error) bool {
 	return hcs.IsNotSupported(getInnerError(err))
 }
 
+// IsOperationInvalidState returns true when err is caused by
+// `ErrVmcomputeOperationInvalidState`.
+func IsOperationInvalidState(err error) bool {
+	return hcs.IsOperationInvalidState(getInnerError(err))
+}
+
+// IsAccessIsDenied returns true when err is caused by
+// `ErrVmcomputeOperationAccessIsDenied`.
+func IsAccessIsDenied(err error) bool {
+	return hcs.IsAccessIsDenied(getInnerError(err))
+}
+
 func getInnerError(err error) error {
 	switch pe := err.(type) {
 	case nil:

--- a/internal/hcs/errors.go
+++ b/internal/hcs/errors.go
@@ -312,6 +312,13 @@ func IsOperationInvalidState(err error) bool {
 	return err == ErrVmcomputeOperationInvalidState
 }
 
+// IsAccessIsDenied returns true when err is caused by
+// `ErrVmcomputeOperationAccessIsDenied`.
+func IsAccessIsDenied(err error) bool {
+	err = getInnerError(err)
+	return err == ErrVmcomputeOperationAccessIsDenied
+}
+
 func getInnerError(err error) error {
 	switch pe := err.(type) {
 	case nil:


### PR DESCRIPTION
As part of https://github.com/kubernetes/kubernetes/issues/98509 we found that a newly started container in the "Created" state but not "Running" returns errors when it queries for stats:

```
failure in a Windows system call: The requested virtual machine or container operation is not valid in the current state. (0xc0370105) 
failure in a Windows system call: Access is denied. (0x5)
```

I've [worked around it by looking for the Error codes](https://github.com/kubernetes/kubernetes/pull/98510/files#diff-63c08ffd47f6926aa51a8bc28cc8c533d83b815c4ec47f534643303eb3af72b6R55) but would be cleaner if there were other helper functions that exposed the interal error stats

Signed-off-by: James Sturtevant <jstur@microsoft.com>