### PR TITLE
Add Check for access denied when looking for stats in Containerd

### DIFF
--- a/cmd/containerd-shim-runhcs-v1/task.go
+++ b/cmd/containerd-shim-runhcs-v1/task.go
@@ -103,5 +103,6 @@ func isStatsNotFound(err error) bool {
 	return errdefs.IsNotFound(err) ||
 		hcs.IsNotExist(err) ||
 		hcs.IsOperationInvalidState(err) ||
-		gcs.IsNotExist(err)
+		gcs.IsNotExist(err) ||
+		hcs.IsAccessIsDenied(err)
 }


### PR DESCRIPTION
After https://github.com/microsoft/hcsshim/pull/933, In some cases we found the container would get the "access is denied" error when checking for stats: https://github.com/kubernetes/kubernetes/issues/98509

/cc  @katiewasnothere 