### PR TITLE
Fix nil dereference in jobobject.Create and Open

### DIFF
--- a/internal/jobobject/jobobject_test.go
+++ b/internal/jobobject/jobobject_test.go
@@ -1,0 +1,30 @@
+package jobobject
+
+import (
+	"context"
+	"testing"
+)
+
+func TestJobNilOptions(t *testing.T) {
+	_, err := Create(context.Background(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestJobCreateAndOpen(t *testing.T) {
+	var (
+		ctx     = context.Background()
+		options = &Options{Name: "test"}
+	)
+
+	_, err := Create(ctx, options)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = Open(ctx, options)
+	if err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
If nil options were passed for `Create` or `Open` both methods would run into a
nil dereference even though for `Create` it states that it will just use default options.

For `Open` you can't open without a name so if nil options are passed just return an error.

Signed-off-by: Daniel Canter <dcanter@microsoft.com>