### PR TITLE
ping localhost in tests

### DIFF
--- a/test/cri-containerd/clone_test.go
+++ b/test/cri-containerd/clone_test.go
@@ -193,7 +193,7 @@ func verifyTemplateContainerState(ctx context.Context, t *testing.T, client runt
 func verifyContainerExec(ctx context.Context, t *testing.T, client runtime.RuntimeServiceClient, containerID string) {
 	execCommand := []string{
 		"ping",
-		"www.microsoft.com",
+		"127.0.0.1",
 	}
 
 	execRequest := &runtime.ExecSyncRequest{


### PR DESCRIPTION
This fixes incorrect test failures when running tests on VMs which don't have network access. If we ping
something like microsoft.com on such VMs then ping fails and because of that test fails when it really shouldn't.