### PR TITLE
Add containerd-shim plumbing for job containers

### DIFF
--- a/cmd/containerd-shim-runhcs-v1/pod.go
+++ b/cmd/containerd-shim-runhcs-v1/pod.go
@@ -83,6 +83,11 @@ func createPod(ctx context.Context, events publisher, req *task.CreateTaskReques
 	owner := filepath.Base(os.Args[0])
 	isWCOW := oci.IsWCOW(s)
 
+	p := pod{
+		events: events,
+		id:     req.ID,
+	}
+
 	var parent *uvm.UtilityVM
 	if oci.IsIsolated(s) {
 		// Create the UVM parent
@@ -125,9 +130,33 @@ func createPod(ctx context.Context, events publisher, req *task.CreateTaskReques
 			parent.Close()
 			return nil, err
 		}
+	} else if oci.IsJobContainer(s) {
+		// If we're making a job container fake a task (i.e reuse the wcowPodSandbox logic)
+		p.sandboxTask = newWcowPodSandboxTask(ctx, events, req.ID, req.Bundle, parent, "")
+		if err := events.publishEvent(
+			ctx,
+			runtime.TaskCreateEventTopic,
+			&eventstypes.TaskCreate{
+				ContainerID: req.ID,
+				Bundle:      req.Bundle,
+				Rootfs:      req.Rootfs,
+				IO: &eventstypes.TaskIO{
+					Stdin:    req.Stdin,
+					Stdout:   req.Stdout,
+					Stderr:   req.Stderr,
+					Terminal: req.Terminal,
+				},
+				Checkpoint: "",
+				Pid:        0,
+			}); err != nil {
+			return nil, err
+		}
+		p.jobContainer = true
+		return &p, nil
 	} else if !isWCOW {
 		return nil, errors.Wrap(errdefs.ErrFailedPrecondition, "oci spec does not contain WCOW or LCOW spec")
 	}
+
 	defer func() {
 		// clean up the uvm if we fail any further operations
 		if err != nil && parent != nil {
@@ -135,12 +164,7 @@ func createPod(ctx context.Context, events publisher, req *task.CreateTaskReques
 		}
 	}()
 
-	p := pod{
-		events: events,
-		id:     req.ID,
-		host:   parent,
-	}
-
+	p.host = parent
 	if parent != nil {
 		cid := req.ID
 		if id, ok := s.Annotations[oci.AnnotationNcproxyContainerID]; ok {
@@ -232,6 +256,11 @@ type pod struct {
 	// It MUST be treated as read only in the lifetime of the pod.
 	host *uvm.UtilityVM
 
+	// jobContainer specifies whether this pod is for WCOW job containers only.
+	//
+	// It MUST be treated as read only in the lifetime of the pod.
+	jobContainer bool
+
 	workloadTasks sync.Map
 }
 
@@ -261,6 +290,17 @@ func (p *pod) CreateTask(ctx context.Context, req *task.CreateTaskRequest, s *sp
 	_, ok := p.workloadTasks.Load(req.ID)
 	if ok {
 		return nil, errors.Wrapf(errdefs.ErrAlreadyExists, "task with id: '%s' already exists id pod: '%s'", req.ID, p.id)
+	}
+
+	if p.jobContainer {
+		// This is a short circuit to make sure that all containers in a pod will have
+		// the same IP address/be added to the same compartment.
+		//
+		// There will need to be OS work needed to support this scenario, so for now we need to block on
+		// this.
+		if !oci.IsJobContainer(s) {
+			return nil, errors.New("cannot create a normal process isolated container if the pod sandbox is a job container")
+		}
 	}
 
 	ct, sid, err := oci.GetSandboxTypeAndID(s.Annotations)

--- a/cmd/containerd-shim-runhcs-v1/task_wcow_podsandbox.go
+++ b/cmd/containerd-shim-runhcs-v1/task_wcow_podsandbox.go
@@ -284,6 +284,9 @@ func (wpst *wcowPodSandboxTask) Share(ctx context.Context, req *shimdiag.ShareRe
 
 func (wpst *wcowPodSandboxTask) Stats(ctx context.Context) (*stats.Statistics, error) {
 	stats := &stats.Statistics{}
+	if wpst.host == nil {
+		return stats, nil
+	}
 	vmStats, err := wpst.host.Stats(ctx)
 	if err != nil && !isStatsNotFound(err) {
 		return nil, err

--- a/internal/hcsoci/resources_lcow.go
+++ b/internal/hcsoci/resources_lcow.go
@@ -42,12 +42,12 @@ func allocateLinuxResources(ctx context.Context, coi *createOptionsInternal, r *
 	containerRootInUVM := r.ContainerRootInUVM()
 	if coi.Spec.Windows != nil && len(coi.Spec.Windows.LayerFolders) > 0 {
 		log.G(ctx).Debug("hcsshim::allocateLinuxResources mounting storage")
-		rootPath, err := layers.MountContainerLayers(ctx, coi.Spec.Windows.LayerFolders, containerRootInUVM, coi.HostingSystem)
+		rootPath, err := layers.MountContainerLayers(ctx, coi.Spec.Windows.LayerFolders, containerRootInUVM, "", coi.HostingSystem)
 		if err != nil {
 			return errors.Wrap(err, "failed to mount container storage")
 		}
 		coi.Spec.Root.Path = rootPath
-		layers := layers.NewImageLayers(coi.HostingSystem, containerRootInUVM, coi.Spec.Windows.LayerFolders, isSandbox)
+		layers := layers.NewImageLayers(coi.HostingSystem, containerRootInUVM, coi.Spec.Windows.LayerFolders, "", isSandbox)
 		r.SetLayers(layers)
 	} else if coi.Spec.Root.Path != "" {
 		// This is the "Plan 9" root filesystem.

--- a/internal/hcsoci/resources_wcow.go
+++ b/internal/hcsoci/resources_wcow.go
@@ -52,12 +52,12 @@ func allocateWindowsResources(ctx context.Context, coi *createOptionsInternal, r
 	if coi.Spec.Root.Path == "" && (coi.HostingSystem != nil || coi.Spec.Windows.HyperV == nil) {
 		log.G(ctx).Debug("hcsshim::allocateWindowsResources mounting storage")
 		containerRootInUVM := r.ContainerRootInUVM()
-		containerRootPath, err := layers.MountContainerLayers(ctx, coi.Spec.Windows.LayerFolders, containerRootInUVM, coi.HostingSystem)
+		containerRootPath, err := layers.MountContainerLayers(ctx, coi.Spec.Windows.LayerFolders, containerRootInUVM, "", coi.HostingSystem)
 		if err != nil {
 			return errors.Wrap(err, "failed to mount container storage")
 		}
 		coi.Spec.Root.Path = containerRootPath
-		layers := layers.NewImageLayers(coi.HostingSystem, containerRootInUVM, coi.Spec.Windows.LayerFolders, isSandbox)
+		layers := layers.NewImageLayers(coi.HostingSystem, containerRootInUVM, coi.Spec.Windows.LayerFolders, "", isSandbox)
 		r.SetLayers(layers)
 	}
 

--- a/internal/jobcontainers/storage.go
+++ b/internal/jobcontainers/storage.go
@@ -10,14 +10,12 @@ import (
 	"github.com/Microsoft/hcsshim/internal/wclayer"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
-	"golang.org/x/sys/windows"
 )
 
 // Trailing backslash required for SetVolumeMountPoint and DeleteVolumeMountPoint
 const sandboxMountFormat = `C:\C\%s\`
 
-func mountLayers(ctx context.Context, s *specs.Spec) error {
+func mountLayers(ctx context.Context, s *specs.Spec, volumeMountPath string) error {
 	if s == nil || s.Windows == nil || s.Windows.LayerFolders == nil {
 		return errors.New("field 'Spec.Windows.Layerfolders' is not populated")
 	}
@@ -43,51 +41,11 @@ func mountLayers(ctx context.Context, s *specs.Spec) error {
 
 	if s.Root.Path == "" {
 		log.G(ctx).Debug("mounting job container storage")
-		containerRootPath, err := layers.MountContainerLayers(ctx, s.Windows.LayerFolders, "", nil)
+		containerRootPath, err := layers.MountContainerLayers(ctx, s.Windows.LayerFolders, "", volumeMountPath, nil)
 		if err != nil {
 			return errors.Wrap(err, "failed to mount container storage")
 		}
 		s.Root.Path = containerRootPath
-	}
-	return nil
-}
-
-// Mount the sandbox vhd to a user friendly path.
-func mountSandboxVolume(ctx context.Context, hostPath, volumeName string) (err error) {
-	log.G(ctx).WithFields(logrus.Fields{
-		"hostpath":   hostPath,
-		"volumeName": volumeName,
-	}).Debug("mounting sandbox volume for job container")
-
-	if _, err := os.Stat(hostPath); os.IsNotExist(err) {
-		if err := os.MkdirAll(hostPath, 0777); err != nil {
-			return err
-		}
-	}
-
-	defer func() {
-		if err != nil {
-			os.RemoveAll(hostPath)
-		}
-	}()
-
-	if err = windows.SetVolumeMountPoint(windows.StringToUTF16Ptr(hostPath), windows.StringToUTF16Ptr(volumeName)); err != nil {
-		return errors.Wrapf(err, "failed to mount sandbox volume to %s on host", hostPath)
-	}
-	return nil
-}
-
-// Remove volume mount point. And remove folder afterwards.
-func removeSandboxMountPoint(ctx context.Context, hostPath string) error {
-	log.G(ctx).WithFields(logrus.Fields{
-		"hostpath": hostPath,
-	}).Debug("mounting sandbox volume for job container")
-
-	if err := windows.DeleteVolumeMountPoint(windows.StringToUTF16Ptr(hostPath)); err != nil {
-		return errors.Wrap(err, "failed to delete sandbox volume mount point")
-	}
-	if err := os.Remove(hostPath); err != nil {
-		return errors.Wrapf(err, "failed to remove sandbox mounted folder path %q", hostPath)
 	}
 	return nil
 }

--- a/internal/oci/util.go
+++ b/internal/oci/util.go
@@ -16,3 +16,8 @@ func IsWCOW(s *specs.Spec) bool {
 func IsIsolated(s *specs.Spec) bool {
 	return IsLCOW(s) || (s.Windows != nil && s.Windows.HyperV != nil)
 }
+
+// IsJobContainer checks if `s` is asking for a Windows job container.
+func IsJobContainer(s *specs.Spec) bool {
+	return s.Annotations[AnnotationHostProcessContainer] == "true"
+}


### PR DESCRIPTION
* Add the necessary plumbing in containerd shim to be able to create a job container
if asked for via the annotation.

Signed-off-by: Daniel Canter <dcanter@microsoft.com>