### PR TITLE
Change image used for Test_PullImageTimestamps

### DIFF
--- a/test/cri-containerd/pullimage_test.go
+++ b/test/cri-containerd/pullimage_test.go
@@ -17,7 +17,7 @@ const (
 	testDirName                     = "testdir"
 	testLinkName                    = "fakelink"
 	testDirPath                     = "C:\\Users\\Public"
-	imageWindowsNanoserverTestImage = "docker.io/mtbar131/hcsshim:nanoserver_test"
+	imageWindowsNanoserverTestImage = "cplatpublic.azurecr.io/timestamp:latest"
 )
 
 func Test_PullImageTimestamps(t *testing.T) {


### PR DESCRIPTION
Swap the image we used to use for the Test_PullImageTimestamps test to one hosted on an
ACR registry.

Signed-off-by: Daniel Canter <dcanter@microsoft.com>