### PR TITLE
Fix tar extraction issue where parent directories don't exist.

### DIFF
--- a/ext4/tar2ext4/tar2ext4.go
+++ b/ext4/tar2ext4/tar2ext4.go
@@ -148,7 +148,7 @@ func Convert(r io.Reader, w io.ReadWriteSeeker, options ...Option) error {
 			}
 			f.Mode &= ^compactext4.TypeMask
 			f.Mode |= typ
-			err = fs.Create(hdr.Name, f)
+			err = fs.CreateWithParents(hdr.Name, f)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Extracting LCOW layers to vhd fails when a file shows up in the
tar list before the parent directory of that file shows up. This change fixes that by
always creating any non existing parent directories and then updating their permissions
later when actual directory entry shows up.

Signed-off-by: Amit Barve <ambarve@microsoft.com>