### PR TITLE
Fix CI badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # hcsshim
 
-[![Build status](https://github.com/microsoft/hcsshim/actions/workflows/CI/badge.svg?branch=master)](https://github.com/microsoft/hcsshim/actions?query=branch%3Amaster)
+[![Build status](https://github.com/microsoft/hcsshim/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/microsoft/hcsshim/actions?query=branch%3Amaster)
 
 This package contains the Golang interface for using the Windows [Host Compute Service](https://techcommunity.microsoft.com/t5/containers/introducing-the-host-compute-service-hcs/ba-p/382332) (HCS) to launch and manage [Windows Containers](https://docs.microsoft.com/en-us/virtualization/windowscontainers/about/). It also contains other helpers and functions for managing Windows Containers such as the Golang interface for the Host Network Service (HNS).
 


### PR DESCRIPTION
This is a follow-up to #970

----

Looks like I used wrong image URL, so it gives 404. Unfortunately, this was not possible to test until GitHub Actions started working for `microsoft/hcsshim` repo. Sorry for inconvenience.