### PR TITLE
Fix golangci linter issues

### DIFF
--- a/cmd/ncproxy/ncproxy.go
+++ b/cmd/ncproxy/ncproxy.go
@@ -25,7 +25,6 @@ import (
 // GRPC service exposed for use by a Node Network Service. Holds a mutex for
 // updating global client.
 type grpcService struct {
-	m sync.Mutex
 }
 
 var _ ncproxygrpc.NetworkConfigProxyServer = &grpcService{}

--- a/computestorage/helpers.go
+++ b/computestorage/helpers.go
@@ -72,9 +72,7 @@ func SetupContainerBaseLayer(ctx context.Context, layerPath, baseVhdPath, diffVh
 		if err != nil {
 			syscall.CloseHandle(handle)
 			os.RemoveAll(baseVhdPath)
-			if os.Stat(diffVhdPath); err == nil {
-				os.RemoveAll(diffVhdPath)
-			}
+			os.RemoveAll(diffVhdPath)
 		}
 	}()
 
@@ -150,9 +148,7 @@ func SetupUtilityVMBaseLayer(ctx context.Context, uvmPath, baseVhdPath, diffVhdP
 		if err != nil {
 			syscall.CloseHandle(handle)
 			os.RemoveAll(baseVhdPath)
-			if os.Stat(diffVhdPath); err == nil {
-				os.RemoveAll(diffVhdPath)
-			}
+			os.RemoveAll(diffVhdPath)
 		}
 	}()
 


### PR DESCRIPTION
* Remove unused mutex for the grpc service in ncproxy
* Remove unnecessary os.Stat call that didn't even check the return value
*facepalm*

Signed-off-by: Daniel Canter <dcanter@microsoft.com>