### PR TITLE
Fix various golangci linter issues

### DIFF
--- a/cmd/containerd-shim-runhcs-v1/events_test.go
+++ b/cmd/containerd-shim-runhcs-v1/events_test.go
@@ -19,7 +19,3 @@ func (p *fakePublisher) publishEvent(ctx context.Context, topic string, event in
 	p.events = append(p.events, event)
 	return nil
 }
-
-func (p *fakePublisher) getEvents() []interface{} {
-	return p.events
-}

--- a/cmd/containerd-shim-runhcs-v1/exec_wcow_podsandbox.go
+++ b/cmd/containerd-shim-runhcs-v1/exec_wcow_podsandbox.go
@@ -130,17 +130,15 @@ func (wpse *wcowPodSandboxExec) Start(ctx context.Context) error {
 	wpse.state = shimExecStateRunning
 	wpse.pid = 1 // Fake but init pid is always 1
 
-	// Publish the task start event. We mever have an exec for the WCOW
+	// Publish the task start event. We never have an exec for the WCOW
 	// PodSandbox.
-	wpse.events.publishEvent(
+	return wpse.events.publishEvent(
 		ctx,
 		runtime.TaskStartEventTopic,
 		&eventstypes.TaskStart{
 			ContainerID: wpse.tid,
 			Pid:         uint32(wpse.pid),
 		})
-
-	return nil
 }
 
 func (wpse *wcowPodSandboxExec) Kill(ctx context.Context, signal uint32) error {

--- a/cmd/containerd-shim-runhcs-v1/main.go
+++ b/cmd/containerd-shim-runhcs-v1/main.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"runtime"
 	"strings"
 
 	"github.com/Microsoft/go-winio/pkg/etw"
@@ -44,17 +43,6 @@ var (
 	idFlag string
 )
 
-func stack() []byte {
-	buf := make([]byte, 1024)
-	for {
-		n := runtime.Stack(buf, true) // true means all goroutines
-		if n < len(buf) {
-			return buf[:n]
-		}
-		buf = make([]byte, 2*len(buf))
-	}
-}
-
 func etwCallback(sourceID guid.GUID, state etw.ProviderState, level etw.Level, matchAnyKeyword uint64, matchAllKeyword uint64, filterData uintptr) {
 	if state == etw.ProviderStateCaptureState {
 		resp, err := svc.DiagStacks(context.Background(), &shimdiag.StacksRequest{})
@@ -83,7 +71,7 @@ func main() {
 		}
 	}
 
-	provider.WriteEvent(
+	_ = provider.WriteEvent(
 		"ShimLaunched",
 		nil,
 		etw.WithFields(

--- a/cmd/containerd-shim-runhcs-v1/pod.go
+++ b/cmd/containerd-shim-runhcs-v1/pod.go
@@ -176,7 +176,7 @@ func createPod(ctx context.Context, events publisher, req *task.CreateTaskReques
 		p.sandboxTask = newWcowPodSandboxTask(ctx, events, req.ID, req.Bundle, parent, nsid)
 		// Publish the created event. We only do this for a fake WCOW task. A
 		// HCS Task will event itself based on actual process lifetime.
-		events.publishEvent(
+		if err := events.publishEvent(
 			ctx,
 			runtime.TaskCreateEventTopic,
 			&eventstypes.TaskCreate{
@@ -191,7 +191,9 @@ func createPod(ctx context.Context, events publisher, req *task.CreateTaskReques
 				},
 				Checkpoint: "",
 				Pid:        0,
-			})
+			}); err != nil {
+			return nil, err
+		}
 	} else {
 		if isWCOW {
 			// The pause container activation will immediately exit on Windows

--- a/cmd/containerd-shim-runhcs-v1/serve.go
+++ b/cmd/containerd-shim-runhcs-v1/serve.go
@@ -282,6 +282,5 @@ func setupDebuggerEvent() {
 		return
 	}
 	logrus.WithField("event", event).Info("Halting until signalled")
-	windows.WaitForSingleObject(handle, windows.INFINITE)
-	return
+	_, _ = windows.WaitForSingleObject(handle, windows.INFINITE)
 }

--- a/cmd/containerd-shim-runhcs-v1/service.go
+++ b/cmd/containerd-shim-runhcs-v1/service.go
@@ -17,11 +17,6 @@ import (
 	"go.opencensus.io/trace"
 )
 
-type cdevent struct {
-	topic string
-	event interface{}
-}
-
 var _ = (task.TaskService)(&service{})
 
 type service struct {
@@ -460,7 +455,7 @@ func (s *service) DiagPid(ctx context.Context, req *shimdiag.PidRequest) (*shimd
 	if s == nil {
 		return nil, nil
 	}
-	ctx, span := trace.StartSpan(ctx, "DiagPid")
+	ctx, span := trace.StartSpan(ctx, "DiagPid") //nolint:ineffassign,staticcheck
 	defer span.End()
 
 	span.AddAttributes(trace.StringAttribute("tid", s.tid))

--- a/cmd/containerd-shim-runhcs-v1/start.go
+++ b/cmd/containerd-shim-runhcs-v1/start.go
@@ -154,7 +154,7 @@ The start command can either start a new shim or return an address to an existin
 			w.Close()
 			defer func() {
 				if err != nil {
-					cmd.Process.Kill()
+					_ = cmd.Process.Kill()
 				}
 			}()
 

--- a/cmd/containerd-shim-runhcs-v1/task.go
+++ b/cmd/containerd-shim-runhcs-v1/task.go
@@ -17,15 +17,6 @@ import (
 
 var errTaskNotIsolated = errors.New("task is not isolated")
 
-// shimTaskPidPair groups a process pid to its execID if it was user generated.
-type shimTaskPidPair struct {
-	// Pid is the pid of the container process.
-	Pid int
-	// ExecID is the id of the exec if this container process was user
-	// generated.
-	ExecID string
-}
-
 type shimTask interface {
 	// ID returns the original id used at `Create`.
 	ID() string

--- a/cmd/containerd-shim-runhcs-v1/task_hcs_test.go
+++ b/cmd/containerd-shim-runhcs-v1/task_hcs_test.go
@@ -176,7 +176,7 @@ func Test_hcsTask_DeleteExec_InitExecID_RunningState_Error(t *testing.T) {
 	lt.execs.Delete(second.id)
 
 	// Start the init exec
-	init.Start(context.TODO())
+	_ = init.Start(context.TODO())
 
 	// try to delete the init exec
 	pid, status, at, err := lt.DeleteExec(context.TODO(), "")
@@ -190,7 +190,7 @@ func Test_hcsTask_DeleteExec_InitExecID_ExitedState_Success(t *testing.T) {
 	// remove the 2nd exec so we just check without it.
 	lt.execs.Delete(second.id)
 
-	init.Kill(context.TODO(), 0xf)
+	_ = init.Kill(context.TODO(), 0xf)
 
 	// try to delete the init exec
 	pid, status, at, err := lt.DeleteExec(context.TODO(), "")
@@ -205,7 +205,7 @@ func Test_hcsTask_DeleteExec_InitExecID_2ndExec_CreatedState_Error(t *testing.T)
 	lt, init, second := setupTestHcsTask(t)
 
 	// start the init exec (required to have 2nd exec)
-	init.Start(context.TODO())
+	_ = init.Start(context.TODO())
 
 	// try to delete the init exec
 	pid, status, at, err := lt.DeleteExec(context.TODO(), "")
@@ -221,10 +221,10 @@ func Test_hcsTask_DeleteExec_InitExecID_2ndExec_RunningState_Error(t *testing.T)
 	lt, init, second := setupTestHcsTask(t)
 
 	// start the init exec (required to have 2nd exec)
-	init.Start(context.TODO())
+	_ = init.Start(context.TODO())
 
 	// put the 2nd exec into the running state
-	second.Start(context.TODO())
+	_ = second.Start(context.TODO())
 
 	// try to delete the init exec
 	pid, status, at, err := lt.DeleteExec(context.TODO(), "")
@@ -240,9 +240,9 @@ func Test_hcsTask_DeleteExec_InitExecID_2ndExec_ExitedState_Success(t *testing.T
 	lt, init, second := setupTestHcsTask(t)
 
 	// put the init exec into the exited state
-	init.Kill(context.TODO(), 0xf)
+	_ = init.Kill(context.TODO(), 0xf)
 	// put the 2nd exec into the exited state
-	second.Kill(context.TODO(), 0xf)
+	_ = second.Kill(context.TODO(), 0xf)
 
 	// try to delete the init exec
 	pid, status, at, err := lt.DeleteExec(context.TODO(), "")
@@ -257,7 +257,7 @@ func Test_hcsTask_DeleteExec_2ndExecID_CreatedState_Success(t *testing.T) {
 	lt, init, second := setupTestHcsTask(t)
 
 	// start the init exec (required to have 2nd exec)
-	init.Start(context.TODO())
+	_ = init.Start(context.TODO())
 
 	// try to delete the 2nd exec
 	pid, status, at, err := lt.DeleteExec(context.TODO(), second.id)
@@ -272,10 +272,10 @@ func Test_hcsTask_DeleteExec_2ndExecID_RunningState_Error(t *testing.T) {
 	lt, init, second := setupTestHcsTask(t)
 
 	// start the init exec (required to have 2nd exec)
-	init.Start(context.TODO())
+	_ = init.Start(context.TODO())
 
 	// put the 2nd exec into the running state
-	second.Start(context.TODO())
+	_ = second.Start(context.TODO())
 
 	// try to delete the 2nd exec
 	pid, status, at, err := lt.DeleteExec(context.TODO(), second.id)
@@ -288,10 +288,10 @@ func Test_hcsTask_DeleteExec_2ndExecID_ExitedState_Success(t *testing.T) {
 	lt, init, second := setupTestHcsTask(t)
 
 	// start the init exec (required to have 2nd exec)
-	init.Kill(context.TODO(), 0xf)
+	_ = init.Kill(context.TODO(), 0xf)
 
 	// put the 2nd exec into the exited state
-	second.Kill(context.TODO(), 0xf)
+	_ = second.Kill(context.TODO(), 0xf)
 
 	// try to delete the 2nd exec
 	pid, status, at, err := lt.DeleteExec(context.TODO(), second.id)

--- a/cmd/ncproxy/main.go
+++ b/cmd/ncproxy/main.go
@@ -68,9 +68,12 @@ func main() {
 
 		opts := []grpc.DialOption{grpc.WithInsecure(), grpc.WithStatsHandler(&ocgrpc.ClientHandler{})}
 		if conf.Timeout > 0 {
-			opts = append(opts, grpc.WithBlock(), grpc.WithTimeout(time.Duration(conf.Timeout)*time.Second))
+			var cancel context.CancelFunc
+			ctx, cancel = context.WithTimeout(ctx, time.Duration(conf.Timeout)*time.Second)
+			defer cancel()
+			opts = append(opts, grpc.WithBlock())
 		}
-		client, err := grpc.Dial(conf.NodeNetSvcAddr, opts...)
+		client, err := grpc.DialContext(ctx, conf.NodeNetSvcAddr, opts...)
 		if err != nil {
 			log.G(ctx).Fatalf("failed to connect to NodeNetworkService at address %s", conf.NodeNetSvcAddr)
 		}

--- a/cmd/ncproxy/ncproxy.go
+++ b/cmd/ncproxy/ncproxy.go
@@ -90,7 +90,7 @@ func (s *grpcService) DeleteNIC(ctx context.Context, req *ncproxygrpc.DeleteNICR
 // HNS Methods
 //
 func (s *grpcService) CreateNetwork(ctx context.Context, req *ncproxygrpc.CreateNetworkRequest) (_ *ncproxygrpc.CreateNetworkResponse, err error) {
-	ctx, span := trace.StartSpan(ctx, "CreateNetwork")
+	ctx, span := trace.StartSpan(ctx, "CreateNetwork") //nolint:ineffassign,staticcheck
 	defer span.End()
 	defer func() { oc.SetSpanStatus(span, err) }()
 
@@ -177,7 +177,7 @@ func (s *grpcService) CreateNetwork(ctx context.Context, req *ncproxygrpc.Create
 }
 
 func (s *grpcService) CreateEndpoint(ctx context.Context, req *ncproxygrpc.CreateEndpointRequest) (_ *ncproxygrpc.CreateEndpointResponse, err error) {
-	ctx, span := trace.StartSpan(ctx, "CreateEndpoint")
+	ctx, span := trace.StartSpan(ctx, "CreateEndpoint") //nolint:ineffassign,staticcheck
 	defer span.End()
 	defer func() { oc.SetSpanStatus(span, err) }()
 
@@ -251,7 +251,7 @@ func (s *grpcService) CreateEndpoint(ctx context.Context, req *ncproxygrpc.Creat
 }
 
 func (s *grpcService) AddEndpoint(ctx context.Context, req *ncproxygrpc.AddEndpointRequest) (_ *ncproxygrpc.AddEndpointResponse, err error) {
-	ctx, span := trace.StartSpan(ctx, "AddEndpoint")
+	ctx, span := trace.StartSpan(ctx, "AddEndpoint") //nolint:ineffassign,staticcheck
 	defer span.End()
 	defer func() { oc.SetSpanStatus(span, err) }()
 
@@ -278,7 +278,7 @@ func (s *grpcService) AddEndpoint(ctx context.Context, req *ncproxygrpc.AddEndpo
 }
 
 func (s *grpcService) DeleteEndpoint(ctx context.Context, req *ncproxygrpc.DeleteEndpointRequest) (_ *ncproxygrpc.DeleteEndpointResponse, err error) {
-	ctx, span := trace.StartSpan(ctx, "DeleteEndpoint")
+	ctx, span := trace.StartSpan(ctx, "DeleteEndpoint") //nolint:ineffassign,staticcheck
 	defer span.End()
 	defer func() { oc.SetSpanStatus(span, err) }()
 
@@ -304,7 +304,7 @@ func (s *grpcService) DeleteEndpoint(ctx context.Context, req *ncproxygrpc.Delet
 }
 
 func (s *grpcService) DeleteNetwork(ctx context.Context, req *ncproxygrpc.DeleteNetworkRequest) (_ *ncproxygrpc.DeleteNetworkResponse, err error) {
-	ctx, span := trace.StartSpan(ctx, "DeleteNetwork")
+	ctx, span := trace.StartSpan(ctx, "DeleteNetwork") //nolint:ineffassign,staticcheck
 	defer span.End()
 	defer func() { oc.SetSpanStatus(span, err) }()
 
@@ -330,7 +330,7 @@ func (s *grpcService) DeleteNetwork(ctx context.Context, req *ncproxygrpc.Delete
 }
 
 func (s *grpcService) GetEndpoint(ctx context.Context, req *ncproxygrpc.GetEndpointRequest) (_ *ncproxygrpc.GetEndpointResponse, err error) {
-	ctx, span := trace.StartSpan(ctx, "GetEndpoint")
+	ctx, span := trace.StartSpan(ctx, "GetEndpoint") //nolint:ineffassign,staticcheck
 	defer span.End()
 	defer func() { oc.SetSpanStatus(span, err) }()
 
@@ -358,7 +358,7 @@ func (s *grpcService) GetEndpoint(ctx context.Context, req *ncproxygrpc.GetEndpo
 }
 
 func (s *grpcService) GetEndpoints(ctx context.Context, req *ncproxygrpc.GetEndpointsRequest) (_ *ncproxygrpc.GetEndpointsResponse, err error) {
-	ctx, span := trace.StartSpan(ctx, "GetEndpoints")
+	ctx, span := trace.StartSpan(ctx, "GetEndpoints") //nolint:ineffassign,staticcheck
 	defer span.End()
 	defer func() { oc.SetSpanStatus(span, err) }()
 
@@ -383,7 +383,7 @@ func (s *grpcService) GetEndpoints(ctx context.Context, req *ncproxygrpc.GetEndp
 }
 
 func (s *grpcService) GetNetwork(ctx context.Context, req *ncproxygrpc.GetNetworkRequest) (_ *ncproxygrpc.GetNetworkResponse, err error) {
-	ctx, span := trace.StartSpan(ctx, "GetNetwork")
+	ctx, span := trace.StartSpan(ctx, "GetNetwork") //nolint:ineffassign,staticcheck
 	defer span.End()
 	defer func() { oc.SetSpanStatus(span, err) }()
 
@@ -409,7 +409,7 @@ func (s *grpcService) GetNetwork(ctx context.Context, req *ncproxygrpc.GetNetwor
 }
 
 func (s *grpcService) GetNetworks(ctx context.Context, req *ncproxygrpc.GetNetworksRequest) (_ *ncproxygrpc.GetNetworksResponse, err error) {
-	ctx, span := trace.StartSpan(ctx, "GetNetworks")
+	ctx, span := trace.StartSpan(ctx, "GetNetworks") //nolint:ineffassign,staticcheck
 	defer span.End()
 	defer func() { oc.SetSpanStatus(span, err) }()
 
@@ -439,7 +439,7 @@ type ttrpcService struct {
 }
 
 func (s *ttrpcService) RegisterComputeAgent(ctx context.Context, req *ncproxyttrpc.RegisterComputeAgentRequest) (_ *ncproxyttrpc.RegisterComputeAgentResponse, err error) {
-	ctx, span := trace.StartSpan(ctx, "RegisterComputeAgent")
+	ctx, span := trace.StartSpan(ctx, "RegisterComputeAgent") //nolint:ineffassign,staticcheck
 	defer span.End()
 	defer func() { oc.SetSpanStatus(span, err) }()
 
@@ -465,7 +465,7 @@ func (s *ttrpcService) RegisterComputeAgent(ctx context.Context, req *ncproxyttr
 }
 
 func (s *ttrpcService) ConfigureNetworking(ctx context.Context, req *ncproxyttrpc.ConfigureNetworkingInternalRequest) (_ *ncproxyttrpc.ConfigureNetworkingInternalResponse, err error) {
-	ctx, span := trace.StartSpan(ctx, "ConfigureNetworking")
+	ctx, span := trace.StartSpan(ctx, "ConfigureNetworking") //nolint:ineffassign,staticcheck
 	defer span.End()
 	defer func() { oc.SetSpanStatus(span, err) }()
 

--- a/cmd/runhcs/create.go
+++ b/cmd/runhcs/create.go
@@ -54,7 +54,7 @@ The specification file includes an args parameter. The args parameter is used
 to specify command(s) that get run when the container is started. To change the
 command(s) that get executed on start, edit the args parameter of the spec. See
 "runc spec --help" for more explanation.`,
-	Flags:  append(createRunFlags),
+	Flags:  createRunFlags,
 	Before: appargs.Validate(argID),
 	Action: func(context *cli.Context) error {
 		cfg, err := containerConfigFromContext(context)

--- a/cmd/runhcs/run.go
+++ b/cmd/runhcs/run.go
@@ -56,7 +56,7 @@ command(s) that get executed on start, edit the args parameter of the spec.`,
 			if err != nil {
 				return err
 			}
-			c.Remove()
+			_ = c.Remove()
 			os.Exit(int(state.Sys().(syscall.WaitStatus).ExitCode))
 		}
 		return nil

--- a/cmd/runhcs/vm.go
+++ b/cmd/runhcs/vm.go
@@ -128,7 +128,7 @@ var vmshimCommand = cli.Command{
 						err = closeWritePipe(pipe)
 					}
 					if err == nil {
-						ioutil.ReadAll(pipe)
+						_, _ = ioutil.ReadAll(pipe)
 					}
 				} else {
 					logrus.WithError(err).
@@ -169,7 +169,7 @@ func processRequest(vm *uvm.UtilityVM, pipe net.Conn) error {
 		c2 := c
 		c = nil
 		go func() {
-			c2.hc.Wait()
+			_ = c2.hc.Wait()
 			c2.Close()
 		}()
 

--- a/cmd/shimdiag/exec.go
+++ b/cmd/shimdiag/exec.go
@@ -60,7 +60,9 @@ var execCommand = cli.Command{
 				if err != nil {
 					return err
 				}
-				defer con.Reset()
+				defer func() {
+					_ = con.Reset()
+				}()
 				// Console reads return EOF whenever the user presses Ctrl-Z.
 				// Wrap the reads to translate these EOFs back.
 				osStdin = rawConReader{os.Stdin}
@@ -120,11 +122,12 @@ func makePipe(f interface{}, in bool) (string, error) {
 			logrus.WithError(err).Error("failed to accept pipe")
 			return
 		}
+
 		if in {
-			io.Copy(c, f.(io.Reader))
+			_, _ = io.Copy(c, f.(io.Reader))
 			c.Close()
 		} else {
-			io.Copy(f.(io.Writer), c)
+			_, _ = io.Copy(f.(io.Writer), c)
 		}
 	}()
 	return p, nil

--- a/cmd/tar2ext4/tar2ext4.go
+++ b/cmd/tar2ext4/tar2ext4.go
@@ -54,7 +54,7 @@ func main() {
 		}
 
 		// Exhaust the tar stream.
-		io.Copy(ioutil.Discard, in)
+		_, _ = io.Copy(ioutil.Discard, in)
 		return nil
 	}()
 	if err != nil {

--- a/cmd/wclayer/mount.go
+++ b/cmd/wclayer/mount.go
@@ -43,7 +43,7 @@ var mountCommand = cli.Command{
 		}
 		defer func() {
 			if err != nil {
-				hcsshim.DeactivateLayer(driverInfo, path)
+				_ = hcsshim.DeactivateLayer(driverInfo, path)
 			}
 		}()
 
@@ -53,7 +53,7 @@ var mountCommand = cli.Command{
 		}
 		defer func() {
 			if err != nil {
-				hcsshim.UnprepareLayer(driverInfo, path)
+				_ = hcsshim.UnprepareLayer(driverInfo, path)
 			}
 		}()
 

--- a/computestorage/attach.go
+++ b/computestorage/attach.go
@@ -18,7 +18,7 @@ import (
 // `layerData` is the parent read-only layer data.
 func AttachLayerStorageFilter(ctx context.Context, layerPath string, layerData LayerData) (err error) {
 	title := "hcsshim.AttachLayerStorageFilter"
-	ctx, span := trace.StartSpan(ctx, title)
+	ctx, span := trace.StartSpan(ctx, title) //nolint:ineffassign,staticcheck
 	defer span.End()
 	defer func() { oc.SetSpanStatus(span, err) }()
 	span.AddAttributes(

--- a/computestorage/destroy.go
+++ b/computestorage/destroy.go
@@ -13,7 +13,7 @@ import (
 // `layerPath` is a path to a directory containing the layer to export.
 func DestroyLayer(ctx context.Context, layerPath string) (err error) {
 	title := "hcsshim.DestroyLayer"
-	ctx, span := trace.StartSpan(ctx, title)
+	ctx, span := trace.StartSpan(ctx, title) //nolint:ineffassign,staticcheck
 	defer span.End()
 	defer func() { oc.SetSpanStatus(span, err) }()
 	span.AddAttributes(trace.StringAttribute("layerPath", layerPath))

--- a/computestorage/detach.go
+++ b/computestorage/detach.go
@@ -13,7 +13,7 @@ import (
 // `layerPath` is a path to a directory containing the layer to export.
 func DetachLayerStorageFilter(ctx context.Context, layerPath string) (err error) {
 	title := "hcsshim.DetachLayerStorageFilter"
-	ctx, span := trace.StartSpan(ctx, title)
+	ctx, span := trace.StartSpan(ctx, title) //nolint:ineffassign,staticcheck
 	defer span.End()
 	defer func() { oc.SetSpanStatus(span, err) }()
 	span.AddAttributes(trace.StringAttribute("layerPath", layerPath))

--- a/computestorage/export.go
+++ b/computestorage/export.go
@@ -20,7 +20,7 @@ import (
 // `options` are the export options applied to the exported layer.
 func ExportLayer(ctx context.Context, layerPath, exportFolderPath string, layerData LayerData, options ExportLayerOptions) (err error) {
 	title := "hcsshim.ExportLayer"
-	ctx, span := trace.StartSpan(ctx, title)
+	ctx, span := trace.StartSpan(ctx, title) //nolint:ineffassign,staticcheck
 	defer span.End()
 	defer func() { oc.SetSpanStatus(span, err) }()
 	span.AddAttributes(

--- a/computestorage/format.go
+++ b/computestorage/format.go
@@ -14,7 +14,7 @@ import (
 // If the VHD is not mounted it will be temporarily mounted.
 func FormatWritableLayerVhd(ctx context.Context, vhdHandle windows.Handle) (err error) {
 	title := "hcsshim.FormatWritableLayerVhd"
-	ctx, span := trace.StartSpan(ctx, title)
+	ctx, span := trace.StartSpan(ctx, title) //nolint:ineffassign,staticcheck
 	defer span.End()
 	defer func() { oc.SetSpanStatus(span, err) }()
 

--- a/computestorage/helpers.go
+++ b/computestorage/helpers.go
@@ -70,7 +70,7 @@ func SetupContainerBaseLayer(ctx context.Context, layerPath, baseVhdPath, diffVh
 
 	defer func() {
 		if err != nil {
-			syscall.CloseHandle(handle)
+			_ = syscall.CloseHandle(handle)
 			os.RemoveAll(baseVhdPath)
 			os.RemoveAll(diffVhdPath)
 		}
@@ -146,7 +146,7 @@ func SetupUtilityVMBaseLayer(ctx context.Context, uvmPath, baseVhdPath, diffVhdP
 
 	defer func() {
 		if err != nil {
-			syscall.CloseHandle(handle)
+			_ = syscall.CloseHandle(handle)
 			os.RemoveAll(baseVhdPath)
 			os.RemoveAll(diffVhdPath)
 		}

--- a/computestorage/import.go
+++ b/computestorage/import.go
@@ -20,7 +20,7 @@ import (
 // `layerData` is the parent layer data.
 func ImportLayer(ctx context.Context, layerPath, sourceFolderPath string, layerData LayerData) (err error) {
 	title := "hcsshim.ImportLayer"
-	ctx, span := trace.StartSpan(ctx, title)
+	ctx, span := trace.StartSpan(ctx, title) //nolint:ineffassign,staticcheck
 	defer span.End()
 	defer func() { oc.SetSpanStatus(span, err) }()
 	span.AddAttributes(

--- a/computestorage/initialize.go
+++ b/computestorage/initialize.go
@@ -17,7 +17,7 @@ import (
 // `layerData` is the parent read-only layer data.
 func InitializeWritableLayer(ctx context.Context, layerPath string, layerData LayerData) (err error) {
 	title := "hcsshim.InitializeWritableLayer"
-	ctx, span := trace.StartSpan(ctx, title)
+	ctx, span := trace.StartSpan(ctx, title) //nolint:ineffassign,staticcheck
 	defer span.End()
 	defer func() { oc.SetSpanStatus(span, err) }()
 	span.AddAttributes(

--- a/computestorage/mount.go
+++ b/computestorage/mount.go
@@ -13,7 +13,7 @@ import (
 // GetLayerVhdMountPath returns the volume path for a virtual disk of a writable container layer.
 func GetLayerVhdMountPath(ctx context.Context, vhdHandle windows.Handle) (path string, err error) {
 	title := "hcsshim.GetLayerVhdMountPath"
-	ctx, span := trace.StartSpan(ctx, title)
+	ctx, span := trace.StartSpan(ctx, title) //nolint:ineffassign,staticcheck
 	defer span.End()
 	defer func() { oc.SetSpanStatus(span, err) }()
 

--- a/computestorage/setup.go
+++ b/computestorage/setup.go
@@ -22,7 +22,7 @@ import (
 // `options` are the options applied while processing the layer.
 func SetupBaseOSLayer(ctx context.Context, layerPath string, vhdHandle windows.Handle, options OsLayerOptions) (err error) {
 	title := "hcsshim.SetupBaseOSLayer"
-	ctx, span := trace.StartSpan(ctx, title)
+	ctx, span := trace.StartSpan(ctx, title) //nolint:ineffassign,staticcheck
 	defer span.End()
 	defer func() { oc.SetSpanStatus(span, err) }()
 	span.AddAttributes(
@@ -53,7 +53,7 @@ func SetupBaseOSVolume(ctx context.Context, layerPath, volumePath string, option
 		return errors.New("SetupBaseOSVolume is not present on builds older than 19645")
 	}
 	title := "hcsshim.SetupBaseOSVolume"
-	ctx, span := trace.StartSpan(ctx, title)
+	ctx, span := trace.StartSpan(ctx, title) //nolint:ineffassign,staticcheck
 	defer span.End()
 	defer func() { oc.SetSpanStatus(span, err) }()
 	span.AddAttributes(

--- a/errors.go
+++ b/errors.go
@@ -132,15 +132,6 @@ func (e *ContainerError) Error() string {
 	return s
 }
 
-func makeContainerError(container *container, operation string, extraInfo string, err error) error {
-	// Don't double wrap errors
-	if _, ok := err.(*ContainerError); ok {
-		return err
-	}
-	containerError := &ContainerError{Container: container, Operation: operation, ExtraInfo: extraInfo, Err: err}
-	return containerError
-}
-
 func (e *ProcessError) Error() string {
 	if e == nil {
 		return "<nil>"
@@ -169,15 +160,6 @@ func (e *ProcessError) Error() string {
 	}
 
 	return s
-}
-
-func makeProcessError(process *process, operation string, extraInfo string, err error) error {
-	// Don't double wrap errors
-	if _, ok := err.(*ProcessError); ok {
-		return err
-	}
-	processError := &ProcessError{Process: process, Operation: operation, ExtraInfo: extraInfo, Err: err}
-	return processError
 }
 
 // IsNotExist checks if an error is caused by the Container or Process not existing.

--- a/ext4/internal/compactext4/compact.go
+++ b/ext4/internal/compactext4/compact.go
@@ -732,7 +732,7 @@ func (w *Writer) seekBlock(block uint32) {
 func (w *Writer) nextBlock() {
 	if w.pos%blockSize != 0 {
 		// Simplify callers; w.err is updated on failure.
-		w.zero(blockSize - w.pos%blockSize)
+		_, _ = w.zero(blockSize - w.pos%blockSize)
 	}
 }
 
@@ -782,7 +782,7 @@ func (w *Writer) writeExtents(inode *inode) error {
 			extents [4]format.ExtentLeafNode
 		}
 		fillExtents(&root.hdr, root.extents[:extents], startBlock, 0, blocks)
-		binary.Write(&b, binary.LittleEndian, root)
+		_ = binary.Write(&b, binary.LittleEndian, root)
 	} else if extents <= 4*extentsPerBlock {
 		const extentsPerBlock = blockSize/extentNodeSize - 1
 		extentBlocks := extents/extentsPerBlock + 1
@@ -817,12 +817,12 @@ func (w *Writer) writeExtents(inode *inode) error {
 
 			offset := i * extentsPerBlock * maxBlocksPerExtent
 			fillExtents(&node.hdr, node.extents[:extentsInBlock], startBlock+offset, offset, blocks)
-			binary.Write(&b2, binary.LittleEndian, node)
+			_ = binary.Write(&b2, binary.LittleEndian, node)
 			if _, err := w.write(b2.Next(blockSize)); err != nil {
 				return err
 			}
 		}
-		binary.Write(&b, binary.LittleEndian, root)
+		_ = binary.Write(&b, binary.LittleEndian, root)
 	} else {
 		panic("file too big")
 	}
@@ -1060,12 +1060,12 @@ func (w *Writer) writeInodeTable(tableSize uint32) error {
 				binary.LittleEndian.PutUint32(binode.Block[4:], dev)
 			}
 
-			binary.Write(&b, binary.LittleEndian, binode)
+			_ = binary.Write(&b, binary.LittleEndian, binode)
 			b.Truncate(inodeUsedSize)
 			n, _ := b.Write(inode.XattrInline)
-			io.CopyN(&b, zero, int64(inodeExtraSize-n))
+			_, _ = io.CopyN(&b, zero, int64(inodeExtraSize-n))
 		} else {
-			io.CopyN(&b, zero, inodeSize)
+			_, _ = io.CopyN(&b, zero, inodeSize)
 		}
 		if _, err := w.write(b.Next(inodeSize)); err != nil {
 			return err
@@ -1315,7 +1315,7 @@ func (w *Writer) Close() error {
 	if w.supportInlineData {
 		sb.FeatureIncompat |= format.IncompatInlineData
 	}
-	binary.Write(b, binary.LittleEndian, sb)
+	_ = binary.Write(b, binary.LittleEndian, sb)
 	w.seekBlock(0)
 	if _, err := w.write(blk[:]); err != nil {
 		return err

--- a/ext4/internal/compactext4/compact_test.go
+++ b/ext4/internal/compactext4/compact_test.go
@@ -51,7 +51,7 @@ func (d *largeData) Read(b []byte) (int, error) {
 		binary.LittleEndian.PutUint64(pb[:], uint64(p+int64(i)))
 		b[i] = pb[i%8]
 	}
-	p += int64(len(b))
+	d.pos += int64(len(b))
 	return len(b), nil
 }
 

--- a/ext4/tar2ext4/vhdfooter.go
+++ b/ext4/tar2ext4/vhdfooter.go
@@ -56,7 +56,7 @@ func calculateCheckSum(footer *vhdFooter) uint32 {
 	footer.Checksum = 0
 
 	buf := &bytes.Buffer{}
-	binary.Write(buf, binary.BigEndian, footer)
+	_ = binary.Write(buf, binary.BigEndian, footer)
 
 	var chk uint32
 	bufBytes := buf.Bytes()

--- a/hcn/hcn.go
+++ b/hcn/hcn.go
@@ -3,7 +3,6 @@
 package hcn
 
 import (
-	"encoding/json"
 	"fmt"
 	"syscall"
 
@@ -64,12 +63,6 @@ import (
 //sys hcnDeleteRoute(id *_guid, result **uint16) (hr error) = computenetwork.HcnDeleteSdnRoute?
 //sys hcnCloseRoute(route hcnRoute) (hr error) = computenetwork.HcnCloseSdnRoute?
 
-// Service
-//sys hcnOpenService(service *hcnService, result **uint16) (hr error) = computenetwork.HcnOpenService?
-//sys hcnRegisterServiceCallback(service hcnService, callback int32, context int32, callbackHandle *hcnCallbackHandle) (hr error) = computenetwork.HcnRegisterServiceCallback?
-//sys hcnUnregisterServiceCallback(callbackHandle hcnCallbackHandle) (hr error) = computenetwork.HcnUnregisterServiceCallback?
-//sys hcnCloseService(service hcnService) (hr error) = computenetwork.HcnCloseService?
-
 type _guid = guid.GUID
 
 type hcnNetwork syscall.Handle
@@ -77,8 +70,6 @@ type hcnEndpoint syscall.Handle
 type hcnNamespace syscall.Handle
 type hcnLoadBalancer syscall.Handle
 type hcnRoute syscall.Handle
-type hcnService syscall.Handle
-type hcnCallbackHandle syscall.Handle
 
 // SchemaVersion for HCN Objects/Queries.
 type SchemaVersion = Version // hcnglobals.go
@@ -126,15 +117,6 @@ func defaultQuery() HostComputeQuery {
 		Flags: HostComputeQueryFlagsNone,
 	}
 	return query
-}
-
-func defaultQueryJson() string {
-	query := defaultQuery()
-	queryJson, err := json.Marshal(query)
-	if err != nil {
-		return ""
-	}
-	return string(queryJson)
 }
 
 // PlatformDoesNotSupportError happens when users are attempting to use a newer shim on an older OS

--- a/hcn/hcnloadbalancer.go
+++ b/hcn/hcnloadbalancer.go
@@ -160,50 +160,6 @@ func createLoadBalancer(settings string) (*HostComputeLoadBalancer, error) {
 	return &outputLoadBalancer, nil
 }
 
-func modifyLoadBalancer(loadBalancerId string, settings string) (*HostComputeLoadBalancer, error) {
-	loadBalancerGuid, err := guid.FromString(loadBalancerId)
-	if err != nil {
-		return nil, errInvalidLoadBalancerID
-	}
-	// Open loadBalancer.
-	var (
-		loadBalancerHandle hcnLoadBalancer
-		resultBuffer       *uint16
-		propertiesBuffer   *uint16
-	)
-	hr := hcnOpenLoadBalancer(&loadBalancerGuid, &loadBalancerHandle, &resultBuffer)
-	if err := checkForErrors("hcnOpenLoadBalancer", hr, resultBuffer); err != nil {
-		return nil, err
-	}
-	// Modify loadBalancer.
-	hr = hcnModifyLoadBalancer(loadBalancerHandle, settings, &resultBuffer)
-	if err := checkForErrors("hcnModifyLoadBalancer", hr, resultBuffer); err != nil {
-		return nil, err
-	}
-	// Query loadBalancer.
-	hcnQuery := defaultQuery()
-	query, err := json.Marshal(hcnQuery)
-	if err != nil {
-		return nil, err
-	}
-	hr = hcnQueryLoadBalancerProperties(loadBalancerHandle, string(query), &propertiesBuffer, &resultBuffer)
-	if err := checkForErrors("hcnQueryLoadBalancerProperties", hr, resultBuffer); err != nil {
-		return nil, err
-	}
-	properties := interop.ConvertAndFreeCoTaskMemString(propertiesBuffer)
-	// Close loadBalancer.
-	hr = hcnCloseLoadBalancer(loadBalancerHandle)
-	if err := checkForErrors("hcnCloseLoadBalancer", hr, nil); err != nil {
-		return nil, err
-	}
-	// Convert output to LoadBalancer
-	var outputLoadBalancer HostComputeLoadBalancer
-	if err := json.Unmarshal([]byte(properties), &outputLoadBalancer); err != nil {
-		return nil, err
-	}
-	return &outputLoadBalancer, nil
-}
-
 func deleteLoadBalancer(loadBalancerId string) error {
 	loadBalancerGuid, err := guid.FromString(loadBalancerId)
 	if err != nil {

--- a/hcn/hcnnamespace.go
+++ b/hcn/hcnnamespace.go
@@ -378,7 +378,7 @@ func (namespace *HostComputeNamespace) Sync() error {
 		// The shim is likey gone. Simply ignore the sync as if it didn't exist.
 		if perr, ok := err.(*os.PathError); ok && perr.Err == syscall.ERROR_FILE_NOT_FOUND {
 			// Remove the reg key there is no point to try again
-			cfg.Remove()
+			_ = cfg.Remove()
 			return nil
 		}
 		f := map[string]interface{}{

--- a/hcn/zsyscall_windows.go
+++ b/hcn/zsyscall_windows.go
@@ -78,10 +78,6 @@ var (
 	procHcnQuerySdnRouteProperties     = modcomputenetwork.NewProc("HcnQuerySdnRouteProperties")
 	procHcnDeleteSdnRoute              = modcomputenetwork.NewProc("HcnDeleteSdnRoute")
 	procHcnCloseSdnRoute               = modcomputenetwork.NewProc("HcnCloseSdnRoute")
-	procHcnOpenService                 = modcomputenetwork.NewProc("HcnOpenService")
-	procHcnRegisterServiceCallback     = modcomputenetwork.NewProc("HcnRegisterServiceCallback")
-	procHcnUnregisterServiceCallback   = modcomputenetwork.NewProc("HcnUnregisterServiceCallback")
-	procHcnCloseService                = modcomputenetwork.NewProc("HcnCloseService")
 )
 
 func SetCurrentThreadCompartmentId(compartmentId uint32) (hr error) {
@@ -789,62 +785,6 @@ func hcnCloseRoute(route hcnRoute) (hr error) {
 		return
 	}
 	r0, _, _ := syscall.Syscall(procHcnCloseSdnRoute.Addr(), 1, uintptr(route), 0, 0)
-	if int32(r0) < 0 {
-		if r0&0x1fff0000 == 0x00070000 {
-			r0 &= 0xffff
-		}
-		hr = syscall.Errno(r0)
-	}
-	return
-}
-
-func hcnOpenService(service *hcnService, result **uint16) (hr error) {
-	if hr = procHcnOpenService.Find(); hr != nil {
-		return
-	}
-	r0, _, _ := syscall.Syscall(procHcnOpenService.Addr(), 2, uintptr(unsafe.Pointer(service)), uintptr(unsafe.Pointer(result)), 0)
-	if int32(r0) < 0 {
-		if r0&0x1fff0000 == 0x00070000 {
-			r0 &= 0xffff
-		}
-		hr = syscall.Errno(r0)
-	}
-	return
-}
-
-func hcnRegisterServiceCallback(service hcnService, callback int32, context int32, callbackHandle *hcnCallbackHandle) (hr error) {
-	if hr = procHcnRegisterServiceCallback.Find(); hr != nil {
-		return
-	}
-	r0, _, _ := syscall.Syscall6(procHcnRegisterServiceCallback.Addr(), 4, uintptr(service), uintptr(callback), uintptr(context), uintptr(unsafe.Pointer(callbackHandle)), 0, 0)
-	if int32(r0) < 0 {
-		if r0&0x1fff0000 == 0x00070000 {
-			r0 &= 0xffff
-		}
-		hr = syscall.Errno(r0)
-	}
-	return
-}
-
-func hcnUnregisterServiceCallback(callbackHandle hcnCallbackHandle) (hr error) {
-	if hr = procHcnUnregisterServiceCallback.Find(); hr != nil {
-		return
-	}
-	r0, _, _ := syscall.Syscall(procHcnUnregisterServiceCallback.Addr(), 1, uintptr(callbackHandle), 0, 0)
-	if int32(r0) < 0 {
-		if r0&0x1fff0000 == 0x00070000 {
-			r0 &= 0xffff
-		}
-		hr = syscall.Errno(r0)
-	}
-	return
-}
-
-func hcnCloseService(service hcnService) (hr error) {
-	if hr = procHcnCloseService.Find(); hr != nil {
-		return
-	}
-	r0, _, _ := syscall.Syscall(procHcnCloseService.Addr(), 1, uintptr(service), 0, 0)
 	if int32(r0) < 0 {
 		if r0&0x1fff0000 == 0x00070000 {
 			r0 &= 0xffff

--- a/hnsendpoint.go
+++ b/hnsendpoint.go
@@ -40,6 +40,9 @@ func HNSListEndpointRequest() ([]HNSEndpoint, error) {
 // HotAttachEndpoint makes a HCS Call to attach the endpoint to the container
 func HotAttachEndpoint(containerID string, endpointID string) error {
 	endpoint, err := GetHNSEndpointByID(endpointID)
+	if err != nil {
+		return err
+	}
 	isAttached, err := endpoint.IsAttached(containerID)
 	if isAttached {
 		return err
@@ -50,6 +53,9 @@ func HotAttachEndpoint(containerID string, endpointID string) error {
 // HotDetachEndpoint makes a HCS Call to detach the endpoint from the container
 func HotDetachEndpoint(containerID string, endpointID string) error {
 	endpoint, err := GetHNSEndpointByID(endpointID)
+	if err != nil {
+		return err
+	}
 	isAttached, err := endpoint.IsAttached(containerID)
 	if !isAttached {
 		return err

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -215,7 +215,10 @@ func (c *Cmd) Start() error {
 				c.stdinErr.Store(err)
 			}
 			// Notify the process that there is no more input.
-			p.CloseStdin(context.TODO())
+			err = p.CloseStdin(context.TODO())
+			if err != nil && c.Log != nil {
+				c.Log.WithError(err).Warn("failed to close pod stdin")
+			}
 		}()
 	}
 
@@ -237,7 +240,7 @@ func (c *Cmd) Start() error {
 		go func() {
 			select {
 			case <-c.Context.Done():
-				c.Process.Kill(context.TODO())
+				_, _ = c.Process.Kill(context.TODO())
 			case <-c.allDoneCh:
 			}
 		}()

--- a/internal/cmd/cmd_test.go
+++ b/internal/cmd/cmd_test.go
@@ -88,7 +88,7 @@ func (h *localProcessHost) CreateProcess(ctx context.Context, cfg interface{}) (
 
 func (p *localProcess) Close() error {
 	if p.p != nil {
-		p.p.Release()
+		_ = p.p.Release()
 	}
 	if p.stdin != nil {
 		p.stdin.Close()
@@ -169,7 +169,7 @@ func TestCmdContext(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	cmd.Process.Wait()
+	_ = cmd.Process.Wait()
 	w.Close()
 	err = cmd.Wait()
 	if e, ok := err.(*ExitError); !ok || e.ExitCode() != 1 || ctx.Err() == nil {
@@ -195,7 +195,7 @@ func TestCmdStdinBlocked(t *testing.T) {
 	defer r.Close()
 	go func() {
 		b := []byte{'\n'}
-		w.Write(b)
+		_, _ = w.Write(b)
 	}()
 	cmd.Stdin = r
 	_, err := cmd.Output()

--- a/internal/cmd/io_binary.go
+++ b/internal/cmd/io_binary.go
@@ -155,7 +155,7 @@ type binaryIO struct {
 
 	binaryCloser sync.Once
 
-	stdin, stdout, stderr string
+	stdout, stderr string
 
 	sout, serr io.ReadWriteCloser
 	soutCloser sync.Once

--- a/internal/cni/registry_test.go
+++ b/internal/cni/registry_test.go
@@ -32,10 +32,12 @@ func Test_LoadPersistedNamespaceConfig_NoConfig(t *testing.T) {
 func Test_LoadPersistedNamespaceConfig_WithConfig(t *testing.T) {
 	pnc := NewPersistedNamespaceConfig(t.Name(), "test-container", newGUID(t))
 	if err := pnc.Store(); err != nil {
-		pnc.Remove()
+		_ = pnc.Remove()
 		t.Fatalf("store failed with: %v", err)
 	}
-	defer pnc.Remove()
+	defer func() {
+		_ = pnc.Remove()
+	}()
 
 	pnc2, err := LoadPersistedNamespaceConfig(t.Name())
 	if err != nil {
@@ -62,24 +64,28 @@ func Test_LoadPersistedNamespaceConfig_WithConfig(t *testing.T) {
 func Test_PersistedNamespaceConfig_StoreNew(t *testing.T) {
 	pnc := NewPersistedNamespaceConfig(t.Name(), "test-container", newGUID(t))
 	if err := pnc.Store(); err != nil {
-		pnc.Remove()
+		_ = pnc.Remove()
 		t.Fatalf("store failed with: %v", err)
 	}
-	defer pnc.Remove()
+	defer func() {
+		_ = pnc.Remove()
+	}()
 }
 
 func Test_PersistedNamespaceConfig_StoreUpdate(t *testing.T) {
 	pnc := NewPersistedNamespaceConfig(t.Name(), "test-container", newGUID(t))
 	if err := pnc.Store(); err != nil {
-		pnc.Remove()
+		_ = pnc.Remove()
 		t.Fatalf("store failed with: %v", err)
 	}
-	defer pnc.Remove()
+	defer func() {
+		_ = pnc.Remove()
+	}()
 
 	pnc.ContainerID = "test-container2"
 	pnc.HostUniqueID = newGUID(t)
 	if err := pnc.Store(); err != nil {
-		pnc.Remove()
+		_ = pnc.Remove()
 		t.Fatalf("store update failed with: %v", err)
 	}
 

--- a/internal/copyfile/copyfile.go
+++ b/internal/copyfile/copyfile.go
@@ -18,7 +18,7 @@ var (
 // CopyFile is a utility for copying a file using CopyFileW win32 API for
 // performance.
 func CopyFile(ctx context.Context, srcFile, destFile string, overwrite bool) (err error) {
-	ctx, span := trace.StartSpan(ctx, "copyfile::CopyFile")
+	ctx, span := trace.StartSpan(ctx, "copyfile::CopyFile") //nolint:ineffassign,staticcheck
 	defer span.End()
 	defer func() { oc.SetSpanStatus(span, err) }()
 	span.AddAttributes(

--- a/internal/cpugroup/cpugroup.go
+++ b/internal/cpugroup/cpugroup.go
@@ -54,6 +54,7 @@ func Create(ctx context.Context, id string, logicalProcessors []uint32) error {
 }
 
 // getCPUGroupConfig finds the cpugroup config information for group with `id`
+//nolint:unused
 func getCPUGroupConfig(ctx context.Context, id string) (*hcsschema.CpuGroupConfig, error) {
 	query := hcsschema.PropertyQuery{
 		PropertyTypes: []hcsschema.PropertyType{hcsschema.PTCPUGroup},
@@ -68,7 +69,7 @@ func getCPUGroupConfig(ctx context.Context, id string) (*hcsschema.CpuGroupConfi
 	}
 
 	for _, c := range groupConfigs.CpuGroups {
-		if strings.ToLower(c.GroupId) == strings.ToLower(id) {
+		if strings.EqualFold(c.GroupId, id) {
 			return &c, nil
 		}
 	}

--- a/internal/devices/assigned_devices.go
+++ b/internal/devices/assigned_devices.go
@@ -145,10 +145,7 @@ func readCsPipeOutput(l net.Listener, errChan chan<- error, result *[]string) {
 
 	elementsAsString := strings.TrimSuffix(string(bytes), "\n")
 	elements := strings.Split(elementsAsString, ",")
-
-	for _, elem := range elements {
-		*result = append(*result, elem)
-	}
+	*result = append(*result, elements...)
 
 	if len(*result) == 0 {
 		errChan <- errors.Wrapf(err, "failed to get any pipe output")

--- a/internal/gcs/guestconnection.go
+++ b/internal/gcs/guestconnection.go
@@ -70,7 +70,7 @@ func (gcc *GuestConnectionConfig) Connect(ctx context.Context, isColdStart bool)
 	gc.brdg = newBridge(gcc.Conn, gc.notify, gcc.Log)
 	gc.brdg.Start()
 	go func() {
-		gc.brdg.Wait()
+		_ = gc.brdg.Wait()
 		gc.clearNotifies()
 	}()
 	err = gc.connect(ctx, isColdStart)

--- a/internal/gcs/guestconnection_test.go
+++ b/internal/gcs/guestconnection_test.go
@@ -51,7 +51,7 @@ func simpleGcsLoop(t *testing.T, rw io.ReadWriter) error {
 		}
 		switch proc := rpcProc(typ &^ msgTypeRequest); proc {
 		case rpcNegotiateProtocol:
-			err := sendJSON(t, rw, msgType(msgTypeResponse|proc), id, &negotiateProtocolResponse{
+			err := sendJSON(t, rw, msgTypeResponse|msgType(proc), id, &negotiateProtocolResponse{
 				Version: protocolVersion,
 				Capabilities: gcsCapabilities{
 					RuntimeOsType: "linux",
@@ -61,7 +61,7 @@ func simpleGcsLoop(t *testing.T, rw io.ReadWriter) error {
 				return err
 			}
 		case rpcCreate:
-			err := sendJSON(t, rw, msgType(msgTypeResponse|proc), id, &containerCreateResponse{})
+			err := sendJSON(t, rw, msgTypeResponse|msgType(proc), id, &containerCreateResponse{})
 			if err != nil {
 				return err
 			}
@@ -105,7 +105,7 @@ func simpleGcsLoop(t *testing.T, rw io.ReadWriter) error {
 					stdout.Close()
 				}()
 			}
-			err = sendJSON(t, rw, msgType(msgTypeResponse|proc), id, &containerExecuteProcessResponse{
+			err = sendJSON(t, rw, msgTypeResponse|msgType(proc), id, &containerExecuteProcessResponse{
 				ProcessID: 42,
 			})
 			if err != nil {
@@ -119,7 +119,7 @@ func simpleGcsLoop(t *testing.T, rw io.ReadWriter) error {
 			if err != nil {
 				return err
 			}
-			err = sendJSON(t, rw, msgType(msgTypeResponse|proc), id, &responseBase{})
+			err = sendJSON(t, rw, msgTypeResponse|msgType(proc), id, &responseBase{})
 			if err != nil {
 				return err
 			}

--- a/internal/gcs/process.go
+++ b/internal/gcs/process.go
@@ -145,7 +145,7 @@ func (p *Process) Close() error {
 
 // CloseStdin causes the process to read EOF on its stdin stream.
 func (p *Process) CloseStdin(ctx context.Context) (err error) {
-	ctx, span := trace.StartSpan(ctx, "gcs::Process::CloseStdin")
+	ctx, span := trace.StartSpan(ctx, "gcs::Process::CloseStdin") //nolint:ineffassign,staticcheck
 	defer span.End()
 	defer func() { oc.SetSpanStatus(span, err) }()
 	span.AddAttributes(

--- a/internal/gcs/protocol.go
+++ b/internal/gcs/protocol.go
@@ -66,9 +66,9 @@ type msgType uint32
 
 const (
 	msgTypeRequest  msgType = 0x10100000
-	msgTypeResponse         = 0x20100000
-	msgTypeNotify           = 0x30100000
-	msgTypeMask             = 0xfff00000
+	msgTypeResponse msgType = 0x20100000
+	msgTypeNotify   msgType = 0x30100000
+	msgTypeMask     msgType = 0xfff00000
 
 	notifyContainer = 1<<8 | 1
 )

--- a/internal/gcs/resourcepaths.go
+++ b/internal/gcs/resourcepaths.go
@@ -2,9 +2,9 @@ package gcs
 
 const (
 	// silo container resources paths
-	siloDeviceResourcePath          string = "Container/Devices/Generic"
-	siloMappedDirectoryResourcePath string = "Container/MappedDirectories"
-	siloMappedPipeResourcePath      string = "Container/MappedPipes"
-	siloMemoryResourcePath          string = "Container/Memory/SizeInMB"
-	siloRegistryFlushStatePath      string = "Container/RegistryFlushState"
+	siloDeviceResourcePath          string = "Container/Devices/Generic"    //nolint
+	siloMappedDirectoryResourcePath string = "Container/MappedDirectories"  //nolint
+	siloMappedPipeResourcePath      string = "Container/MappedPipes"        //nolint
+	siloMemoryResourcePath          string = "Container/Memory/SizeInMB"    //nolint
+	siloRegistryFlushStatePath      string = "Container/RegistryFlushState" //nolint
 )

--- a/internal/hcs/errors.go
+++ b/internal/hcs/errors.go
@@ -332,12 +332,3 @@ func getInnerError(err error) error {
 	}
 	return err
 }
-
-func getOperationLogResult(err error) (string, error) {
-	switch err {
-	case nil:
-		return "Success", nil
-	default:
-		return "Error", err
-	}
-}

--- a/internal/hcs/system.go
+++ b/internal/hcs/system.go
@@ -73,7 +73,7 @@ func CreateComputeSystem(ctx context.Context, id string, hcsDocumentInterface in
 		if err = computeSystem.registerCallback(ctx); err != nil {
 			// Terminate the compute system if it still exists. We're okay to
 			// ignore a failure here.
-			computeSystem.Terminate(ctx)
+			_ = computeSystem.Terminate(ctx)
 			return nil, makeSystemError(computeSystem, operation, "", err, nil)
 		}
 	}
@@ -83,7 +83,7 @@ func CreateComputeSystem(ctx context.Context, id string, hcsDocumentInterface in
 		if err == ErrTimeout {
 			// Terminate the compute system if it still exists. We're okay to
 			// ignore a failure here.
-			computeSystem.Terminate(ctx)
+			_ = computeSystem.Terminate(ctx)
 		}
 		return nil, makeSystemError(computeSystem, operation, hcsDocument, err, events)
 	}
@@ -605,7 +605,7 @@ func (computeSystem *System) unregisterCallback(ctx context.Context) error {
 	delete(callbackMap, callbackNumber)
 	callbackMapLock.Unlock()
 
-	handle = 0
+	handle = 0 //nolint:ineffassign
 
 	return nil
 }

--- a/internal/hcs/waithelper.go
+++ b/internal/hcs/waithelper.go
@@ -65,5 +65,4 @@ func waitForNotification(ctx context.Context, callbackNumber uintptr, expectedNo
 	case <-c:
 		return ErrTimeout
 	}
-	return nil
 }

--- a/internal/hcsoci/create.go
+++ b/internal/hcsoci/create.go
@@ -83,11 +83,6 @@ func cmpSlices(s1, s2 []string) bool {
 	return equal
 }
 
-// Compares to mount structs and returns true if they are equal, returns false otherwise.
-func compareMounts(m1, m2 specs.Mount) bool {
-	return cmpSlices(m1.Options, m2.Options) && (m1.Source == m2.Source) && (m1.Destination == m2.Destination) && (m1.Type == m2.Type)
-}
-
 // verifyCloneContainerSpecs compares the container creation spec provided during the template container
 // creation and the spec provided during cloned container creation and checks that all the fields match
 // (except for the certain fields that are allowed to be different).
@@ -276,7 +271,7 @@ func CreateContainer(ctx context.Context, createOptions *CreateOptions) (_ cow.C
 	defer func() {
 		if err != nil {
 			if !coi.DoNotReleaseResourcesOnFailure {
-				resources.ReleaseResources(ctx, r, coi.HostingSystem, true)
+				_ = resources.ReleaseResources(ctx, r, coi.HostingSystem, true)
 			}
 		}
 	}()
@@ -393,7 +388,7 @@ func CloneContainer(ctx context.Context, createOptions *CreateOptions) (_ cow.Co
 	defer func() {
 		if err != nil {
 			if !coi.DoNotReleaseResourcesOnFailure {
-				resources.ReleaseResources(ctx, r, coi.HostingSystem, true)
+				_ = resources.ReleaseResources(ctx, r, coi.HostingSystem, true)
 			}
 		}
 	}()

--- a/internal/hcsoci/resources_lcow.go
+++ b/internal/hcsoci/resources_lcow.go
@@ -99,7 +99,6 @@ func allocateLinuxResources(ctx context.Context, coi *createOptionsInternal, r *
 				}
 
 				uvmPathForFile = scsiMount.UVMPath
-				uvmPathForShare = scsiMount.UVMPath
 				r.Add(scsiMount)
 				coi.Spec.Mounts[i].Type = "none"
 			} else if mount.Type == "virtual-disk" {
@@ -114,7 +113,6 @@ func allocateLinuxResources(ctx context.Context, coi *createOptionsInternal, r *
 				}
 
 				uvmPathForFile = scsiMount.UVMPath
-				uvmPathForShare = scsiMount.UVMPath
 				r.Add(scsiMount)
 				coi.Spec.Mounts[i].Type = "none"
 			} else if strings.HasPrefix(mount.Source, "sandbox://") {

--- a/internal/hns/hnsnetwork.go
+++ b/internal/hns/hnsnetwork.go
@@ -39,12 +39,6 @@ type HNSNetwork struct {
 	AutomaticDNS         bool              `json:",omitempty"`
 }
 
-type hnsNetworkResponse struct {
-	Success bool
-	Error   string
-	Output  HNSNetwork
-}
-
 type hnsResponse struct {
 	Success bool
 	Error   string

--- a/internal/jobcontainers/env.go
+++ b/internal/jobcontainers/env.go
@@ -23,7 +23,9 @@ func defaultEnvBlock(token windows.Token) (env []string, err error) {
 	if err := windows.CreateEnvironmentBlock(&block, token, false); err != nil {
 		return nil, err
 	}
-	defer windows.DestroyEnvironmentBlock(block)
+	defer func() {
+		_ = windows.DestroyEnvironmentBlock(block)
+	}()
 
 	blockp := uintptr(unsafe.Pointer(block))
 	for {

--- a/internal/jobcontainers/jobcontainer.go
+++ b/internal/jobcontainers/jobcontainer.go
@@ -138,7 +138,7 @@ func Create(ctx context.Context, id string, s *specs.Spec) (_ cow.Container, err
 		if err != nil {
 			container.Close()
 			if path != "" {
-				removeSandboxMountPoint(ctx, path)
+				_ = removeSandboxMountPoint(ctx, path)
 			}
 		}
 	}()
@@ -404,7 +404,7 @@ func (c *JobContainer) waitBackground(ctx context.Context) {
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 	if err := c.Shutdown(ctx); err != nil {
-		c.Terminate(ctx)
+		_ = c.Terminate(ctx)
 	}
 
 	c.closedWaitOnce.Do(func() {

--- a/internal/jobobject/jobobject_test.go
+++ b/internal/jobobject/jobobject_test.go
@@ -43,7 +43,7 @@ func createProcsAndAssign(num int, job *JobObject) (_ []*exec.Cmd, err error) {
 	defer func() {
 		if err != nil {
 			for _, proc := range procs {
-				proc.Process.Kill()
+				_ = proc.Process.Kill()
 			}
 		}
 	}()
@@ -108,7 +108,7 @@ func TestSetTerminateOnLastHandleClose(t *testing.T) {
 			t.Fatal(err)
 		}
 	case <-time.After(time.Second * 10):
-		procs[0].Process.Kill()
+		_ = procs[0].Process.Kill()
 		t.Fatal("process didn't complete wait within timeout")
 	}
 }

--- a/internal/jobobject/limits.go
+++ b/internal/jobobject/limits.go
@@ -10,8 +10,7 @@ import (
 )
 
 const (
-	processorWeightMax float64 = 10000
-	memoryLimitMax     uint64  = 0xffffffffffffffff
+	memoryLimitMax uint64 = 0xffffffffffffffff
 )
 
 func isFlagSet(flag, controlFlags uint32) bool {

--- a/internal/layers/layers.go
+++ b/internal/layers/layers.go
@@ -83,7 +83,7 @@ func MountContainerLayers(ctx context.Context, layerFolders []string, guestRoot 
 		}
 		defer func() {
 			if err != nil {
-				wclayer.DeactivateLayer(ctx, path)
+				_ = wclayer.DeactivateLayer(ctx, path)
 			}
 		}()
 
@@ -92,7 +92,7 @@ func MountContainerLayers(ctx context.Context, layerFolders []string, guestRoot 
 		}
 		defer func() {
 			if err != nil {
-				wclayer.UnprepareLayer(ctx, path)
+				_ = wclayer.UnprepareLayer(ctx, path)
 			}
 		}()
 
@@ -188,7 +188,8 @@ func MountContainerLayers(ctx context.Context, layerFolders []string, guestRoot 
 	if uvm.OS() == "windows" {
 		// 	Load the filter at the C:\s<ID> location calculated above. We pass into this request each of the
 		// 	read-only layer folders.
-		layers, err := GetHCSLayers(ctx, uvm, layersAdded)
+		var layers []hcsschema.Layer
+		layers, err = GetHCSLayers(ctx, uvm, layersAdded)
 		if err != nil {
 			return "", err
 		}

--- a/internal/lcow/disk.go
+++ b/internal/lcow/disk.go
@@ -34,7 +34,7 @@ func FormatDisk(ctx context.Context, lcowUVM *uvm.UtilityVM, destPath string) er
 	}
 
 	defer func() {
-		scsi.Release(ctx)
+		_ = scsi.Release(ctx)
 	}()
 
 	log.G(ctx).WithFields(logrus.Fields{

--- a/internal/lcow/scratch.go
+++ b/internal/lcow/scratch.go
@@ -73,7 +73,7 @@ func CreateScratch(ctx context.Context, lcowUVM *uvm.UtilityVM, destFile string,
 	removeSCSI := true
 	defer func() {
 		if removeSCSI {
-			lcowUVM.RemoveSCSI(ctx, destFile)
+			_ = lcowUVM.RemoveSCSI(ctx, destFile)
 		}
 	}()
 

--- a/internal/queue/queue_test.go
+++ b/internal/queue/queue_test.go
@@ -40,9 +40,9 @@ func TestReadOrWaitClose(t *testing.T) {
 	q := NewMessageQueue()
 
 	go func() {
-		q.Write(1)
-		q.Write(2)
-		q.Write(3)
+		_ = q.Write(1)
+		_ = q.Write(2)
+		_ = q.Write(3)
 		time.Sleep(time.Second * 5)
 		q.Close()
 	}()
@@ -65,11 +65,11 @@ func TestReadOrWait(t *testing.T) {
 	q := NewMessageQueue()
 
 	go func() {
-		q.Write(1)
-		q.Write(2)
-		q.Write(3)
+		_ = q.Write(1)
+		_ = q.Write(2)
+		_ = q.Write(3)
 		time.Sleep(time.Second * 5)
-		q.Write(4)
+		_ = q.Write(4)
 	}()
 
 	// Small sleep so that we can give time to ensure a value is written to the queue so we

--- a/internal/regstate/regstate.go
+++ b/internal/regstate/regstate.go
@@ -9,6 +9,7 @@ import (
 	"reflect"
 	"syscall"
 
+	"golang.org/x/sys/windows"
 	"golang.org/x/sys/windows/registry"
 )
 
@@ -19,7 +20,6 @@ import (
 const (
 	_REG_OPTION_VOLATILE = 1
 
-	_REG_CREATED_NEW_KEY     = 1
 	_REG_OPENED_EXISTING_KEY = 2
 )
 
@@ -61,7 +61,8 @@ func createVolatileKey(k *Key, path string, access uint32) (newk *Key, openedExi
 		d uint32
 	)
 	fullpath := filepath.Join(k.Name, path)
-	err = regCreateKeyEx(syscall.Handle(k.Key), syscall.StringToUTF16Ptr(path), 0, nil, _REG_OPTION_VOLATILE, access, nil, &h, &d)
+	pathPtr, _ := windows.UTF16PtrFromString(path)
+	err = regCreateKeyEx(syscall.Handle(k.Key), pathPtr, 0, nil, _REG_OPTION_VOLATILE, access, nil, &h, &d)
 	if err != nil {
 		return nil, false, &os.PathError{Op: "RegCreateKeyEx", Path: fullpath, Err: err}
 	}

--- a/internal/runhcs/container.go
+++ b/internal/runhcs/container.go
@@ -51,7 +51,7 @@ func GetErrorFromPipe(pipe io.Reader, p *os.Process) error {
 
 	extra := ""
 	if p != nil {
-		p.Kill()
+		_ = p.Kill()
 		state, err := p.Wait()
 		if err != nil {
 			panic(err)

--- a/internal/safefile/safeopen.go
+++ b/internal/safefile/safeopen.go
@@ -244,7 +244,7 @@ func RemoveRelative(path string, root *os.File) error {
 		err = deleteOnClose(f)
 		if err == syscall.ERROR_ACCESS_DENIED {
 			// Maybe the file is marked readonly. Clear the bit and retry.
-			clearReadOnly(f)
+			_ = clearReadOnly(f)
 			err = deleteOnClose(f)
 		}
 	}

--- a/internal/schema1/schema1.go
+++ b/internal/schema1/schema1.go
@@ -119,9 +119,9 @@ type PropertyType string
 
 const (
 	PropertyTypeStatistics        PropertyType = "Statistics"        // V1 and V2
-	PropertyTypeProcessList                    = "ProcessList"       // V1 and V2
-	PropertyTypeMappedVirtualDisk              = "MappedVirtualDisk" // Not supported in V2 schema call
-	PropertyTypeGuestConnection                = "GuestConnection"   // V1 and V2. Nil return from HCS before RS5
+	PropertyTypeProcessList       PropertyType = "ProcessList"       // V1 and V2
+	PropertyTypeMappedVirtualDisk PropertyType = "MappedVirtualDisk" // Not supported in V2 schema call
+	PropertyTypeGuestConnection   PropertyType = "GuestConnection"   // V1 and V2. Nil return from HCS before RS5
 )
 
 type PropertyQuery struct {

--- a/internal/schema2/device.go
+++ b/internal/schema2/device.go
@@ -13,8 +13,8 @@ type DeviceType string
 
 const (
 	ClassGUID      DeviceType = "ClassGuid"
-	DeviceInstance            = "DeviceInstance"
-	GPUMirror                 = "GpuMirror"
+	DeviceInstance DeviceType = "DeviceInstance"
+	GPUMirror      DeviceType = "GpuMirror"
 )
 
 type Device struct {

--- a/internal/schema2/logical_processor.go
+++ b/internal/schema2/logical_processor.go
@@ -11,8 +11,8 @@ package hcsschema
 
 type LogicalProcessor struct {
 	LpIndex     uint32 `json:"LpIndex,omitempty"`
-	NodeNumber  uint8  `json:"NodeNumber, omitempty"`
-	PackageId   uint32 `json:"PackageId, omitempty"`
-	CoreId      uint32 `json:"CoreId, omitempty"`
-	RootVpIndex int32  `json:"RootVpIndex, omitempty"`
+	NodeNumber  uint8  `json:"NodeNumber,omitempty"`
+	PackageId   uint32 `json:"PackageId,omitempty"`
+	CoreId      uint32 `json:"CoreId,omitempty"`
+	RootVpIndex int32  `json:"RootVpIndex,omitempty"`
 }

--- a/internal/tools/uvmboot/lcow.go
+++ b/internal/tools/uvmboot/lcow.go
@@ -124,7 +124,9 @@ var lcowCommand = cli.Command{
 				if c.IsSet(outputHandlingArgName) {
 					switch strings.ToLower(c.String(outputHandlingArgName)) {
 					case "stdout":
-						options.OutputHandler = uvm.OutputHandler(func(r io.Reader) { io.Copy(os.Stdout, r) })
+						options.OutputHandler = uvm.OutputHandler(func(r io.Reader) {
+							_, _ = io.Copy(os.Stdout, r)
+						})
 					default:
 						logrus.Fatalf("Unrecognized value '%s' for option %s", c.String(outputHandlingArgName), outputHandlingArgName)
 					}
@@ -159,8 +161,8 @@ func runLCOW(ctx context.Context, options *uvm.OptionsLCOW, c *cli.Context) erro
 		if err := execViaGcs(uvm, c); err != nil {
 			return err
 		}
-		uvm.Terminate(ctx)
-		uvm.Wait()
+		_ = uvm.Terminate(ctx)
+		_ = uvm.Wait()
 		return uvm.ExitError()
 	}
 
@@ -180,7 +182,9 @@ func execViaGcs(vm *uvm.UtilityVM, c *cli.Context) error {
 			if err != nil {
 				return err
 			}
-			defer con.Reset()
+			defer func() {
+				_ = con.Reset()
+			}()
 		}
 	} else if c.String(outputHandlingArgName) == "stdout" {
 		if c.Bool(forwardStdoutArgName) {

--- a/internal/tools/uvmboot/wcow.go
+++ b/internal/tools/uvmboot/wcow.go
@@ -98,7 +98,9 @@ var wcowCommand = cli.Command{
 						if err != nil {
 							return err
 						}
-						defer con.Reset()
+						defer func() {
+							_ = con.Reset()
+						}()
 					}
 				} else {
 					cmd.Stdout = os.Stdout
@@ -109,8 +111,8 @@ var wcowCommand = cli.Command{
 					return err
 				}
 			}
-			vm.Terminate(context.TODO())
-			vm.Wait()
+			_ = vm.Terminate(context.TODO())
+			_ = vm.Wait()
 			return vm.ExitError()
 		})
 		return nil

--- a/internal/uvm/create.go
+++ b/internal/uvm/create.go
@@ -217,8 +217,8 @@ func (uvm *UtilityVM) create(ctx context.Context, doc interface{}) error {
 	}
 	defer func() {
 		if system != nil {
-			system.Terminate(ctx)
-			system.Wait()
+			_ = system.Terminate(ctx)
+			_ = system.Wait()
 		}
 	}()
 
@@ -251,8 +251,8 @@ func (uvm *UtilityVM) Close() (err error) {
 		if err := uvm.ReleaseCPUGroup(ctx); err != nil {
 			log.G(ctx).WithError(err).Warn("failed to release VM resource")
 		}
-		uvm.hcsSystem.Terminate(ctx)
-		uvm.Wait()
+		_ = uvm.hcsSystem.Terminate(ctx)
+		_ = uvm.Wait()
 	}
 
 	if err := uvm.CloseGCSConnection(); err != nil {

--- a/internal/uvm/resourcepaths.go
+++ b/internal/uvm/resourcepaths.go
@@ -1,5 +1,6 @@
 package uvm
 
+//nolint:deadcode,varcheck
 const (
 	gpuResourcePath                  string = "VirtualMachine/ComputeTopology/Gpu"
 	memoryResourcePath               string = "VirtualMachine/ComputeTopology/Memory/SizeInMB"

--- a/internal/uvm/share.go
+++ b/internal/uvm/share.go
@@ -22,7 +22,7 @@ func (uvm *UtilityVM) Share(ctx context.Context, reqHostPath, reqUVMPath string,
 		}
 		defer func() {
 			if err != nil {
-				vsmbShare.Release(ctx)
+				_ = vsmbShare.Release(ctx)
 			}
 		}()
 
@@ -64,7 +64,7 @@ func (uvm *UtilityVM) Share(ctx context.Context, reqHostPath, reqUVMPath string,
 		}
 		defer func() {
 			if err != nil {
-				plan9Share.Release(ctx)
+				_ = plan9Share.Release(ctx)
 			}
 		}()
 	}

--- a/internal/uvm/start.go
+++ b/internal/uvm/start.go
@@ -153,7 +153,9 @@ func (uvm *UtilityVM) configureHvSocketForGCS(ctx context.Context) (err error) {
 func (uvm *UtilityVM) Start(ctx context.Context) (err error) {
 	ctx, cancel := context.WithTimeout(ctx, 2*time.Minute)
 	g, gctx := errgroup.WithContext(ctx)
-	defer g.Wait()
+	defer func() {
+		_ = g.Wait()
+	}()
 	defer cancel()
 
 	// Prepare to provide entropy to the init process in the background. This
@@ -198,8 +200,8 @@ func (uvm *UtilityVM) Start(ctx context.Context) (err error) {
 	}
 	defer func() {
 		if err != nil {
-			uvm.hcsSystem.Terminate(ctx)
-			uvm.hcsSystem.Wait()
+			_ = uvm.hcsSystem.Terminate(ctx)
+			_ = uvm.hcsSystem.Wait()
 		}
 	}()
 

--- a/internal/uvm/vsmb.go
+++ b/internal/uvm/vsmb.go
@@ -79,7 +79,6 @@ func (uvm *UtilityVM) SetSaveableVSMBOptions(opts *hcsschema.VirtualSmbShareOpti
 	opts.NoLocks = true
 	opts.PseudoDirnotify = true
 	opts.NoDirectmap = true
-	return
 }
 
 // findVSMBShare finds a share by `hostPath`. If not found returns `ErrNotAttached`.
@@ -142,7 +141,9 @@ func forceNoDirectMap(path string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	defer windows.CloseHandle(h)
+	defer func() {
+		_ = windows.CloseHandle(h)
+	}()
 	var info winapi.FILE_ID_INFO
 	// We check for any error, rather than just ERROR_INVALID_PARAMETER. It seems better to also
 	// fall back if e.g. some other backing filesystem is used which returns a different error.

--- a/internal/vmcompute/vmcompute.go
+++ b/internal/vmcompute/vmcompute.go
@@ -62,7 +62,7 @@ type HcsCallback syscall.Handle
 type HcsProcessInformation struct {
 	// ProcessId is the pid of the created process.
 	ProcessId uint32
-	reserved  uint32
+	reserved  uint32 //nolint:structcheck
 	// StdInput is the handle associated with the stdin of the process.
 	StdInput syscall.Handle
 	// StdOutput is the handle associated with the stdout of the process.

--- a/internal/wclayer/activatelayer.go
+++ b/internal/wclayer/activatelayer.go
@@ -14,7 +14,7 @@ import (
 // An activated layer must later be deactivated via DeactivateLayer.
 func ActivateLayer(ctx context.Context, path string) (err error) {
 	title := "hcsshim::ActivateLayer"
-	ctx, span := trace.StartSpan(ctx, title)
+	ctx, span := trace.StartSpan(ctx, title) //nolint:ineffassign,staticcheck
 	defer span.End()
 	defer func() { oc.SetSpanStatus(span, err) }()
 	span.AddAttributes(trace.StringAttribute("path", path))

--- a/internal/wclayer/createlayer.go
+++ b/internal/wclayer/createlayer.go
@@ -12,7 +12,7 @@ import (
 // the parent layer provided.
 func CreateLayer(ctx context.Context, path, parent string) (err error) {
 	title := "hcsshim::CreateLayer"
-	ctx, span := trace.StartSpan(ctx, title)
+	ctx, span := trace.StartSpan(ctx, title) //nolint:ineffassign,staticcheck
 	defer span.End()
 	defer func() { oc.SetSpanStatus(span, err) }()
 	span.AddAttributes(

--- a/internal/wclayer/deactivatelayer.go
+++ b/internal/wclayer/deactivatelayer.go
@@ -11,7 +11,7 @@ import (
 // DeactivateLayer will dismount a layer that was mounted via ActivateLayer.
 func DeactivateLayer(ctx context.Context, path string) (err error) {
 	title := "hcsshim::DeactivateLayer"
-	ctx, span := trace.StartSpan(ctx, title)
+	ctx, span := trace.StartSpan(ctx, title) //nolint:ineffassign,staticcheck
 	defer span.End()
 	defer func() { oc.SetSpanStatus(span, err) }()
 	span.AddAttributes(trace.StringAttribute("path", path))

--- a/internal/wclayer/destroylayer.go
+++ b/internal/wclayer/destroylayer.go
@@ -12,7 +12,7 @@ import (
 // path, including that layer's containing folder, if any.
 func DestroyLayer(ctx context.Context, path string) (err error) {
 	title := "hcsshim::DestroyLayer"
-	ctx, span := trace.StartSpan(ctx, title)
+	ctx, span := trace.StartSpan(ctx, title) //nolint:ineffassign,staticcheck
 	defer span.End()
 	defer func() { oc.SetSpanStatus(span, err) }()
 	span.AddAttributes(trace.StringAttribute("path", path))

--- a/internal/wclayer/getlayermountpath.go
+++ b/internal/wclayer/getlayermountpath.go
@@ -21,8 +21,7 @@ func GetLayerMountPath(ctx context.Context, path string) (_ string, err error) {
 	defer func() { oc.SetSpanStatus(span, err) }()
 	span.AddAttributes(trace.StringAttribute("path", path))
 
-	var mountPathLength uintptr
-	mountPathLength = 0
+	var mountPathLength uintptr = 0
 
 	// Call the procedure itself.
 	log.G(ctx).Debug("Calling proc (1)")

--- a/internal/wclayer/getsharedbaseimages.go
+++ b/internal/wclayer/getsharedbaseimages.go
@@ -14,7 +14,7 @@ import (
 // of registering them with the graphdriver, graph, and tagstore.
 func GetSharedBaseImages(ctx context.Context) (_ string, err error) {
 	title := "hcsshim::GetSharedBaseImages"
-	ctx, span := trace.StartSpan(ctx, title)
+	ctx, span := trace.StartSpan(ctx, title) //nolint:ineffassign,staticcheck
 	defer span.End()
 	defer func() { oc.SetSpanStatus(span, err) }()
 

--- a/internal/wclayer/grantvmaccess.go
+++ b/internal/wclayer/grantvmaccess.go
@@ -11,7 +11,7 @@ import (
 // GrantVmAccess adds access to a file for a given VM
 func GrantVmAccess(ctx context.Context, vmid string, filepath string) (err error) {
 	title := "hcsshim::GrantVmAccess"
-	ctx, span := trace.StartSpan(ctx, title)
+	ctx, span := trace.StartSpan(ctx, title) //nolint:ineffassign,staticcheck
 	defer span.End()
 	defer func() { oc.SetSpanStatus(span, err) }()
 	span.AddAttributes(

--- a/internal/wclayer/layerexists.go
+++ b/internal/wclayer/layerexists.go
@@ -12,7 +12,7 @@ import (
 // to the system.
 func LayerExists(ctx context.Context, path string) (_ bool, err error) {
 	title := "hcsshim::LayerExists"
-	ctx, span := trace.StartSpan(ctx, title)
+	ctx, span := trace.StartSpan(ctx, title) //nolint:ineffassign,staticcheck
 	defer span.End()
 	defer func() { oc.SetSpanStatus(span, err) }()
 	span.AddAttributes(trace.StringAttribute("path", path))

--- a/internal/wclayer/legacy.go
+++ b/internal/wclayer/legacy.go
@@ -390,7 +390,7 @@ func (w *legacyLayerWriter) CloseRoots() {
 		w.destRoot = nil
 	}
 	for i := range w.parentRoots {
-		w.parentRoots[i].Close()
+		_ = w.parentRoots[i].Close()
 	}
 	w.parentRoots = nil
 }
@@ -640,7 +640,7 @@ func (w *legacyLayerWriter) Add(name string, fileInfo *winio.FileBasicInfo) erro
 		defer func() {
 			if f != nil {
 				f.Close()
-				safefile.RemoveRelative(name, w.destRoot)
+				_ = safefile.RemoveRelative(name, w.destRoot)
 			}
 		}()
 
@@ -676,7 +676,7 @@ func (w *legacyLayerWriter) Add(name string, fileInfo *winio.FileBasicInfo) erro
 	defer func() {
 		if f != nil {
 			f.Close()
-			safefile.RemoveRelative(fname, w.root)
+			_ = safefile.RemoveRelative(fname, w.root)
 		}
 	}()
 

--- a/internal/wclayer/nametoguid.go
+++ b/internal/wclayer/nametoguid.go
@@ -14,7 +14,7 @@ import (
 // across all clients.
 func NameToGuid(ctx context.Context, name string) (_ guid.GUID, err error) {
 	title := "hcsshim::NameToGuid"
-	ctx, span := trace.StartSpan(ctx, title)
+	ctx, span := trace.StartSpan(ctx, title) //nolint:ineffassign,staticcheck
 	defer span.End()
 	defer func() { oc.SetSpanStatus(span, err) }()
 	span.AddAttributes(trace.StringAttribute("name", name))

--- a/internal/wclayer/processimage.go
+++ b/internal/wclayer/processimage.go
@@ -12,7 +12,7 @@ import (
 // The files should have been extracted to <path>\Files.
 func ProcessBaseLayer(ctx context.Context, path string) (err error) {
 	title := "hcsshim::ProcessBaseLayer"
-	ctx, span := trace.StartSpan(ctx, title)
+	ctx, span := trace.StartSpan(ctx, title) //nolint:ineffassign,staticcheck
 	defer span.End()
 	defer func() { oc.SetSpanStatus(span, err) }()
 	span.AddAttributes(trace.StringAttribute("path", path))
@@ -28,7 +28,7 @@ func ProcessBaseLayer(ctx context.Context, path string) (err error) {
 // The files should have been extracted to <path>\Files.
 func ProcessUtilityVMImage(ctx context.Context, path string) (err error) {
 	title := "hcsshim::ProcessUtilityVMImage"
-	ctx, span := trace.StartSpan(ctx, title)
+	ctx, span := trace.StartSpan(ctx, title) //nolint:ineffassign,staticcheck
 	defer span.End()
 	defer func() { oc.SetSpanStatus(span, err) }()
 	span.AddAttributes(trace.StringAttribute("path", path))

--- a/internal/wclayer/unpreparelayer.go
+++ b/internal/wclayer/unpreparelayer.go
@@ -12,7 +12,7 @@ import (
 // the given id.
 func UnprepareLayer(ctx context.Context, path string) (err error) {
 	title := "hcsshim::UnprepareLayer"
-	ctx, span := trace.StartSpan(ctx, title)
+	ctx, span := trace.StartSpan(ctx, title) //nolint:ineffassign,staticcheck
 	defer span.End()
 	defer func() { oc.SetSpanStatus(span, err) }()
 	span.AddAttributes(trace.StringAttribute("path", path))

--- a/osversion/osversion_windows.go
+++ b/osversion/osversion_windows.go
@@ -15,21 +15,6 @@ type OSVersion struct {
 	Build        uint16
 }
 
-// https://msdn.microsoft.com/en-us/library/windows/desktop/ms724833(v=vs.85).aspx
-type osVersionInfoEx struct {
-	OSVersionInfoSize uint32
-	MajorVersion      uint32
-	MinorVersion      uint32
-	BuildNumber       uint32
-	PlatformID        uint32
-	CSDVersion        [128]uint16
-	ServicePackMajor  uint16
-	ServicePackMinor  uint16
-	SuiteMask         uint16
-	ProductType       byte
-	Reserve           byte
-}
-
 // Get gets the operating system version on Windows.
 // The calling application must be manifested to get the correct version information.
 func Get() OSVersion {

--- a/pkg/go-runhcs/runhcs_create.go
+++ b/pkg/go-runhcs/runhcs_create.go
@@ -97,5 +97,5 @@ func (r *Runhcs) Create(context context.Context, id, bundle string, opts *Create
 	if err == nil && status != 0 {
 		err = fmt.Errorf("%s did not terminate sucessfully", cmd.Args[0])
 	}
-	return nil
+	return err
 }

--- a/pkg/ociwclayer/export.go
+++ b/pkg/ociwclayer/export.go
@@ -25,7 +25,9 @@ func ExportLayerToTar(ctx context.Context, w io.Writer, path string, parentLayer
 	if err != nil {
 		return err
 	}
-	defer hcsshim.DeactivateLayer(driverInfo, path)
+	defer func() {
+		_ = hcsshim.DeactivateLayer(driverInfo, path)
+	}()
 
 	// Prepare and unprepare the layer to ensure that it has been initialized.
 	err = hcsshim.PrepareLayer(driverInfo, path, parentLayerPaths)

--- a/test/functional/test.go
+++ b/test/functional/test.go
@@ -14,8 +14,7 @@ import (
 )
 
 const (
-	bytesPerMB   = 1024 * 1024
-	bytesPerPage = 4096
+	bytesPerMB = 1024 * 1024
 )
 
 var pauseDurationOnCreateContainerFailure time.Duration
@@ -36,7 +35,7 @@ func init() {
 
 	// Try to stop any pre-existing compute processes
 	cmd := exec.Command("powershell", `get-computeprocess | stop-computeprocess -force`)
-	cmd.Run()
+	_ = cmd.Run()
 
 }
 
@@ -48,7 +47,7 @@ func CreateContainerTestWrapper(ctx context.Context, options *hcsoci.CreateOptio
 	if err != nil {
 		logrus.Warnf("Test is pausing for %s for debugging CreateContainer failure", pauseDurationOnCreateContainerFailure)
 		time.Sleep(pauseDurationOnCreateContainerFailure)
-		resources.ReleaseResources(ctx, r, options.HostingSystem, true)
+		_ = resources.ReleaseResources(ctx, r, options.HostingSystem, true)
 	}
 	return s, r, err
 }

--- a/test/functional/utilities/scratch.go
+++ b/test/functional/utilities/scratch.go
@@ -20,7 +20,7 @@ var (
 
 func init() {
 	if hcsSystem, err := hcs.OpenComputeSystem(context.Background(), lcowGlobalSVMID); err == nil {
-		hcsSystem.Terminate(context.Background())
+		_ = hcsSystem.Terminate(context.Background())
 	}
 }
 

--- a/test/vendor/github.com/Microsoft/hcsshim/computestorage/attach.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/computestorage/attach.go
@@ -18,7 +18,7 @@ import (
 // `layerData` is the parent read-only layer data.
 func AttachLayerStorageFilter(ctx context.Context, layerPath string, layerData LayerData) (err error) {
 	title := "hcsshim.AttachLayerStorageFilter"
-	ctx, span := trace.StartSpan(ctx, title)
+	ctx, span := trace.StartSpan(ctx, title) //nolint:ineffassign,staticcheck
 	defer span.End()
 	defer func() { oc.SetSpanStatus(span, err) }()
 	span.AddAttributes(

--- a/test/vendor/github.com/Microsoft/hcsshim/computestorage/destroy.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/computestorage/destroy.go
@@ -13,7 +13,7 @@ import (
 // `layerPath` is a path to a directory containing the layer to export.
 func DestroyLayer(ctx context.Context, layerPath string) (err error) {
 	title := "hcsshim.DestroyLayer"
-	ctx, span := trace.StartSpan(ctx, title)
+	ctx, span := trace.StartSpan(ctx, title) //nolint:ineffassign,staticcheck
 	defer span.End()
 	defer func() { oc.SetSpanStatus(span, err) }()
 	span.AddAttributes(trace.StringAttribute("layerPath", layerPath))

--- a/test/vendor/github.com/Microsoft/hcsshim/computestorage/detach.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/computestorage/detach.go
@@ -13,7 +13,7 @@ import (
 // `layerPath` is a path to a directory containing the layer to export.
 func DetachLayerStorageFilter(ctx context.Context, layerPath string) (err error) {
 	title := "hcsshim.DetachLayerStorageFilter"
-	ctx, span := trace.StartSpan(ctx, title)
+	ctx, span := trace.StartSpan(ctx, title) //nolint:ineffassign,staticcheck
 	defer span.End()
 	defer func() { oc.SetSpanStatus(span, err) }()
 	span.AddAttributes(trace.StringAttribute("layerPath", layerPath))

--- a/test/vendor/github.com/Microsoft/hcsshim/computestorage/export.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/computestorage/export.go
@@ -20,7 +20,7 @@ import (
 // `options` are the export options applied to the exported layer.
 func ExportLayer(ctx context.Context, layerPath, exportFolderPath string, layerData LayerData, options ExportLayerOptions) (err error) {
 	title := "hcsshim.ExportLayer"
-	ctx, span := trace.StartSpan(ctx, title)
+	ctx, span := trace.StartSpan(ctx, title) //nolint:ineffassign,staticcheck
 	defer span.End()
 	defer func() { oc.SetSpanStatus(span, err) }()
 	span.AddAttributes(

--- a/test/vendor/github.com/Microsoft/hcsshim/computestorage/format.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/computestorage/format.go
@@ -14,7 +14,7 @@ import (
 // If the VHD is not mounted it will be temporarily mounted.
 func FormatWritableLayerVhd(ctx context.Context, vhdHandle windows.Handle) (err error) {
 	title := "hcsshim.FormatWritableLayerVhd"
-	ctx, span := trace.StartSpan(ctx, title)
+	ctx, span := trace.StartSpan(ctx, title) //nolint:ineffassign,staticcheck
 	defer span.End()
 	defer func() { oc.SetSpanStatus(span, err) }()
 

--- a/test/vendor/github.com/Microsoft/hcsshim/computestorage/helpers.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/computestorage/helpers.go
@@ -70,7 +70,7 @@ func SetupContainerBaseLayer(ctx context.Context, layerPath, baseVhdPath, diffVh
 
 	defer func() {
 		if err != nil {
-			syscall.CloseHandle(handle)
+			syscall.CloseHandle(handle) //nolint:errcheck
 			os.RemoveAll(baseVhdPath)
 			if os.Stat(diffVhdPath); err == nil {
 				os.RemoveAll(diffVhdPath)
@@ -148,7 +148,7 @@ func SetupUtilityVMBaseLayer(ctx context.Context, uvmPath, baseVhdPath, diffVhdP
 
 	defer func() {
 		if err != nil {
-			syscall.CloseHandle(handle)
+			syscall.CloseHandle(handle) //nolint:errcheck
 			os.RemoveAll(baseVhdPath)
 			if os.Stat(diffVhdPath); err == nil {
 				os.RemoveAll(diffVhdPath)

--- a/test/vendor/github.com/Microsoft/hcsshim/computestorage/import.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/computestorage/import.go
@@ -20,7 +20,7 @@ import (
 // `layerData` is the parent layer data.
 func ImportLayer(ctx context.Context, layerPath, sourceFolderPath string, layerData LayerData) (err error) {
 	title := "hcsshim.ImportLayer"
-	ctx, span := trace.StartSpan(ctx, title)
+	ctx, span := trace.StartSpan(ctx, title) //nolint:ineffassign,staticcheck
 	defer span.End()
 	defer func() { oc.SetSpanStatus(span, err) }()
 	span.AddAttributes(

--- a/test/vendor/github.com/Microsoft/hcsshim/computestorage/initialize.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/computestorage/initialize.go
@@ -17,7 +17,7 @@ import (
 // `layerData` is the parent read-only layer data.
 func InitializeWritableLayer(ctx context.Context, layerPath string, layerData LayerData) (err error) {
 	title := "hcsshim.InitializeWritableLayer"
-	ctx, span := trace.StartSpan(ctx, title)
+	ctx, span := trace.StartSpan(ctx, title) //nolint:ineffassign,staticcheck
 	defer span.End()
 	defer func() { oc.SetSpanStatus(span, err) }()
 	span.AddAttributes(

--- a/test/vendor/github.com/Microsoft/hcsshim/computestorage/mount.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/computestorage/mount.go
@@ -13,7 +13,7 @@ import (
 // GetLayerVhdMountPath returns the volume path for a virtual disk of a writable container layer.
 func GetLayerVhdMountPath(ctx context.Context, vhdHandle windows.Handle) (path string, err error) {
 	title := "hcsshim.GetLayerVhdMountPath"
-	ctx, span := trace.StartSpan(ctx, title)
+	ctx, span := trace.StartSpan(ctx, title) //nolint:ineffassign,staticcheck
 	defer span.End()
 	defer func() { oc.SetSpanStatus(span, err) }()
 

--- a/test/vendor/github.com/Microsoft/hcsshim/computestorage/setup.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/computestorage/setup.go
@@ -22,7 +22,7 @@ import (
 // `options` are the options applied while processing the layer.
 func SetupBaseOSLayer(ctx context.Context, layerPath string, vhdHandle windows.Handle, options OsLayerOptions) (err error) {
 	title := "hcsshim.SetupBaseOSLayer"
-	ctx, span := trace.StartSpan(ctx, title)
+	ctx, span := trace.StartSpan(ctx, title) //nolint:ineffassign,staticcheck
 	defer span.End()
 	defer func() { oc.SetSpanStatus(span, err) }()
 	span.AddAttributes(
@@ -53,7 +53,7 @@ func SetupBaseOSVolume(ctx context.Context, layerPath, volumePath string, option
 		return errors.New("SetupBaseOSVolume is not present on builds older than 19645")
 	}
 	title := "hcsshim.SetupBaseOSVolume"
-	ctx, span := trace.StartSpan(ctx, title)
+	ctx, span := trace.StartSpan(ctx, title) //nolint:ineffassign,staticcheck
 	defer span.End()
 	defer func() { oc.SetSpanStatus(span, err) }()
 	span.AddAttributes(

--- a/test/vendor/github.com/Microsoft/hcsshim/errors.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/errors.go
@@ -132,15 +132,6 @@ func (e *ContainerError) Error() string {
 	return s
 }
 
-func makeContainerError(container *container, operation string, extraInfo string, err error) error {
-	// Don't double wrap errors
-	if _, ok := err.(*ContainerError); ok {
-		return err
-	}
-	containerError := &ContainerError{Container: container, Operation: operation, ExtraInfo: extraInfo, Err: err}
-	return containerError
-}
-
 func (e *ProcessError) Error() string {
 	if e == nil {
 		return "<nil>"
@@ -169,15 +160,6 @@ func (e *ProcessError) Error() string {
 	}
 
 	return s
-}
-
-func makeProcessError(process *process, operation string, extraInfo string, err error) error {
-	// Don't double wrap errors
-	if _, ok := err.(*ProcessError); ok {
-		return err
-	}
-	processError := &ProcessError{Process: process, Operation: operation, ExtraInfo: extraInfo, Err: err}
-	return processError
 }
 
 // IsNotExist checks if an error is caused by the Container or Process not existing.

--- a/test/vendor/github.com/Microsoft/hcsshim/hcn/hcn.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/hcn/hcn.go
@@ -3,7 +3,6 @@
 package hcn
 
 import (
-	"encoding/json"
 	"fmt"
 	"syscall"
 
@@ -64,12 +63,6 @@ import (
 //sys hcnDeleteRoute(id *_guid, result **uint16) (hr error) = computenetwork.HcnDeleteSdnRoute?
 //sys hcnCloseRoute(route hcnRoute) (hr error) = computenetwork.HcnCloseSdnRoute?
 
-// Service
-//sys hcnOpenService(service *hcnService, result **uint16) (hr error) = computenetwork.HcnOpenService?
-//sys hcnRegisterServiceCallback(service hcnService, callback int32, context int32, callbackHandle *hcnCallbackHandle) (hr error) = computenetwork.HcnRegisterServiceCallback?
-//sys hcnUnregisterServiceCallback(callbackHandle hcnCallbackHandle) (hr error) = computenetwork.HcnUnregisterServiceCallback?
-//sys hcnCloseService(service hcnService) (hr error) = computenetwork.HcnCloseService?
-
 type _guid = guid.GUID
 
 type hcnNetwork syscall.Handle
@@ -77,8 +70,6 @@ type hcnEndpoint syscall.Handle
 type hcnNamespace syscall.Handle
 type hcnLoadBalancer syscall.Handle
 type hcnRoute syscall.Handle
-type hcnService syscall.Handle
-type hcnCallbackHandle syscall.Handle
 
 // SchemaVersion for HCN Objects/Queries.
 type SchemaVersion = Version // hcnglobals.go
@@ -126,15 +117,6 @@ func defaultQuery() HostComputeQuery {
 		Flags: HostComputeQueryFlagsNone,
 	}
 	return query
-}
-
-func defaultQueryJson() string {
-	query := defaultQuery()
-	queryJson, err := json.Marshal(query)
-	if err != nil {
-		return ""
-	}
-	return string(queryJson)
 }
 
 // PlatformDoesNotSupportError happens when users are attempting to use a newer shim on an older OS

--- a/test/vendor/github.com/Microsoft/hcsshim/hcn/hcnloadbalancer.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/hcn/hcnloadbalancer.go
@@ -160,50 +160,6 @@ func createLoadBalancer(settings string) (*HostComputeLoadBalancer, error) {
 	return &outputLoadBalancer, nil
 }
 
-func modifyLoadBalancer(loadBalancerId string, settings string) (*HostComputeLoadBalancer, error) {
-	loadBalancerGuid, err := guid.FromString(loadBalancerId)
-	if err != nil {
-		return nil, errInvalidLoadBalancerID
-	}
-	// Open loadBalancer.
-	var (
-		loadBalancerHandle hcnLoadBalancer
-		resultBuffer       *uint16
-		propertiesBuffer   *uint16
-	)
-	hr := hcnOpenLoadBalancer(&loadBalancerGuid, &loadBalancerHandle, &resultBuffer)
-	if err := checkForErrors("hcnOpenLoadBalancer", hr, resultBuffer); err != nil {
-		return nil, err
-	}
-	// Modify loadBalancer.
-	hr = hcnModifyLoadBalancer(loadBalancerHandle, settings, &resultBuffer)
-	if err := checkForErrors("hcnModifyLoadBalancer", hr, resultBuffer); err != nil {
-		return nil, err
-	}
-	// Query loadBalancer.
-	hcnQuery := defaultQuery()
-	query, err := json.Marshal(hcnQuery)
-	if err != nil {
-		return nil, err
-	}
-	hr = hcnQueryLoadBalancerProperties(loadBalancerHandle, string(query), &propertiesBuffer, &resultBuffer)
-	if err := checkForErrors("hcnQueryLoadBalancerProperties", hr, resultBuffer); err != nil {
-		return nil, err
-	}
-	properties := interop.ConvertAndFreeCoTaskMemString(propertiesBuffer)
-	// Close loadBalancer.
-	hr = hcnCloseLoadBalancer(loadBalancerHandle)
-	if err := checkForErrors("hcnCloseLoadBalancer", hr, nil); err != nil {
-		return nil, err
-	}
-	// Convert output to LoadBalancer
-	var outputLoadBalancer HostComputeLoadBalancer
-	if err := json.Unmarshal([]byte(properties), &outputLoadBalancer); err != nil {
-		return nil, err
-	}
-	return &outputLoadBalancer, nil
-}
-
 func deleteLoadBalancer(loadBalancerId string) error {
 	loadBalancerGuid, err := guid.FromString(loadBalancerId)
 	if err != nil {

--- a/test/vendor/github.com/Microsoft/hcsshim/hcn/hcnnamespace.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/hcn/hcnnamespace.go
@@ -378,7 +378,7 @@ func (namespace *HostComputeNamespace) Sync() error {
 		// The shim is likey gone. Simply ignore the sync as if it didn't exist.
 		if perr, ok := err.(*os.PathError); ok && perr.Err == syscall.ERROR_FILE_NOT_FOUND {
 			// Remove the reg key there is no point to try again
-			cfg.Remove()
+			cfg.Remove() //nolint:errcheck
 			return nil
 		}
 		f := map[string]interface{}{

--- a/test/vendor/github.com/Microsoft/hcsshim/hcn/zsyscall_windows.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/hcn/zsyscall_windows.go
@@ -78,10 +78,6 @@ var (
 	procHcnQuerySdnRouteProperties     = modcomputenetwork.NewProc("HcnQuerySdnRouteProperties")
 	procHcnDeleteSdnRoute              = modcomputenetwork.NewProc("HcnDeleteSdnRoute")
 	procHcnCloseSdnRoute               = modcomputenetwork.NewProc("HcnCloseSdnRoute")
-	procHcnOpenService                 = modcomputenetwork.NewProc("HcnOpenService")
-	procHcnRegisterServiceCallback     = modcomputenetwork.NewProc("HcnRegisterServiceCallback")
-	procHcnUnregisterServiceCallback   = modcomputenetwork.NewProc("HcnUnregisterServiceCallback")
-	procHcnCloseService                = modcomputenetwork.NewProc("HcnCloseService")
 )
 
 func SetCurrentThreadCompartmentId(compartmentId uint32) (hr error) {
@@ -789,62 +785,6 @@ func hcnCloseRoute(route hcnRoute) (hr error) {
 		return
 	}
 	r0, _, _ := syscall.Syscall(procHcnCloseSdnRoute.Addr(), 1, uintptr(route), 0, 0)
-	if int32(r0) < 0 {
-		if r0&0x1fff0000 == 0x00070000 {
-			r0 &= 0xffff
-		}
-		hr = syscall.Errno(r0)
-	}
-	return
-}
-
-func hcnOpenService(service *hcnService, result **uint16) (hr error) {
-	if hr = procHcnOpenService.Find(); hr != nil {
-		return
-	}
-	r0, _, _ := syscall.Syscall(procHcnOpenService.Addr(), 2, uintptr(unsafe.Pointer(service)), uintptr(unsafe.Pointer(result)), 0)
-	if int32(r0) < 0 {
-		if r0&0x1fff0000 == 0x00070000 {
-			r0 &= 0xffff
-		}
-		hr = syscall.Errno(r0)
-	}
-	return
-}
-
-func hcnRegisterServiceCallback(service hcnService, callback int32, context int32, callbackHandle *hcnCallbackHandle) (hr error) {
-	if hr = procHcnRegisterServiceCallback.Find(); hr != nil {
-		return
-	}
-	r0, _, _ := syscall.Syscall6(procHcnRegisterServiceCallback.Addr(), 4, uintptr(service), uintptr(callback), uintptr(context), uintptr(unsafe.Pointer(callbackHandle)), 0, 0)
-	if int32(r0) < 0 {
-		if r0&0x1fff0000 == 0x00070000 {
-			r0 &= 0xffff
-		}
-		hr = syscall.Errno(r0)
-	}
-	return
-}
-
-func hcnUnregisterServiceCallback(callbackHandle hcnCallbackHandle) (hr error) {
-	if hr = procHcnUnregisterServiceCallback.Find(); hr != nil {
-		return
-	}
-	r0, _, _ := syscall.Syscall(procHcnUnregisterServiceCallback.Addr(), 1, uintptr(callbackHandle), 0, 0)
-	if int32(r0) < 0 {
-		if r0&0x1fff0000 == 0x00070000 {
-			r0 &= 0xffff
-		}
-		hr = syscall.Errno(r0)
-	}
-	return
-}
-
-func hcnCloseService(service hcnService) (hr error) {
-	if hr = procHcnCloseService.Find(); hr != nil {
-		return
-	}
-	r0, _, _ := syscall.Syscall(procHcnCloseService.Addr(), 1, uintptr(service), 0, 0)
 	if int32(r0) < 0 {
 		if r0&0x1fff0000 == 0x00070000 {
 			r0 &= 0xffff

--- a/test/vendor/github.com/Microsoft/hcsshim/hnsendpoint.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/hnsendpoint.go
@@ -40,6 +40,9 @@ func HNSListEndpointRequest() ([]HNSEndpoint, error) {
 // HotAttachEndpoint makes a HCS Call to attach the endpoint to the container
 func HotAttachEndpoint(containerID string, endpointID string) error {
 	endpoint, err := GetHNSEndpointByID(endpointID)
+	if err != nil {
+		return err
+	}
 	isAttached, err := endpoint.IsAttached(containerID)
 	if isAttached {
 		return err
@@ -50,6 +53,9 @@ func HotAttachEndpoint(containerID string, endpointID string) error {
 // HotDetachEndpoint makes a HCS Call to detach the endpoint from the container
 func HotDetachEndpoint(containerID string, endpointID string) error {
 	endpoint, err := GetHNSEndpointByID(endpointID)
+	if err != nil {
+		return err
+	}
 	isAttached, err := endpoint.IsAttached(containerID)
 	if !isAttached {
 		return err

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/cmd/cmd.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/cmd/cmd.go
@@ -215,7 +215,10 @@ func (c *Cmd) Start() error {
 				c.stdinErr.Store(err)
 			}
 			// Notify the process that there is no more input.
-			p.CloseStdin(context.TODO())
+			err = p.CloseStdin(context.TODO())
+			if err != nil && c.Log != nil {
+				c.Log.WithError(err).Warn("failed to close pod stdin")
+			}
 		}()
 	}
 
@@ -237,7 +240,7 @@ func (c *Cmd) Start() error {
 		go func() {
 			select {
 			case <-c.Context.Done():
-				c.Process.Kill(context.TODO())
+				c.Process.Kill(context.TODO()) //nolint:errcheck
 			case <-c.allDoneCh:
 			}
 		}()

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/cmd/io_binary.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/cmd/io_binary.go
@@ -155,7 +155,7 @@ type binaryIO struct {
 
 	binaryCloser sync.Once
 
-	stdin, stdout, stderr string
+	stdout, stderr string
 
 	sout, serr io.ReadWriteCloser
 	soutCloser sync.Once

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/copyfile/copyfile.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/copyfile/copyfile.go
@@ -18,7 +18,7 @@ var (
 // CopyFile is a utility for copying a file using CopyFileW win32 API for
 // performance.
 func CopyFile(ctx context.Context, srcFile, destFile string, overwrite bool) (err error) {
-	ctx, span := trace.StartSpan(ctx, "copyfile::CopyFile")
+	ctx, span := trace.StartSpan(ctx, "copyfile::CopyFile") //nolint:ineffassign,staticcheck
 	defer span.End()
 	defer func() { oc.SetSpanStatus(span, err) }()
 	span.AddAttributes(

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/cpugroup/cpugroup.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/cpugroup/cpugroup.go
@@ -54,6 +54,7 @@ func Create(ctx context.Context, id string, logicalProcessors []uint32) error {
 }
 
 // getCPUGroupConfig finds the cpugroup config information for group with `id`
+//nolint:unused
 func getCPUGroupConfig(ctx context.Context, id string) (*hcsschema.CpuGroupConfig, error) {
 	query := hcsschema.PropertyQuery{
 		PropertyTypes: []hcsschema.PropertyType{hcsschema.PTCPUGroup},
@@ -68,7 +69,7 @@ func getCPUGroupConfig(ctx context.Context, id string) (*hcsschema.CpuGroupConfi
 	}
 
 	for _, c := range groupConfigs.CpuGroups {
-		if strings.ToLower(c.GroupId) == strings.ToLower(id) {
+		if strings.EqualFold(c.GroupId, id) {
 			return &c, nil
 		}
 	}

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/devices/assigned_devices.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/devices/assigned_devices.go
@@ -145,10 +145,7 @@ func readCsPipeOutput(l net.Listener, errChan chan<- error, result *[]string) {
 
 	elementsAsString := strings.TrimSuffix(string(bytes), "\n")
 	elements := strings.Split(elementsAsString, ",")
-
-	for _, elem := range elements {
-		*result = append(*result, elem)
-	}
+	*result = append(*result, elements...)
 
 	if len(*result) == 0 {
 		errChan <- errors.Wrapf(err, "failed to get any pipe output")

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/gcs/guestconnection.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/gcs/guestconnection.go
@@ -70,7 +70,7 @@ func (gcc *GuestConnectionConfig) Connect(ctx context.Context, isColdStart bool)
 	gc.brdg = newBridge(gcc.Conn, gc.notify, gcc.Log)
 	gc.brdg.Start()
 	go func() {
-		gc.brdg.Wait()
+		gc.brdg.Wait() //nolint:errcheck
 		gc.clearNotifies()
 	}()
 	err = gc.connect(ctx, isColdStart)

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/gcs/process.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/gcs/process.go
@@ -145,7 +145,7 @@ func (p *Process) Close() error {
 
 // CloseStdin causes the process to read EOF on its stdin stream.
 func (p *Process) CloseStdin(ctx context.Context) (err error) {
-	ctx, span := trace.StartSpan(ctx, "gcs::Process::CloseStdin")
+	ctx, span := trace.StartSpan(ctx, "gcs::Process::CloseStdin") //nolint:ineffassign,staticcheck
 	defer span.End()
 	defer func() { oc.SetSpanStatus(span, err) }()
 	span.AddAttributes(

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/gcs/protocol.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/gcs/protocol.go
@@ -66,9 +66,9 @@ type msgType uint32
 
 const (
 	msgTypeRequest  msgType = 0x10100000
-	msgTypeResponse         = 0x20100000
-	msgTypeNotify           = 0x30100000
-	msgTypeMask             = 0xfff00000
+	msgTypeResponse msgType = 0x20100000
+	msgTypeNotify   msgType = 0x30100000
+	msgTypeMask     msgType = 0xfff00000
 
 	notifyContainer = 1<<8 | 1
 )

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/gcs/resourcepaths.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/gcs/resourcepaths.go
@@ -2,9 +2,9 @@ package gcs
 
 const (
 	// silo container resources paths
-	siloDeviceResourcePath          string = "Container/Devices/Generic"
-	siloMappedDirectoryResourcePath string = "Container/MappedDirectories"
-	siloMappedPipeResourcePath      string = "Container/MappedPipes"
-	siloMemoryResourcePath          string = "Container/Memory/SizeInMB"
-	siloRegistryFlushStatePath      string = "Container/RegistryFlushState"
+	siloDeviceResourcePath          string = "Container/Devices/Generic"    //nolint
+	siloMappedDirectoryResourcePath string = "Container/MappedDirectories"  //nolint
+	siloMappedPipeResourcePath      string = "Container/MappedPipes"        //nolint
+	siloMemoryResourcePath          string = "Container/Memory/SizeInMB"    //nolint
+	siloRegistryFlushStatePath      string = "Container/RegistryFlushState" //nolint
 )

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/hcs/errors.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/hcs/errors.go
@@ -332,12 +332,3 @@ func getInnerError(err error) error {
 	}
 	return err
 }
-
-func getOperationLogResult(err error) (string, error) {
-	switch err {
-	case nil:
-		return "Success", nil
-	default:
-		return "Error", err
-	}
-}

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/hcs/system.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/hcs/system.go
@@ -73,7 +73,7 @@ func CreateComputeSystem(ctx context.Context, id string, hcsDocumentInterface in
 		if err = computeSystem.registerCallback(ctx); err != nil {
 			// Terminate the compute system if it still exists. We're okay to
 			// ignore a failure here.
-			computeSystem.Terminate(ctx)
+			computeSystem.Terminate(ctx) //nolint:errcheck
 			return nil, makeSystemError(computeSystem, operation, "", err, nil)
 		}
 	}
@@ -83,7 +83,7 @@ func CreateComputeSystem(ctx context.Context, id string, hcsDocumentInterface in
 		if err == ErrTimeout {
 			// Terminate the compute system if it still exists. We're okay to
 			// ignore a failure here.
-			computeSystem.Terminate(ctx)
+			computeSystem.Terminate(ctx) //nolint:errcheck
 		}
 		return nil, makeSystemError(computeSystem, operation, hcsDocument, err, events)
 	}
@@ -605,7 +605,7 @@ func (computeSystem *System) unregisterCallback(ctx context.Context) error {
 	delete(callbackMap, callbackNumber)
 	callbackMapLock.Unlock()
 
-	handle = 0
+	handle = 0 //nolint:ineffassign
 
 	return nil
 }

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/hcs/waithelper.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/hcs/waithelper.go
@@ -65,5 +65,4 @@ func waitForNotification(ctx context.Context, callbackNumber uintptr, expectedNo
 	case <-c:
 		return ErrTimeout
 	}
-	return nil
 }

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/hcsoci/create.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/hcsoci/create.go
@@ -83,11 +83,6 @@ func cmpSlices(s1, s2 []string) bool {
 	return equal
 }
 
-// Compares to mount structs and returns true if they are equal, returns false otherwise.
-func compareMounts(m1, m2 specs.Mount) bool {
-	return cmpSlices(m1.Options, m2.Options) && (m1.Source == m2.Source) && (m1.Destination == m2.Destination) && (m1.Type == m2.Type)
-}
-
 // verifyCloneContainerSpecs compares the container creation spec provided during the template container
 // creation and the spec provided during cloned container creation and checks that all the fields match
 // (except for the certain fields that are allowed to be different).
@@ -276,7 +271,7 @@ func CreateContainer(ctx context.Context, createOptions *CreateOptions) (_ cow.C
 	defer func() {
 		if err != nil {
 			if !coi.DoNotReleaseResourcesOnFailure {
-				resources.ReleaseResources(ctx, r, coi.HostingSystem, true)
+				resources.ReleaseResources(ctx, r, coi.HostingSystem, true) //nolint:errcheck
 			}
 		}
 	}()
@@ -393,7 +388,7 @@ func CloneContainer(ctx context.Context, createOptions *CreateOptions) (_ cow.Co
 	defer func() {
 		if err != nil {
 			if !coi.DoNotReleaseResourcesOnFailure {
-				resources.ReleaseResources(ctx, r, coi.HostingSystem, true)
+				resources.ReleaseResources(ctx, r, coi.HostingSystem, true) //nolint:errcheck
 			}
 		}
 	}()

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/hcsoci/resources_lcow.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/hcsoci/resources_lcow.go
@@ -99,7 +99,6 @@ func allocateLinuxResources(ctx context.Context, coi *createOptionsInternal, r *
 				}
 
 				uvmPathForFile = scsiMount.UVMPath
-				uvmPathForShare = scsiMount.UVMPath
 				r.Add(scsiMount)
 				coi.Spec.Mounts[i].Type = "none"
 			} else if mount.Type == "virtual-disk" {
@@ -114,7 +113,6 @@ func allocateLinuxResources(ctx context.Context, coi *createOptionsInternal, r *
 				}
 
 				uvmPathForFile = scsiMount.UVMPath
-				uvmPathForShare = scsiMount.UVMPath
 				r.Add(scsiMount)
 				coi.Spec.Mounts[i].Type = "none"
 			} else if strings.HasPrefix(mount.Source, "sandbox://") {

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/hns/hnsnetwork.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/hns/hnsnetwork.go
@@ -39,12 +39,6 @@ type HNSNetwork struct {
 	AutomaticDNS         bool              `json:",omitempty"`
 }
 
-type hnsNetworkResponse struct {
-	Success bool
-	Error   string
-	Output  HNSNetwork
-}
-
 type hnsResponse struct {
 	Success bool
 	Error   string

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/layers/layers.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/layers/layers.go
@@ -83,7 +83,7 @@ func MountContainerLayers(ctx context.Context, layerFolders []string, guestRoot 
 		}
 		defer func() {
 			if err != nil {
-				wclayer.DeactivateLayer(ctx, path)
+				wclayer.DeactivateLayer(ctx, path) //nolint:errcheck
 			}
 		}()
 
@@ -92,7 +92,7 @@ func MountContainerLayers(ctx context.Context, layerFolders []string, guestRoot 
 		}
 		defer func() {
 			if err != nil {
-				wclayer.UnprepareLayer(ctx, path)
+				wclayer.UnprepareLayer(ctx, path) //nolint:errcheck
 			}
 		}()
 
@@ -188,7 +188,8 @@ func MountContainerLayers(ctx context.Context, layerFolders []string, guestRoot 
 	if uvm.OS() == "windows" {
 		// 	Load the filter at the C:\s<ID> location calculated above. We pass into this request each of the
 		// 	read-only layer folders.
-		layers, err := GetHCSLayers(ctx, uvm, layersAdded)
+		var layers []hcsschema.Layer
+		layers, err = GetHCSLayers(ctx, uvm, layersAdded)
 		if err != nil {
 			return "", err
 		}

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/lcow/disk.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/lcow/disk.go
@@ -34,7 +34,7 @@ func FormatDisk(ctx context.Context, lcowUVM *uvm.UtilityVM, destPath string) er
 	}
 
 	defer func() {
-		scsi.Release(ctx)
+		scsi.Release(ctx) //nolint:errcheck
 	}()
 
 	log.G(ctx).WithFields(logrus.Fields{

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/lcow/scratch.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/lcow/scratch.go
@@ -73,7 +73,7 @@ func CreateScratch(ctx context.Context, lcowUVM *uvm.UtilityVM, destFile string,
 	removeSCSI := true
 	defer func() {
 		if removeSCSI {
-			lcowUVM.RemoveSCSI(ctx, destFile)
+			lcowUVM.RemoveSCSI(ctx, destFile) //nolint:errcheck
 		}
 	}()
 

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/regstate/regstate.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/regstate/regstate.go
@@ -9,6 +9,7 @@ import (
 	"reflect"
 	"syscall"
 
+	"golang.org/x/sys/windows"
 	"golang.org/x/sys/windows/registry"
 )
 
@@ -19,7 +20,6 @@ import (
 const (
 	_REG_OPTION_VOLATILE = 1
 
-	_REG_CREATED_NEW_KEY     = 1
 	_REG_OPENED_EXISTING_KEY = 2
 )
 
@@ -61,7 +61,8 @@ func createVolatileKey(k *Key, path string, access uint32) (newk *Key, openedExi
 		d uint32
 	)
 	fullpath := filepath.Join(k.Name, path)
-	err = regCreateKeyEx(syscall.Handle(k.Key), syscall.StringToUTF16Ptr(path), 0, nil, _REG_OPTION_VOLATILE, access, nil, &h, &d)
+	pathPtr, _ := windows.UTF16PtrFromString(path)
+	err = regCreateKeyEx(syscall.Handle(k.Key), pathPtr, 0, nil, _REG_OPTION_VOLATILE, access, nil, &h, &d)
 	if err != nil {
 		return nil, false, &os.PathError{Op: "RegCreateKeyEx", Path: fullpath, Err: err}
 	}

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/runhcs/container.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/runhcs/container.go
@@ -51,7 +51,7 @@ func GetErrorFromPipe(pipe io.Reader, p *os.Process) error {
 
 	extra := ""
 	if p != nil {
-		p.Kill()
+		p.Kill() //nolint:errcheck
 		state, err := p.Wait()
 		if err != nil {
 			panic(err)

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/safefile/safeopen.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/safefile/safeopen.go
@@ -244,7 +244,7 @@ func RemoveRelative(path string, root *os.File) error {
 		err = deleteOnClose(f)
 		if err == syscall.ERROR_ACCESS_DENIED {
 			// Maybe the file is marked readonly. Clear the bit and retry.
-			clearReadOnly(f)
+			clearReadOnly(f) //nolint:errcheck
 			err = deleteOnClose(f)
 		}
 	}

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/schema1/schema1.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/schema1/schema1.go
@@ -119,9 +119,9 @@ type PropertyType string
 
 const (
 	PropertyTypeStatistics        PropertyType = "Statistics"        // V1 and V2
-	PropertyTypeProcessList                    = "ProcessList"       // V1 and V2
-	PropertyTypeMappedVirtualDisk              = "MappedVirtualDisk" // Not supported in V2 schema call
-	PropertyTypeGuestConnection                = "GuestConnection"   // V1 and V2. Nil return from HCS before RS5
+	PropertyTypeProcessList       PropertyType = "ProcessList"       // V1 and V2
+	PropertyTypeMappedVirtualDisk PropertyType = "MappedVirtualDisk" // Not supported in V2 schema call
+	PropertyTypeGuestConnection   PropertyType = "GuestConnection"   // V1 and V2. Nil return from HCS before RS5
 )
 
 type PropertyQuery struct {

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/schema2/device.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/schema2/device.go
@@ -13,8 +13,8 @@ type DeviceType string
 
 const (
 	ClassGUID      DeviceType = "ClassGuid"
-	DeviceInstance            = "DeviceInstance"
-	GPUMirror                 = "GpuMirror"
+	DeviceInstance DeviceType = "DeviceInstance"
+	GPUMirror      DeviceType = "GpuMirror"
 )
 
 type Device struct {

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/schema2/logical_processor.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/schema2/logical_processor.go
@@ -11,8 +11,8 @@ package hcsschema
 
 type LogicalProcessor struct {
 	LpIndex     uint32 `json:"LpIndex,omitempty"`
-	NodeNumber  uint8  `json:"NodeNumber, omitempty"`
-	PackageId   uint32 `json:"PackageId, omitempty"`
-	CoreId      uint32 `json:"CoreId, omitempty"`
-	RootVpIndex int32  `json:"RootVpIndex, omitempty"`
+	NodeNumber  uint8  `json:"NodeNumber,omitempty"`
+	PackageId   uint32 `json:"PackageId,omitempty"`
+	CoreId      uint32 `json:"CoreId,omitempty"`
+	RootVpIndex int32  `json:"RootVpIndex,omitempty"`
 }

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/uvm/create.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/uvm/create.go
@@ -216,6 +216,7 @@ func (uvm *UtilityVM) create(ctx context.Context, doc interface{}) error {
 		return err
 	}
 	defer func() {
+		//nolint:errcheck
 		if system != nil {
 			system.Terminate(ctx)
 			system.Wait()
@@ -251,8 +252,8 @@ func (uvm *UtilityVM) Close() (err error) {
 		if err := uvm.ReleaseCPUGroup(ctx); err != nil {
 			log.G(ctx).WithError(err).Warn("failed to release VM resource")
 		}
-		uvm.hcsSystem.Terminate(ctx)
-		uvm.Wait()
+		uvm.hcsSystem.Terminate(ctx) //nolint:errcheck
+		uvm.Wait()                   //nolint:errcheck
 	}
 
 	if err := uvm.CloseGCSConnection(); err != nil {

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/uvm/resourcepaths.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/uvm/resourcepaths.go
@@ -1,5 +1,6 @@
 package uvm
 
+//nolint:deadcode,varcheck
 const (
 	gpuResourcePath                  string = "VirtualMachine/ComputeTopology/Gpu"
 	memoryResourcePath               string = "VirtualMachine/ComputeTopology/Memory/SizeInMB"

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/uvm/share.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/uvm/share.go
@@ -22,7 +22,7 @@ func (uvm *UtilityVM) Share(ctx context.Context, reqHostPath, reqUVMPath string,
 		}
 		defer func() {
 			if err != nil {
-				vsmbShare.Release(ctx)
+				vsmbShare.Release(ctx) //nolint:errcheck
 			}
 		}()
 
@@ -64,7 +64,7 @@ func (uvm *UtilityVM) Share(ctx context.Context, reqHostPath, reqUVMPath string,
 		}
 		defer func() {
 			if err != nil {
-				plan9Share.Release(ctx)
+				plan9Share.Release(ctx) //nolint:errcheck
 			}
 		}()
 	}

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/uvm/start.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/uvm/start.go
@@ -153,7 +153,7 @@ func (uvm *UtilityVM) configureHvSocketForGCS(ctx context.Context) (err error) {
 func (uvm *UtilityVM) Start(ctx context.Context) (err error) {
 	ctx, cancel := context.WithTimeout(ctx, 2*time.Minute)
 	g, gctx := errgroup.WithContext(ctx)
-	defer g.Wait()
+	defer g.Wait() //nolint:errcheck
 	defer cancel()
 
 	// Prepare to provide entropy to the init process in the background. This
@@ -197,6 +197,7 @@ func (uvm *UtilityVM) Start(ctx context.Context) (err error) {
 		return err
 	}
 	defer func() {
+		//nolint:errcheck
 		if err != nil {
 			uvm.hcsSystem.Terminate(ctx)
 			uvm.hcsSystem.Wait()

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/uvm/vsmb.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/uvm/vsmb.go
@@ -79,7 +79,6 @@ func (uvm *UtilityVM) SetSaveableVSMBOptions(opts *hcsschema.VirtualSmbShareOpti
 	opts.NoLocks = true
 	opts.PseudoDirnotify = true
 	opts.NoDirectmap = true
-	return
 }
 
 // findVSMBShare finds a share by `hostPath`. If not found returns `ErrNotAttached`.
@@ -142,7 +141,7 @@ func forceNoDirectMap(path string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	defer windows.CloseHandle(h)
+	defer windows.CloseHandle(h) //nolint:errcheck
 	var info winapi.FILE_ID_INFO
 	// We check for any error, rather than just ERROR_INVALID_PARAMETER. It seems better to also
 	// fall back if e.g. some other backing filesystem is used which returns a different error.

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/vmcompute/vmcompute.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/vmcompute/vmcompute.go
@@ -62,7 +62,7 @@ type HcsCallback syscall.Handle
 type HcsProcessInformation struct {
 	// ProcessId is the pid of the created process.
 	ProcessId uint32
-	reserved  uint32
+	reserved  uint32 //nolint:structcheck
 	// StdInput is the handle associated with the stdin of the process.
 	StdInput syscall.Handle
 	// StdOutput is the handle associated with the stdout of the process.

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/wclayer/activatelayer.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/wclayer/activatelayer.go
@@ -14,7 +14,7 @@ import (
 // An activated layer must later be deactivated via DeactivateLayer.
 func ActivateLayer(ctx context.Context, path string) (err error) {
 	title := "hcsshim::ActivateLayer"
-	ctx, span := trace.StartSpan(ctx, title)
+	ctx, span := trace.StartSpan(ctx, title) //nolint:ineffassign,staticcheck
 	defer span.End()
 	defer func() { oc.SetSpanStatus(span, err) }()
 	span.AddAttributes(trace.StringAttribute("path", path))

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/wclayer/createlayer.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/wclayer/createlayer.go
@@ -12,7 +12,7 @@ import (
 // the parent layer provided.
 func CreateLayer(ctx context.Context, path, parent string) (err error) {
 	title := "hcsshim::CreateLayer"
-	ctx, span := trace.StartSpan(ctx, title)
+	ctx, span := trace.StartSpan(ctx, title) //nolint:ineffassign,staticcheck
 	defer span.End()
 	defer func() { oc.SetSpanStatus(span, err) }()
 	span.AddAttributes(

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/wclayer/deactivatelayer.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/wclayer/deactivatelayer.go
@@ -11,7 +11,7 @@ import (
 // DeactivateLayer will dismount a layer that was mounted via ActivateLayer.
 func DeactivateLayer(ctx context.Context, path string) (err error) {
 	title := "hcsshim::DeactivateLayer"
-	ctx, span := trace.StartSpan(ctx, title)
+	ctx, span := trace.StartSpan(ctx, title) //nolint:ineffassign,staticcheck
 	defer span.End()
 	defer func() { oc.SetSpanStatus(span, err) }()
 	span.AddAttributes(trace.StringAttribute("path", path))

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/wclayer/destroylayer.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/wclayer/destroylayer.go
@@ -12,7 +12,7 @@ import (
 // path, including that layer's containing folder, if any.
 func DestroyLayer(ctx context.Context, path string) (err error) {
 	title := "hcsshim::DestroyLayer"
-	ctx, span := trace.StartSpan(ctx, title)
+	ctx, span := trace.StartSpan(ctx, title) //nolint:ineffassign,staticcheck
 	defer span.End()
 	defer func() { oc.SetSpanStatus(span, err) }()
 	span.AddAttributes(trace.StringAttribute("path", path))

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/wclayer/getlayermountpath.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/wclayer/getlayermountpath.go
@@ -21,8 +21,7 @@ func GetLayerMountPath(ctx context.Context, path string) (_ string, err error) {
 	defer func() { oc.SetSpanStatus(span, err) }()
 	span.AddAttributes(trace.StringAttribute("path", path))
 
-	var mountPathLength uintptr
-	mountPathLength = 0
+	var mountPathLength uintptr = 0
 
 	// Call the procedure itself.
 	log.G(ctx).Debug("Calling proc (1)")

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/wclayer/getsharedbaseimages.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/wclayer/getsharedbaseimages.go
@@ -14,7 +14,7 @@ import (
 // of registering them with the graphdriver, graph, and tagstore.
 func GetSharedBaseImages(ctx context.Context) (_ string, err error) {
 	title := "hcsshim::GetSharedBaseImages"
-	ctx, span := trace.StartSpan(ctx, title)
+	ctx, span := trace.StartSpan(ctx, title) //nolint:ineffassign,staticcheck
 	defer span.End()
 	defer func() { oc.SetSpanStatus(span, err) }()
 

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/wclayer/grantvmaccess.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/wclayer/grantvmaccess.go
@@ -11,7 +11,7 @@ import (
 // GrantVmAccess adds access to a file for a given VM
 func GrantVmAccess(ctx context.Context, vmid string, filepath string) (err error) {
 	title := "hcsshim::GrantVmAccess"
-	ctx, span := trace.StartSpan(ctx, title)
+	ctx, span := trace.StartSpan(ctx, title) //nolint:ineffassign,staticcheck
 	defer span.End()
 	defer func() { oc.SetSpanStatus(span, err) }()
 	span.AddAttributes(

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/wclayer/layerexists.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/wclayer/layerexists.go
@@ -12,7 +12,7 @@ import (
 // to the system.
 func LayerExists(ctx context.Context, path string) (_ bool, err error) {
 	title := "hcsshim::LayerExists"
-	ctx, span := trace.StartSpan(ctx, title)
+	ctx, span := trace.StartSpan(ctx, title) //nolint:ineffassign,staticcheck
 	defer span.End()
 	defer func() { oc.SetSpanStatus(span, err) }()
 	span.AddAttributes(trace.StringAttribute("path", path))

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/wclayer/legacy.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/wclayer/legacy.go
@@ -390,7 +390,7 @@ func (w *legacyLayerWriter) CloseRoots() {
 		w.destRoot = nil
 	}
 	for i := range w.parentRoots {
-		w.parentRoots[i].Close()
+		w.parentRoots[i].Close() //nolint:errcheck
 	}
 	w.parentRoots = nil
 }
@@ -640,7 +640,7 @@ func (w *legacyLayerWriter) Add(name string, fileInfo *winio.FileBasicInfo) erro
 		defer func() {
 			if f != nil {
 				f.Close()
-				safefile.RemoveRelative(name, w.destRoot)
+				safefile.RemoveRelative(name, w.destRoot) //nolint:errcheck
 			}
 		}()
 
@@ -676,7 +676,7 @@ func (w *legacyLayerWriter) Add(name string, fileInfo *winio.FileBasicInfo) erro
 	defer func() {
 		if f != nil {
 			f.Close()
-			safefile.RemoveRelative(fname, w.root)
+			safefile.RemoveRelative(fname, w.root) //nolint:errcheck
 		}
 	}()
 

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/wclayer/nametoguid.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/wclayer/nametoguid.go
@@ -14,7 +14,7 @@ import (
 // across all clients.
 func NameToGuid(ctx context.Context, name string) (_ guid.GUID, err error) {
 	title := "hcsshim::NameToGuid"
-	ctx, span := trace.StartSpan(ctx, title)
+	ctx, span := trace.StartSpan(ctx, title) //nolint:ineffassign,staticcheck
 	defer span.End()
 	defer func() { oc.SetSpanStatus(span, err) }()
 	span.AddAttributes(trace.StringAttribute("name", name))

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/wclayer/processimage.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/wclayer/processimage.go
@@ -12,7 +12,7 @@ import (
 // The files should have been extracted to <path>\Files.
 func ProcessBaseLayer(ctx context.Context, path string) (err error) {
 	title := "hcsshim::ProcessBaseLayer"
-	ctx, span := trace.StartSpan(ctx, title)
+	ctx, span := trace.StartSpan(ctx, title) //nolint:ineffassign,staticcheck
 	defer span.End()
 	defer func() { oc.SetSpanStatus(span, err) }()
 	span.AddAttributes(trace.StringAttribute("path", path))
@@ -28,7 +28,7 @@ func ProcessBaseLayer(ctx context.Context, path string) (err error) {
 // The files should have been extracted to <path>\Files.
 func ProcessUtilityVMImage(ctx context.Context, path string) (err error) {
 	title := "hcsshim::ProcessUtilityVMImage"
-	ctx, span := trace.StartSpan(ctx, title)
+	ctx, span := trace.StartSpan(ctx, title) //nolint:ineffassign,staticcheck
 	defer span.End()
 	defer func() { oc.SetSpanStatus(span, err) }()
 	span.AddAttributes(trace.StringAttribute("path", path))

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/wclayer/unpreparelayer.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/wclayer/unpreparelayer.go
@@ -12,7 +12,7 @@ import (
 // the given id.
 func UnprepareLayer(ctx context.Context, path string) (err error) {
 	title := "hcsshim::UnprepareLayer"
-	ctx, span := trace.StartSpan(ctx, title)
+	ctx, span := trace.StartSpan(ctx, title) //nolint:ineffassign,staticcheck
 	defer span.End()
 	defer func() { oc.SetSpanStatus(span, err) }()
 	span.AddAttributes(trace.StringAttribute("path", path))

--- a/test/vendor/github.com/Microsoft/hcsshim/osversion/osversion_windows.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/osversion/osversion_windows.go
@@ -15,21 +15,6 @@ type OSVersion struct {
 	Build        uint16
 }
 
-// https://msdn.microsoft.com/en-us/library/windows/desktop/ms724833(v=vs.85).aspx
-type osVersionInfoEx struct {
-	OSVersionInfoSize uint32
-	MajorVersion      uint32
-	MinorVersion      uint32
-	BuildNumber       uint32
-	PlatformID        uint32
-	CSDVersion        [128]uint16
-	ServicePackMajor  uint16
-	ServicePackMinor  uint16
-	SuiteMask         uint16
-	ProductType       byte
-	Reserve           byte
-}
-
 // Get gets the operating system version on Windows.
 // The calling application must be manifested to get the correct version information.
 func Get() OSVersion {

--- a/test/vendor/github.com/Microsoft/hcsshim/pkg/go-runhcs/runhcs_create.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/pkg/go-runhcs/runhcs_create.go
@@ -97,5 +97,5 @@ func (r *Runhcs) Create(context context.Context, id, bundle string, opts *Create
 	if err == nil && status != 0 {
 		err = fmt.Errorf("%s did not terminate sucessfully", cmd.Args[0])
 	}
-	return nil
+	return err
 }


### PR DESCRIPTION
This PR fixes the various linter issues discovered in https://github.com/microsoft/hcsshim/pull/975. 

Many of the fixes involved adding a comment to exclude code from specific linters, see [No Lint](https://golangci-lint.run/usage/false-positives/#nolint). 

For warnings relating to deadcode, the related code was removed. Warnings that related to ineffectual value assignment for context variables, I excluded the line from the `ineffassign` and `staticcheck` linters. This was to help ensure future log statements that may be made in these functions use the correct `ctx` value. For warnings relating to not checking the error code of a function call, I excluded the `errcheck` linter for that line, since it was likely intentional to ignore the error. If this is not the case, we can fix the relevant areas. 

To see a list of the default checks made with golangci, see [here](https://golangci-lint.run/usage/linters/). 

Signed-off-by: Kathryn Baldauf <kabaldau@microsoft.com>