### PR TITLE
Add stats support for job containers

### DIFF
--- a/internal/jobcontainers/system_test.go
+++ b/internal/jobcontainers/system_test.go
@@ -1,0 +1,12 @@
+package jobcontainers
+
+import (
+	"testing"
+)
+
+func TestSystemInfo(t *testing.T) {
+	_, err := systemProcessInformation()
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/winapi/system.go
+++ b/internal/winapi/system.go
@@ -1,0 +1,52 @@
+package winapi
+
+import "golang.org/x/sys/windows"
+
+const SystemProcessInformation = 5
+
+const STATUS_INFO_LENGTH_MISMATCH = 0xC0000004
+
+// __kernel_entry NTSTATUS NtQuerySystemInformation(
+// 	SYSTEM_INFORMATION_CLASS SystemInformationClass,
+// 	PVOID                    SystemInformation,
+// 	ULONG                    SystemInformationLength,
+// 	PULONG                   ReturnLength
+// );
+//sys NtQuerySystemInformation(systemInfoClass int, systemInformation uintptr, systemInfoLength uint32, returnLength *uint32) (status uint32) = ntdll.NtQuerySystemInformation
+
+type SYSTEM_PROCESS_INFORMATION struct {
+	NextEntryOffset              uint32         // ULONG
+	NumberOfThreads              uint32         // ULONG
+	WorkingSetPrivateSize        int64          // LARGE_INTEGER
+	HardFaultCount               uint32         // ULONG
+	NumberOfThreadsHighWatermark uint32         // ULONG
+	CycleTime                    uint64         // ULONGLONG
+	CreateTime                   int64          // LARGE_INTEGER
+	UserTime                     int64          // LARGE_INTEGER
+	KernelTime                   int64          // LARGE_INTEGER
+	ImageName                    UnicodeString  // UNICODE_STRING
+	BasePriority                 int32          // KPRIORITY
+	UniqueProcessID              windows.Handle // HANDLE
+	InheritedFromUniqueProcessID windows.Handle // HANDLE
+	HandleCount                  uint32         // ULONG
+	SessionID                    uint32         // ULONG
+	UniqueProcessKey             *uint32        // ULONG_PTR
+	PeakVirtualSize              uintptr        // SIZE_T
+	VirtualSize                  uintptr        // SIZE_T
+	PageFaultCount               uint32         // ULONG
+	PeakWorkingSetSize           uintptr        // SIZE_T
+	WorkingSetSize               uintptr        // SIZE_T
+	QuotaPeakPagedPoolUsage      uintptr        // SIZE_T
+	QuotaPagedPoolUsage          uintptr        // SIZE_T
+	QuotaPeakNonPagedPoolUsage   uintptr        // SIZE_T
+	QuotaNonPagedPoolUsage       uintptr        // SIZE_T
+	PagefileUsage                uintptr        // SIZE_T
+	PeakPagefileUsage            uintptr        // SIZE_T
+	PrivatePageCount             uintptr        // SIZE_T
+	ReadOperationCount           int64          // LARGE_INTEGER
+	WriteOperationCount          int64          // LARGE_INTEGER
+	OtherOperationCount          int64          // LARGE_INTEGER
+	ReadTransferCount            int64          // LARGE_INTEGER
+	WriteTransferCount           int64          // LARGE_INTEGER
+	OtherTransferCount           int64          // LARGE_INTEGER
+}

--- a/internal/winapi/thread.go
+++ b/internal/winapi/thread.go
@@ -1,3 +1,12 @@
 package winapi
 
+// HANDLE CreateRemoteThread(
+// 	HANDLE                 hProcess,
+// 	LPSECURITY_ATTRIBUTES  lpThreadAttributes,
+// 	SIZE_T                 dwStackSize,
+// 	LPTHREAD_START_ROUTINE lpStartAddress,
+// 	LPVOID                 lpParameter,
+// 	DWORD                  dwCreationFlags,
+// 	LPDWORD                lpThreadId
+// );
 //sys CreateRemoteThread(process windows.Handle, sa *windows.SecurityAttributes, stackSize uint32, startAddr uintptr, parameter uintptr, creationFlags uint32, threadID *uint32) (handle windows.Handle, err error) = kernel32.CreateRemoteThread

--- a/internal/winapi/winapi.go
+++ b/internal/winapi/winapi.go
@@ -2,4 +2,4 @@
 // be thought of as an extension to golang.org/x/sys/windows.
 package winapi
 
-//go:generate go run ..\..\mksyscall_windows.go -output zsyscall_windows.go net.go path.go thread.go iocp.go jobobject.go logon.go memory.go process.go processor.go devices.go filesystem.go errors.go
+//go:generate go run ..\..\mksyscall_windows.go -output zsyscall_windows.go system.go net.go path.go thread.go iocp.go jobobject.go logon.go memory.go process.go processor.go devices.go filesystem.go errors.go

--- a/internal/winapi/zsyscall_windows.go
+++ b/internal/winapi/zsyscall_windows.go
@@ -37,13 +37,14 @@ func errnoErr(e syscall.Errno) error {
 }
 
 var (
+	modntdll    = windows.NewLazySystemDLL("ntdll.dll")
 	modiphlpapi = windows.NewLazySystemDLL("iphlpapi.dll")
 	modkernel32 = windows.NewLazySystemDLL("kernel32.dll")
-	modntdll    = windows.NewLazySystemDLL("ntdll.dll")
 	modadvapi32 = windows.NewLazySystemDLL("advapi32.dll")
 	modpsapi    = windows.NewLazySystemDLL("psapi.dll")
 	modcfgmgr32 = windows.NewLazySystemDLL("cfgmgr32.dll")
 
+	procNtQuerySystemInformation               = modntdll.NewProc("NtQuerySystemInformation")
 	procSetJobCompartmentId                    = modiphlpapi.NewProc("SetJobCompartmentId")
 	procSearchPathW                            = modkernel32.NewProc("SearchPathW")
 	procCreateRemoteThread                     = modkernel32.NewProc("CreateRemoteThread")
@@ -72,6 +73,12 @@ var (
 	procNtQueryDirectoryObject                 = modntdll.NewProc("NtQueryDirectoryObject")
 	procRtlNtStatusToDosError                  = modntdll.NewProc("RtlNtStatusToDosError")
 )
+
+func NtQuerySystemInformation(systemInfoClass int, systemInformation uintptr, systemInfoLength uint32, returnLength *uint32) (status uint32) {
+	r0, _, _ := syscall.Syscall6(procNtQuerySystemInformation.Addr(), 4, uintptr(systemInfoClass), uintptr(systemInformation), uintptr(systemInfoLength), uintptr(unsafe.Pointer(returnLength)), 0, 0)
+	status = uint32(r0)
+	return
+}
 
 func SetJobCompartmentId(handle windows.Handle, compartmentId uint32) (win32Err error) {
 	r0, _, _ := syscall.Syscall(procSetJobCompartmentId.Addr(), 2, uintptr(handle), uintptr(compartmentId), 0)


### PR DESCRIPTION
* Add PropertiesV2 and Properties calls for host process containers. The only supported queries for them are
PropertiesV2: Statistics
Properties: ProcessList
* Add NtQuerySystemInformation and SYSTEM_PROCESS_INFORMATION binds.

This work will be utilized in the containerd shim just as the PropertiesV2 and Properties calls
are today for process and hv isolated containers.

Signed-off-by: Daniel Canter <dcanter@microsoft.com>