### PR TITLE
Update ArgsUsage for shimdiag commands to add flags

### DIFF
--- a/cmd/shimdiag/exec.go
+++ b/cmd/shimdiag/exec.go
@@ -35,7 +35,7 @@ var execTty bool
 var execCommand = cli.Command{
 	Name:      "exec",
 	Usage:     "Executes a command in a shim's hosting utility VM",
-	ArgsUsage: "<shim name> <command> [args...]",
+	ArgsUsage: "[flags] <shim name> <command> [args...]",
 	Flags: []cli.Flag{
 		cli.BoolFlag{
 			Name:        "tty,t",

--- a/cmd/shimdiag/list.go
+++ b/cmd/shimdiag/list.go
@@ -12,7 +12,7 @@ import (
 var listCommand = cli.Command{
 	Name:      "list",
 	Usage:     "Lists running shims",
-	ArgsUsage: " ",
+	ArgsUsage: "[flags]",
 	Flags: []cli.Flag{
 		cli.BoolFlag{
 			Name:  "pids",

--- a/cmd/shimdiag/share.go
+++ b/cmd/shimdiag/share.go
@@ -17,7 +17,7 @@ import (
 var shareCommand = cli.Command{
 	Name:      "share",
 	Usage:     "Share a file/directory in a shim's hosting utility VM",
-	ArgsUsage: "<shim name> <host_path> <uvm_path>",
+	ArgsUsage: "[flags] <shim name> <host_path> <uvm_path>",
 	Flags: []cli.Flag{
 		cli.BoolFlag{
 			Name:  "readonly,ro",


### PR DESCRIPTION
None of the ArgsUsage's for any of the commands listed flags so add this.

Signed-off-by: Daniel Canter <dcanter@microsoft.com>