### PR TITLE
Set CREATE_BREAKAWAY_FROM_JOB flag for job container processes

### DIFF
--- a/internal/jobcontainers/jobcontainer.go
+++ b/internal/jobcontainers/jobcontainer.go
@@ -218,7 +218,9 @@ func (c *JobContainer) CreateProcess(ctx context.Context, config interface{}) (_
 		Path: absPath,
 		Args: splitArgs(commandLine),
 		SysProcAttr: &syscall.SysProcAttr{
-			CreationFlags: windows.CREATE_NEW_PROCESS_GROUP,
+			// CREATE_BREAKAWAY_FROM_JOB to make sure that we're not inheriting the job object (and by extension its limits)
+			// from whatever process is running this code.
+			CreationFlags: windows.CREATE_NEW_PROCESS_GROUP | windows.CREATE_BREAKAWAY_FROM_JOB,
 			Token:         syscall.Token(token),
 		},
 	}


### PR DESCRIPTION
We don't want to inherit the job object of whatever process is running the job container code (the containerd-shim
generally but this would apply for any process). Set the CREATE_BREAKAWAY_FROM_JOB flag on job container processes
to prevent this from happening. The job object itself will also need to have the JOB_OBJECT_LIMIT_BREAKAWAY_OK limit
set for this to take affect.

Signed-off-by: Daniel Canter <dcanter@microsoft.com>