### PR TITLE
Support passing in propagation flags on scsi mounts for LCOW

### DIFF
--- a/internal/guestrequest/types.go
+++ b/internal/guestrequest/types.go
@@ -25,10 +25,11 @@ type CombinedLayers struct {
 
 // SCSI. Scratch space for remote file-system commands, or R/W layer for containers
 type LCOWMappedVirtualDisk struct {
-	MountPath  string `json:"MountPath,omitempty"`
-	Lun        uint8  `json:"Lun,omitempty"`
-	Controller uint8  `json:"Controller,omitempty"`
-	ReadOnly   bool   `json:"ReadOnly,omitempty"`
+	MountPath  string   `json:"MountPath,omitempty"`
+	Lun        uint8    `json:"Lun,omitempty"`
+	Controller uint8    `json:"Controller,omitempty"`
+	ReadOnly   bool     `json:"ReadOnly,omitempty"`
+	Options    []string `json:"Options,omitempty"`
 }
 
 type WCOWMappedVirtualDisk struct {

--- a/internal/hcsoci/resources_lcow.go
+++ b/internal/hcsoci/resources_lcow.go
@@ -89,11 +89,12 @@ func allocateLinuxResources(ctx context.Context, coi *createOptionsInternal, r *
 					break
 				}
 			}
+
 			l := log.G(ctx).WithField("mount", fmt.Sprintf("%+v", mount))
 			if mount.Type == "physical-disk" {
 				l.Debug("hcsshim::allocateLinuxResources Hot-adding SCSI physical disk for OCI mount")
 				uvmPathForShare = fmt.Sprintf(uvm.LCOWGlobalMountPrefix, coi.HostingSystem.UVMMountCounter())
-				scsiMount, err := coi.HostingSystem.AddSCSIPhysicalDisk(ctx, hostPath, uvmPathForShare, readOnly)
+				scsiMount, err := coi.HostingSystem.AddSCSIPhysicalDisk(ctx, hostPath, uvmPathForShare, readOnly, mount.Options)
 				if err != nil {
 					return errors.Wrapf(err, "adding SCSI physical disk mount %+v", mount)
 				}
@@ -107,7 +108,7 @@ func allocateLinuxResources(ctx context.Context, coi *createOptionsInternal, r *
 
 				// if the scsi device is already attached then we take the uvm path that the function below returns
 				// that is where it was previously mounted in UVM
-				scsiMount, err := coi.HostingSystem.AddSCSI(ctx, hostPath, uvmPathForShare, readOnly, uvm.VMAccessTypeIndividual)
+				scsiMount, err := coi.HostingSystem.AddSCSI(ctx, hostPath, uvmPathForShare, readOnly, mount.Options, uvm.VMAccessTypeIndividual)
 				if err != nil {
 					return errors.Wrapf(err, "adding SCSI virtual disk mount %+v", mount)
 				}
@@ -136,6 +137,7 @@ func allocateLinuxResources(ctx context.Context, coi *createOptionsInternal, r *
 					uvmPathForFile = path.Join(uvmPathForShare, fileName)
 				}
 				l.Debug("hcsshim::allocateLinuxResources Hot-adding Plan9 for OCI mount")
+
 				share, err := coi.HostingSystem.AddPlan9(ctx, hostPath, uvmPathForShare, readOnly, restrictAccess, allowedNames)
 				if err != nil {
 					return errors.Wrapf(err, "adding plan9 mount %+v", mount)
@@ -172,7 +174,8 @@ func allocateLinuxResources(ctx context.Context, coi *createOptionsInternal, r *
 		// use lcowNvidiaMountPath since we only support nvidia gpus right now
 		// must use scsi here since DDA'ing a hyper-v pci device is not supported on VMs that have ANY virtual memory
 		// gpuvhd must be granted VM Group access.
-		scsiMount, err := coi.HostingSystem.AddSCSI(ctx, gpuSupportVhdPath, uvm.LCOWNvidiaMountPath, true, uvm.VMAccessTypeNoop)
+		options := []string{"ro"}
+		scsiMount, err := coi.HostingSystem.AddSCSI(ctx, gpuSupportVhdPath, uvm.LCOWNvidiaMountPath, true, options, uvm.VMAccessTypeNoop)
 		if err != nil {
 			return errors.Wrapf(err, "failed to add scsi device %s in the UVM %s at %s", gpuSupportVhdPath, coi.HostingSystem.ID(), uvm.LCOWNvidiaMountPath)
 		}

--- a/internal/hcsoci/resources_wcow.go
+++ b/internal/hcsoci/resources_wcow.go
@@ -135,7 +135,7 @@ func setupMounts(ctx context.Context, coi *createOptionsInternal, r *resources.R
 			l := log.G(ctx).WithField("mount", fmt.Sprintf("%+v", mount))
 			if mount.Type == "physical-disk" {
 				l.Debug("hcsshim::allocateWindowsResources Hot-adding SCSI physical disk for OCI mount")
-				scsiMount, err := coi.HostingSystem.AddSCSIPhysicalDisk(ctx, mount.Source, uvmPath, readOnly)
+				scsiMount, err := coi.HostingSystem.AddSCSIPhysicalDisk(ctx, mount.Source, uvmPath, readOnly, mount.Options)
 				if err != nil {
 					return errors.Wrapf(err, "adding SCSI physical disk mount %+v", mount)
 				}
@@ -143,7 +143,7 @@ func setupMounts(ctx context.Context, coi *createOptionsInternal, r *resources.R
 				r.Add(scsiMount)
 			} else if mount.Type == "virtual-disk" {
 				l.Debug("hcsshim::allocateWindowsResources Hot-adding SCSI virtual disk for OCI mount")
-				scsiMount, err := coi.HostingSystem.AddSCSI(ctx, mount.Source, uvmPath, readOnly, uvm.VMAccessTypeIndividual)
+				scsiMount, err := coi.HostingSystem.AddSCSI(ctx, mount.Source, uvmPath, readOnly, mount.Options, uvm.VMAccessTypeIndividual)
 				if err != nil {
 					return errors.Wrapf(err, "adding SCSI virtual disk mount %+v", mount)
 				}

--- a/internal/layers/layers.go
+++ b/internal/layers/layers.go
@@ -161,7 +161,8 @@ func MountContainerLayers(ctx context.Context, layerFolders []string, guestRoot 
 	}
 	log.G(ctx).WithField("hostPath", hostPath).Debug("mounting scratch VHD")
 
-	scsiMount, err := uvm.AddSCSI(ctx, hostPath, containerScratchPathInUVM, false, uvmpkg.VMAccessTypeIndividual)
+	var options []string
+	scsiMount, err := uvm.AddSCSI(ctx, hostPath, containerScratchPathInUVM, false, options, uvmpkg.VMAccessTypeIndividual)
 	if err != nil {
 		return "", fmt.Errorf("failed to add SCSI scratch VHD: %s", err)
 	}
@@ -223,8 +224,9 @@ func addLCOWLayer(ctx context.Context, uvm *uvmpkg.UtilityVM, layerPath string) 
 		}
 	}
 
+	options := []string{"ro"}
 	uvmPath = fmt.Sprintf(uvmpkg.LCOWGlobalMountPrefix, uvm.UVMMountCounter())
-	sm, err := uvm.AddSCSI(ctx, layerPath, uvmPath, true, uvmpkg.VMAccessTypeNoop)
+	sm, err := uvm.AddSCSI(ctx, layerPath, uvmPath, true, options, uvmpkg.VMAccessTypeNoop)
 	if err != nil {
 		return "", fmt.Errorf("failed to add SCSI layer: %s", err)
 	}

--- a/internal/lcow/disk.go
+++ b/internal/lcow/disk.go
@@ -28,7 +28,8 @@ func FormatDisk(ctx context.Context, lcowUVM *uvm.UtilityVM, destPath string) er
 		"dest": destPath,
 	}).Debug("lcow::FormatDisk opts")
 
-	scsi, err := lcowUVM.AddSCSIPhysicalDisk(ctx, destPath, "", false) // No destination as not formatted
+	var options []string
+	scsi, err := lcowUVM.AddSCSIPhysicalDisk(ctx, destPath, "", false, options) // No destination as not formatted
 	if err != nil {
 		return err
 	}

--- a/internal/lcow/scratch.go
+++ b/internal/lcow/scratch.go
@@ -66,7 +66,8 @@ func CreateScratch(ctx context.Context, lcowUVM *uvm.UtilityVM, destFile string,
 		return fmt.Errorf("failed to create VHDx %s: %s", destFile, err)
 	}
 
-	scsi, err := lcowUVM.AddSCSI(ctx, destFile, "", false, uvm.VMAccessTypeIndividual) // No destination as not formatted
+	var options []string
+	scsi, err := lcowUVM.AddSCSI(ctx, destFile, "", false, options, uvm.VMAccessTypeIndividual) // No destination as not formatted
 	if err != nil {
 		return err
 	}

--- a/internal/uvm/scsi.go
+++ b/internal/uvm/scsi.go
@@ -221,9 +221,12 @@ func (uvm *UtilityVM) RemoveSCSI(ctx context.Context, hostPath string) error {
 //
 // `readOnly` set to `true` if the vhd/vhdx should be attached read only.
 //
+// `guestOptions` is a slice that contains optional information to pass
+// to the guest service
+//
 // `vmAccess` indicates what access to grant the vm for the hostpath
-func (uvm *UtilityVM) AddSCSI(ctx context.Context, hostPath string, uvmPath string, readOnly bool, vmAccess VMAccessType) (*SCSIMount, error) {
-	return uvm.addSCSIActual(ctx, hostPath, uvmPath, "VirtualDisk", readOnly, vmAccess)
+func (uvm *UtilityVM) AddSCSI(ctx context.Context, hostPath string, uvmPath string, readOnly bool, guestOptions []string, vmAccess VMAccessType) (*SCSIMount, error) {
+	return uvm.addSCSIActual(ctx, hostPath, uvmPath, "VirtualDisk", readOnly, guestOptions, vmAccess)
 }
 
 // AddSCSIPhysicalDisk attaches a physical disk from the host directly to the
@@ -234,8 +237,11 @@ func (uvm *UtilityVM) AddSCSI(ctx context.Context, hostPath string, uvmPath stri
 // `uvmPath` is optional if a guest mount is not requested.
 //
 // `readOnly` set to `true` if the physical disk should be attached read only.
-func (uvm *UtilityVM) AddSCSIPhysicalDisk(ctx context.Context, hostPath, uvmPath string, readOnly bool) (*SCSIMount, error) {
-	return uvm.addSCSIActual(ctx, hostPath, uvmPath, "PassThru", readOnly, VMAccessTypeIndividual)
+//
+// `guestOptions` is a slice that contains optional information to pass
+// to the guest service
+func (uvm *UtilityVM) AddSCSIPhysicalDisk(ctx context.Context, hostPath, uvmPath string, readOnly bool, guestOptions []string) (*SCSIMount, error) {
+	return uvm.addSCSIActual(ctx, hostPath, uvmPath, "PassThru", readOnly, guestOptions, VMAccessTypeIndividual)
 }
 
 // addSCSIActual is the implementation behind the external functions AddSCSI and
@@ -249,10 +255,13 @@ func (uvm *UtilityVM) AddSCSIPhysicalDisk(ctx context.Context, hostPath, uvmPath
 //
 // `readOnly` indicates the attachment should be added read only.
 //
+// `guestOptions` is a slice that contains optional information to pass
+// to the guest service
+//
 // `vmAccess` indicates what access to grant the vm for the hostpath
 //
 // Returns result from calling modify with the given scsi mount
-func (uvm *UtilityVM) addSCSIActual(ctx context.Context, hostPath, uvmPath, attachmentType string, readOnly bool, vmAccess VMAccessType) (sm *SCSIMount, err error) {
+func (uvm *UtilityVM) addSCSIActual(ctx context.Context, hostPath, uvmPath, attachmentType string, readOnly bool, guestOptions []string, vmAccess VMAccessType) (sm *SCSIMount, err error) {
 	sm, existed, err := uvm.allocateSCSIMount(ctx, readOnly, hostPath, uvmPath, attachmentType, vmAccess)
 	if err != nil {
 		return nil, err
@@ -304,6 +313,7 @@ func (uvm *UtilityVM) addSCSIActual(ctx context.Context, hostPath, uvmPath, atta
 				Lun:        uint8(sm.LUN),
 				Controller: uint8(sm.Controller),
 				ReadOnly:   readOnly,
+				Options:    guestOptions,
 			}
 		}
 		SCSIModification.GuestRequest = guestReq

--- a/test/functional/lcow_test.go
+++ b/test/functional/lcow_test.go
@@ -143,7 +143,9 @@ func TestLCOWSimplePodScenario(t *testing.T) {
 	if err := lcow.CreateScratch(context.Background(), lcowUVM, uvmScratchFile, lcow.DefaultScratchSizeGB, cacheFile); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := lcowUVM.AddSCSI(context.Background(), uvmScratchFile, `/tmp/scratch`, false, uvm.VMAccessTypeIndividual); err != nil {
+
+	var options []string
+	if _, err := lcowUVM.AddSCSI(context.Background(), uvmScratchFile, `/tmp/scratch`, false, options, uvm.VMAccessTypeIndividual); err != nil {
 		t.Fatal(err)
 	}
 

--- a/test/functional/uvm_scratch_test.go
+++ b/test/functional/uvm_scratch_test.go
@@ -45,7 +45,8 @@ func TestScratchCreateLCOW(t *testing.T) {
 	}
 
 	// Make sure it can be added (verifies it has access correctly)
-	scsiMount, err := targetUVM.AddSCSI(context.Background(), destTwo, "", false, uvm.VMAccessTypeIndividual)
+	var options []string
+	scsiMount, err := targetUVM.AddSCSI(context.Background(), destTwo, "", false, options, uvm.VMAccessTypeIndividual)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/functional/uvm_scsi_test.go
+++ b/test/functional/uvm_scsi_test.go
@@ -51,7 +51,8 @@ func testAddSCSI(u *uvm.UtilityVM, disks []string, pathPrefix string, usePath bo
 		if usePath {
 			uvmPath = fmt.Sprintf(`%s%d`, pathPrefix, i)
 		}
-		scsiMount, err := u.AddSCSI(context.Background(), disks[i], uvmPath, false, uvm.VMAccessTypeIndividual)
+		var options []string
+		scsiMount, err := u.AddSCSI(context.Background(), disks[i], uvmPath, false, options, uvm.VMAccessTypeIndividual)
 		if err != nil {
 			return err
 		}
@@ -274,7 +275,9 @@ func TestParallelScsiOps(t *testing.T) {
 					t.Errorf("failed to grantvmaccess for worker: %d, iteration: %d with err: %v", scsiIndex, iteration, err)
 					continue
 				}
-				_, err = u.AddSCSI(context.Background(), path, "", false, uvm.VMAccessTypeIndividual)
+
+				var options []string
+				_, err = u.AddSCSI(context.Background(), path, "", false, options, uvm.VMAccessTypeIndividual)
 				if err != nil {
 					os.Remove(path)
 					t.Errorf("failed to AddSCSI for worker: %d, iteration: %d with err: %v", scsiIndex, iteration, err)
@@ -286,7 +289,8 @@ func TestParallelScsiOps(t *testing.T) {
 					// This worker cant continue because the index is dead. We have to stop
 					break
 				}
-				_, err = u.AddSCSI(context.Background(), path, fmt.Sprintf("/run/gcs/c/0/scsi/%d", iteration), false, uvm.VMAccessTypeIndividual)
+
+				_, err = u.AddSCSI(context.Background(), path, fmt.Sprintf("/run/gcs/c/0/scsi/%d", iteration), false, options, uvm.VMAccessTypeIndividual)
 				if err != nil {
 					os.Remove(path)
 					t.Errorf("failed to AddSCSI for worker: %d, iteration: %d with err: %v", scsiIndex, iteration, err)

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/guestrequest/types.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/guestrequest/types.go
@@ -25,10 +25,11 @@ type CombinedLayers struct {
 
 // SCSI. Scratch space for remote file-system commands, or R/W layer for containers
 type LCOWMappedVirtualDisk struct {
-	MountPath  string `json:"MountPath,omitempty"`
-	Lun        uint8  `json:"Lun,omitempty"`
-	Controller uint8  `json:"Controller,omitempty"`
-	ReadOnly   bool   `json:"ReadOnly,omitempty"`
+	MountPath  string   `json:"MountPath,omitempty"`
+	Lun        uint8    `json:"Lun,omitempty"`
+	Controller uint8    `json:"Controller,omitempty"`
+	ReadOnly   bool     `json:"ReadOnly,omitempty"`
+	Options    []string `json:"Options,omitempty"`
 }
 
 type WCOWMappedVirtualDisk struct {

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/hcsoci/resources_lcow.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/hcsoci/resources_lcow.go
@@ -89,11 +89,12 @@ func allocateLinuxResources(ctx context.Context, coi *createOptionsInternal, r *
 					break
 				}
 			}
+
 			l := log.G(ctx).WithField("mount", fmt.Sprintf("%+v", mount))
 			if mount.Type == "physical-disk" {
 				l.Debug("hcsshim::allocateLinuxResources Hot-adding SCSI physical disk for OCI mount")
 				uvmPathForShare = fmt.Sprintf(uvm.LCOWGlobalMountPrefix, coi.HostingSystem.UVMMountCounter())
-				scsiMount, err := coi.HostingSystem.AddSCSIPhysicalDisk(ctx, hostPath, uvmPathForShare, readOnly)
+				scsiMount, err := coi.HostingSystem.AddSCSIPhysicalDisk(ctx, hostPath, uvmPathForShare, readOnly, mount.Options)
 				if err != nil {
 					return errors.Wrapf(err, "adding SCSI physical disk mount %+v", mount)
 				}
@@ -107,7 +108,7 @@ func allocateLinuxResources(ctx context.Context, coi *createOptionsInternal, r *
 
 				// if the scsi device is already attached then we take the uvm path that the function below returns
 				// that is where it was previously mounted in UVM
-				scsiMount, err := coi.HostingSystem.AddSCSI(ctx, hostPath, uvmPathForShare, readOnly, uvm.VMAccessTypeIndividual)
+				scsiMount, err := coi.HostingSystem.AddSCSI(ctx, hostPath, uvmPathForShare, readOnly, mount.Options, uvm.VMAccessTypeIndividual)
 				if err != nil {
 					return errors.Wrapf(err, "adding SCSI virtual disk mount %+v", mount)
 				}
@@ -136,6 +137,7 @@ func allocateLinuxResources(ctx context.Context, coi *createOptionsInternal, r *
 					uvmPathForFile = path.Join(uvmPathForShare, fileName)
 				}
 				l.Debug("hcsshim::allocateLinuxResources Hot-adding Plan9 for OCI mount")
+
 				share, err := coi.HostingSystem.AddPlan9(ctx, hostPath, uvmPathForShare, readOnly, restrictAccess, allowedNames)
 				if err != nil {
 					return errors.Wrapf(err, "adding plan9 mount %+v", mount)
@@ -172,7 +174,8 @@ func allocateLinuxResources(ctx context.Context, coi *createOptionsInternal, r *
 		// use lcowNvidiaMountPath since we only support nvidia gpus right now
 		// must use scsi here since DDA'ing a hyper-v pci device is not supported on VMs that have ANY virtual memory
 		// gpuvhd must be granted VM Group access.
-		scsiMount, err := coi.HostingSystem.AddSCSI(ctx, gpuSupportVhdPath, uvm.LCOWNvidiaMountPath, true, uvm.VMAccessTypeNoop)
+		options := []string{"ro"}
+		scsiMount, err := coi.HostingSystem.AddSCSI(ctx, gpuSupportVhdPath, uvm.LCOWNvidiaMountPath, true, options, uvm.VMAccessTypeNoop)
 		if err != nil {
 			return errors.Wrapf(err, "failed to add scsi device %s in the UVM %s at %s", gpuSupportVhdPath, coi.HostingSystem.ID(), uvm.LCOWNvidiaMountPath)
 		}

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/hcsoci/resources_wcow.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/hcsoci/resources_wcow.go
@@ -135,7 +135,7 @@ func setupMounts(ctx context.Context, coi *createOptionsInternal, r *resources.R
 			l := log.G(ctx).WithField("mount", fmt.Sprintf("%+v", mount))
 			if mount.Type == "physical-disk" {
 				l.Debug("hcsshim::allocateWindowsResources Hot-adding SCSI physical disk for OCI mount")
-				scsiMount, err := coi.HostingSystem.AddSCSIPhysicalDisk(ctx, mount.Source, uvmPath, readOnly)
+				scsiMount, err := coi.HostingSystem.AddSCSIPhysicalDisk(ctx, mount.Source, uvmPath, readOnly, mount.Options)
 				if err != nil {
 					return errors.Wrapf(err, "adding SCSI physical disk mount %+v", mount)
 				}
@@ -143,7 +143,7 @@ func setupMounts(ctx context.Context, coi *createOptionsInternal, r *resources.R
 				r.Add(scsiMount)
 			} else if mount.Type == "virtual-disk" {
 				l.Debug("hcsshim::allocateWindowsResources Hot-adding SCSI virtual disk for OCI mount")
-				scsiMount, err := coi.HostingSystem.AddSCSI(ctx, mount.Source, uvmPath, readOnly, uvm.VMAccessTypeIndividual)
+				scsiMount, err := coi.HostingSystem.AddSCSI(ctx, mount.Source, uvmPath, readOnly, mount.Options, uvm.VMAccessTypeIndividual)
 				if err != nil {
 					return errors.Wrapf(err, "adding SCSI virtual disk mount %+v", mount)
 				}

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/layers/layers.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/layers/layers.go
@@ -161,7 +161,8 @@ func MountContainerLayers(ctx context.Context, layerFolders []string, guestRoot 
 	}
 	log.G(ctx).WithField("hostPath", hostPath).Debug("mounting scratch VHD")
 
-	scsiMount, err := uvm.AddSCSI(ctx, hostPath, containerScratchPathInUVM, false, uvmpkg.VMAccessTypeIndividual)
+	var options []string
+	scsiMount, err := uvm.AddSCSI(ctx, hostPath, containerScratchPathInUVM, false, options, uvmpkg.VMAccessTypeIndividual)
 	if err != nil {
 		return "", fmt.Errorf("failed to add SCSI scratch VHD: %s", err)
 	}
@@ -223,8 +224,9 @@ func addLCOWLayer(ctx context.Context, uvm *uvmpkg.UtilityVM, layerPath string) 
 		}
 	}
 
+	options := []string{"ro"}
 	uvmPath = fmt.Sprintf(uvmpkg.LCOWGlobalMountPrefix, uvm.UVMMountCounter())
-	sm, err := uvm.AddSCSI(ctx, layerPath, uvmPath, true, uvmpkg.VMAccessTypeNoop)
+	sm, err := uvm.AddSCSI(ctx, layerPath, uvmPath, true, options, uvmpkg.VMAccessTypeNoop)
 	if err != nil {
 		return "", fmt.Errorf("failed to add SCSI layer: %s", err)
 	}

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/lcow/disk.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/lcow/disk.go
@@ -28,7 +28,8 @@ func FormatDisk(ctx context.Context, lcowUVM *uvm.UtilityVM, destPath string) er
 		"dest": destPath,
 	}).Debug("lcow::FormatDisk opts")
 
-	scsi, err := lcowUVM.AddSCSIPhysicalDisk(ctx, destPath, "", false) // No destination as not formatted
+	var options []string
+	scsi, err := lcowUVM.AddSCSIPhysicalDisk(ctx, destPath, "", false, options) // No destination as not formatted
 	if err != nil {
 		return err
 	}

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/lcow/scratch.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/lcow/scratch.go
@@ -66,7 +66,8 @@ func CreateScratch(ctx context.Context, lcowUVM *uvm.UtilityVM, destFile string,
 		return fmt.Errorf("failed to create VHDx %s: %s", destFile, err)
 	}
 
-	scsi, err := lcowUVM.AddSCSI(ctx, destFile, "", false, uvm.VMAccessTypeIndividual) // No destination as not formatted
+	var options []string
+	scsi, err := lcowUVM.AddSCSI(ctx, destFile, "", false, options, uvm.VMAccessTypeIndividual) // No destination as not formatted
 	if err != nil {
 		return err
 	}

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/uvm/scsi.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/uvm/scsi.go
@@ -222,8 +222,8 @@ func (uvm *UtilityVM) RemoveSCSI(ctx context.Context, hostPath string) error {
 // `readOnly` set to `true` if the vhd/vhdx should be attached read only.
 //
 // `vmAccess` indicates what access to grant the vm for the hostpath
-func (uvm *UtilityVM) AddSCSI(ctx context.Context, hostPath string, uvmPath string, readOnly bool, vmAccess VMAccessType) (*SCSIMount, error) {
-	return uvm.addSCSIActual(ctx, hostPath, uvmPath, "VirtualDisk", readOnly, vmAccess)
+func (uvm *UtilityVM) AddSCSI(ctx context.Context, hostPath string, uvmPath string, readOnly bool, options []string, vmAccess VMAccessType) (*SCSIMount, error) {
+	return uvm.addSCSIActual(ctx, hostPath, uvmPath, "VirtualDisk", readOnly, options, vmAccess)
 }
 
 // AddSCSIPhysicalDisk attaches a physical disk from the host directly to the
@@ -234,8 +234,8 @@ func (uvm *UtilityVM) AddSCSI(ctx context.Context, hostPath string, uvmPath stri
 // `uvmPath` is optional if a guest mount is not requested.
 //
 // `readOnly` set to `true` if the physical disk should be attached read only.
-func (uvm *UtilityVM) AddSCSIPhysicalDisk(ctx context.Context, hostPath, uvmPath string, readOnly bool) (*SCSIMount, error) {
-	return uvm.addSCSIActual(ctx, hostPath, uvmPath, "PassThru", readOnly, VMAccessTypeIndividual)
+func (uvm *UtilityVM) AddSCSIPhysicalDisk(ctx context.Context, hostPath, uvmPath string, readOnly bool, options []string) (*SCSIMount, error) {
+	return uvm.addSCSIActual(ctx, hostPath, uvmPath, "PassThru", readOnly, options, VMAccessTypeIndividual)
 }
 
 // addSCSIActual is the implementation behind the external functions AddSCSI and
@@ -252,7 +252,7 @@ func (uvm *UtilityVM) AddSCSIPhysicalDisk(ctx context.Context, hostPath, uvmPath
 // `vmAccess` indicates what access to grant the vm for the hostpath
 //
 // Returns result from calling modify with the given scsi mount
-func (uvm *UtilityVM) addSCSIActual(ctx context.Context, hostPath, uvmPath, attachmentType string, readOnly bool, vmAccess VMAccessType) (sm *SCSIMount, err error) {
+func (uvm *UtilityVM) addSCSIActual(ctx context.Context, hostPath, uvmPath, attachmentType string, readOnly bool, options []string, vmAccess VMAccessType) (sm *SCSIMount, err error) {
 	sm, existed, err := uvm.allocateSCSIMount(ctx, readOnly, hostPath, uvmPath, attachmentType, vmAccess)
 	if err != nil {
 		return nil, err
@@ -304,6 +304,7 @@ func (uvm *UtilityVM) addSCSIActual(ctx context.Context, hostPath, uvmPath, atta
 				Lun:        uint8(sm.LUN),
 				Controller: uint8(sm.Controller),
 				ReadOnly:   readOnly,
+				Options:    options,
 			}
 		}
 		SCSIModification.GuestRequest = guestReq


### PR DESCRIPTION
See https://github.com/microsoft/opengcs/pull/398 for details. 

This PR updates the fields for scsi disk attachment to match those in the PR mentioned above and adds a test for the expected behavior of `rshared` mount propagation for scsi disks. 

Signed-off-by: Kathryn Baldauf <kabaldau@microsoft.com>