### PR TITLE
prevents a goroutine from being leaked if binary cmd fails to finish

### DIFF
--- a/internal/cmd/io_binary.go
+++ b/internal/cmd/io_binary.go
@@ -182,7 +182,7 @@ func (b *binaryIO) Close(ctx context.Context) {
 		}
 	})
 	b.binaryCloser.Do(func() {
-		done := make(chan error)
+		done := make(chan error, 1)
 		go func() {
 			done <- b.cmd.Wait()
 		}()


### PR DESCRIPTION
Prevents an egde case where a goroutine would be leaked when the following case executes 

```go
		case <-time.After(binaryCmdWaitTimeout):
			log.G(ctx).Errorf("timeout while waiting for binaryIO process to finish. Killing")
			err := b.cmd.Process.Kill()
			if err != nil {
				log.G(ctx).WithError(err).Errorf("error while killing binaryIO process")
			}
		}
```
If the above occurs before or at the same time as the case below (and the scheduler chooses to the above case), the goroutine above the `select` block would be leaked as it is blocked by the send to the `done` channel.

```go
		go func() {
			done <- b.cmd.Wait()
		}()

		select {
		case err := <-done:
			if err != nil {
				log.G(ctx).WithError(err).Errorf("error while waiting for binary cmd to finish")
			}
```