### PR TITLE
Fix stderr comment in containerd-shim serve command

### DIFF
--- a/cmd/containerd-shim-runhcs-v1/serve.go
+++ b/cmd/containerd-shim-runhcs-v1/serve.go
@@ -57,7 +57,7 @@ var serveCommand = cli.Command{
 		// new one. If serve is decided it execs this entry point `shim serve`.
 		// The handoff logic is that this shim will serve the ttrpc entrypoint
 		// with only stderr set by the caller. Once the shim has successfully
-		// served the entrypoint it is required to close stderr to alert the
+		// served the entrypoint it is required to close stdout to alert the
 		// caller it has completed to the point of handoff. If it fails it will
 		// write the error to stderr and the caller will forward the error on as
 		// part of the `shim start` failure path. Once successfully served the


### PR DESCRIPTION
In a comment in the serve command for the containerd-shim it says that to signify that we're
successfully serving the ttrpc endpoint we should close stderr, but we actually seem to close stdout
to signify this. The write end of the pipe is hooked up to stdout on the "serve" command invocation
of the shim and we simply forward stderr to the read side until close. Stderr for the serve
invocation is hooked up to the panic.log file 

Signed-off-by: Daniel Canter <dcanter@microsoft.com>