### PR TITLE
Remove incorrect comment from ncproxy grpc service struct

### DIFF
--- a/cmd/ncproxy/ncproxy.go
+++ b/cmd/ncproxy/ncproxy.go
@@ -23,10 +23,8 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-// GRPC service exposed for use by a Node Network Service. Holds a mutex for
-// updating global client.
-type grpcService struct {
-}
+// GRPC service exposed for use by a Node Network Service.
+type grpcService struct{}
 
 var _ ncproxygrpc.NetworkConfigProxyServer = &grpcService{}
 


### PR DESCRIPTION
The GRPC service doesn't hold a mutex. This was left in from an older iteration
where the client map would get updated in the grpc service.

Signed-off-by: Daniel Canter <dcanter@microsoft.com>