### PR TITLE
Get rid of mergemaps functionality for v2 codepaths

### DIFF
--- a/internal/uvm/create.go
+++ b/internal/uvm/create.go
@@ -23,9 +23,8 @@ import (
 
 // Options are the set of options passed to Create() to create a utility vm.
 type Options struct {
-	ID                      string // Identifier for the uvm. Defaults to generated GUID.
-	Owner                   string // Specifies the owner. Defaults to executable name.
-	AdditionHCSDocumentJSON string // Optional additional JSON to merge into the HCS document prior
+	ID    string // Identifier for the uvm. Defaults to generated GUID.
+	Owner string // Specifies the owner. Defaults to executable name.
 
 	// MemorySizeInMB sets the UVM memory. If `0` will default to platform
 	// default.
@@ -105,9 +104,7 @@ func verifyCloneUvmCreateOpts(templateOpts, cloneOpts *OptionsWCOW) bool {
 	// Save the original values of the fields that we want to ignore and replace them with
 	// the same values as that of the other object. So that we can simply use `==` operator.
 	templateIDBackup := templateOpts.ID
-	templateAdditionalJsonBackup := templateOpts.AdditionHCSDocumentJSON
 	templateOpts.ID = cloneOpts.ID
-	templateOpts.AdditionHCSDocumentJSON = cloneOpts.AdditionHCSDocumentJSON
 
 	// We can't use `==` operator on structs which include slices in them. So compare the
 	// Layerfolders separately and then directly compare the Options struct.
@@ -119,7 +116,6 @@ func verifyCloneUvmCreateOpts(templateOpts, cloneOpts *OptionsWCOW) bool {
 
 	// set original values
 	templateOpts.ID = templateIDBackup
-	templateOpts.AdditionHCSDocumentJSON = templateAdditionalJsonBackup
 	return result
 }
 

--- a/internal/uvm/create_lcow.go
+++ b/internal/uvm/create_lcow.go
@@ -17,7 +17,6 @@ import (
 	"github.com/Microsoft/hcsshim/internal/gcs"
 	"github.com/Microsoft/hcsshim/internal/log"
 	"github.com/Microsoft/hcsshim/internal/logfields"
-	"github.com/Microsoft/hcsshim/internal/mergemaps"
 	"github.com/Microsoft/hcsshim/internal/oc"
 	"github.com/Microsoft/hcsshim/internal/processorinfo"
 	hcsschema "github.com/Microsoft/hcsshim/internal/schema2"
@@ -377,12 +376,7 @@ func CreateLCOW(ctx context.Context, opts *OptionsLCOW) (_ *UtilityVM, err error
 		}
 	}
 
-	fullDoc, err := mergemaps.MergeJSON(doc, ([]byte)(opts.AdditionHCSDocumentJSON))
-	if err != nil {
-		return nil, fmt.Errorf("failed to merge additional JSON '%s': %s", opts.AdditionHCSDocumentJSON, err)
-	}
-
-	err = uvm.create(ctx, fullDoc)
+	err = uvm.create(ctx, doc)
 	if err != nil {
 		return nil, fmt.Errorf("error while creating the compute system: %s", err)
 	}

--- a/internal/uvm/create_wcow.go
+++ b/internal/uvm/create_wcow.go
@@ -11,7 +11,6 @@ import (
 	"github.com/Microsoft/hcsshim/internal/gcs"
 	"github.com/Microsoft/hcsshim/internal/log"
 	"github.com/Microsoft/hcsshim/internal/logfields"
-	"github.com/Microsoft/hcsshim/internal/mergemaps"
 	"github.com/Microsoft/hcsshim/internal/ncproxyttrpc"
 	"github.com/Microsoft/hcsshim/internal/oc"
 	"github.com/Microsoft/hcsshim/internal/processorinfo"
@@ -315,12 +314,7 @@ func CreateWCOW(ctx context.Context, opts *OptionsWCOW) (_ *UtilityVM, err error
 		uvm.IsTemplate = true
 	}
 
-	fullDoc, err := mergemaps.MergeJSON(doc, ([]byte)(opts.AdditionHCSDocumentJSON))
-	if err != nil {
-		return nil, fmt.Errorf("failed to merge additional JSON '%s': %s", opts.AdditionHCSDocumentJSON, err)
-	}
-
-	err = uvm.create(ctx, fullDoc)
+	err = uvm.create(ctx, doc)
 	if err != nil {
 		return nil, fmt.Errorf("error while creating the compute system: %s", err)
 	}


### PR DESCRIPTION
There's not a single place we used to set the uvm.Options `AdditionHCSDocumentJSON` field to anything so it was as good as not there already. Just skip the calls entirely and remove the copying of the fields for lateclone scenarios. 

I've left in the package and code for v1 (docker) in case anyone out there is actually using it 😃 

Signed-off-by: Daniel Canter <dcanter@microsoft.com>