### PR TITLE
WS 2004 supports dual stack

### DIFF
--- a/hcn/hcnglobals.go
+++ b/hcn/hcnglobals.go
@@ -53,10 +53,9 @@ var (
 	}
 	// HNS 12.0 allows for session affinity for loadbalancing
 	SessionAffinityVersion = VersionRanges{VersionRange{MinVersion: Version{Major: 12, Minor: 0}, MaxVersion: Version{Major: math.MaxInt32, Minor: math.MaxInt32}}}
-	// HNS 10.5 through 11 (not included) and 12.0+ supports Ipv6 dual stack.
+	// HNS 11.10+ supports Ipv6 dual stack.
 	IPv6DualStackVersion = VersionRanges{
-		VersionRange{MinVersion: Version{Major: 10, Minor: 5}, MaxVersion: Version{Major: 10, Minor: math.MaxInt32}},
-		VersionRange{MinVersion: Version{Major: 12, Minor: 0}, MaxVersion: Version{Major: math.MaxInt32, Minor: math.MaxInt32}},
+		VersionRange{MinVersion: Version{Major: 11, Minor: 10}, MaxVersion: Version{Major: math.MaxInt32, Minor: math.MaxInt32}},
 	}
 	// HNS 13.0 allows for Set Policy support
 	SetPolicyVersion = VersionRanges{VersionRange{MinVersion: Version{Major: 13, Minor: 0}, MaxVersion: Version{Major: math.MaxInt32, Minor: math.MaxInt32}}}


### PR DESCRIPTION
While working on https://github.com/kubernetes/kubernetes/pull/101047 I found that WS 2004 is not being shown as support.

[Docs state](https://kubernetes.io/docs/setup/production-environment/windows/intro-windows-in-kubernetes/#ipv4-ipv6-dual-stack): 2004 (kernel version 10.0.19041.610) 

```
cmd /c ver

Microsoft Windows [Version 10.0.19041.867]
```

I added custom logging to kubeproxy which showed I was on version `11` of HNS on `10.0.19041`

```
I0414 22:35:15.143135    3372 proxier.go:202] hns version%!(EXTRA hcn.Version={11 10})                    
```                                       

I am not sure how HNS versions map to WS versions.  Maybe there are minor versions of 2004 that don't support it?