### PR TITLE
Add VmEndpointRequest in hcn for eventual usage in the shim

### DIFF
--- a/hcn/hcn.go
+++ b/hcn/hcn.go
@@ -3,6 +3,7 @@
 package hcn
 
 import (
+	"encoding/json"
 	"fmt"
 	"syscall"
 
@@ -93,12 +94,12 @@ type HostComputeQuery struct {
 }
 
 type ExtraParams struct {
-	Resources        interface{} `json:",omitempty"`
-	SharedContainers interface{} `json:",omitempty"`
-	LayeredOn        string      `json:",omitempty"`
-	SwitchGuid       string      `json:",omitempty"`
-	UtilityVM        string      `json:",omitempty"`
-	VirtualMachine   string      `json:",omitempty"`
+	Resources        json.RawMessage `json:",omitempty"`
+	SharedContainers json.RawMessage `json:",omitempty"`
+	LayeredOn        string          `json:",omitempty"`
+	SwitchGuid       string          `json:",omitempty"`
+	UtilityVM        string          `json:",omitempty"`
+	VirtualMachine   string          `json:",omitempty"`
 }
 
 type Health struct {

--- a/hcn/hcnendpoint.go
+++ b/hcn/hcnendpoint.go
@@ -37,6 +37,7 @@ type HostComputeEndpoint struct {
 	Routes               []Route          `json:",omitempty"`
 	MacAddress           string           `json:",omitempty"`
 	Flags                EndpointFlags    `json:",omitempty"`
+	Health               Health           `json:",omitempty"`
 	SchemaVersion        SchemaVersion    `json:",omitempty"`
 }
 
@@ -56,6 +57,13 @@ type ModifyEndpointSettingRequest struct {
 	ResourceType EndpointResourceType `json:",omitempty"` // Policy, Port
 	RequestType  RequestType          `json:",omitempty"` // Add, Remove, Update, Refresh
 	Settings     json.RawMessage      `json:",omitempty"`
+}
+
+// VmEndpointRequest creates a switch port with identifier `PortId`.
+type VmEndpointRequest struct {
+	PortId           guid.GUID `json:",omitempty"`
+	VirtualNicName   string    `json:",omitempty"`
+	VirtualMachineId guid.GUID `json:",omitempty"`
 }
 
 type PolicyEndpointRequest struct {


### PR DESCRIPTION
HCS today for adding a network adapter to a virtual machine sets up the switch port itself by making a VmEndpointRequest. There are cases where we will want to do this ourselves, and we need the switch ID for this which will only exist after this request.

Below is an example of using this:

```go
        portID, err := guid.NewV4()
	if err != nil {
		return errors.Wrap(err, "failed to generate guid for port")
	}

	vmEndpointRequest := hcn.VmEndpointRequest{
		PortId:           portID,
		VirtualNicName:   fmt.Sprintf("%s--%s", "cool-NIC-ID", portID),
		VirtualMachineId: guid.GUID{},
	}

	m, err := json.Marshal(vmEndpointRequest)
	if err != nil {
		return errors.Wrap(err, "failed to marshal endpoint request json")
	}

	if err := hcn.ModifyEndpointSettings(endpointID, &hcn.ModifyEndpointSettingRequest{
		ResourceType: hcn.EndpointResourceTypePort,
		RequestType:  hcn.RequestTypeAdd,
		Settings:     json.RawMessage(m),
	}); err != nil {
		return errors.Wrap(err, "failed to configure switch port")
	}

	// Get updated endpoint with new fields (need switch ID)
	ep, err := hcn.GetEndpointByID(endpointID)
	if err != nil {
		return errors.Wrapf(err, "failed to get endpoint %q", endpointID)
	}

	type ExtraInfo struct {
		Allocators []struct {
			SwitchId         string
			EndpointPortGuid string
		}
	}

	var exi ExtraInfo
	if err := json.Unmarshal(ep.Health.Extra.Resources, &exi); err != nil {
		return errors.Wrapf(err, "failed to unmarshal resource data from endpoint %q", endpointID)
	}

	if len(exi.Allocators) == 0 {
		return errors.New("no resource data found for endpoint")
	}

	// NIC should only ever belong to one switch but there are cases where there's more than one allocator
	// in the returned data. It seems they only ever contain empty strings so search for the first entry
	// that actually contains a switch ID and that has the matching port GUID we made earlier.
	var switchID string
	for _, allocator := range exi.Allocators {
		if allocator.SwitchId != "" && strings.ToLower(allocator.EndpointPortGuid) == portID.String() {
			switchID = allocator.SwitchId
			break
		}
	}
```

Signed-off-by: Daniel Canter <dcanter@microsoft.com>