### PR TITLE
Fix tar2vhd on specific unordered tars

### DIFF
--- a/ext4/internal/compactext4/compact.go
+++ b/ext4/internal/compactext4/compact.go
@@ -520,6 +520,9 @@ func (w *Writer) lookup(name string, mustExist bool) (*inode, *inode, string, er
 // call to make these parent directories will be made at a later point with the correct
 // permissions, at that time the permissions of these directories will be updated.
 func (w *Writer) CreateWithParents(name string, f *File) error {
+	if err := w.finishInode(); err != nil {
+		return err
+	}
 	// go through the directories in the path one by one and create the
 	// parent directories if they don't exist.
 	cleanname := path.Clean("/" + name)[1:]

--- a/ext4/tar2ext4/tar2ext4_test.go
+++ b/ext4/tar2ext4/tar2ext4_test.go
@@ -28,9 +28,9 @@ func Test_UnorderedTarExpansion(t *testing.T) {
 	var files = []struct {
 		path, body string
 	}{
+		{"foo/bar.txt", "inside bar.txt"},
 		{"data/", ""},
 		{"root.txt", "inside root.txt"},
-		{"foo/bar.txt", "inside bar.txt"},
 		{"foo/", ""},
 		{"A/B/b.txt", "inside b.txt"},
 		{"A/a.txt", "inside a.txt"},


### PR DESCRIPTION
This addresses nil dereference bug we encountered when doing tar2vhd conversion and extends on the previous fix to address when parent directories don't exist.

In this case the issue arises if the root directory has not yet been initialized by the time a file not in the root directory is processed. For the bug to happen the tar has to be built in such a way that the first file processed:

1. Does not have a whiteout prefix (.wh)
2. Is not a Hard link
3. Does not have root as its parent folder (my guess is in most orderings this starts with root which is why we hadn't encountered this before). 

In the particular case of the image for which we found the issue the first file seen looked something like: /folder1/folder2/somefile which meets all the conditions above causing the failure.  As a note I swapped the order in the test at tar2ext4_test.go to show how to replicate and to include the scenario of this fix there.

As a fix I am calling finishInode at the start of CreateWithParents following the convention of Create and the other methods which rely on its init check and state cleanup


