### PR TITLE
Add NatFlags flag to OutboundNatPolicySetting

### DIFF
--- a/hcn/hcnloadbalancer.go
+++ b/hcn/hcnloadbalancer.go
@@ -36,6 +36,7 @@ var (
 	LoadBalancerFlagsNone LoadBalancerFlags = 0
 	// LoadBalancerFlagsDSR enables Direct Server Return (DSR)
 	LoadBalancerFlagsDSR LoadBalancerFlags = 1
+	LoadBalancerFlagsIPv6 LoadBalancerFlags = 2
 )
 
 // LoadBalancerPortMappingFlags are special settings on a loadbalancer.

--- a/hcn/hcnpolicy.go
+++ b/hcn/hcnpolicy.go
@@ -75,6 +75,12 @@ type SubnetPolicy struct {
 // NatFlags are flags for portmappings.
 type NatFlags uint32
 
+const (
+	NatFlagsNone            NatFlags = 0
+	NatFlagsLocalRoutedVip  NatFlags = 1
+	NatFlagsIPv6            NatFlags = 2
+)
+
 /// Endpoint Policy objects
 
 // PortMappingPolicySetting defines Port Mapping (NAT)

--- a/hcn/hcnpolicy.go
+++ b/hcn/hcnpolicy.go
@@ -76,9 +76,9 @@ type SubnetPolicy struct {
 type NatFlags uint32
 
 const (
-	NatFlagsNone            NatFlags = 0
-	NatFlagsLocalRoutedVip  NatFlags = 1
-	NatFlagsIPv6            NatFlags = 2
+	NatFlagsNone            NatFlags = iota
+	NatFlagsLocalRoutedVip
+	NatFlagsIPv6
 )
 
 /// Endpoint Policy objects

--- a/hcn/hcnpolicy.go
+++ b/hcn/hcnpolicy.go
@@ -135,6 +135,7 @@ type OutboundNatPolicySetting struct {
 	VirtualIP    string   `json:",omitempty"`
 	Exceptions   []string `json:",omitempty"`
 	Destinations []string `json:",omitempty"`
+	Flags        NatFlags `json:",omitempty"`
 }
 
 // SDNRoutePolicySetting sets SDN Route on an Endpoint.


### PR DESCRIPTION
This is to allow setting the ipv6 flag when creating outbound nat policy.