### PR TITLE
Fix spelling mistake with `notificationWatcherContext`

### DIFF
--- a/internal/hcs/callback.go
+++ b/internal/hcs/callback.go
@@ -13,7 +13,7 @@ import (
 
 var (
 	nextCallback    uintptr
-	callbackMap     = map[uintptr]*notifcationWatcherContext{}
+	callbackMap     = map[uintptr]*notificationWatcherContext{}
 	callbackMapLock = sync.RWMutex{}
 
 	notificationWatcherCallback = syscall.NewCallback(notificationWatcher)
@@ -87,7 +87,7 @@ func (hn hcsNotification) String() string {
 
 type notificationChannel chan error
 
-type notifcationWatcherContext struct {
+type notificationWatcherContext struct {
 	channels notificationChannels
 	handle   vmcompute.HcsCallback
 

--- a/internal/hcs/process.go
+++ b/internal/hcs/process.go
@@ -414,7 +414,7 @@ func (process *Process) Close() (err error) {
 }
 
 func (process *Process) registerCallback(ctx context.Context) error {
-	callbackContext := &notifcationWatcherContext{
+	callbackContext := &notificationWatcherContext{
 		channels:  newProcessChannels(),
 		systemID:  process.SystemID(),
 		processID: process.processID,

--- a/internal/hcs/system.go
+++ b/internal/hcs/system.go
@@ -554,7 +554,7 @@ func (computeSystem *System) Close() (err error) {
 }
 
 func (computeSystem *System) registerCallback(ctx context.Context) error {
-	callbackContext := &notifcationWatcherContext{
+	callbackContext := &notificationWatcherContext{
 		channels: newSystemChannels(),
 		systemID: computeSystem.id,
 	}


### PR DESCRIPTION
notifcationWatcherContext -> notificationWatcherContext

Signed-off-by: Daniel Canter <dcanter@microsoft.com>