### PR TITLE
Take off hcn package CODEOWNERS line

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,1 @@
 * @microsoft/containerplat
-
-/hcn/* @nagiesek


### PR DESCRIPTION
The CODEOWNERS logic for the hcn package shouldn't work as the required reviewer
doesn't have write access which is required.

From https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners:

"The people you choose as code owners must have write permissions for the repository. When the code owner
is a team, that team must have write permissions, even if all the individual members of the team already have
write permissions directly, through organization membership, or through another team membership."

Signed-off-by: Daniel Canter <dcanter@microsoft.com>