### PR TITLE
Add new flags to integration tests to specify virtstack

### DIFF
--- a/test/cri-containerd/container_downlevel_test.go
+++ b/test/cri-containerd/container_downlevel_test.go
@@ -16,7 +16,7 @@ func Test_CreateContainer_DownLevel_WCOW_Hypervisor(t *testing.T) {
 
 	pullRequiredImages(t, []string{imageWindowsNanoserver17763})
 
-	sandboxRequest := getRunPodSandboxRequest(t, wcowHypervisor17763RuntimeHandler)
+	sandboxRequest := getRunPodSandboxRequest(t, wcowHypervisor17763RuntimeHandler, nil)
 
 	request := &runtime.CreateContainerRequest{
 		Config: &runtime.ContainerConfig{

--- a/test/cri-containerd/container_network_test.go
+++ b/test/cri-containerd/container_network_test.go
@@ -32,7 +32,7 @@ func Test_Container_Network_LCOW(t *testing.T) {
 	}()
 	log := filepath.Join(dir, "ping.txt")
 
-	sandboxRequest := getRunPodSandboxRequest(t, lcowRuntimeHandler)
+	sandboxRequest := getRunPodSandboxRequest(t, lcowRuntimeHandler, nil)
 
 	client := newTestRuntimeClient(t)
 	ctx, cancel := context.WithCancel(context.Background())
@@ -137,7 +137,7 @@ func Test_Container_Network_Hostname(t *testing.T) {
 				pullRequiredImages(t, []string{test.sandboxImage, test.containerImage})
 			}
 
-			sandboxRequest := getRunPodSandboxRequest(t, test.runtimeHandler)
+			sandboxRequest := getRunPodSandboxRequest(t, test.runtimeHandler, nil)
 			sandboxRequest.Config.Hostname = "TestHost"
 
 			client := newTestRuntimeClient(t)

--- a/test/cri-containerd/container_test.go
+++ b/test/cri-containerd/container_test.go
@@ -80,7 +80,7 @@ func Test_RotateLogs_LCOW(t *testing.T) {
 	pullRequiredLcowImages(t, []string{imageLcowK8sPause, image})
 	logrus.SetLevel(logrus.DebugLevel)
 
-	sandboxRequest := getRunPodSandboxRequest(t, lcowRuntimeHandler)
+	sandboxRequest := getRunPodSandboxRequest(t, lcowRuntimeHandler, nil)
 
 	request := &runtime.CreateContainerRequest{
 		Config: &runtime.ContainerConfig{
@@ -142,7 +142,7 @@ func Test_RunContainer_Events_LCOW(t *testing.T) {
 	defer podcancel()
 	targetNamespace := "k8s.io"
 
-	sandboxRequest := getRunPodSandboxRequest(t, lcowRuntimeHandler)
+	sandboxRequest := getRunPodSandboxRequest(t, lcowRuntimeHandler, nil)
 
 	podID := runPodSandbox(t, client, podctx, sandboxRequest)
 	defer removePodSandbox(t, client, podctx, podID)
@@ -211,7 +211,7 @@ func Test_RunContainer_ForksThenExits_ShowsAsExited_LCOW(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 	defer cancel()
 
-	podRequest := getRunPodSandboxRequest(t, lcowRuntimeHandler)
+	podRequest := getRunPodSandboxRequest(t, lcowRuntimeHandler, nil)
 	podID := runPodSandbox(t, client, ctx, podRequest)
 	defer removePodSandbox(t, client, ctx, podID)
 	defer stopPodSandbox(t, client, ctx, podID)
@@ -263,11 +263,14 @@ func Test_RunContainer_ZeroVPMEM_LCOW(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	sandboxRequest := getRunPodSandboxRequest(t, lcowRuntimeHandler)
-	sandboxRequest.Config.Annotations = map[string]string{
-		"io.microsoft.virtualmachine.lcow.preferredrootfstype":         "initrd",
-		"io.microsoft.virtualmachine.devices.virtualpmem.maximumcount": "0",
-	}
+	sandboxRequest := getRunPodSandboxRequest(
+		t,
+		lcowRuntimeHandler,
+		map[string]string{
+			"io.microsoft.virtualmachine.lcow.preferredrootfstype":         "initrd",
+			"io.microsoft.virtualmachine.devices.virtualpmem.maximumcount": "0",
+		},
+	)
 
 	podID := runPodSandbox(t, client, ctx, sandboxRequest)
 	defer removePodSandbox(t, client, ctx, podID)
@@ -302,11 +305,14 @@ func Test_RunContainer_ZeroVPMEM_Multiple_LCOW(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	sandboxRequest := getRunPodSandboxRequest(t, lcowRuntimeHandler)
-	sandboxRequest.Config.Annotations = map[string]string{
-		"io.microsoft.virtualmachine.lcow.preferredrootfstype":         "initrd",
-		"io.microsoft.virtualmachine.devices.virtualpmem.maximumcount": "0",
-	}
+	sandboxRequest := getRunPodSandboxRequest(
+		t,
+		lcowRuntimeHandler,
+		map[string]string{
+			"io.microsoft.virtualmachine.lcow.preferredrootfstype":         "initrd",
+			"io.microsoft.virtualmachine.devices.virtualpmem.maximumcount": "0",
+		},
+	)
 
 	podID := runPodSandbox(t, client, ctx, sandboxRequest)
 	defer removePodSandbox(t, client, ctx, podID)
@@ -350,7 +356,7 @@ func Test_RunContainer_GMSA_WCOW_Process(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	sandboxRequest := getRunPodSandboxRequest(t, wcowProcessRuntimeHandler)
+	sandboxRequest := getRunPodSandboxRequest(t, wcowProcessRuntimeHandler, nil)
 
 	podID := runPodSandbox(t, client, ctx, sandboxRequest)
 	defer removePodSandbox(t, client, ctx, podID)
@@ -414,7 +420,7 @@ func Test_RunContainer_GMSA_WCOW_Hypervisor(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	sandboxRequest := getRunPodSandboxRequest(t, wcowHypervisorRuntimeHandler)
+	sandboxRequest := getRunPodSandboxRequest(t, wcowHypervisorRuntimeHandler, nil)
 
 	podID := runPodSandbox(t, client, ctx, sandboxRequest)
 	defer removePodSandbox(t, client, ctx, podID)
@@ -478,7 +484,7 @@ func Test_RunContainer_SandboxDevice_LCOW(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	sandboxRequest := getRunPodSandboxRequest(t, lcowRuntimeHandler)
+	sandboxRequest := getRunPodSandboxRequest(t, lcowRuntimeHandler, nil)
 	sandboxRequest.Config.Linux = &runtime.LinuxPodSandboxConfig{
 		SecurityContext: &runtime.LinuxSandboxSecurityContext{
 			Privileged: true,
@@ -544,7 +550,7 @@ func Test_RunContainer_NonDefault_User(t *testing.T) {
 
 	pullRequiredLcowImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
 
-	podReq := getRunPodSandboxRequest(t, lcowRuntimeHandler)
+	podReq := getRunPodSandboxRequest(t, lcowRuntimeHandler, nil)
 	podID := runPodSandbox(t, client, ctx, podReq)
 	defer removePodSandbox(t, client, ctx, podID)
 	defer stopPodSandbox(t, client, ctx, podID)

--- a/test/cri-containerd/createcontainer_test.go
+++ b/test/cri-containerd/createcontainer_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func runCreateContainerTest(t *testing.T, runtimeHandler string, request *runtime.CreateContainerRequest) {
-	sandboxRequest := getRunPodSandboxRequest(t, runtimeHandler)
+	sandboxRequest := getRunPodSandboxRequest(t, runtimeHandler, nil)
 	runCreateContainerTestWithSandbox(t, sandboxRequest, request)
 }
 
@@ -188,7 +188,7 @@ func Test_CreateContainer_LCOW_Privileged(t *testing.T) {
 
 	pullRequiredLcowImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
 
-	sandboxRequest := getRunPodSandboxRequest(t, lcowRuntimeHandler)
+	sandboxRequest := getRunPodSandboxRequest(t, lcowRuntimeHandler, nil)
 	sandboxRequest.Config.Linux = &runtime.LinuxPodSandboxConfig{
 		SecurityContext: &runtime.LinuxSandboxSecurityContext{
 			Privileged: true,
@@ -222,7 +222,7 @@ func Test_CreateContainer_SandboxDevice_LCOW(t *testing.T) {
 
 	pullRequiredLcowImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
 
-	sandboxRequest := getRunPodSandboxRequest(t, lcowRuntimeHandler)
+	sandboxRequest := getRunPodSandboxRequest(t, lcowRuntimeHandler, nil)
 	sandboxRequest.Config.Linux = &runtime.LinuxPodSandboxConfig{
 		SecurityContext: &runtime.LinuxSandboxSecurityContext{
 			Privileged: true,
@@ -1227,7 +1227,7 @@ func Test_Mount_ReadOnlyDirReuse_WCOW(t *testing.T) {
 	}
 	defer os.RemoveAll(tempDir)
 
-	sandboxRequest := getRunPodSandboxRequest(t, wcowHypervisorRuntimeHandler)
+	sandboxRequest := getRunPodSandboxRequest(t, wcowHypervisorRuntimeHandler, nil)
 
 	podID := runPodSandbox(t, client, ctx, sandboxRequest)
 	defer removePodSandbox(t, client, ctx, podID)

--- a/test/cri-containerd/execcontainer_test.go
+++ b/test/cri-containerd/execcontainer_test.go
@@ -37,7 +37,7 @@ func execContainerLCOW(t *testing.T, uid int64, cmd []string) *runtime.ExecSyncR
 	pullRequiredLcowImages(t, []string{imageLcowK8sPause, imageLcowCosmos})
 
 	// run podsandbox request
-	sandboxRequest := getRunPodSandboxRequest(t, lcowRuntimeHandler)
+	sandboxRequest := getRunPodSandboxRequest(t, lcowRuntimeHandler, nil)
 	sandboxRequest.Config.Linux = &runtime.LinuxPodSandboxConfig{
 		SecurityContext: &runtime.LinuxSandboxSecurityContext{
 			Privileged: true,

--- a/test/cri-containerd/logging_binary_test.go
+++ b/test/cri-containerd/logging_binary_test.go
@@ -85,7 +85,7 @@ func Test_Run_Container_With_Binary_Logger(t *testing.T) {
 				pullRequiredImages(t, requiredImages)
 			}
 
-			podReq := getRunPodSandboxRequest(t, test.runtimeHandler)
+			podReq := getRunPodSandboxRequest(t, test.runtimeHandler, nil)
 			podID := runPodSandbox(t, client, ctx, podReq)
 			defer removePodSandbox(t, client, ctx, podID)
 
@@ -123,7 +123,7 @@ func Test_Run_Container_With_Binary_Logger(t *testing.T) {
 				pullRequiredImages(t, requiredImages)
 			}
 
-			podReq := getRunPodSandboxRequest(t, test.runtimeHandler)
+			podReq := getRunPodSandboxRequest(t, test.runtimeHandler, nil)
 			podID := runPodSandbox(t, client, ctx, podReq)
 			defer removePodSandbox(t, client, ctx, podID)
 

--- a/test/cri-containerd/main.go
+++ b/test/cri-containerd/main.go
@@ -40,6 +40,9 @@ const (
 	testDriversPath        = "C:\\ContainerPlat\\testdrivers"
 	testGPUBootFiles       = "C:\\ContainerPlat\\LinuxBootFiles\\nvidiagpu"
 
+	testVMServiceAddress = "C:\\ContainerPlat\\vmservice.sock"
+	testVMServiceBinary  = "C:\\Containerplat\\vmservice.exe"
+
 	lcowRuntimeHandler   = "runhcs-lcow"
 	imageLcowK8sPause    = "k8s.gcr.io/pause:3.1"
 	imageLcowAlpine      = "docker.io/library/alpine:latest"
@@ -69,8 +72,10 @@ var (
 
 // Flags
 var (
-	flagFeatures    = testutilities.NewStringSetFlag()
-	flagCRIEndpoint = flag.String("cri-endpoint", "tcp://127.0.0.1:2376", "Address of CRI runtime and image service.")
+	flagFeatures        = testutilities.NewStringSetFlag()
+	flagCRIEndpoint     = flag.String("cri-endpoint", "tcp://127.0.0.1:2376", "Address of CRI runtime and image service.")
+	flagVirtstack       = flag.String("virtstack", "", "Virtstack to use for hypervisor isolated containers")
+	flagVMServiceBinary = flag.String("vmservice-binary", "", "Path to a binary implementing the vmservice ttrpc service")
 )
 
 // Features

--- a/test/cri-containerd/pullimage_test.go
+++ b/test/cri-containerd/pullimage_test.go
@@ -44,7 +44,7 @@ func Test_PullImageTimestamps(t *testing.T) {
 	pullRequiredImages(t, []string{imageWindowsNanoserverTestImage})
 	defer removeImages(t, []string{imageWindowsNanoserverTestImage})
 
-	sandboxRequest := getRunPodSandboxRequest(t, wcowHypervisor18362RuntimeHandler)
+	sandboxRequest := getRunPodSandboxRequest(t, wcowHypervisor18362RuntimeHandler, nil)
 
 	podID := runPodSandbox(t, client, ctx, sandboxRequest)
 	defer removePodSandbox(t, client, ctx, podID)

--- a/test/cri-containerd/removepodsandbox_test.go
+++ b/test/cri-containerd/removepodsandbox_test.go
@@ -42,7 +42,7 @@ func runPodSandboxTestWithoutPodStop(t *testing.T, request *runtime.RunPodSandbo
 
 // Utility function to start sandbox with one container and make sure that sandbox is removed in the end
 func runPodWithContainer(t *testing.T, client runtime.RuntimeServiceClient, ctx context.Context, tc *TestConfig) (string, string) {
-	request := getRunPodSandboxRequest(t, tc.runtimeHandler)
+	request := getRunPodSandboxRequest(t, tc.runtimeHandler, nil)
 	podID := runPodSandbox(t, client, ctx, request)
 	defer removePodSandbox(t, client, ctx, podID)
 
@@ -112,7 +112,7 @@ func Test_RunPodSandbox_Without_Sandbox_Stop(t *testing.T) {
 				pullRequiredImages(t, []string{test.sandboxImage})
 			}
 
-			request := getRunPodSandboxRequest(t, test.runtimeHandler)
+			request := getRunPodSandboxRequest(t, test.runtimeHandler, nil)
 			runPodSandboxTestWithoutPodStop(t, request)
 		})
 	}

--- a/test/cri-containerd/runpodsandbox_test.go
+++ b/test/cri-containerd/runpodsandbox_test.go
@@ -38,7 +38,7 @@ func Test_RunPodSandbox_WCOW_Process(t *testing.T) {
 
 	pullRequiredImages(t, []string{imageWindowsNanoserver})
 
-	request := getRunPodSandboxRequest(t, wcowProcessRuntimeHandler)
+	request := getRunPodSandboxRequest(t, wcowProcessRuntimeHandler, nil)
 	runPodSandboxTest(t, request)
 }
 
@@ -47,7 +47,7 @@ func Test_RunPodSandbox_WCOW_Hypervisor(t *testing.T) {
 
 	pullRequiredImages(t, []string{imageWindowsNanoserver})
 
-	request := getRunPodSandboxRequest(t, wcowHypervisorRuntimeHandler)
+	request := getRunPodSandboxRequest(t, wcowHypervisorRuntimeHandler, nil)
 	runPodSandboxTest(t, request)
 }
 
@@ -56,10 +56,13 @@ func Test_RunPodSandbox_WCOW_Hypervisor_WithoutExternalBridge(t *testing.T) {
 
 	pullRequiredImages(t, []string{imageWindowsNanoserver})
 
-	request := getRunPodSandboxRequest(t, wcowHypervisorRuntimeHandler)
-	request.Config.Annotations = map[string]string{
-		"io.microsoft.virtualmachine.useexternalgcsbridge": "false",
-	}
+	request := getRunPodSandboxRequest(
+		t,
+		wcowHypervisorRuntimeHandler,
+		map[string]string{
+			"io.microsoft.virtualmachine.useexternalgcsbridge": "false",
+		},
+	)
 	runPodSandboxTest(t, request)
 }
 
@@ -68,7 +71,7 @@ func Test_RunPodSandbox_LCOW(t *testing.T) {
 
 	pullRequiredLcowImages(t, []string{imageLcowK8sPause})
 
-	request := getRunPodSandboxRequest(t, lcowRuntimeHandler)
+	request := getRunPodSandboxRequest(t, lcowRuntimeHandler, nil)
 	runPodSandboxTest(t, request)
 }
 
@@ -83,7 +86,7 @@ func Test_RunPodSandbox_Events_LCOW(t *testing.T) {
 
 	pullRequiredLcowImages(t, []string{imageLcowK8sPause})
 
-	request := getRunPodSandboxRequest(t, lcowRuntimeHandler)
+	request := getRunPodSandboxRequest(t, lcowRuntimeHandler, nil)
 
 	topicNames, filters := getTargetRunTopics()
 	targetNamespace := "k8s.io"
@@ -128,10 +131,13 @@ func Test_RunPodSandbox_VirtualMemory_WCOW_Hypervisor(t *testing.T) {
 
 	pullRequiredImages(t, []string{imageWindowsNanoserver})
 
-	request := getRunPodSandboxRequest(t, wcowHypervisorRuntimeHandler)
-	request.Config.Annotations = map[string]string{
-		"io.microsoft.virtualmachine.computetopology.memory.allowovercommit": "true",
-	}
+	request := getRunPodSandboxRequest(
+		t,
+		wcowHypervisorRuntimeHandler,
+		map[string]string{
+			"io.microsoft.virtualmachine.computetopology.memory.allowovercommit": "true",
+		},
+	)
 	runPodSandboxTest(t, request)
 }
 
@@ -140,10 +146,13 @@ func Test_RunPodSandbox_VirtualMemory_LCOW(t *testing.T) {
 
 	pullRequiredLcowImages(t, []string{imageLcowK8sPause})
 
-	request := getRunPodSandboxRequest(t, lcowRuntimeHandler)
-	request.Config.Annotations = map[string]string{
-		"io.microsoft.virtualmachine.computetopology.memory.allowovercommit": "true",
-	}
+	request := getRunPodSandboxRequest(
+		t,
+		lcowRuntimeHandler,
+		map[string]string{
+			"io.microsoft.virtualmachine.computetopology.memory.allowovercommit": "true",
+		},
+	)
 	runPodSandboxTest(t, request)
 }
 
@@ -152,11 +161,14 @@ func Test_RunPodSandbox_VirtualMemory_DeferredCommit_WCOW_Hypervisor(t *testing.
 
 	pullRequiredImages(t, []string{imageWindowsNanoserver})
 
-	request := getRunPodSandboxRequest(t, wcowHypervisorRuntimeHandler)
-	request.Config.Annotations = map[string]string{
-		"io.microsoft.virtualmachine.computetopology.memory.allowovercommit":      "true",
-		"io.microsoft.virtualmachine.computetopology.memory.enabledeferredcommit": "true",
-	}
+	request := getRunPodSandboxRequest(
+		t,
+		wcowHypervisorRuntimeHandler,
+		map[string]string{
+			"io.microsoft.virtualmachine.computetopology.memory.allowovercommit":      "true",
+			"io.microsoft.virtualmachine.computetopology.memory.enabledeferredcommit": "true",
+		},
+	)
 	runPodSandboxTest(t, request)
 }
 
@@ -165,11 +177,14 @@ func Test_RunPodSandbox_VirtualMemory_DeferredCommit_LCOW(t *testing.T) {
 
 	pullRequiredLcowImages(t, []string{imageLcowK8sPause})
 
-	request := getRunPodSandboxRequest(t, lcowRuntimeHandler)
-	request.Config.Annotations = map[string]string{
-		"io.microsoft.virtualmachine.computetopology.memory.allowovercommit":      "true",
-		"io.microsoft.virtualmachine.computetopology.memory.enabledeferredcommit": "true",
-	}
+	request := getRunPodSandboxRequest(
+		t,
+		lcowRuntimeHandler,
+		map[string]string{
+			"io.microsoft.virtualmachine.computetopology.memory.allowovercommit":      "true",
+			"io.microsoft.virtualmachine.computetopology.memory.enabledeferredcommit": "true",
+		},
+	)
 	runPodSandboxTest(t, request)
 }
 
@@ -178,10 +193,13 @@ func Test_RunPodSandbox_PhysicalMemory_WCOW_Hypervisor(t *testing.T) {
 
 	pullRequiredImages(t, []string{imageWindowsNanoserver})
 
-	request := getRunPodSandboxRequest(t, wcowHypervisorRuntimeHandler)
-	request.Config.Annotations = map[string]string{
-		"io.microsoft.virtualmachine.computetopology.memory.allowovercommit": "false",
-	}
+	request := getRunPodSandboxRequest(
+		t,
+		wcowHypervisorRuntimeHandler,
+		map[string]string{
+			"io.microsoft.virtualmachine.computetopology.memory.allowovercommit": "false",
+		},
+	)
 	runPodSandboxTest(t, request)
 }
 
@@ -190,10 +208,13 @@ func Test_RunPodSandbox_FullyPhysicallyBacked_WCOW_Hypervisor(t *testing.T) {
 
 	pullRequiredImages(t, []string{imageWindowsNanoserver})
 
-	request := getRunPodSandboxRequest(t, wcowHypervisorRuntimeHandler)
-	request.Config.Annotations = map[string]string{
-		"io.microsoft.virtualmachine.fullyphysicallybacked": "true",
-	}
+	request := getRunPodSandboxRequest(
+		t,
+		wcowHypervisorRuntimeHandler,
+		map[string]string{
+			"io.microsoft.virtualmachine.fullyphysicallybacked": "true",
+		},
+	)
 	runPodSandboxTest(t, request)
 }
 
@@ -202,10 +223,13 @@ func Test_RunPodSandbox_PhysicalMemory_LCOW(t *testing.T) {
 
 	pullRequiredLcowImages(t, []string{imageLcowK8sPause})
 
-	request := getRunPodSandboxRequest(t, lcowRuntimeHandler)
-	request.Config.Annotations = map[string]string{
-		"io.microsoft.virtualmachine.computetopology.memory.allowovercommit": "false",
-	}
+	request := getRunPodSandboxRequest(
+		t,
+		lcowRuntimeHandler,
+		map[string]string{
+			"io.microsoft.virtualmachine.computetopology.memory.allowovercommit": "false",
+		},
+	)
 	runPodSandboxTest(t, request)
 }
 
@@ -214,10 +238,13 @@ func Test_RunPodSandbox_FullyPhysicallyBacked_LCOW(t *testing.T) {
 
 	pullRequiredLcowImages(t, []string{imageLcowK8sPause})
 
-	request := getRunPodSandboxRequest(t, lcowRuntimeHandler)
-	request.Config.Annotations = map[string]string{
-		"io.microsoft.virtualmachine.fullyphysicallybacked": "true",
-	}
+	request := getRunPodSandboxRequest(
+		t,
+		lcowRuntimeHandler,
+		map[string]string{
+			"io.microsoft.virtualmachine.fullyphysicallybacked": "true",
+		},
+	)
 	runPodSandboxTest(t, request)
 }
 
@@ -226,10 +253,13 @@ func Test_RunPodSandbox_MemorySize_WCOW_Process(t *testing.T) {
 
 	pullRequiredImages(t, []string{imageWindowsNanoserver})
 
-	request := getRunPodSandboxRequest(t, wcowProcessRuntimeHandler)
-	request.Config.Annotations = map[string]string{
-		"io.microsoft.container.memory.sizeinmb": "128",
-	}
+	request := getRunPodSandboxRequest(
+		t,
+		wcowProcessRuntimeHandler,
+		map[string]string{
+			"io.microsoft.container.memory.sizeinmb": "128",
+		},
+	)
 	runPodSandboxTest(t, request)
 }
 
@@ -238,10 +268,13 @@ func Test_RunPodSandbox_MemorySize_WCOW_Hypervisor(t *testing.T) {
 
 	pullRequiredImages(t, []string{imageWindowsNanoserver})
 
-	request := getRunPodSandboxRequest(t, wcowHypervisorRuntimeHandler)
-	request.Config.Annotations = map[string]string{
-		"io.microsoft.virtualmachine.computetopology.memory.sizeinmb": "768", // 128 is too small for WCOW. It is really slow boot.
-	}
+	request := getRunPodSandboxRequest(
+		t,
+		wcowHypervisorRuntimeHandler,
+		map[string]string{
+			"io.microsoft.virtualmachine.computetopology.memory.sizeinmb": "768", // 128 is too small for WCOW. It is really slow boot.
+		},
+	)
 	runPodSandboxTest(t, request)
 }
 
@@ -250,10 +283,13 @@ func Test_RunPodSandbox_MemorySize_LCOW(t *testing.T) {
 
 	pullRequiredLcowImages(t, []string{imageLcowK8sPause})
 
-	request := getRunPodSandboxRequest(t, lcowRuntimeHandler)
-	request.Config.Annotations = map[string]string{
-		"io.microsoft.virtualmachine.computetopology.memory.sizeinmb": "200",
-	}
+	request := getRunPodSandboxRequest(
+		t,
+		lcowRuntimeHandler,
+		map[string]string{
+			"io.microsoft.virtualmachine.computetopology.memory.sizeinmb": "200",
+		},
+	)
 	runPodSandboxTest(t, request)
 }
 
@@ -265,12 +301,15 @@ func Test_RunPodSandbox_MMIO_WCOW_Process(t *testing.T) {
 	}
 	pullRequiredImages(t, []string{imageWindowsNanoserver})
 
-	request := getRunPodSandboxRequest(t, wcowProcessRuntimeHandler)
-	request.Config.Annotations = map[string]string{
-		"io.microsoft.virtualmachine.computetopology.memory.lowmmiogapinmb":   "100",
-		"io.microsoft.virtualmachine.computetopology.memory.highmmiobaseinmb": "100",
-		"io.microsoft.virtualmachine.computetopology.memory.highmmiogapinmb":  "100",
-	}
+	request := getRunPodSandboxRequest(
+		t,
+		wcowProcessRuntimeHandler,
+		map[string]string{
+			"io.microsoft.virtualmachine.computetopology.memory.lowmmiogapinmb":   "100",
+			"io.microsoft.virtualmachine.computetopology.memory.highmmiobaseinmb": "100",
+			"io.microsoft.virtualmachine.computetopology.memory.highmmiogapinmb":  "100",
+		},
+	)
 	runPodSandboxTest(t, request)
 }
 
@@ -282,12 +321,15 @@ func Test_RunPodSandbox_MMIO_WCOW_Hypervisor(t *testing.T) {
 	}
 	pullRequiredImages(t, []string{imageWindowsNanoserver})
 
-	request := getRunPodSandboxRequest(t, wcowHypervisorRuntimeHandler)
-	request.Config.Annotations = map[string]string{
-		"io.microsoft.virtualmachine.computetopology.memory.lowmmiogapinmb":   "100",
-		"io.microsoft.virtualmachine.computetopology.memory.highmmiobaseinmb": "100",
-		"io.microsoft.virtualmachine.computetopology.memory.highmmiogapinmb":  "100",
-	}
+	request := getRunPodSandboxRequest(
+		t,
+		wcowHypervisorRuntimeHandler,
+		map[string]string{
+			"io.microsoft.virtualmachine.computetopology.memory.lowmmiogapinmb":   "100",
+			"io.microsoft.virtualmachine.computetopology.memory.highmmiobaseinmb": "100",
+			"io.microsoft.virtualmachine.computetopology.memory.highmmiogapinmb":  "100",
+		},
+	)
 	runPodSandboxTest(t, request)
 }
 
@@ -299,12 +341,15 @@ func Test_RunPodSandbox_MMIO_LCOW(t *testing.T) {
 	}
 	pullRequiredLcowImages(t, []string{imageLcowK8sPause})
 
-	request := getRunPodSandboxRequest(t, lcowRuntimeHandler)
-	request.Config.Annotations = map[string]string{
-		"io.microsoft.virtualmachine.computetopology.memory.lowmmiogapinmb":   "100",
-		"io.microsoft.virtualmachine.computetopology.memory.highmmiobaseinmb": "100",
-		"io.microsoft.virtualmachine.computetopology.memory.highmmiogapinmb":  "100",
-	}
+	request := getRunPodSandboxRequest(
+		t,
+		lcowRuntimeHandler,
+		map[string]string{
+			"io.microsoft.virtualmachine.computetopology.memory.lowmmiogapinmb":   "100",
+			"io.microsoft.virtualmachine.computetopology.memory.highmmiobaseinmb": "100",
+			"io.microsoft.virtualmachine.computetopology.memory.highmmiogapinmb":  "100",
+		},
+	)
 	runPodSandboxTest(t, request)
 }
 
@@ -313,10 +358,13 @@ func Test_RunPodSandbox_CPUCount_WCOW_Process(t *testing.T) {
 
 	pullRequiredImages(t, []string{imageWindowsNanoserver})
 
-	request := getRunPodSandboxRequest(t, wcowProcessRuntimeHandler)
-	request.Config.Annotations = map[string]string{
-		"io.microsoft.container.processor.count": "1",
-	}
+	request := getRunPodSandboxRequest(
+		t,
+		wcowProcessRuntimeHandler,
+		map[string]string{
+			"io.microsoft.container.processor.count": "1",
+		},
+	)
 	runPodSandboxTest(t, request)
 }
 
@@ -325,10 +373,13 @@ func Test_RunPodSandbox_CPUCount_WCOW_Hypervisor(t *testing.T) {
 
 	pullRequiredImages(t, []string{imageWindowsNanoserver})
 
-	request := getRunPodSandboxRequest(t, wcowHypervisorRuntimeHandler)
-	request.Config.Annotations = map[string]string{
-		"io.microsoft.virtualmachine.computetopology.processor.count": "1",
-	}
+	request := getRunPodSandboxRequest(
+		t,
+		wcowHypervisorRuntimeHandler,
+		map[string]string{
+			"io.microsoft.virtualmachine.computetopology.processor.count": "1",
+		},
+	)
 	runPodSandboxTest(t, request)
 }
 
@@ -337,10 +388,13 @@ func Test_RunPodSandbox_CPUCount_LCOW(t *testing.T) {
 
 	pullRequiredLcowImages(t, []string{imageLcowK8sPause})
 
-	request := getRunPodSandboxRequest(t, lcowRuntimeHandler)
-	request.Config.Annotations = map[string]string{
-		"io.microsoft.virtualmachine.computetopology.processor.count": "1",
-	}
+	request := getRunPodSandboxRequest(
+		t,
+		lcowRuntimeHandler,
+		map[string]string{
+			"io.microsoft.virtualmachine.computetopology.processor.count": "1",
+		},
+	)
 	runPodSandboxTest(t, request)
 }
 
@@ -349,10 +403,13 @@ func Test_RunPodSandbox_CPULimit_WCOW_Process(t *testing.T) {
 
 	pullRequiredImages(t, []string{imageWindowsNanoserver})
 
-	request := getRunPodSandboxRequest(t, wcowProcessRuntimeHandler)
-	request.Config.Annotations = map[string]string{
-		"io.microsoft.container.processor.limit": "9000",
-	}
+	request := getRunPodSandboxRequest(
+		t,
+		wcowProcessRuntimeHandler,
+		map[string]string{
+			"io.microsoft.container.processor.limit": "9000",
+		},
+	)
 	runPodSandboxTest(t, request)
 }
 
@@ -361,10 +418,13 @@ func Test_RunPodSandbox_CPULimit_WCOW_Hypervisor(t *testing.T) {
 
 	pullRequiredImages(t, []string{imageWindowsNanoserver})
 
-	request := getRunPodSandboxRequest(t, wcowHypervisorRuntimeHandler)
-	request.Config.Annotations = map[string]string{
-		"io.microsoft.virtualmachine.computetopology.processor.limit": "90000",
-	}
+	request := getRunPodSandboxRequest(
+		t,
+		wcowHypervisorRuntimeHandler,
+		map[string]string{
+			"io.microsoft.virtualmachine.computetopology.processor.limit": "90000",
+		},
+	)
 	runPodSandboxTest(t, request)
 }
 
@@ -373,10 +433,13 @@ func Test_RunPodSandbox_CPULimit_LCOW(t *testing.T) {
 
 	pullRequiredLcowImages(t, []string{imageLcowK8sPause})
 
-	request := getRunPodSandboxRequest(t, lcowRuntimeHandler)
-	request.Config.Annotations = map[string]string{
-		"io.microsoft.virtualmachine.computetopology.processor.limit": "90000",
-	}
+	request := getRunPodSandboxRequest(
+		t,
+		lcowRuntimeHandler,
+		map[string]string{
+			"io.microsoft.virtualmachine.computetopology.processor.limit": "90000",
+		},
+	)
 	runPodSandboxTest(t, request)
 }
 
@@ -385,10 +448,13 @@ func Test_RunPodSandbox_CPUWeight_WCOW_Process(t *testing.T) {
 
 	pullRequiredImages(t, []string{imageWindowsNanoserver})
 
-	request := getRunPodSandboxRequest(t, wcowProcessRuntimeHandler)
-	request.Config.Annotations = map[string]string{
-		"io.microsoft.container.processor.weight": "500",
-	}
+	request := getRunPodSandboxRequest(
+		t,
+		wcowProcessRuntimeHandler,
+		map[string]string{
+			"io.microsoft.container.processor.weight": "500",
+		},
+	)
 	runPodSandboxTest(t, request)
 }
 
@@ -397,10 +463,13 @@ func Test_RunPodSandbox_CPUWeight_WCOW_Hypervisor(t *testing.T) {
 
 	pullRequiredImages(t, []string{imageWindowsNanoserver})
 
-	request := getRunPodSandboxRequest(t, wcowHypervisorRuntimeHandler)
-	request.Config.Annotations = map[string]string{
-		"io.microsoft.virtualmachine.computetopology.processor.weight": "500",
-	}
+	request := getRunPodSandboxRequest(
+		t,
+		wcowHypervisorRuntimeHandler,
+		map[string]string{
+			"io.microsoft.container.processor.weight": "500",
+		},
+	)
 	runPodSandboxTest(t, request)
 }
 
@@ -409,10 +478,13 @@ func Test_RunPodSandbox_CPUWeight_LCOW(t *testing.T) {
 
 	pullRequiredLcowImages(t, []string{imageLcowK8sPause})
 
-	request := getRunPodSandboxRequest(t, lcowRuntimeHandler)
-	request.Config.Annotations = map[string]string{
-		"io.microsoft.virtualmachine.computetopology.processor.weight": "500",
-	}
+	request := getRunPodSandboxRequest(
+		t,
+		lcowRuntimeHandler,
+		map[string]string{
+			"io.microsoft.virtualmachine.computetopology.processor.weight": "500",
+		},
+	)
 	runPodSandboxTest(t, request)
 }
 
@@ -421,10 +493,13 @@ func Test_RunPodSandbox_StorageQoSBandwithMax_WCOW_Process(t *testing.T) {
 
 	pullRequiredImages(t, []string{imageWindowsNanoserver})
 
-	request := getRunPodSandboxRequest(t, wcowProcessRuntimeHandler)
-	request.Config.Annotations = map[string]string{
-		"io.microsoft.container.storage.qos.bandwidthmaximum": fmt.Sprintf("%d", 1024*1024), // 1MB/s
-	}
+	request := getRunPodSandboxRequest(
+		t,
+		wcowProcessRuntimeHandler,
+		map[string]string{
+			"io.microsoft.container.storage.qos.bandwidthmaximum": fmt.Sprintf("%d", 1024*1024), // 1MB/s
+		},
+	)
 	runPodSandboxTest(t, request)
 }
 
@@ -433,10 +508,13 @@ func Test_RunPodSandbox_StorageQoSBandwithMax_WCOW_Hypervisor(t *testing.T) {
 
 	pullRequiredImages(t, []string{imageWindowsNanoserver})
 
-	request := getRunPodSandboxRequest(t, wcowHypervisorRuntimeHandler)
-	request.Config.Annotations = map[string]string{
-		"io.microsoft.virtualmachine.storageqos.bandwidthmaximum": fmt.Sprintf("%d", 1024*1024), // 1MB/s
-	}
+	request := getRunPodSandboxRequest(
+		t,
+		wcowHypervisorRuntimeHandler,
+		map[string]string{
+			"io.microsoft.virtualmachine.storageqos.bandwidthmaximum": fmt.Sprintf("%d", 1024*1024), // 1MB/s
+		},
+	)
 	runPodSandboxTest(t, request)
 }
 
@@ -445,10 +523,13 @@ func Test_RunPodSandbox_StorageQoSBandwithMax_LCOW(t *testing.T) {
 
 	pullRequiredLcowImages(t, []string{imageLcowK8sPause})
 
-	request := getRunPodSandboxRequest(t, lcowRuntimeHandler)
-	request.Config.Annotations = map[string]string{
-		"io.microsoft.virtualmachine.storageqos.bandwidthmaximum": fmt.Sprintf("%d", 1024*1024), // 1MB/s
-	}
+	request := getRunPodSandboxRequest(
+		t,
+		lcowRuntimeHandler,
+		map[string]string{
+			"io.microsoft.virtualmachine.storageqos.bandwidthmaximum": fmt.Sprintf("%d", 1024*1024), // 1MB/s
+		},
+	)
 	runPodSandboxTest(t, request)
 }
 
@@ -457,10 +538,13 @@ func Test_RunPodSandbox_StorageQoSIopsMax_WCOW_Process(t *testing.T) {
 
 	pullRequiredImages(t, []string{imageWindowsNanoserver})
 
-	request := getRunPodSandboxRequest(t, wcowProcessRuntimeHandler)
-	request.Config.Annotations = map[string]string{
-		"io.microsoft.container.storage.qos.iopsmaximum": "300",
-	}
+	request := getRunPodSandboxRequest(
+		t,
+		wcowProcessRuntimeHandler,
+		map[string]string{
+			"io.microsoft.container.storage.qos.iopsmaximum": "300",
+		},
+	)
 	runPodSandboxTest(t, request)
 }
 
@@ -469,10 +553,13 @@ func Test_RunPodSandbox_StorageQoSIopsMax_WCOW_Hypervisor(t *testing.T) {
 
 	pullRequiredImages(t, []string{imageWindowsNanoserver})
 
-	request := getRunPodSandboxRequest(t, wcowHypervisorRuntimeHandler)
-	request.Config.Annotations = map[string]string{
-		"io.microsoft.virtualmachine.storageqos.iopsmaximum": "300",
-	}
+	request := getRunPodSandboxRequest(
+		t,
+		wcowHypervisorRuntimeHandler,
+		map[string]string{
+			"io.microsoft.virtualmachine.storageqos.iopsmaximum": "300",
+		},
+	)
 	runPodSandboxTest(t, request)
 }
 
@@ -481,10 +568,13 @@ func Test_RunPodSandbox_StorageQoSIopsMax_LCOW(t *testing.T) {
 
 	pullRequiredLcowImages(t, []string{imageLcowK8sPause})
 
-	request := getRunPodSandboxRequest(t, lcowRuntimeHandler)
-	request.Config.Annotations = map[string]string{
-		"io.microsoft.virtualmachine.storageqos.iopsmaximum": "300",
-	}
+	request := getRunPodSandboxRequest(
+		t,
+		lcowRuntimeHandler,
+		map[string]string{
+			"io.microsoft.virtualmachine.storageqos.iopsmaximum": "300",
+		},
+	)
 	runPodSandboxTest(t, request)
 }
 
@@ -493,10 +583,13 @@ func Test_RunPodSandbox_InitrdBoot_LCOW(t *testing.T) {
 
 	pullRequiredLcowImages(t, []string{imageLcowK8sPause})
 
-	request := getRunPodSandboxRequest(t, lcowRuntimeHandler)
-	request.Config.Annotations = map[string]string{
-		"io.microsoft.virtualmachine.lcow.preferredrootfstype": "initrd",
-	}
+	request := getRunPodSandboxRequest(
+		t,
+		lcowRuntimeHandler,
+		map[string]string{
+			"io.microsoft.virtualmachine.lcow.preferredrootfstype": "initrd",
+		},
+	)
 	runPodSandboxTest(t, request)
 }
 
@@ -505,10 +598,13 @@ func Test_RunPodSandbox_RootfsVhdBoot_LCOW(t *testing.T) {
 
 	pullRequiredLcowImages(t, []string{imageLcowK8sPause})
 
-	request := getRunPodSandboxRequest(t, lcowRuntimeHandler)
-	request.Config.Annotations = map[string]string{
-		"io.microsoft.virtualmachine.lcow.preferredrootfstype": "vhd",
-	}
+	request := getRunPodSandboxRequest(
+		t,
+		lcowRuntimeHandler,
+		map[string]string{
+			"io.microsoft.virtualmachine.lcow.preferredrootfstype": "vhd",
+		},
+	)
 	runPodSandboxTest(t, request)
 }
 
@@ -517,10 +613,13 @@ func Test_RunPodSandbox_VPCIEnabled_LCOW(t *testing.T) {
 
 	pullRequiredLcowImages(t, []string{imageLcowK8sPause})
 
-	request := getRunPodSandboxRequest(t, lcowRuntimeHandler)
-	request.Config.Annotations = map[string]string{
-		"io.microsoft.virtualmachine.lcow.vpcienabled": "true",
-	}
+	request := getRunPodSandboxRequest(
+		t,
+		lcowRuntimeHandler,
+		map[string]string{
+			"io.microsoft.virtualmachine.lcow.vpcienabled": "true",
+		},
+	)
 	runPodSandboxTest(t, request)
 }
 
@@ -529,10 +628,13 @@ func Test_RunPodSandbox_UEFIBoot_LCOW(t *testing.T) {
 
 	pullRequiredLcowImages(t, []string{imageLcowK8sPause})
 
-	request := getRunPodSandboxRequest(t, lcowRuntimeHandler)
-	request.Config.Annotations = map[string]string{
-		"io.microsoft.virtualmachine.lcow.kerneldirectboot": "false",
-	}
+	request := getRunPodSandboxRequest(
+		t,
+		lcowRuntimeHandler,
+		map[string]string{
+			"io.microsoft.virtualmachine.lcow.kerneldirectboot": "false",
+		},
+	)
 	runPodSandboxTest(t, request)
 }
 
@@ -541,7 +643,7 @@ func Test_RunPodSandbox_DnsConfig_WCOW_Process(t *testing.T) {
 
 	pullRequiredImages(t, []string{imageWindowsNanoserver})
 
-	request := getRunPodSandboxRequest(t, wcowProcessRuntimeHandler)
+	request := getRunPodSandboxRequest(t, wcowProcessRuntimeHandler, nil)
 	request.Config.DnsConfig = &runtime.DNSConfig{
 		Searches: []string{"8.8.8.8", "8.8.4.4"},
 	}
@@ -556,7 +658,7 @@ func Test_RunPodSandbox_DnsConfig_WCOW_Hypervisor(t *testing.T) {
 
 	pullRequiredImages(t, []string{imageWindowsNanoserver})
 
-	request := getRunPodSandboxRequest(t, wcowHypervisorRuntimeHandler)
+	request := getRunPodSandboxRequest(t, wcowHypervisorRuntimeHandler, nil)
 	request.Config.DnsConfig = &runtime.DNSConfig{
 		Searches: []string{"8.8.8.8", "8.8.4.4"},
 	}
@@ -571,7 +673,7 @@ func Test_RunPodSandbox_DnsConfig_LCOW(t *testing.T) {
 
 	pullRequiredLcowImages(t, []string{imageLcowK8sPause})
 
-	request := getRunPodSandboxRequest(t, lcowRuntimeHandler)
+	request := getRunPodSandboxRequest(t, lcowRuntimeHandler, nil)
 	request.Config.DnsConfig = &runtime.DNSConfig{
 		Searches: []string{"8.8.8.8", "8.8.4.4"},
 	}
@@ -586,7 +688,7 @@ func Test_RunPodSandbox_PortMappings_WCOW_Process(t *testing.T) {
 
 	pullRequiredImages(t, []string{imageWindowsNanoserver})
 
-	request := getRunPodSandboxRequest(t, wcowProcessRuntimeHandler)
+	request := getRunPodSandboxRequest(t, wcowProcessRuntimeHandler, nil)
 	request.Config.PortMappings = []*runtime.PortMapping{
 		{
 			Protocol:      runtime.Protocol_TCP,
@@ -602,7 +704,7 @@ func Test_RunPodSandbox_PortMappings_WCOW_Hypervisor(t *testing.T) {
 
 	pullRequiredImages(t, []string{imageWindowsNanoserver})
 
-	request := getRunPodSandboxRequest(t, wcowHypervisorRuntimeHandler)
+	request := getRunPodSandboxRequest(t, wcowHypervisorRuntimeHandler, nil)
 	request.Config.PortMappings = []*runtime.PortMapping{
 		{
 			Protocol:      runtime.Protocol_TCP,
@@ -618,7 +720,7 @@ func Test_RunPodSandbox_PortMappings_LCOW(t *testing.T) {
 
 	pullRequiredLcowImages(t, []string{imageLcowK8sPause})
 
-	request := getRunPodSandboxRequest(t, lcowRuntimeHandler)
+	request := getRunPodSandboxRequest(t, lcowRuntimeHandler, nil)
 	request.Config.PortMappings = []*runtime.PortMapping{
 		{
 			Protocol:      runtime.Protocol_TCP,
@@ -861,8 +963,7 @@ func Test_RunPodSandbox_MultipleContainersSameVhd_LCOW(t *testing.T) {
 		},
 	}
 
-	sbRequest := getRunPodSandboxRequest(t, lcowRuntimeHandler)
-	sbRequest.Config.Annotations = annotations
+	sbRequest := getRunPodSandboxRequest(t, lcowRuntimeHandler, annotations)
 
 	podID := runPodSandbox(t, client, ctx, sbRequest)
 	defer removePodSandbox(t, client, ctx, podID)
@@ -922,7 +1023,7 @@ func Test_RunPodSandbox_MultipleContainersSameVhd_RShared_LCOW(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	sbRequest := getRunPodSandboxRequest(t, lcowRuntimeHandler)
+	sbRequest := getRunPodSandboxRequest(t, lcowRuntimeHandler, nil)
 	sbRequest.Config.Linux = &runtime.LinuxPodSandboxConfig{
 		SecurityContext: &runtime.LinuxSandboxSecurityContext{
 			Privileged: true,
@@ -1078,8 +1179,7 @@ func Test_RunPodSandbox_MultipleContainersSameVhd_WCOW(t *testing.T) {
 		},
 	}
 
-	sbRequest := getRunPodSandboxRequest(t, wcowHypervisorRuntimeHandler)
-	sbRequest.Config.Annotations = annotations
+	sbRequest := getRunPodSandboxRequest(t, wcowHypervisorRuntimeHandler, annotations)
 
 	podID := runPodSandbox(t, client, ctx, sbRequest)
 	defer removePodSandbox(t, client, ctx, podID)
@@ -1174,8 +1274,7 @@ func createSandboxContainerAndExec(t *testing.T, annotations map[string]string, 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	sbRequest := getRunPodSandboxRequest(t, lcowRuntimeHandler)
-	sbRequest.Config.Annotations = annotations
+	sbRequest := getRunPodSandboxRequest(t, lcowRuntimeHandler, annotations)
 
 	podID := runPodSandbox(t, client, ctx, sbRequest)
 	defer removePodSandbox(t, client, ctx, podID)

--- a/test/cri-containerd/sandbox.go
+++ b/test/cri-containerd/sandbox.go
@@ -35,14 +35,28 @@ func removePodSandbox(t *testing.T, client runtime.RuntimeServiceClient, ctx con
 	}
 }
 
-func getRunPodSandboxRequest(t *testing.T, runtimeHandler string) *runtime.RunPodSandboxRequest {
-	return &runtime.RunPodSandboxRequest{
+func getRunPodSandboxRequest(t *testing.T, runtimeHandler string, annotations map[string]string) *runtime.RunPodSandboxRequest {
+	req := &runtime.RunPodSandboxRequest{
 		Config: &runtime.PodSandboxConfig{
 			Metadata: &runtime.PodSandboxMetadata{
 				Name:      t.Name(),
 				Namespace: testNamespace,
 			},
+			Annotations: annotations,
 		},
 		RuntimeHandler: runtimeHandler,
 	}
+
+	if *flagVirtstack != "" {
+		if req.Config.Annotations == nil {
+			req.Config.Annotations = make(map[string]string)
+		}
+		req.Config.Annotations["io.microsoft.virtualmachine.vmsource"] = *flagVirtstack
+		req.Config.Annotations["io.microsoft.virtualmachine.vmservice.address"] = testVMServiceAddress
+		req.Config.Annotations["io.microsoft.virtualmachine.vmservice.path"] = testVMServiceBinary
+		if *flagVMServiceBinary != "" {
+			req.Config.Annotations["io.microsoft.virtualmachine.vmservice.path"] = *flagVMServiceBinary
+		}
+	}
+	return req
 }

--- a/test/cri-containerd/scale_cpu_limits_to_sandbox_test.go
+++ b/test/cri-containerd/scale_cpu_limits_to_sandbox_test.go
@@ -20,7 +20,7 @@ func Test_Scale_CPU_Limits_To_Sandbox(t *testing.T) {
 	defer cancel()
 
 	client := newTestRuntimeClient(t)
-	podReq := getRunPodSandboxRequest(t, wcowHypervisor17763RuntimeHandler)
+	podReq := getRunPodSandboxRequest(t, wcowHypervisor17763RuntimeHandler, nil)
 	podID := runPodSandbox(t, client, ctx, podReq)
 	defer removePodSandbox(t, client, ctx, podID)
 

--- a/test/cri-containerd/stats_test.go
+++ b/test/cri-containerd/stats_test.go
@@ -88,7 +88,7 @@ func Test_SandboxStats_Single_LCOW(t *testing.T) {
 
 	pullRequiredLcowImages(t, []string{imageLcowK8sPause})
 
-	request := getRunPodSandboxRequest(t, lcowRuntimeHandler)
+	request := getRunPodSandboxRequest(t, lcowRuntimeHandler, nil)
 
 	client := newTestRuntimeClient(t)
 	ctx, cancel := context.WithCancel(context.Background())
@@ -116,7 +116,7 @@ func Test_SandboxStats_List_ContainerID_LCOW(t *testing.T) {
 
 	pullRequiredLcowImages(t, []string{imageLcowK8sPause})
 
-	request := getRunPodSandboxRequest(t, lcowRuntimeHandler)
+	request := getRunPodSandboxRequest(t, lcowRuntimeHandler, nil)
 
 	client := newTestRuntimeClient(t)
 	ctx, cancel := context.WithCancel(context.Background())
@@ -149,7 +149,7 @@ func Test_SandboxStats_List_PodID_LCOW(t *testing.T) {
 
 	pullRequiredLcowImages(t, []string{imageLcowK8sPause})
 
-	request := getRunPodSandboxRequest(t, lcowRuntimeHandler)
+	request := getRunPodSandboxRequest(t, lcowRuntimeHandler, nil)
 
 	client := newTestRuntimeClient(t)
 	ctx, cancel := context.WithCancel(context.Background())
@@ -223,7 +223,7 @@ func Test_ContainerStats_ContainerID(t *testing.T) {
 				pullRequiredImages(t, []string{test.sandboxImage, test.containerImage})
 			}
 
-			podRequest := getRunPodSandboxRequest(t, test.runtimeHandler)
+			podRequest := getRunPodSandboxRequest(t, test.runtimeHandler, nil)
 
 			client := newTestRuntimeClient(t)
 			ctx, cancel := context.WithCancel(context.Background())
@@ -298,7 +298,7 @@ func Test_ContainerStats_List_ContainerID(t *testing.T) {
 				pullRequiredImages(t, []string{test.sandboxImage, test.containerImage})
 			}
 
-			podRequest := getRunPodSandboxRequest(t, test.runtimeHandler)
+			podRequest := getRunPodSandboxRequest(t, test.runtimeHandler, nil)
 
 			client := newTestRuntimeClient(t)
 			ctx, cancel := context.WithCancel(context.Background())
@@ -364,12 +364,15 @@ func Test_SandboxStats_WorkingSet_PhysicallyBacked(t *testing.T) {
 			// sluggish.
 			var sizeInMB uint64 = 1536
 			sizeInMBStr := strconv.FormatUint(sizeInMB, 10)
-			podRequest := getRunPodSandboxRequest(t, test.runtimeHandler)
-			podRequest.Config.Annotations = map[string]string{
-				"io.microsoft.virtualmachine.computetopology.memory.allowovercommit":      "false",
-				"io.microsoft.virtualmachine.computetopology.memory.enabledeferredcommit": "false",
-				"io.microsoft.virtualmachine.computetopology.memory.sizeinmb":             sizeInMBStr,
-			}
+			podRequest := getRunPodSandboxRequest(
+				t,
+				test.runtimeHandler,
+				map[string]string{
+					"io.microsoft.virtualmachine.computetopology.memory.allowovercommit":      "false",
+					"io.microsoft.virtualmachine.computetopology.memory.enabledeferredcommit": "false",
+					"io.microsoft.virtualmachine.computetopology.memory.sizeinmb":             sizeInMBStr,
+				},
+			)
 
 			client := newTestRuntimeClient(t)
 			ctx, cancel := context.WithCancel(context.Background())

--- a/test/cri-containerd/stopcontainer_test.go
+++ b/test/cri-containerd/stopcontainer_test.go
@@ -18,7 +18,7 @@ func Test_StopContainer_LCOW(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	sandboxRequest := getRunPodSandboxRequest(t, lcowRuntimeHandler)
+	sandboxRequest := getRunPodSandboxRequest(t, lcowRuntimeHandler, nil)
 
 	podID := runPodSandbox(t, client, ctx, sandboxRequest)
 	defer removePodSandbox(t, client, ctx, podID)
@@ -56,7 +56,7 @@ func Test_StopContainer_WithTimeout_LCOW(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	sandboxRequest := getRunPodSandboxRequest(t, lcowRuntimeHandler)
+	sandboxRequest := getRunPodSandboxRequest(t, lcowRuntimeHandler, nil)
 
 	podID := runPodSandbox(t, client, ctx, sandboxRequest)
 	defer removePodSandbox(t, client, ctx, podID)
@@ -94,7 +94,7 @@ func Test_StopContainer_WithExec_LCOW(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	sandboxRequest := getRunPodSandboxRequest(t, lcowRuntimeHandler)
+	sandboxRequest := getRunPodSandboxRequest(t, lcowRuntimeHandler, nil)
 
 	podID := runPodSandbox(t, client, ctx, sandboxRequest)
 	defer removePodSandbox(t, client, ctx, podID)
@@ -140,7 +140,7 @@ func Test_StopContainer_ReusePod_LCOW(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	sandboxRequest := getRunPodSandboxRequest(t, lcowRuntimeHandler)
+	sandboxRequest := getRunPodSandboxRequest(t, lcowRuntimeHandler, nil)
 
 	podID := runPodSandbox(t, client, ctx, sandboxRequest)
 	defer removePodSandbox(t, client, ctx, podID)


### PR DESCRIPTION
Add some new flags to the integration test suite that enables choosing what virtstack
to use for hypervisor isolated containers. This makes it so we can re-use our existing tests
and just pass in new flags to run them with a new stack.

To have this play nice with the test suite I changed `getRunPodSandboxRequest` to take in whatever
annotations we'd want to set on the pod config directly instead of us having to set them on the
returned object itself.

Signed-off-by: Daniel Canter <dcanter@microsoft.com>