### PR TITLE
Change VSMBNoDirectMap_WCOW_Hypervisor test to fix CI break

### DIFF
--- a/test/cri-containerd/runpodsandbox_test.go
+++ b/test/cri-containerd/runpodsandbox_test.go
@@ -223,10 +223,13 @@ func Test_RunPodSandbox_VSMBNoDirectMap_WCOW_Hypervisor(t *testing.T) {
 
 	pullRequiredImages(t, []string{imageWindowsNanoserver})
 
-	request := getRunPodSandboxRequest(t, wcowHypervisorRuntimeHandler)
-	request.Config.Annotations = map[string]string{
-		"io.microsoft.virtualmachine.wcow.virtualSMB.nodirectmap": "true",
-	}
+	request := getRunPodSandboxRequest(
+		t,
+		wcowHypervisorRuntimeHandler,
+		map[string]string{
+			"io.microsoft.virtualmachine.wcow.virtualSMB.nodirectmap": "true",
+		},
+	)
 	runPodSandboxTest(t, request)
 }
 


### PR DESCRIPTION
In this PR (https://github.com/microsoft/hcsshim/pull/1019) I changed how we pass annotations to
the cri-containerd suite, but this PR (https://github.com/microsoft/hcsshim/pull/1030) got in before
which added a new test. This caused the CI to fail on checkin of the first PR. Always rebase kids

Signed-off-by: Daniel Canter <dcanter@microsoft.com>