### PR TITLE
fix break in cpu groups test on machines with build < 20124

### DIFF
--- a/test/cri-containerd/runpodsandbox_test.go
+++ b/test/cri-containerd/runpodsandbox_test.go
@@ -763,6 +763,7 @@ func Test_RunPodSandbox_Mount_SandboxDir_LCOW(t *testing.T) {
 }
 
 func Test_RunPodSandbox_CPUGroup(t *testing.T) {
+	testutilities.RequiresBuild(t, 20124)
 	ctx := context.Background()
 	presentID := "FA22A12C-36B3-486D-A3E9-BC526C2B450B"
 


### PR DESCRIPTION
Signed-off-by: Kathryn Baldauf <kabaldau@microsoft.com>