### PR TITLE
[release/0.8] shim: Clean up delete invocation behavior

### DIFF
--- a/cmd/containerd-shim-runhcs-v1/delete.go
+++ b/cmd/containerd-shim-runhcs-v1/delete.go
@@ -71,31 +71,6 @@ The delete command will be executed in the container's bundle as its cwd.
 			}
 		}
 
-		// Determine if the config file was a POD and if so kill the whole POD.
-		if s, err := getSpecAnnotations(bundleFlag); err != nil {
-			if !os.IsNotExist(err) {
-				return err
-			}
-		} else {
-			if containerType := s["io.kubernetes.cri.container-type"]; containerType == "container" {
-				if sandboxID := s["io.kubernetes.cri.sandbox-id"]; sandboxID != "" {
-					if sys, _ := hcs.OpenComputeSystem(ctx, sandboxID); sys != nil {
-						if err := sys.Terminate(ctx); err != nil {
-							fmt.Fprintf(os.Stderr, "failed to terminate '%s': %v", idFlag, err)
-						} else if err := sys.Wait(); err != nil {
-							fmt.Fprintf(os.Stderr, "failed to wait for '%s' to terminate: %v", idFlag, err)
-						}
-						sys.Close()
-					}
-				}
-			}
-		}
-
-		// Remove the bundle on disk
-		if err := os.RemoveAll(bundleFlag); err != nil && !os.IsNotExist(err) {
-			return err
-		}
-
 		if data, err := proto.Marshal(&task.DeleteResponse{
 			ExitedAt:   time.Now(),
 			ExitStatus: 255,


### PR DESCRIPTION
Backport of 450cdb150a74aa594d7fe63bb0b3a2a37f5dd782 for `release/0.8`.

This changes the behavior when the shim is invoked with the "delete"
command line argument.

Previously, the delete path did two things it should not:
- Attempted to locate the sandbox container for the pod and delete it as
  well. This meant if "shim delete" was invoked for a workload
  container, it could bring down the whole pod. The only reason we did
  not see this in the past is that prior to containerd 1.5 "shim delete"
  was not called for successful container stop operations.

- Deleted the bundle directory. We shouldn't do this in the shim, as
  containerd does it itself.

For reference on what the Linux shim does, see here: https://github.com/containerd/containerd/blob/master/runtime/v2/runc/v2/service.go#L291

Signed-off-by: Kevin Parsons <kevpar@microsoft.com>
(cherry picked from commit 450cdb150a74aa594d7fe63bb0b3a2a37f5dd782)
Signed-off-by: Kevin Parsons <kevpar@microsoft.com>