### PR TITLE
Add DNSDomain to hns endpoint object

### DIFF
--- a/internal/hns/hnsendpoint.go
+++ b/internal/hns/hnsendpoint.go
@@ -20,6 +20,7 @@ type HNSEndpoint struct {
 	IPv6Address        net.IP            `json:",omitempty"`
 	DNSSuffix          string            `json:",omitempty"`
 	DNSServerList      string            `json:",omitempty"`
+	DNSDomain          string            `json:",omitempty"`
 	GatewayAddress     string            `json:",omitempty"`
 	GatewayAddressV6   string            `json:",omitempty"`
 	EnableInternalDNS  bool              `json:",omitempty"`


### PR DESCRIPTION
It was missing from our go definition. For instance if the hcn definitions were used to set the
dns information/make the endpoint and then we requery for the endpoint with the v1 hns schema/calls,
this information won't be present.

This controls the `Connection-specific DNS Suffix` you'd see on ipconfig for example.

Signed-off-by: Daniel Canter <dcanter@microsoft.com>