### PR TITLE
Support adding container drivers as layers to lcow container

### DIFF
--- a/internal/oci/uvm.go
+++ b/internal/oci/uvm.go
@@ -87,6 +87,10 @@ const (
 	// files and information needed to install given driver(s). This may include .sys,
 	// .inf, .cer, and/or other files used during standard installation with pnputil.
 	AnnotationAssignedDeviceKernelDrivers = "io.microsoft.assigneddevice.kerneldrivers"
+	// AnnotationContainerExtraLayers contains a comma separated list of directories that contain a
+	// layer vhd, named layer.vhd, that should additionally be added to the container's list of layers
+	// to be created with.
+	AnnotationContainerExtraLayers = "io.microsoft.container.extralayers"
 	// AnnotationHostProcessInheritUser indicates whether to ignore the username passed in to run a host process
 	// container as and instead inherit the user token from the executable that is launching the container process.
 	AnnotationHostProcessInheritUser = "microsoft.com/hostprocess-inherit-user"


### PR DESCRIPTION
This PR adds a new annotation that can be used to indicate additional layer files to add to an LCOW container. As an example, drivers can be packaged as a .vhd file and the path to that file can be specified in the container config using the new annotation. Then when the container is being constructed, the driver vhd will be added as a layer. Driver files can then be found in their expected locations within the container on container start. 

This PR additionally adds a test for the behavior in cri-containerd test suite. However, since we do not currently package any drivers in the format necessary for this test, it doesn't work properly. Its purpose is to indicate that this work has been tested to work :) 

Signed-off-by: Kathryn Baldauf <kabaldau@microsoft.com>