### PR TITLE
Add volume mount support for job containers

### DIFF
--- a/internal/jobcontainers/mounts.go
+++ b/internal/jobcontainers/mounts.go
@@ -1,0 +1,56 @@
+package jobcontainers
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	specs "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/pkg/errors"
+)
+
+// namedPipePath returns true if the given path is to a named pipe.
+func isnamedPipePath(p string) bool {
+	return strings.HasPrefix(p, `\\.\pipe\`)
+}
+
+// Strip the drive letter (if there is one) so we don't end up with "%CONTAINER_SANDBOX_MOUNT_POINT%"\C:\path\to\mount
+func stripDriveLetter(name string) string {
+	// Remove drive letter
+	if len(name) == 2 && name[1] == ':' {
+		name = "."
+	} else if len(name) > 2 && name[1] == ':' {
+		name = name[2:]
+	}
+	return name
+}
+
+// setupMounts adds the custom mounts requested in the OCI runtime spec. Mounts are a bit funny as you already have
+// access to everything on the host, so just symlink in whatever was requested to the path where the container volume
+// is mounted. At least then the mount can be accessed from a path relative to the default working directory/where the volume
+// is.
+func setupMounts(spec *specs.Spec, sandboxVolumePath string) error {
+	for _, mount := range spec.Mounts {
+		if mount.Destination == "" || mount.Source == "" {
+			return fmt.Errorf("invalid OCI spec - a mount must have both source and a destination: %+v", mount)
+		}
+
+		if isnamedPipePath(mount.Source) {
+			return errors.New("named pipe mounts not supported for job containers - interact with the pipe directly")
+		}
+
+		fullCtrPath := filepath.Join(sandboxVolumePath, stripDriveLetter(mount.Destination))
+		// Make sure all of the dirs leading up to the full path exist.
+		strippedCtrPath := filepath.Dir(fullCtrPath)
+		if err := os.MkdirAll(strippedCtrPath, 0777); err != nil {
+			return errors.Wrap(err, "failed to make directory for job container mount")
+		}
+
+		if err := os.Symlink(mount.Source, fullCtrPath); err != nil {
+			return errors.Wrap(err, "failed to setup mount for job container")
+		}
+	}
+
+	return nil
+}

--- a/internal/jobcontainers/mounts_test.go
+++ b/internal/jobcontainers/mounts_test.go
@@ -1,0 +1,21 @@
+package jobcontainers
+
+import (
+	"testing"
+
+	specs "github.com/opencontainers/runtime-spec/specs-go"
+)
+
+func TestNamePipeDeny(t *testing.T) {
+	s := &specs.Spec{
+		Mounts: []specs.Mount{
+			{
+				Destination: "/path/in/container",
+				Source:      `\\.\pipe\dummy\path`,
+			},
+		},
+	}
+	if err := setupMounts(s, "/test"); err == nil {
+		t.Fatal("expected named pipe mount validation to fail for job container")
+	}
+}


### PR DESCRIPTION
This adds basic directory mount support for job containers. As any path on the host
is already accessible from the container, the concept of volume mounts is a bit funny
for job containers. However, it still makes sense to treat the volume mount point where
the container image is mounted as where most things should be found regarding the container.

The manner in which this is done is by appending the container mount path for the volume to
where the rootfs volume is mounted on the host and then symlinking it.

So:
Container rootfs volume path = "C:\C\123456789abcdefgh\"

Example #1
--------------
{
    "host_path": "C:\mydir"
    "container_path": "\dir\in\container"
}

"C:\mydir" would be symlinked to "C:\C\123456789abcdefgh\dir\in\container"

Example #2
---------------
Drive letters will be stripped
{
    "host_path": "C:\mydir"
    "container_path": "C:\dir\in\container"
}
"C:\mydir" would be symlinked to "C:\C\123456789abcdefgh\dir\in\container"

Signed-off-by: Daniel Canter <dcanter@microsoft.com>