### PR TITLE
Add process dump functionality for WCOW/LCOW

### DIFF
--- a/internal/guest/runtime/hcsv2/container.go
+++ b/internal/guest/runtime/hcsv2/container.go
@@ -66,6 +66,9 @@ func (c *Container) ExecProcess(ctx context.Context, process *oci.Process, conSe
 		return -1, err
 	}
 
+	// Add in the core rlimit specified on the container in case there was one set. This makes it so that execed processes can also generate
+	// core dumps.
+	process.Rlimits = c.spec.Process.Rlimits
 	p, err := c.container.ExecProcess(process, stdioSet)
 	if err != nil {
 		stdioSet.Close()

--- a/internal/guest/runtime/hcsv2/sandbox_container.go
+++ b/internal/guest/runtime/hcsv2/sandbox_container.go
@@ -108,6 +108,12 @@ func setupSandboxContainerSpec(ctx context.Context, id string, spec *oci.Spec) (
 		}
 	}
 
+	if rlimCore := spec.Annotations["io.microsoft.lcow.rlimitcore"]; rlimCore != "" {
+		if err := setCoreRLimit(spec, rlimCore); err != nil {
+			return err
+		}
+	}
+
 	// TODO: JTERRY75 /dev/shm is not properly setup for LCOW I believe. CRI
 	// also has a concept of a sandbox/shm file when the IPC NamespaceMode !=
 	// NODE.

--- a/internal/guest/runtime/hcsv2/spec.go
+++ b/internal/guest/runtime/hcsv2/spec.go
@@ -63,6 +63,32 @@ func setProcess(spec *oci.Spec) {
 	}
 }
 
+func setCoreRLimit(spec *oci.Spec, value string) error {
+	setProcess(spec)
+
+	vals := strings.Split(value, ";")
+	if len(vals) != 2 {
+		return errors.New("wrong number of values supplied for rlimit core")
+	}
+
+	soft, err := strconv.ParseUint(vals[0], 10, 64)
+	if err != nil {
+		return errors.Wrap(err, "failed to parse soft core rlimit")
+	}
+	hard, err := strconv.ParseUint(vals[1], 10, 64)
+	if err != nil {
+		return errors.Wrap(err, "failed to parse hard core rlimit")
+	}
+
+	spec.Process.Rlimits = append(spec.Process.Rlimits, oci.POSIXRlimit{
+		Type: "RLIMIT_CORE",
+		Soft: soft,
+		Hard: hard,
+	})
+
+	return nil
+}
+
 // setUserStr sets `spec.Process` to the valid `userstr` based on the OCI Image Spec
 // v1.0.0 `userstr`.
 //

--- a/internal/guest/runtime/hcsv2/workload_container.go
+++ b/internal/guest/runtime/hcsv2/workload_container.go
@@ -161,6 +161,12 @@ func setupWorkloadContainerSpec(ctx context.Context, sbid, id string, spec *oci.
 		return err
 	}
 
+	if rlimCore := spec.Annotations["io.microsoft.lcow.rlimitcore"]; rlimCore != "" {
+		if err := setCoreRLimit(spec, rlimCore); err != nil {
+			return err
+		}
+	}
+
 	// Force the parent cgroup into our /containers root
 	spec.Linux.CgroupsPath = "/containers/" + id
 

--- a/internal/hcsoci/hcsdoc_wcow.go
+++ b/internal/hcsoci/hcsdoc_wcow.go
@@ -4,6 +4,7 @@ package hcsoci
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"regexp"
@@ -385,6 +386,51 @@ func createWindowsContainerDocument(ctx context.Context, coi *createOptionsInter
 	}
 	v2Container.AdditionalDeviceNamespace = extensions
 
+	// Process dump setup (if requested)
+	dumpPath := ""
+	if coi.HostingSystem != nil {
+		dumpPath = coi.HostingSystem.ProcessDumpLocation()
+	}
+
+	if specDumpPath, ok := coi.Spec.Annotations[oci.AnnotationContainerProcessDumpLocation]; ok {
+		// If a process dump path was specified at pod creation time for a hypervisor isolated pod, then
+		// use this value. If one was specified on the container creation document then override with this
+		// instead. Unlike Linux, Windows containers can set the dump path on a per container basis.
+		dumpPath = specDumpPath
+	}
+
+	if dumpPath != "" {
+		dumpType, err := parseDumpType(coi.Spec.Annotations)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		// Setup WER registry keys for local process dump creation if specified.
+		// https://docs.microsoft.com/en-us/windows/win32/wer/collecting-user-mode-dumps
+		v2Container.RegistryChanges = &hcsschema.RegistryChanges{
+			AddValues: []hcsschema.RegistryValue{
+				{
+					Key: &hcsschema.RegistryKey{
+						Hive: "Software",
+						Name: "Microsoft\\Windows\\Windows Error Reporting\\LocalDumps",
+					},
+					Name:        "DumpFolder",
+					StringValue: dumpPath,
+					Type_:       "String",
+				},
+				{
+					Key: &hcsschema.RegistryKey{
+						Hive: "Software",
+						Name: "Microsoft\\Windows\\Windows Error Reporting\\LocalDumps",
+					},
+					Name:       "DumpType",
+					DWordValue: dumpType,
+					Type_:      "DWord",
+				},
+			},
+		}
+	}
+
 	return v1, v2Container, nil
 }
 
@@ -414,4 +460,23 @@ func parseAssignedDevices(ctx context.Context, coi *createOptionsInternal, v2 *h
 	}
 	v2.AssignedDevices = v2AssignedDevices
 	return nil
+}
+
+// parseDumpType parses the passed in string representation of the local user mode process dump type to the
+// corresponding value the registry expects to be set.
+//
+// See DumpType at https://docs.microsoft.com/en-us/windows/win32/wer/collecting-user-mode-dumps for the mappings
+func parseDumpType(annotations map[string]string) (int32, error) {
+	dmpTypeStr := annotations[oci.AnnotationWCOWProcessDumpType]
+	switch dmpTypeStr {
+	case "":
+		// If no type specified, default to full dumps.
+		return 2, nil
+	case "mini":
+		return 1, nil
+	case "full":
+		return 2, nil
+	default:
+		return -1, errors.New(`unknown dump type specified, valid values are "mini" or "full"`)
+	}
 }

--- a/internal/oci/annotations.go
+++ b/internal/oci/annotations.go
@@ -221,4 +221,17 @@ const (
 
 	// AnnotationSecurityPolicy is used to specify a security policy for opengcs to enforce
 	AnnotationSecurityPolicy = "io.microsoft.virtualmachine.lcow.securitypolicy"
+	// AnnotationContainerProcessDumpLocation specifies a path inside of containers to save process dumps to. As
+	// the scratch space for a container is generally cleaned up after exit, this is best set to a volume mount of
+	// some kind (vhd, bind mount, fileshare mount etc.)
+	AnnotationContainerProcessDumpLocation = "io.microsoft.container.processdumplocation"
+
+	// AnnotationWCOWProcessDumpType specifies the type of dump to create when generating a local user mode
+	// process dump for Windows containers. The supported options are "mini", and "full".
+	// See DumpType: https://docs.microsoft.com/en-us/windows/win32/wer/collecting-user-mode-dumps
+	AnnotationWCOWProcessDumpType = "io.microsoft.wcow.processdumptype"
+
+	// AnnotationRLimitCore specifies the core rlimit value for a container. This will need to be set
+	// in order to have core dumps generated for a given container.
+	AnnotationRLimitCore = "io.microsoft.lcow.rlimitcore"
 )

--- a/internal/oci/uvm.go
+++ b/internal/oci/uvm.go
@@ -332,7 +332,7 @@ func SpecToUVMCreateOpts(ctx context.Context, s *specs.Spec, id, owner string) (
 		lopts.EnableScratchEncryption = parseAnnotationsBool(ctx, s.Annotations, AnnotationEncryptedScratchDisk, lopts.EnableScratchEncryption)
 		lopts.SecurityPolicy = parseAnnotationsString(s.Annotations, AnnotationSecurityPolicy, lopts.SecurityPolicy)
 		lopts.KernelBootOptions = parseAnnotationsString(s.Annotations, AnnotationKernelBootOptions, lopts.KernelBootOptions)
-
+		lopts.ProcessDumpLocation = parseAnnotationsString(s.Annotations, AnnotationContainerProcessDumpLocation, lopts.ProcessDumpLocation)
 		handleAnnotationPreferredRootFSType(ctx, s.Annotations, lopts)
 		handleAnnotationKernelDirectBoot(ctx, s.Annotations, lopts)
 
@@ -357,6 +357,7 @@ func SpecToUVMCreateOpts(ctx context.Context, s *specs.Spec, id, owner string) (
 		wopts.CPUGroupID = parseAnnotationsString(s.Annotations, AnnotationCPUGroupID, wopts.CPUGroupID)
 		wopts.NetworkConfigProxy = parseAnnotationsString(s.Annotations, AnnotationNetworkConfigProxy, wopts.NetworkConfigProxy)
 		wopts.NoDirectMap = parseAnnotationsBool(ctx, s.Annotations, AnnotationVSMBNoDirectMap, wopts.NoDirectMap)
+		wopts.ProcessDumpLocation = parseAnnotationsString(s.Annotations, AnnotationContainerProcessDumpLocation, wopts.ProcessDumpLocation)
 		handleAnnotationFullyPhysicallyBacked(ctx, s.Annotations, wopts)
 		if err := handleCloneAnnotations(ctx, s.Annotations, wopts); err != nil {
 			return nil, err

--- a/internal/uvm/create.go
+++ b/internal/uvm/create.go
@@ -85,6 +85,11 @@ type Options struct {
 	// that receives the UVMs set of NICs from this proxy instead of enumerating
 	// the endpoints locally.
 	NetworkConfigProxy string
+
+	// Sets the location for process dumps to be placed in. On Linux this is a kernel setting so it will be
+	// applied to all containers. On Windows it's configurable per container, but we can mimic this for
+	// Windows by just applying the location specified here per container.
+	ProcessDumpLocation string
 }
 
 // compares the create opts used during template creation with the create opts
@@ -345,6 +350,12 @@ func (uvm *UtilityVM) ProcessorCount() int32 {
 // (Over commit and deferred commit both false)
 func (uvm *UtilityVM) PhysicallyBacked() bool {
 	return uvm.physicallyBacked
+}
+
+// ProcessDumpLocation returns the location that process dumps will get written to for containers running
+// in the UVM.
+func (uvm *UtilityVM) ProcessDumpLocation() string {
+	return uvm.processDumpLocation
 }
 
 func (uvm *UtilityVM) normalizeMemorySize(ctx context.Context, requested uint64) uint64 {

--- a/internal/uvm/create_lcow.go
+++ b/internal/uvm/create_lcow.go
@@ -384,6 +384,10 @@ func CreateLCOW(ctx context.Context, opts *OptionsLCOW) (_ *UtilityVM, err error
 
 	initArgs += " " + opts.ExecCommandLine
 
+	if opts.ProcessDumpLocation != "" {
+		initArgs += " -core-dump-location " + opts.ProcessDumpLocation
+	}
+
 	if vmDebugging {
 		// Launch a shell on the console.
 		initArgs = `sh -c "` + initArgs + ` & exec sh"`

--- a/internal/uvm/types.go
+++ b/internal/uvm/types.go
@@ -122,9 +122,13 @@ type UtilityVM struct {
 	// is true
 	TemplateID string
 
+	// Location that container process dumps will get written too.
+	processDumpLocation string
+
 	// The CreateOpts used to create this uvm. These can be either of type
 	// uvm.OptionsLCOW or uvm.OptionsWCOW
 	createOpts interface{}
+
 	// Network config proxy client. If nil then this wasn't requested and the
 	// uvms network will be configured locally.
 	ncProxyClient ncproxyttrpc.NetworkConfigProxyService

--- a/test/cri-containerd/main.go
+++ b/test/cri-containerd/main.go
@@ -48,6 +48,8 @@ const (
 	lcowRuntimeHandler       = "runhcs-lcow"
 	imageLcowK8sPause        = "k8s.gcr.io/pause:3.1"
 	imageLcowAlpine          = "docker.io/library/alpine:latest"
+	imageLcowAlpineCoreDump  = "cplatpublic.azurecr.io/stackoverflow-alpine:latest"
+	imageWindowsProcessDump  = "cplatpublic.azurecr.io/crashdump:latest"
 	imageLcowCosmos          = "cosmosarno/spark-master:2.4.1_2019-04-18_8e864ce"
 	imageJobContainerHNS     = "cplatpublic.azurecr.io/jobcontainer_hns:latest"
 	imageJobContainerETW     = "cplatpublic.azurecr.io/jobcontainer_etw:latest"
@@ -162,7 +164,7 @@ func getWindowsNanoserverImage(build uint16) string {
 	case osversion.V20H2:
 		return "mcr.microsoft.com/windows/nanoserver:2009"
 	default:
-		panic("unsupported build")
+		return "mcr.microsoft.com/windows/nanoserver:2009"
 	}
 }
 
@@ -179,7 +181,7 @@ func getWindowsServerCoreImage(build uint16) string {
 	case osversion.V20H2:
 		return "mcr.microsoft.com/windows/servercore:2009"
 	default:
-		panic("unsupported build")
+		return "mcr.microsoft.com/windows/nanoserver:2009"
 	}
 }
 

--- a/test/cri-containerd/runpodsandbox_test.go
+++ b/test/cri-containerd/runpodsandbox_test.go
@@ -1361,6 +1361,226 @@ func Test_RunPodSandbox_MultipleContainersSameVhd_WCOW(t *testing.T) {
 	}
 }
 
+func Test_RunPodSandbox_ProcessDump_LCOW(t *testing.T) {
+	requireFeatures(t, featureLCOW)
+
+	pullRequiredLcowImages(t, []string{imageLcowK8sPause, imageLcowAlpineCoreDump})
+
+	client := newTestRuntimeClient(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	sbRequest := getRunPodSandboxRequest(t, lcowRuntimeHandler, map[string]string{
+		oci.AnnotationContainerProcessDumpLocation: "/coredumps/core",
+	})
+
+	podID := runPodSandbox(t, client, ctx, sbRequest)
+	defer removePodSandbox(t, client, ctx, podID)
+	defer stopPodSandbox(t, client, ctx, podID)
+
+	mounts := []*runtime.Mount{
+		{
+			HostPath:      "sandbox:///coredump",
+			ContainerPath: "/coredumps",
+		},
+	}
+
+	annotations := map[string]string{
+		oci.AnnotationRLimitCore: "18446744073709551615;18446744073709551615",
+	}
+
+	// Setup container 1 that uses an image that stackoverflows shortly after starting.
+	// This should generate a core dump file in the sandbox mount location
+	c1Request := &runtime.CreateContainerRequest{
+		Config: &runtime.ContainerConfig{
+			Metadata: &runtime.ContainerMetadata{
+				Name: t.Name() + "-Container1",
+			},
+			Image: &runtime.ImageSpec{
+				Image: imageLcowAlpineCoreDump,
+			},
+			Command: []string{
+				"./stackoverflow",
+			},
+			Annotations: annotations,
+			Mounts:      mounts,
+		},
+		PodSandboxId:  podID,
+		SandboxConfig: sbRequest.Config,
+	}
+
+	container1ID := createContainer(t, client, ctx, c1Request)
+	defer removeContainer(t, client, ctx, container1ID)
+
+	startContainer(t, client, ctx, container1ID)
+	defer stopContainer(t, client, ctx, container1ID)
+
+	// Then setup a secondary container that will mount the same sandbox mount and
+	// just verify that the core dump file is present.
+	c2Request := &runtime.CreateContainerRequest{
+		Config: &runtime.ContainerConfig{
+			Metadata: &runtime.ContainerMetadata{
+				Name: t.Name() + "-Container2",
+			},
+			Image: &runtime.ImageSpec{
+				Image: imageLcowAlpineCoreDump,
+			},
+			// Hold this command open until killed
+			Command: []string{
+				"top",
+			},
+			Mounts: mounts,
+		},
+		PodSandboxId:  podID,
+		SandboxConfig: sbRequest.Config,
+	}
+
+	mounts = []*runtime.Mount{
+		{
+			HostPath:      "sandbox:///coredump",
+			ContainerPath: "/coredumps",
+		},
+	}
+
+	// Wait for the first container to die and create the core dump.
+	time.Sleep(time.Second * 5)
+
+	container2ID := createContainer(t, client, ctx, c2Request)
+	defer removeContainer(t, client, ctx, container2ID)
+
+	startContainer(t, client, ctx, container2ID)
+	defer stopContainer(t, client, ctx, container2ID)
+
+	// Check if the core dump file is present
+	execCommand := []string{
+		"ls",
+		"/coredumps/core",
+	}
+	execRequest := &runtime.ExecSyncRequest{
+		ContainerId: container2ID,
+		Cmd:         execCommand,
+		Timeout:     20,
+	}
+
+	r := execSync(t, client, ctx, execRequest)
+	if r.ExitCode != 0 {
+		t.Fatalf("failed with exit code %d running `ls`: %s", r.ExitCode, string(r.Stderr))
+	}
+}
+
+func Test_RunPodSandbox_ProcessDump_WCOW_Hypervisor(t *testing.T) {
+	requireFeatures(t, featureWCOWHypervisor)
+
+	pullRequiredImages(t, []string{imageWindowsProcessDump})
+
+	client := newTestRuntimeClient(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	sbRequest := getRunPodSandboxRequest(t, wcowHypervisor19041RuntimeHandler, map[string]string{
+		oci.AnnotationContainerProcessDumpLocation: "C:\\processdump",
+	})
+
+	podID := runPodSandbox(t, client, ctx, sbRequest)
+	defer removePodSandbox(t, client, ctx, podID)
+	defer stopPodSandbox(t, client, ctx, podID)
+
+	mounts := []*runtime.Mount{
+		{
+			HostPath:      "sandbox:///processdump",
+			ContainerPath: "C:\\processdump",
+		},
+	}
+
+	// Setup container 1 that uses an image that throws a user exception shortly after starting.
+	// This should generate a process dump file in the sandbox mount location
+	c1Request := &runtime.CreateContainerRequest{
+		Config: &runtime.ContainerConfig{
+			Metadata: &runtime.ContainerMetadata{
+				Name: t.Name() + "-Container1",
+			},
+			Image: &runtime.ImageSpec{
+				Image: imageWindowsProcessDump,
+			},
+			Command: []string{
+				"C:\\app\\crashtest.exe",
+				"ue",
+			},
+			Mounts: mounts,
+		},
+		PodSandboxId:  podID,
+		SandboxConfig: sbRequest.Config,
+	}
+
+	container1ID := createContainer(t, client, ctx, c1Request)
+	defer removeContainer(t, client, ctx, container1ID)
+
+	startContainer(t, client, ctx, container1ID)
+	defer stopContainer(t, client, ctx, container1ID)
+
+	// Then setup a secondary container that will mount the same sandbox mount and
+	// just verify that the process dump file is present.
+	c2Request := &runtime.CreateContainerRequest{
+		Config: &runtime.ContainerConfig{
+			Metadata: &runtime.ContainerMetadata{
+				Name: t.Name() + "-Container2",
+			},
+			Image: &runtime.ImageSpec{
+				Image: imageWindowsProcessDump,
+			},
+			// Hold this command open until killed
+			Command: []string{
+				"cmd",
+				"/c",
+				"ping",
+				"-t",
+				"127.0.0.1",
+			},
+			Mounts: mounts,
+		},
+		PodSandboxId:  podID,
+		SandboxConfig: sbRequest.Config,
+	}
+
+	mounts = []*runtime.Mount{
+		{
+			HostPath:      "sandbox:///processdump",
+			ContainerPath: "C:\\processdump",
+		},
+	}
+
+	// Wait for the first container to die and create the process dump.
+	time.Sleep(time.Second * 10)
+
+	container2ID := createContainer(t, client, ctx, c2Request)
+	defer removeContainer(t, client, ctx, container2ID)
+
+	startContainer(t, client, ctx, container2ID)
+	defer stopContainer(t, client, ctx, container2ID)
+
+	// Check if the core dump file is present
+	execCommand := []string{
+		"cmd",
+		"/c",
+		"dir",
+		"C:\\processdump",
+	}
+	execRequest := &runtime.ExecSyncRequest{
+		ContainerId: container2ID,
+		Cmd:         execCommand,
+		Timeout:     20,
+	}
+
+	r := execSync(t, client, ctx, execRequest)
+	if r.ExitCode != 0 {
+		t.Fatalf("failed with exit code %d running `dir`: %s", r.ExitCode, string(r.Stderr))
+	}
+
+	if !strings.Contains(string(r.Stdout), ".dmp") {
+		t.Fatalf("expected dmp file to be present in the directory, got: %s", string(r.Stdout))
+	}
+}
+
 func createSandboxContainerAndExecForCustomScratch(t *testing.T, annotations map[string]string) (string, string, int) {
 	cmd := []string{
 		"df",

--- a/test/cri-containerd/test-images/stackoverflow-lcow/Dockerfile
+++ b/test/cri-containerd/test-images/stackoverflow-lcow/Dockerfile
@@ -1,0 +1,7 @@
+FROM alpine
+
+RUN apk add --no-cache build-base
+WORKDIR /app
+COPY main.c .
+
+RUN gcc -g -o stackoverflow main.c

--- a/test/cri-containerd/test-images/stackoverflow-lcow/main.c
+++ b/test/cri-containerd/test-images/stackoverflow-lcow/main.c
@@ -1,0 +1,10 @@
+#include <stdio.h>
+
+void foo(){
+    foo();
+}
+
+int main() {
+  foo();
+  return 0;
+}

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/hcsoci/hcsdoc_wcow.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/hcsoci/hcsdoc_wcow.go
@@ -4,6 +4,7 @@ package hcsoci
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"regexp"
@@ -385,6 +386,51 @@ func createWindowsContainerDocument(ctx context.Context, coi *createOptionsInter
 	}
 	v2Container.AdditionalDeviceNamespace = extensions
 
+	// Process dump setup (if requested)
+	dumpPath := ""
+	if coi.HostingSystem != nil {
+		dumpPath = coi.HostingSystem.ProcessDumpLocation()
+	}
+
+	if specDumpPath, ok := coi.Spec.Annotations[oci.AnnotationContainerProcessDumpLocation]; ok {
+		// If a process dump path was specified at pod creation time for a hypervisor isolated pod, then
+		// use this value. If one was specified on the container creation document then override with this
+		// instead. Unlike Linux, Windows containers can set the dump path on a per container basis.
+		dumpPath = specDumpPath
+	}
+
+	if dumpPath != "" {
+		dumpType, err := parseDumpType(coi.Spec.Annotations)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		// Setup WER registry keys for local process dump creation if specified.
+		// https://docs.microsoft.com/en-us/windows/win32/wer/collecting-user-mode-dumps
+		v2Container.RegistryChanges = &hcsschema.RegistryChanges{
+			AddValues: []hcsschema.RegistryValue{
+				{
+					Key: &hcsschema.RegistryKey{
+						Hive: "Software",
+						Name: "Microsoft\\Windows\\Windows Error Reporting\\LocalDumps",
+					},
+					Name:        "DumpFolder",
+					StringValue: dumpPath,
+					Type_:       "String",
+				},
+				{
+					Key: &hcsschema.RegistryKey{
+						Hive: "Software",
+						Name: "Microsoft\\Windows\\Windows Error Reporting\\LocalDumps",
+					},
+					Name:       "DumpType",
+					DWordValue: dumpType,
+					Type_:      "DWord",
+				},
+			},
+		}
+	}
+
 	return v1, v2Container, nil
 }
 
@@ -414,4 +460,23 @@ func parseAssignedDevices(ctx context.Context, coi *createOptionsInternal, v2 *h
 	}
 	v2.AssignedDevices = v2AssignedDevices
 	return nil
+}
+
+// parseDumpType parses the passed in string representation of the local user mode process dump type to the
+// corresponding value the registry expects to be set.
+//
+// See DumpType at https://docs.microsoft.com/en-us/windows/win32/wer/collecting-user-mode-dumps for the mappings
+func parseDumpType(annotations map[string]string) (int32, error) {
+	dmpTypeStr := annotations[oci.AnnotationWCOWProcessDumpType]
+	switch dmpTypeStr {
+	case "":
+		// If no type specified, default to full dumps.
+		return 2, nil
+	case "mini":
+		return 1, nil
+	case "full":
+		return 2, nil
+	default:
+		return -1, errors.New(`unknown dump type specified, valid values are "mini" or "full"`)
+	}
 }

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/oci/annotations.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/oci/annotations.go
@@ -221,4 +221,17 @@ const (
 
 	// AnnotationSecurityPolicy is used to specify a security policy for opengcs to enforce
 	AnnotationSecurityPolicy = "io.microsoft.virtualmachine.lcow.securitypolicy"
+	// AnnotationContainerProcessDumpLocation specifies a path inside of containers to save process dumps to. As
+	// the scratch space for a container is generally cleaned up after exit, this is best set to a volume mount of
+	// some kind (vhd, bind mount, fileshare mount etc.)
+	AnnotationContainerProcessDumpLocation = "io.microsoft.container.processdumplocation"
+
+	// AnnotationWCOWProcessDumpType specifies the type of dump to create when generating a local user mode
+	// process dump for Windows containers. The supported options are "mini", and "full".
+	// See DumpType: https://docs.microsoft.com/en-us/windows/win32/wer/collecting-user-mode-dumps
+	AnnotationWCOWProcessDumpType = "io.microsoft.wcow.processdumptype"
+
+	// AnnotationRLimitCore specifies the core rlimit value for a container. This will need to be set
+	// in order to have core dumps generated for a given container.
+	AnnotationRLimitCore = "io.microsoft.lcow.rlimitcore"
 )

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/oci/uvm.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/oci/uvm.go
@@ -332,7 +332,7 @@ func SpecToUVMCreateOpts(ctx context.Context, s *specs.Spec, id, owner string) (
 		lopts.EnableScratchEncryption = parseAnnotationsBool(ctx, s.Annotations, AnnotationEncryptedScratchDisk, lopts.EnableScratchEncryption)
 		lopts.SecurityPolicy = parseAnnotationsString(s.Annotations, AnnotationSecurityPolicy, lopts.SecurityPolicy)
 		lopts.KernelBootOptions = parseAnnotationsString(s.Annotations, AnnotationKernelBootOptions, lopts.KernelBootOptions)
-
+		lopts.ProcessDumpLocation = parseAnnotationsString(s.Annotations, AnnotationContainerProcessDumpLocation, lopts.ProcessDumpLocation)
 		handleAnnotationPreferredRootFSType(ctx, s.Annotations, lopts)
 		handleAnnotationKernelDirectBoot(ctx, s.Annotations, lopts)
 
@@ -357,6 +357,7 @@ func SpecToUVMCreateOpts(ctx context.Context, s *specs.Spec, id, owner string) (
 		wopts.CPUGroupID = parseAnnotationsString(s.Annotations, AnnotationCPUGroupID, wopts.CPUGroupID)
 		wopts.NetworkConfigProxy = parseAnnotationsString(s.Annotations, AnnotationNetworkConfigProxy, wopts.NetworkConfigProxy)
 		wopts.NoDirectMap = parseAnnotationsBool(ctx, s.Annotations, AnnotationVSMBNoDirectMap, wopts.NoDirectMap)
+		wopts.ProcessDumpLocation = parseAnnotationsString(s.Annotations, AnnotationContainerProcessDumpLocation, wopts.ProcessDumpLocation)
 		handleAnnotationFullyPhysicallyBacked(ctx, s.Annotations, wopts)
 		if err := handleCloneAnnotations(ctx, s.Annotations, wopts); err != nil {
 			return nil, err

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/uvm/create.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/uvm/create.go
@@ -85,6 +85,11 @@ type Options struct {
 	// that receives the UVMs set of NICs from this proxy instead of enumerating
 	// the endpoints locally.
 	NetworkConfigProxy string
+
+	// Sets the location for process dumps to be placed in. On Linux this is a kernel setting so it will be
+	// applied to all containers. On Windows it's configurable per container, but we can mimic this for
+	// Windows by just applying the location specified here per container.
+	ProcessDumpLocation string
 }
 
 // compares the create opts used during template creation with the create opts
@@ -345,6 +350,12 @@ func (uvm *UtilityVM) ProcessorCount() int32 {
 // (Over commit and deferred commit both false)
 func (uvm *UtilityVM) PhysicallyBacked() bool {
 	return uvm.physicallyBacked
+}
+
+// ProcessDumpLocation returns the location that process dumps will get written to for containers running
+// in the UVM.
+func (uvm *UtilityVM) ProcessDumpLocation() string {
+	return uvm.processDumpLocation
 }
 
 func (uvm *UtilityVM) normalizeMemorySize(ctx context.Context, requested uint64) uint64 {

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/uvm/create_lcow.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/uvm/create_lcow.go
@@ -384,6 +384,10 @@ func CreateLCOW(ctx context.Context, opts *OptionsLCOW) (_ *UtilityVM, err error
 
 	initArgs += " " + opts.ExecCommandLine
 
+	if opts.ProcessDumpLocation != "" {
+		initArgs += " -core-dump-location " + opts.ProcessDumpLocation
+	}
+
 	if vmDebugging {
 		// Launch a shell on the console.
 		initArgs = `sh -c "` + initArgs + ` & exec sh"`

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/uvm/types.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/uvm/types.go
@@ -122,9 +122,13 @@ type UtilityVM struct {
 	// is true
 	TemplateID string
 
+	// Location that container process dumps will get written too.
+	processDumpLocation string
+
 	// The CreateOpts used to create this uvm. These can be either of type
 	// uvm.OptionsLCOW or uvm.OptionsWCOW
 	createOpts interface{}
+
 	// Network config proxy client. If nil then this wasn't requested and the
 	// uvms network will be configured locally.
 	ncProxyClient ncproxyttrpc.NetworkConfigProxyService


### PR DESCRIPTION
This commit adds support for generating process dumps for hypervisor isolated containers. This includes
a new annotation to specify where process dumps should get placed on creation, which is global
to all containers.

This was verified the following way through crictl:
```json
Linux Pod spec
--------------
{
    "metadata": {
        "name": "sandbox-coredump",
        "namespace": "default",
        "attempt": 1
    },
    "annotations": {
        "io.microsoft.container.processdumplocation": "/coredumps/core.%s.%e.%P.%t" 
    }
}
```

```json
Linux container spec 
-----------------
{
        "metadata": {
                "name": "coredump-test"
        },
        "image": {
                "image": "docker.io/library/ubuntu:latest"
        },
        "command": [
                "sh",
                "-c",
                "while true; do echo 'Hello, World!'; sleep 1; done"
        ],
        "mounts": [
                {
                        "container_path": "/coredumps",
                        "host_path": "sandbox:///core"
                },
                {
                         "container_path": "/host",
                         "host_path": "C:\\users\\dcanter\\desktop\\coredump"
                }
        ],
        "annotations": {
                "io.microsoft.lcow.rlimitcore": "18446744073709551615;18446744073709551615"
        },
        "linux": {}
}
```
Get a shell into the container and then grab the current pid (`echo $$`) and do a `kill -6 <pid>`. Re-exec in and there should be a file in /coredumps named something like "core.6.sh.176.1626339581". Then cp the file to /host and try out gdb on the file through wsl. `gdb -c /mnt/c/Users/dcanter/desktop/coredump/core.6.sh.176.1626339581`


Below is the Windows configs for this as well:
```json
Windows Pod Spec:
--------------
{
    "metadata": {
        "name": "sandbox-wcow",
        "namespace": "default",
        "attempt": 1
    },
    "annotations": {
        "io.microsoft.container.processdumplocation": "C:\\crashdump"
    }
}
```

```json
Windows container spec 
-----------------
{
        "metadata": {
                "name": "wcow-test"
        },
        "image": {
                "image": "cplatpublic.azurecr.io/crashdump:latest"
        },
        "command": [
                "C:\\app\\crashtest.exe",
                "so"
        ],
        "mounts": [{
                "container_path": "C:\\crashdump",
                "host_path": "C:\\users\\dcanter\\desktop\\coredump"
        }]
}
```
Afterwards there should a dmp at whatever the specified directory was. The container image is a slightly modified version of https://github.com/spreadex/win-docker-crash-dump. As we're setting wersvc to auto-start Stackoverflow exceptions work as well.

Signed-off-by: Daniel Canter <dcanter@microsoft.com>