### PR TITLE
[release/0.8] Remove ERROR_PROC_NOT_FOUND from error checks

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -59,7 +59,7 @@ var (
 	// ErrVmcomputeOperationInvalidState is an error encountered when the compute system is not in a valid state for the requested operation
 	ErrVmcomputeOperationInvalidState = hcs.ErrVmcomputeOperationInvalidState
 
-	// ErrProcNotFound is an error encountered when the the process cannot be found
+	// ErrProcNotFound is an error encountered when a procedure look up fails.
 	ErrProcNotFound = hcs.ErrProcNotFound
 
 	// ErrVmcomputeOperationAccessIsDenied is an error which can be encountered when enumerating compute systems in RS1/RS2
@@ -159,7 +159,7 @@ func (e *ProcessError) Error() string {
 // IsNotExist checks if an error is caused by the Container or Process not existing.
 // Note: Currently, ErrElementNotFound can mean that a Process has either
 // already exited, or does not exist. Both IsAlreadyStopped and IsNotExist
-// will currently return true when the error is ErrElementNotFound or ErrProcNotFound.
+// will currently return true when the error is ErrElementNotFound.
 func IsNotExist(err error) bool {
 	if _, ok := err.(EndpointNotFoundError); ok {
 		return true
@@ -192,7 +192,7 @@ func IsTimeout(err error) bool {
 // a Container or Process being already stopped.
 // Note: Currently, ErrElementNotFound can mean that a Process has either
 // already exited, or does not exist. Both IsAlreadyStopped and IsNotExist
-// will currently return true when the error is ErrElementNotFound or ErrProcNotFound.
+// will currently return true when the error is ErrElementNotFound.
 func IsAlreadyStopped(err error) bool {
 	return hcs.IsAlreadyStopped(getInnerError(err))
 }

--- a/internal/hcs/errors.go
+++ b/internal/hcs/errors.go
@@ -60,7 +60,7 @@ var (
 	// ErrVmcomputeOperationInvalidState is an error encountered when the compute system is not in a valid state for the requested operation
 	ErrVmcomputeOperationInvalidState = syscall.Errno(0xc0370105)
 
-	// ErrProcNotFound is an error encountered when the the process cannot be found
+	// ErrProcNotFound is an error encountered when a procedure look up fails.
 	ErrProcNotFound = syscall.Errno(0x7f)
 
 	// ErrVmcomputeOperationAccessIsDenied is an error which can be encountered when enumerating compute systems in RS1/RS2
@@ -242,12 +242,11 @@ func makeProcessError(process *Process, op string, err error, events []ErrorEven
 // IsNotExist checks if an error is caused by the Container or Process not existing.
 // Note: Currently, ErrElementNotFound can mean that a Process has either
 // already exited, or does not exist. Both IsAlreadyStopped and IsNotExist
-// will currently return true when the error is ErrElementNotFound or ErrProcNotFound.
+// will currently return true when the error is ErrElementNotFound.
 func IsNotExist(err error) bool {
 	err = getInnerError(err)
 	return err == ErrComputeSystemDoesNotExist ||
-		err == ErrElementNotFound ||
-		err == ErrProcNotFound
+		err == ErrElementNotFound
 }
 
 // IsAlreadyClosed checks if an error is caused by the Container or Process having been
@@ -278,12 +277,11 @@ func IsTimeout(err error) bool {
 // a Container or Process being already stopped.
 // Note: Currently, ErrElementNotFound can mean that a Process has either
 // already exited, or does not exist. Both IsAlreadyStopped and IsNotExist
-// will currently return true when the error is ErrElementNotFound or ErrProcNotFound.
+// will currently return true when the error is ErrElementNotFound.
 func IsAlreadyStopped(err error) bool {
 	err = getInnerError(err)
 	return err == ErrVmcomputeAlreadyStopped ||
-		err == ErrElementNotFound ||
-		err == ErrProcNotFound
+		err == ErrElementNotFound
 }
 
 // IsNotSupported returns a boolean indicating whether the error is caused by


### PR DESCRIPTION
Backport to `release/0.8` of #1064.

Previously, certain error check functions like IsAlreadyStopped returned
true if the error was ERROR_PROC_NOT_FOUND. Based on the comment in the
file, this was intended to be used to indicate a case where the process
could not be found. However, it seems this may have been added
erroneously. ERROR_PROC_NOT_FOUND is actually typically used to mean
that a _procedure_ lookup failed, and has nothing to do with processes.

The original change[1] to check against ERROR_PROC_NOT_FOUND was made
five years ago, and did not contain much information on why this error
would be returned. We are removing this now based on several factors:

- We are not aware of any condition where HCS would intentionally return
  ERROR_PROC_NOT_FOUND to indicate a condition "process does not exist".
- There is an issue where HcsShutdownComputeSystem sometimes returns
  ERROR_PROC_NOT_FOUND due to something failing internally. The current
  error checks are causing this to be treated as "the container has
  already exited", causing moby to not properly stop the container via
  HcsTerminateComputeSystem.

This change leaves the definition for ErrProcNotFound in the code, as it
may be used by external callers, but fixes its comment.

[1]: See commit 0ae7e7ecebd7b5609582153ed680c35ba666a264

Signed-off-by: Kevin Parsons <kevpar@microsoft.com>
(cherry picked from commit d78544d6c2c2cbfde54155662138bf275cab7fca)
Signed-off-by: Kevin Parsons <kevpar@microsoft.com>