### PR TITLE
Add missing 'functional' tag to test source

### DIFF
--- a/test/cri-containerd/scale_cpu_limits_to_sandbox_test.go
+++ b/test/cri-containerd/scale_cpu_limits_to_sandbox_test.go
@@ -1,3 +1,5 @@
+// +build functional
+
 package cri_containerd
 
 import (


### PR DESCRIPTION
Without this tag, gopls under VSCode notes that this file calls undefined functions when no build tags are defined (the default).