### PR TITLE
Fix lost span attribute for NameToGuid

### DIFF
--- a/internal/wclayer/nametoguid.go
+++ b/internal/wclayer/nametoguid.go
@@ -17,7 +17,7 @@ func NameToGuid(ctx context.Context, name string) (_ guid.GUID, err error) {
 	ctx, span := trace.StartSpan(ctx, title) //nolint:ineffassign,staticcheck
 	defer span.End()
 	defer func() { oc.SetSpanStatus(span, err) }()
-	span.AddAttributes(trace.StringAttribute("name", name))
+	span.AddAttributes(trace.StringAttribute("objectName", name))
 
 	var id guid.GUID
 	err = nameToGuid(name, &id)

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/wclayer/nametoguid.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/wclayer/nametoguid.go
@@ -17,7 +17,7 @@ func NameToGuid(ctx context.Context, name string) (_ guid.GUID, err error) {
 	ctx, span := trace.StartSpan(ctx, title) //nolint:ineffassign,staticcheck
 	defer span.End()
 	defer func() { oc.SetSpanStatus(span, err) }()
-	span.AddAttributes(trace.StringAttribute("name", name))
+	span.AddAttributes(trace.StringAttribute("objectName", name))
 
 	var id guid.GUID
 	err = nameToGuid(name, &id)


### PR DESCRIPTION
"name" is also used for the span title, so this attribute is lost, at least in the textual output.

I noticed the missing log attribute while trying to diagnose possible causes for "file in use" issues on https://github.com/containerd/containerd/pull/4419.