### PR TITLE
Updating HNS v1 policy schemas with correct omitEmpty fields

### DIFF
--- a/hcn/hcnpolicy.go
+++ b/hcn/hcnpolicy.go
@@ -320,7 +320,7 @@ type L4ProxyPolicySetting struct {
 	Protocol    ProtocolType `json:",omitempty"`
 	Exceptions  []string     `json:",omitempty"`
 	Destination string
-	OutboundNAT bool `json:",omitempty"`
+	OutboundNAT bool         `json:",omitempty"`
 }
 
 // TierAclRule represents an ACL within TierAclPolicySetting

--- a/internal/hns/hnspolicy.go
+++ b/internal/hns/hnspolicy.go
@@ -22,9 +22,9 @@ const (
 
 type NatPolicy struct {
 	Type         PolicyType `json:"Type"`
-	Protocol     string
-	InternalPort uint16
-	ExternalPort uint16
+	Protocol     string     `json:",omitempty"`
+	InternalPort uint16     `json:",omitempty"`
+	ExternalPort uint16     `json:",omitempty"`
 }
 
 type QosPolicy struct {
@@ -88,20 +88,20 @@ const (
 type ACLPolicy struct {
 	Type            PolicyType `json:"Type"`
 	Id              string     `json:"Id,omitempty"`
-	Protocol        uint16
-	Protocols       string `json:"Protocols,omitempty"`
-	InternalPort    uint16
+	Protocol        uint16     `json:",omitempty"`
+	Protocols       string     `json:"Protocols,omitempty"`
+	InternalPort    uint16     `json:",omitempty"`
 	Action          ActionType
 	Direction       DirectionType
-	LocalAddresses  string
-	RemoteAddresses string
-	LocalPorts      string `json:"LocalPorts,omitempty"`
-	LocalPort       uint16
-	RemotePorts     string `json:"RemotePorts,omitempty"`
-	RemotePort      uint16
-	RuleType        RuleType `json:"RuleType,omitempty"`
-	Priority        uint16
-	ServiceName     string
+	LocalAddresses  string     `json:",omitempty"`
+	RemoteAddresses string     `json:",omitempty"`
+	LocalPorts      string     `json:"LocalPorts,omitempty"`
+	LocalPort       uint16     `json:",omitempty"`
+	RemotePorts     string     `json:"RemotePorts,omitempty"`
+	RemotePort      uint16     `json:",omitempty"`
+	RuleType        RuleType   `json:"RuleType,omitempty"`
+	Priority        uint16     `json:",omitempty"`
+	ServiceName     string     `json:",omitempty"`
 }
 
 type Policy struct {


### PR DESCRIPTION
Signed-off-by: elweb9858 <elweb@microsoft.com>

Several fields in the NatPolicy and AclPolicy v1 schema structs do not reflect the omitEmpty json field. This can be problematic in cases of integer fields because if the user does not specify a value for this field, it will be assigned a 0 during marshalling. In cases like protocol, a value of 0 is not something HNS recognizes so policy application will fail. This PR reflects all the omitEmpty fields properly in the hcsshim v1 policy schema structs (all v2 structs are currently up to date). 