### PR TITLE
Gate CRI update container tests behind feature flag

### DIFF
--- a/test/cri-containerd/container_update_test.go
+++ b/test/cri-containerd/container_update_test.go
@@ -43,7 +43,7 @@ func Test_Container_UpdateResources_CPUShare(t *testing.T) {
 	tests := []config{
 		{
 			name:             "WCOW_Process",
-			requiredFeatures: []string{featureWCOWProcess},
+			requiredFeatures: []string{featureWCOWProcess, featureCRIUpdateContainer},
 			runtimeHandler:   wcowProcessRuntimeHandler,
 			sandboxImage:     imageWindowsNanoserver,
 			containerImage:   imageWindowsNanoserver,
@@ -51,7 +51,7 @@ func Test_Container_UpdateResources_CPUShare(t *testing.T) {
 		},
 		{
 			name:             "WCOW_Hypervisor",
-			requiredFeatures: []string{featureWCOWHypervisor},
+			requiredFeatures: []string{featureWCOWHypervisor, featureCRIUpdateContainer},
 			runtimeHandler:   wcowHypervisorRuntimeHandler,
 			sandboxImage:     imageWindowsNanoserver,
 			containerImage:   imageWindowsNanoserver,
@@ -59,7 +59,7 @@ func Test_Container_UpdateResources_CPUShare(t *testing.T) {
 		},
 		{
 			name:             "LCOW",
-			requiredFeatures: []string{featureLCOW},
+			requiredFeatures: []string{featureLCOW, featureCRIUpdateContainer},
 			runtimeHandler:   lcowRuntimeHandler,
 			sandboxImage:     imageLcowK8sPause,
 			containerImage:   imageLcowAlpine,
@@ -158,7 +158,7 @@ func Test_Container_UpdateResources_CPUShare_NotRunning(t *testing.T) {
 	tests := []config{
 		{
 			name:             "WCOW_Process",
-			requiredFeatures: []string{featureWCOWProcess},
+			requiredFeatures: []string{featureWCOWProcess, featureCRIUpdateContainer},
 			runtimeHandler:   wcowProcessRuntimeHandler,
 			sandboxImage:     imageWindowsNanoserver,
 			containerImage:   imageWindowsNanoserver,
@@ -166,7 +166,7 @@ func Test_Container_UpdateResources_CPUShare_NotRunning(t *testing.T) {
 		},
 		{
 			name:             "WCOW_Hypervisor",
-			requiredFeatures: []string{featureWCOWHypervisor},
+			requiredFeatures: []string{featureWCOWHypervisor, featureCRIUpdateContainer},
 			runtimeHandler:   wcowHypervisorRuntimeHandler,
 			sandboxImage:     imageWindowsNanoserver,
 			containerImage:   imageWindowsNanoserver,
@@ -174,7 +174,7 @@ func Test_Container_UpdateResources_CPUShare_NotRunning(t *testing.T) {
 		},
 		{
 			name:             "LCOW",
-			requiredFeatures: []string{featureLCOW},
+			requiredFeatures: []string{featureLCOW, featureCRIUpdateContainer},
 			runtimeHandler:   lcowRuntimeHandler,
 			sandboxImage:     imageLcowK8sPause,
 			containerImage:   imageLcowAlpine,
@@ -273,7 +273,7 @@ func Test_Container_UpdateResources_Memory(t *testing.T) {
 	tests := []config{
 		{
 			name:             "WCOW_Process",
-			requiredFeatures: []string{featureWCOWProcess},
+			requiredFeatures: []string{featureWCOWProcess, featureCRIUpdateContainer},
 			runtimeHandler:   wcowProcessRuntimeHandler,
 			sandboxImage:     imageWindowsNanoserver,
 			containerImage:   imageWindowsNanoserver,
@@ -281,7 +281,7 @@ func Test_Container_UpdateResources_Memory(t *testing.T) {
 		},
 		{
 			name:             "WCOW_Hypervisor",
-			requiredFeatures: []string{featureWCOWHypervisor},
+			requiredFeatures: []string{featureWCOWHypervisor, featureCRIUpdateContainer},
 			runtimeHandler:   wcowHypervisorRuntimeHandler,
 			sandboxImage:     imageWindowsNanoserver,
 			containerImage:   imageWindowsNanoserver,
@@ -289,7 +289,7 @@ func Test_Container_UpdateResources_Memory(t *testing.T) {
 		},
 		{
 			name:             "LCOW",
-			requiredFeatures: []string{featureLCOW},
+			requiredFeatures: []string{featureLCOW, featureCRIUpdateContainer},
 			runtimeHandler:   lcowRuntimeHandler,
 			sandboxImage:     imageLcowK8sPause,
 			containerImage:   imageLcowAlpine,

--- a/test/cri-containerd/main.go
+++ b/test/cri-containerd/main.go
@@ -83,12 +83,13 @@ var (
 // Features
 // Make sure you update allFeatures below with any new features you add.
 const (
-	featureLCOW           = "LCOW"
-	featureWCOWProcess    = "WCOWProcess"
-	featureWCOWHypervisor = "WCOWHypervisor"
-	featureHostProcess    = "HostProcess"
-	featureGMSA           = "GMSA"
-	featureGPU            = "GPU"
+	featureLCOW               = "LCOW"
+	featureWCOWProcess        = "WCOWProcess"
+	featureWCOWHypervisor     = "WCOWHypervisor"
+	featureHostProcess        = "HostProcess"
+	featureGMSA               = "GMSA"
+	featureGPU                = "GPU"
+	featureCRIUpdateContainer = "UpdateContainer"
 )
 
 var allFeatures = []string{
@@ -98,6 +99,7 @@ var allFeatures = []string{
 	featureHostProcess,
 	featureGMSA,
 	featureGPU,
+	featureCRIUpdateContainer,
 }
 
 func init() {


### PR DESCRIPTION
Upstream containerd/cri doesn't have support for updating container resources,
so running these tests currently fails.

Signed-off-by: Daniel Canter <dcanter@microsoft.com>