### PR TITLE
Fix relative paths (with dot) not working for job containers

### DIFF
--- a/internal/jobcontainers/path.go
+++ b/internal/jobcontainers/path.go
@@ -3,6 +3,7 @@ package jobcontainers
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/Microsoft/hcsshim/internal/winapi"
@@ -71,6 +72,10 @@ func getApplicationName(commandLine, workingDirectory, pathEnv string) (string, 
 		searchPath string
 		result     string
 	)
+
+	// Clean the path, to get rid of any . elements
+	commandLine = filepath.Clean(commandLine)
+
 	// First we get the system paths concatenated with semicolons (C:\windows;C:\windows\system32;C:\windows\system;)
 	// and use this as the basis for the directories to search for the application.
 	systemPaths, err := getSystemPaths()

--- a/internal/jobcontainers/path_test.go
+++ b/internal/jobcontainers/path_test.go
@@ -3,8 +3,15 @@ package jobcontainers
 import (
 	"os"
 	"os/exec"
+	"strings"
 	"testing"
 )
+
+func assertStr(t *testing.T, a string, b string) {
+	if !strings.EqualFold(a, b) {
+		t.Fatalf("expected %s, got %s", a, b)
+	}
+}
 
 func TestSearchPath(t *testing.T) {
 	// Testing that relative paths work.
@@ -17,30 +24,52 @@ func TestSearchPath(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	_, err = searchPathForExe("ping", "C:\\windows\\system32")
+	if err != nil {
+		t.Fatal(err)
+	}
 }
 
 func TestGetApplicationName(t *testing.T) {
+	expected := "C:\\WINDOWS\\system32\\ping.exe"
+
 	cwd, err := os.Getwd()
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	_, _, err = getApplicationName("ping", cwd, os.Getenv("PATH"))
+	path, _, err := getApplicationName("ping", cwd, os.Getenv("PATH"))
 	if err != nil {
 		t.Fatal(err)
 	}
+	assertStr(t, expected, path)
+
+	path, _, err = getApplicationName("./ping", cwd, os.Getenv("PATH"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertStr(t, expected, path)
+
+	path, _, err = getApplicationName(".\\ping", cwd, os.Getenv("PATH"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertStr(t, expected, path)
 
 	// Test that we only find the first element of the commandline if the binary exists.
-	_, _, err = getApplicationName("ping test", cwd, os.Getenv("PATH"))
+	path, _, err = getApplicationName("ping test", cwd, os.Getenv("PATH"))
 	if err != nil {
 		t.Fatal(err)
 	}
+	assertStr(t, expected, path)
 
 	// Test quoted application name with an argument afterwards.
 	path, cmdLine, err := getApplicationName("\"ping\" 127.0.0.1", cwd, os.Getenv("PATH"))
 	if err != nil {
 		t.Fatal(err)
 	}
+	assertStr(t, expected, path)
 
 	args := splitArgs(cmdLine)
 	cmd := &exec.Cmd{


### PR DESCRIPTION
Relative paths supplying a dot don't make it through our commandline
parsing for job containers, this change fixes that.

In addition to this, this change adds logic to actually honor the working
directory specified for the container.

Signed-off-by: Daniel Canter <dcanter@microsoft.com>