### PR TITLE
Stop setting up Go in lint CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,6 @@ jobs:
     runs-on: 'windows-2019'
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
-        with:
-          go-version: '^1.15.0'
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2


### PR DESCRIPTION
golangci-lint-action installs latest Go automatically.

From golangci-lint-action [documentation](https://github.com/golangci/golangci-lint-action#internals):

> install the latest Go 1.x version using @actions/setup-go