### PR TITLE
Add WCOW sandbox mount support

### DIFF
--- a/internal/hcsoci/hcsdoc_wcow.go
+++ b/internal/hcsoci/hcsdoc_wcow.go
@@ -75,6 +75,9 @@ func createMountsConfig(ctx context.Context, coi *createOptionsInternal) (*mount
 					return nil, err
 				}
 				mdv2.HostPath = uvmPath
+			} else if strings.HasPrefix(mount.Source, "sandbox://") {
+				// Convert to the path in the guest that was asked for.
+				mdv2.HostPath = convertToWCOWSandboxMountPath(mount.Source)
 			} else {
 				// vsmb mount
 				uvmPath, err := coi.HostingSystem.GetVSMBUvmPath(ctx, mount.Source, readOnly)

--- a/test/cri-containerd/runpodsandbox_test.go
+++ b/test/cri-containerd/runpodsandbox_test.go
@@ -853,6 +853,130 @@ func Test_RunPodSandbox_Mount_SandboxDir_LCOW(t *testing.T) {
 	//TODO: Parse the output of the exec command to make sure the uvm mount was successful
 }
 
+func Test_RunPodSandbox_Mount_SandboxDir_WCOW(t *testing.T) {
+	requireFeatures(t, featureWCOWHypervisor)
+
+	pullRequiredImages(t, []string{imageWindowsNanoserver})
+
+	client := newTestRuntimeClient(t)
+	ctx := context.Background()
+
+	sbRequest := getRunPodSandboxRequest(t, wcowHypervisorRuntimeHandler, nil)
+	podID := runPodSandbox(t, client, ctx, sbRequest)
+	defer removePodSandbox(t, client, ctx, podID)
+	defer stopPodSandbox(t, client, ctx, podID)
+
+	command := []string{
+		"cmd",
+		"/c",
+		"ping",
+		"-t",
+		"127.0.0.1",
+	}
+
+	mounts := []*runtime.Mount{
+		{
+			HostPath:      "sandbox:///test",
+			ContainerPath: "C:\\test",
+		},
+	}
+	// Create 2 containers with sandbox mounts and verify both can write and see the others files
+	container1Name := t.Name() + "-Container-" + "1"
+	container1Id := createContainerInSandbox(t, client, ctx, podID, container1Name, imageWindowsNanoserver, command, nil, mounts, sbRequest.Config)
+	defer removeContainer(t, client, ctx, container1Id)
+
+	startContainer(t, client, ctx, container1Id)
+	defer stopContainer(t, client, ctx, container1Id)
+
+	execEcho := []string{
+		"cmd",
+		"/c",
+		"echo",
+		`"test"`,
+		">",
+		"C:\\test\\test.txt",
+	}
+	_, errorMsg, exitCode := execContainer(t, client, ctx, container1Id, execEcho)
+	if exitCode != 0 {
+		t.Fatalf("Exec into container failed with: %v and exit code: %d, %s", errorMsg, exitCode, container1Id)
+	}
+
+	container2Name := t.Name() + "-Container-" + "2"
+	container2Id := createContainerInSandbox(t, client, ctx, podID, container2Name, imageWindowsNanoserver, command, nil, mounts, sbRequest.Config)
+	defer removeContainer(t, client, ctx, container2Id)
+
+	startContainer(t, client, ctx, container2Id)
+	defer stopContainer(t, client, ctx, container2Id)
+
+	// Test that we can see the file made in the first container in the second one.
+	execDir := []string{
+		"cmd",
+		"/c",
+		"dir",
+		"C:\\test\\test.txt",
+	}
+	_, errorMsg, exitCode = execContainer(t, client, ctx, container2Id, execDir)
+	if exitCode != 0 {
+		t.Fatalf("Exec into container failed with: %v and exit code: %d, %s", errorMsg, exitCode, container2Id)
+	}
+}
+
+func Test_RunPodSandbox_Mount_SandboxDir_NoShare_WCOW(t *testing.T) {
+	requireFeatures(t, featureWCOWHypervisor)
+
+	pullRequiredImages(t, []string{imageWindowsNanoserver})
+
+	client := newTestRuntimeClient(t)
+	ctx := context.Background()
+
+	sbRequest := getRunPodSandboxRequest(t, wcowHypervisorRuntimeHandler, nil)
+	podID := runPodSandbox(t, client, ctx, sbRequest)
+	defer removePodSandbox(t, client, ctx, podID)
+	defer stopPodSandbox(t, client, ctx, podID)
+
+	command := []string{
+		"cmd",
+		"/c",
+		"ping",
+		"-t",
+		"127.0.0.1",
+	}
+
+	mounts := []*runtime.Mount{
+		{
+			HostPath:      "sandbox:///test",
+			ContainerPath: "C:\\test",
+		},
+	}
+	// This test case is making sure that the sandbox mount doesn't show up in another container if not
+	// explicitly asked for. Make first container with the mount and another shortly after without.
+	container1Name := t.Name() + "-Container-" + "1"
+	container1Id := createContainerInSandbox(t, client, ctx, podID, container1Name, imageWindowsNanoserver, command, nil, mounts, sbRequest.Config)
+	defer removeContainer(t, client, ctx, container1Id)
+
+	startContainer(t, client, ctx, container1Id)
+	defer stopContainer(t, client, ctx, container1Id)
+
+	container2Name := t.Name() + "-Container-" + "2"
+	container2Id := createContainerInSandbox(t, client, ctx, podID, container2Name, imageWindowsNanoserver, command, nil, nil, sbRequest.Config)
+	defer removeContainer(t, client, ctx, container2Id)
+
+	startContainer(t, client, ctx, container2Id)
+	defer stopContainer(t, client, ctx, container2Id)
+
+	// Test that we can't see the file made in the first container in the second one.
+	execDir := []string{
+		"cmd",
+		"/c",
+		"dir",
+		"C:\\test\\",
+	}
+	output, _, exitCode := execContainer(t, client, ctx, container2Id, execDir)
+	if exitCode == 0 {
+		t.Fatalf("Found directory in second container when not expected: %s", output)
+	}
+}
+
 func Test_RunPodSandbox_CPUGroup(t *testing.T) {
 	testutilities.RequiresBuild(t, 20124)
 	ctx := context.Background()

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/hcsoci/hcsdoc_wcow.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/hcsoci/hcsdoc_wcow.go
@@ -75,6 +75,9 @@ func createMountsConfig(ctx context.Context, coi *createOptionsInternal) (*mount
 					return nil, err
 				}
 				mdv2.HostPath = uvmPath
+			} else if strings.HasPrefix(mount.Source, "sandbox://") {
+				// Convert to the path in the guest that was asked for.
+				mdv2.HostPath = convertToWCOWSandboxMountPath(mount.Source)
 			} else {
 				// vsmb mount
 				uvmPath, err := coi.HostingSystem.GetVSMBUvmPath(ctx, mount.Source, readOnly)


### PR DESCRIPTION
This change adds sandbox mount like support for WCOW. Sandboxmounts were our LCOW
solution similar to a k8s empty dir mount. We create a directory that will house
various other subdirectories that a user can specify by supplying a sandbox:// prefix
for the host path of a mount. In the usual case the hostpath of a mount is in the context of the
physical host (e.g. I want C:\path on my machine mapped to C:\containerpath in my container),
however for sandbox mounts the host path is treated as relative to this directory we have
made in the VM. The root directory for these sandbox mounts I defined as C:\SandboxMounts

Example:
```json
"mounts": [
    {
    "container_path": "C:\\test",
    "host_path": "sandbox:///test"
    }
]
```

The above will make a directory at C:\SandboxMounts\test in the Utility VM that will be mapped to
C:\test in the container. If another container in the same pod supplied the same mount then
you would end up "sharing" this directory with the other container, meaning you would
both see anything placed/modified in this directory.

The backing storage for these mounts will be the UVMs scratch disk, which currently is always 10GB
(8.5 actually usable) as that's what's hardcoded in HCS for the call we use that generates the vhd.
For some reason the expand vhd function from HCS doesn't function for the VM scratch disk which needs
some investigation :(

Signed-off-by: Daniel Canter <dcanter@microsoft.com>