### PR TITLE
tests: increase opengcs tests verbosity

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ clean:
 	rm -rf bin deps rootfs out
 
 test:
-	cd $(SRCROOT) && go test ./internal/guest/...
+	cd $(SRCROOT) && go test -v ./internal/guest/...
 
 out/delta.tar.gz: bin/init bin/vsockexec bin/cmd/gcs bin/cmd/gcstools Makefile
 	@mkdir -p out


### PR DESCRIPTION
currently opengcs unit tests are not verbose enough and it's hard
to tell which tests are actually run. Increase verbosisty by
adding -v flag

Signed-off-by: Maksim An <maksiman@microsoft.com>