### PR TITLE
Skip setting security policy when it's empty

### DIFF
--- a/internal/guest/runtime/hcsv2/uvm.go
+++ b/internal/guest/runtime/hcsv2/uvm.go
@@ -73,7 +73,7 @@ func NewHost(rtime runtime.Runtime, vsock transport.Transport) *Host {
 // so we first have to remove the base64 encoding that allows
 // the JSON based policy to be passed as a string. From there,
 // we decode the JSON and setup our security policy state
-func (h *Host) SetSecurityPolicy(base64_policy string) error {
+func (h *Host) SetSecurityPolicy(base64Policy string) error {
 	h.policyMutex.Lock()
 	defer h.policyMutex.Unlock()
 	if h.securityPolicyEnforcerSet {
@@ -84,16 +84,18 @@ func (h *Host) SetSecurityPolicy(base64_policy string) error {
 	// its base64 encoded because it is coming from an annotation
 	// annotations are a map of string to string
 	// we want to store a complex json object so.... base64 it is
-	jsonPolicy, err := base64.StdEncoding.DecodeString(base64_policy)
+	jsonPolicy, err := base64.StdEncoding.DecodeString(base64Policy)
 	if err != nil {
 		return errors.Wrap(err, "unable to decode policy from Base64 format")
 	}
 
 	// json unmarshall the decoded to a SecurityPolicy
-	securityPolicy := &securitypolicy.SecurityPolicy{}
-	json.Unmarshal(jsonPolicy, securityPolicy)
+	var securityPolicy securitypolicy.SecurityPolicy
+	if err := json.Unmarshal(jsonPolicy, &securityPolicy); err != nil {
+		return errors.Wrap(err, "unable to unmarshal policy")
+	}
 
-	p, err := securitypolicy.NewSecurityPolicyEnforcer(securityPolicy)
+	p, err := securitypolicy.NewSecurityPolicyEnforcer(&securityPolicy)
 	if err != nil {
 		return err
 	}

--- a/internal/uvm/security_policy.go
+++ b/internal/uvm/security_policy.go
@@ -24,6 +24,10 @@ func (uvm *UtilityVM) SetSecurityPolicy(ctx context.Context, policy string) erro
 		return errNotSupported
 	}
 
+	if policy == "" {
+		return nil
+	}
+
 	uvm.m.Lock()
 	defer uvm.m.Unlock()
 


### PR DESCRIPTION
Due to an error ignored when calling to json.Unmarshal the call
to SetSecurityPolicy with an empty or invalid string policy results
in a policy with no Containers and AllowAll set to false. No
container can be run as a result.

Fix the behavior by not sending modification request for SetSecurityPolicy
when policy string is empty (which is the default) and checking the
error result from json.Unmarshal call

Signed-off-by: Maksim An <maksiman@microsoft.com>