### PR TITLE
Add network stats to the enable getting stats directly 

### DIFF
--- a/hcn/hnsv1_test.go
+++ b/hcn/hnsv1_test.go
@@ -79,6 +79,39 @@ func TestEndpointGetAll(t *testing.T) {
 	}
 }
 
+func TestEndpointStatsAll(t *testing.T) {
+	network, err := CreateTestNetwork()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	Endpoint := &hcsshim.HNSEndpoint{
+		Name: NatTestEndpointName,
+	}
+
+	Endpoint, err = network.CreateEndpoint(Endpoint)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	epList, err := hcsshim.HNSListEndpointRequest()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, e := range epList {
+		_, err := hcsshim.GetHNSEndpointStats(e.Id)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	_, err = network.Delete()
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestNetworkGetAll(t *testing.T) {
 	_, err := hcsshim.HNSListNetworkRequest("GET", "", "")
 	if err != nil {

--- a/hnsendpoint.go
+++ b/hnsendpoint.go
@@ -7,6 +7,9 @@ import (
 // HNSEndpoint represents a network endpoint in HNS
 type HNSEndpoint = hns.HNSEndpoint
 
+// HNSEndpointStats represent the stats for an networkendpoint in HNS
+type HNSEndpointStats = hns.EndpointStats
+
 // Namespace represents a Compartment.
 type Namespace = hns.Namespace
 
@@ -107,4 +110,9 @@ func GetHNSEndpointByID(endpointID string) (*HNSEndpoint, error) {
 // GetHNSEndpointByName gets the endpoint filtered by Name
 func GetHNSEndpointByName(endpointName string) (*HNSEndpoint, error) {
 	return hns.GetHNSEndpointByName(endpointName)
+}
+
+// GetHNSEndpointStats gets the endpoint stats by ID
+func GetHNSEndpointStats(endpointName string) (*HNSEndpointStats, error) {
+	return hns.GetHNSEndpointStats(endpointName)
 }

--- a/internal/hns/hnsendpoint.go
+++ b/internal/hns/hnsendpoint.go
@@ -58,6 +58,18 @@ type EndpointResquestResponse struct {
 	Error   string
 }
 
+// EndpointStats is the object that has stats for a given endpoint
+type EndpointStats struct {
+	BytesReceived          uint64 `json:"BytesReceived"`
+	BytesSent              uint64 `json:"BytesSent"`
+	DroppedPacketsIncoming uint64 `json:"DroppedPacketsIncoming"`
+	DroppedPacketsOutgoing uint64 `json:"DroppedPacketsOutgoing"`
+	EndpointID             string `json:"EndpointId"`
+	InstanceID             string `json:"InstanceId"`
+	PacketsReceived        uint64 `json:"PacketsReceived"`
+	PacketsSent            uint64 `json:"PacketsSent"`
+}
+
 // HNSEndpointRequest makes a HNS call to modify/query a network endpoint
 func HNSEndpointRequest(method, path, request string) (*HNSEndpoint, error) {
 	endpoint := &HNSEndpoint{}
@@ -80,9 +92,25 @@ func HNSListEndpointRequest() ([]HNSEndpoint, error) {
 	return endpoint, nil
 }
 
+// hnsEndpointStatsRequest makes a HNS call to query the stats for a given endpoint ID
+func hnsEndpointStatsRequest(id string) (*EndpointStats, error) {
+	var stats EndpointStats
+	err := hnsCall("GET", "/endpointstats/"+id, "", &stats)
+	if err != nil {
+		return nil, err
+	}
+
+	return &stats, nil
+}
+
 // GetHNSEndpointByID get the Endpoint by ID
 func GetHNSEndpointByID(endpointID string) (*HNSEndpoint, error) {
 	return HNSEndpointRequest("GET", endpointID, "")
+}
+
+// GetHNSEndpointStats get the stats for a n Endpoint by ID
+func GetHNSEndpointStats(endpointID string) (*EndpointStats, error) {
+	return hnsEndpointStatsRequest(endpointID)
 }
 
 // GetHNSEndpointByName gets the endpoint filtered by Name

--- a/internal/hns/hnsendpoint.go
+++ b/internal/hns/hnsendpoint.go
@@ -31,6 +31,7 @@ type HNSEndpoint struct {
 	EnableLowMetric    bool              `json:",omitempty"`
 	Namespace          *Namespace        `json:",omitempty"`
 	EncapOverhead      uint16            `json:",omitempty"`
+	SharedContainers   []string          `json:",omitempty"`
 }
 
 //SystemType represents the type of the system on which actions are done


### PR DESCRIPTION
The metrics endpoint with containerd running doesn't return stats (https://github.com/kubernetes/kubernetes/issues/104286) and the dockershim component calls metrics twice  (https://github.com/kubernetes/kubernetes/issues/104285)

This PR enables the gathering the stats to enable the two scenarios.