### PR TITLE
Fix incorrect casing in error message

### DIFF
--- a/internal/guest/runtime/hcsv2/uvm.go
+++ b/internal/guest/runtime/hcsv2/uvm.go
@@ -86,7 +86,7 @@ func (h *Host) SetSecurityPolicy(base64_policy string) error {
 	// we want to store a complex json object so.... base64 it is
 	jsonPolicy, err := base64.StdEncoding.DecodeString(base64_policy)
 	if err != nil {
-		return errors.Wrap(err, "Unable to decode policy from Base64 format")
+		return errors.Wrap(err, "unable to decode policy from Base64 format")
 	}
 
 	// json unmarshall the decoded to a SecurityPolicy


### PR DESCRIPTION
I have a habit of capitalizing the first letter of error messages. We missed this one as part of the review for my PR that added the security policy functionality.