### PR TITLE
New approach for job container file system aspects

### DIFF
--- a/internal/jobcontainers/mounts.go
+++ b/internal/jobcontainers/mounts.go
@@ -54,3 +54,16 @@ func setupMounts(spec *specs.Spec, sandboxVolumePath string) error {
 
 	return nil
 }
+
+func (c *JobContainer) setupMounts(spec *specs.Spec) error {
+	for _, mount := range spec.Mounts {
+		if mount.Destination == "" || mount.Source == "" {
+			return fmt.Errorf("invalid OCI spec - a mount must have both source and a destination: %+v", mount)
+		}
+
+		if err := c.job.ApplyFileBinding(mount.Destination, mount.Source, false); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/jobcontainers/net.go
+++ b/internal/jobcontainers/net.go
@@ -1,0 +1,24 @@
+package jobcontainers
+
+import (
+	"github.com/Microsoft/hcsshim/hcn"
+	"github.com/pkg/errors"
+)
+
+func (c *JobContainer) netSetup(namespaceID string) error {
+	// Network setup. We expect that the network namespace has already been setup by a previous container and we simply set the
+	// job objects compartment to the one created.
+	ns, err := hcn.GetNamespaceByID(namespaceID)
+	if err != nil {
+		return errors.Wrap(err, "failed to grab network namespace for job container")
+	}
+
+	// If the ns is 0, then no other container has created the compartment (or we're asking for host networking). If it isn't that
+	// means that we have a compartment that we can attach to (which should have a virtual net adapter in it also).
+	if ns.NamespaceId != 0 {
+		if err := c.job.SetNetworkCompartment(ns.NamespaceId); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/jobcontainers/path.go
+++ b/internal/jobcontainers/path.go
@@ -3,7 +3,6 @@ package jobcontainers
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/Microsoft/hcsshim/internal/winapi"
@@ -74,7 +73,10 @@ func getApplicationName(commandLine, workingDirectory, pathEnv string) (string, 
 	)
 
 	// Clean the path, to get rid of any . elements
-	commandLine = filepath.Clean(commandLine)
+	// commandLine = filepath.Clean(commandLine)
+	if len(commandLine) >= 3 && commandLine[0:2] == "./" || commandLine[0:2] == ".\\" {
+		commandLine = commandLine[2:]
+	}
 
 	// First we get the system paths concatenated with semicolons (C:\windows;C:\windows\system32;C:\windows\system;)
 	// and use this as the basis for the directories to search for the application.

--- a/internal/jobcontainers/process.go
+++ b/internal/jobcontainers/process.go
@@ -92,21 +92,33 @@ func (p *JobProcess) Signal(ctx context.Context, options interface{}) (bool, err
 func (p *JobProcess) CloseStdin(ctx context.Context) error {
 	p.stdioLock.Lock()
 	defer p.stdioLock.Unlock()
-	return p.stdin.Close()
+
+	if p.stdin != nil {
+		return p.stdin.Close()
+	}
+	return nil
 }
 
 // CloseStdout closes the stdout pipe of the process.
 func (p *JobProcess) CloseStdout(ctx context.Context) error {
 	p.stdioLock.Lock()
 	defer p.stdioLock.Unlock()
-	return p.stdout.Close()
+
+	if p.stdout != nil {
+		return p.stdout.Close()
+	}
+	return nil
 }
 
 // CloseStderr closes the stderr pipe of the process.
 func (p *JobProcess) CloseStderr(ctx context.Context) error {
 	p.stdioLock.Lock()
 	defer p.stdioLock.Unlock()
-	return p.stderr.Close()
+
+	if p.stderr != nil {
+		return p.stderr.Close()
+	}
+	return nil
 }
 
 // Wait waits for the process to exit. If the process has already exited returns

--- a/internal/jobcontainers/storage.go
+++ b/internal/jobcontainers/storage.go
@@ -2,6 +2,7 @@ package jobcontainers
 
 import (
 	"context"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -12,26 +13,23 @@ import (
 	"github.com/pkg/errors"
 )
 
-// Trailing backslash required for SetVolumeMountPoint and DeleteVolumeMountPoint
-const sandboxMountFormat = `C:\C\%s\`
-
-func mountLayers(ctx context.Context, containerId string, s *specs.Spec, volumeMountPath string) error {
+func mountLayers(ctx context.Context, containerId string, s *specs.Spec) (string, error) {
 	if s == nil || s.Windows == nil || s.Windows.LayerFolders == nil {
-		return errors.New("field 'Spec.Windows.Layerfolders' is not populated")
+		return "", errors.New("field 'Spec.Windows.Layerfolders' is not populated")
 	}
 
 	// Last layer always contains the sandbox.vhdx, or 'scratch' space for the container.
 	scratchFolder := s.Windows.LayerFolders[len(s.Windows.LayerFolders)-1]
 	if _, err := os.Stat(scratchFolder); os.IsNotExist(err) {
 		if err := os.MkdirAll(scratchFolder, 0777); err != nil {
-			return errors.Wrapf(err, "failed to auto-create container scratch folder %s", scratchFolder)
+			return "", errors.Wrapf(err, "failed to auto-create container scratch folder %s", scratchFolder)
 		}
 	}
 
 	// Create sandbox.vhdx if it doesn't exist in the scratch folder.
 	if _, err := os.Stat(filepath.Join(scratchFolder, "sandbox.vhdx")); os.IsNotExist(err) {
 		if err := wclayer.CreateScratchLayer(ctx, scratchFolder, s.Windows.LayerFolders[:len(s.Windows.LayerFolders)-1]); err != nil {
-			return errors.Wrap(err, "failed to CreateSandboxLayer")
+			return "", errors.Wrap(err, "failed to CreateSandboxLayer")
 		}
 	}
 
@@ -39,13 +37,57 @@ func mountLayers(ctx context.Context, containerId string, s *specs.Spec, volumeM
 		s.Root = &specs.Root{}
 	}
 
-	if s.Root.Path == "" {
-		log.G(ctx).Debug("mounting job container storage")
-		containerRootPath, err := layers.MountContainerLayers(ctx, containerId, s.Windows.LayerFolders, "", volumeMountPath, nil)
-		if err != nil {
-			return errors.Wrap(err, "failed to mount container storage")
+	// Make a temp directory to mount the volume (for now). Can't figure out how to pass volume path to any of the
+	// go stdlib io methods. Might just have to call win32 calls directly (also need to figure this out :) ).
+	tempDir, err := ioutil.TempDir("", containerId)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to create a temp directory for job container volume")
+	}
+	// SetVolumeMountPoint requires a trailing slash.
+	tempDir += "\\"
+
+	log.G(ctx).Debug("mounting job container storage")
+	containerRootPath, err := layers.MountContainerLayers(ctx, containerId, s.Windows.LayerFolders, "", tempDir, nil)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to mount job container storage")
+	}
+	s.Root.Path = containerRootPath
+
+	return tempDir, nil
+}
+
+// setupBindings sets up the file system view for the container. This is done by using a filesystem minifilter that allows us to bind
+// a file system namespace to another location. The filter allows per silo bindings, so only the silo that you made the mapping for would be
+// viewable by processes in the silo. Processes on the host, or processes in another silo would not see anything bound for a specific silo.
+//
+// The steps we take are to loop through every top level file and directory in the image and then bind each one to the root of the C drive.
+// The files in the image are merged together with files on the host, and if any files conflict (same name) the files from the image will take precedence
+// and shadow the files on the host. As we're still using the same copy on write scratch volume based mechanism as we do for Windows Server Containers,
+// any files or directories that are from the container image and are unique (no directory with the same name on the host), we'll still get copy on write for
+// those files.
+//
+// For now, we skip binding the Windows directory (if there is one) as there's some wonky behavior with loading certain programs (powershell for one).
+// The Bind Filter is essentially analogous to a bind mount on Linux, and this is also how directory mounts are handled for Windows Server Containers as well.
+func (c *JobContainer) setupBindings(volumeMountPath string) error {
+	files, err := ioutil.ReadDir(volumeMountPath)
+	if err != nil {
+		return errors.Wrap(err, "failed to root of job containers volume")
+	}
+
+	for _, file := range files {
+		// Skip the Windows dir for now. Also skip the wcsandboxstate dir that is usually a hidden folder.
+		if file.Name() == "Windows" || file.Name() == "WcSandboxState" {
+			continue
 		}
-		s.Root.Path = containerRootPath
+		// This could also potentially be the entire C volume against the entire volume of the container image,
+		// but I'll need to see how exclusions work.
+		if err := c.job.ApplyFileBinding(
+			filepath.Join("C:\\", file.Name()),
+			filepath.Join(volumeMountPath, file.Name()),
+			true,
+		); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/internal/winapi/bindflt.go
+++ b/internal/winapi/bindflt.go
@@ -1,0 +1,18 @@
+package winapi
+
+const (
+	BINDFLT_FLAG_READ_ONLY_MAPPING        uint32 = 0x00000001
+	BINDFLT_FLAG_MERGED_BIND_MAPPING      uint32 = 0x00000002
+	BINDFLT_FLAG_USE_CURRENT_SILO_MAPPING uint32 = 0x00000004
+)
+
+// HRESULT
+// BfSetupFilter(
+// _In_opt_ HANDLE JobHandle,
+// _In_ ULONG Flags,
+// _In_ LPCWSTR VirtualizationRootPath,
+// _In_ LPCWSTR VirtualizationTargetPath,
+// _In_reads_opt_( VirtualizationExceptionPathCount ) LPCWSTR* VirtualizationExceptionPaths,
+// _In_opt_ ULONG VirtualizationExceptionPathCount
+// );
+//sys BfSetupFilter(jobHandle windows.Handle, flags uint32, virtRootPath *uint16, virtTargetPath *uint16, virtExceptions **uint16, virtExceptionPathCount uint32) (hr error) = bindflt.BfSetupFilter

--- a/internal/winapi/jobobject.go
+++ b/internal/winapi/jobobject.go
@@ -52,6 +52,7 @@ const (
 	JobObjectLimitViolationInformation       uint32 = 13
 	JobObjectMemoryUsageInformation          uint32 = 28
 	JobObjectNotificationLimitInformation2   uint32 = 33
+	JobObjectCreateSilo                      uint32 = 35
 	JobObjectIoAttribution                   uint32 = 42
 )
 
@@ -213,3 +214,13 @@ type JOBOBJECT_ASSOCIATE_COMPLETION_PORT struct {
 //     _In_opt_ POBJECT_ATTRIBUTES ObjectAttributes
 // );
 //sys NtCreateJobObject(jobHandle *windows.Handle, desiredAccess uint32, objAttributes *ObjectAttributes) (status uint32) = ntdll.NtCreateJobObject
+
+// NTSTATUS
+// NTAPI
+// NtSetInformationJobObject (
+//     __in HANDLE JobHandle,
+//     __in JOBOBJECTINFOCLASS JobObjectInformationClass,
+//     __in_bcount(JobObjectInformationLength) PVOID JobObjectInformation,
+//     __in ULONG JobObjectInformationLength
+// );
+//sys NtSetInformationJobObject(jobHandle windows.Handle, JobObjectInformationClass uint32, JobObjectInformation uintptr, JobObjectInformationLength uint32) (status uint32) = ntdll.NtSetInformationJobObject

--- a/internal/winapi/winapi.go
+++ b/internal/winapi/winapi.go
@@ -2,4 +2,4 @@
 // be thought of as an extension to golang.org/x/sys/windows.
 package winapi
 
-//go:generate go run ..\..\mksyscall_windows.go -output zsyscall_windows.go system.go net.go path.go thread.go iocp.go jobobject.go logon.go memory.go process.go processor.go devices.go filesystem.go errors.go
+//go:generate go run ..\..\mksyscall_windows.go -output zsyscall_windows.go bindflt.go system.go net.go path.go thread.go iocp.go jobobject.go logon.go memory.go process.go processor.go devices.go filesystem.go errors.go


### PR DESCRIPTION
This change reworks the way that the file system aspects function for job containers.
This is a pretty radical difference, and adds in some new Windows APIs to
accomplish the job.

The gist of things, is instead of mounting the wcifs volume containing the unioned
view of the containers layers on the host at a certain path, and then treating this
as the "C:\" of the container, we now bind the files from this volume on top of the hosts C drive.
This might sound odd, but it's possible for two reasons.

1. There is a file system minifilter in Windows that allows you to bind a filesystem
namespace to another path, so you see whatever was at the first path at the second,
akin to a bind mount on Linux.
2. This filter allows you to create these bindings at a per silo level. So only
processes in that silo will see these bindings. The binding will appear to be a unique
file system layout in each.

Before this change, the containers were just comprised of regular job objects so
we need to first upgrade the job to a silo, and then we start employing these bindings.
This change (irrelevant to the filesystem aspects but just for testing to try out something 
different) now joins a network compartment if available, so it should only have access to 
a virtual adapter.

* Add bindings for the Bind Filter from bindfltapi.dll
* Define a silo flag to be able to upgrade the containers job object to a silo
* Rework the pod sandbox container for job containers. Previously we faked out
the pod sandbox container, as an optimization. But if we launch a normal Windows
Server Container as the pod sandbox always, then we can take advantage of the
network compartment that will be created, so we don't always have to use the
hosts network.
* Rework directory mounts for job containers to also make use of the Bind Filter.

Signed-off-by: Daniel Canter <dcanter@microsoft.com>