### PR TITLE
Support for Kernel Boot Options - LCOW

### DIFF
--- a/internal/oci/annotations.go
+++ b/internal/oci/annotations.go
@@ -166,6 +166,9 @@ const (
 	// AnnotationVPMemNoMultiMapping indicates that we should disable LCOW vpmem layer multi mapping
 	AnnotationVPMemNoMultiMapping = "io.microsoft.virtualmachine.lcow.vpmem.nomultimapping"
 
+	// AnnotationKernelBootOptions is used to specify kernel options used while booting a linux kernel
+	AnnotationKernelBootOptions = "io.microsoft.virtualmachine.lcow.kernelbootoptions"
+
 	// AnnotationStorageQoSBandwidthMaximum indicates the maximum number of bytes per second. If `0`
 	// will default to the platform default.
 	AnnotationStorageQoSBandwidthMaximum = "io.microsoft.virtualmachine.storageqos.bandwidthmaximum"

--- a/internal/oci/uvm.go
+++ b/internal/oci/uvm.go
@@ -330,6 +330,7 @@ func SpecToUVMCreateOpts(ctx context.Context, s *specs.Spec, id, owner string) (
 		lopts.CPUGroupID = parseAnnotationsString(s.Annotations, AnnotationCPUGroupID, lopts.CPUGroupID)
 		lopts.NetworkConfigProxy = parseAnnotationsString(s.Annotations, AnnotationNetworkConfigProxy, lopts.NetworkConfigProxy)
 		lopts.SecurityPolicy = parseAnnotationsString(s.Annotations, AnnotationSecurityPolicy, lopts.SecurityPolicy)
+		lopts.KernelBootOptions = parseAnnotationsString(s.Annotations, AnnotationKernelBootOptions, lopts.KernelBootOptions)
 
 		handleAnnotationPreferredRootFSType(ctx, s.Annotations, lopts)
 		handleAnnotationKernelDirectBoot(ctx, s.Annotations, lopts)

--- a/internal/uvm/create_lcow.go
+++ b/internal/uvm/create_lcow.go
@@ -355,6 +355,7 @@ func CreateLCOW(ctx context.Context, opts *OptionsLCOW) (_ *UtilityVM, err error
 		kernelArgs += " panic=-1 quiet"
 	}
 
+	// Add Kernel Boot options
 	if opts.KernelBootOptions != "" {
 		kernelArgs += " " + opts.KernelBootOptions
 	}

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/oci/annotations.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/oci/annotations.go
@@ -166,6 +166,9 @@ const (
 	// AnnotationVPMemNoMultiMapping indicates that we should disable LCOW vpmem layer multi mapping
 	AnnotationVPMemNoMultiMapping = "io.microsoft.virtualmachine.lcow.vpmem.nomultimapping"
 
+	// AnnotationKernelBootOptions is used to specify kernel options used while booting a linux kernerl
+	AnnotationKernelBootOptions = "io.microsoft.virtualmachine.lcow.kernelbootoptions"
+
 	// AnnotationStorageQoSBandwidthMaximum indicates the maximum number of bytes per second. If `0`
 	// will default to the platform default.
 	AnnotationStorageQoSBandwidthMaximum = "io.microsoft.virtualmachine.storageqos.bandwidthmaximum"

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/oci/uvm.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/oci/uvm.go
@@ -330,6 +330,7 @@ func SpecToUVMCreateOpts(ctx context.Context, s *specs.Spec, id, owner string) (
 		lopts.CPUGroupID = parseAnnotationsString(s.Annotations, AnnotationCPUGroupID, lopts.CPUGroupID)
 		lopts.NetworkConfigProxy = parseAnnotationsString(s.Annotations, AnnotationNetworkConfigProxy, lopts.NetworkConfigProxy)
 		lopts.SecurityPolicy = parseAnnotationsString(s.Annotations, AnnotationSecurityPolicy, lopts.SecurityPolicy)
+		lopts.KernelBootOptions = parseAnnotationsString(s.Annotations, AnnotationKernelBootOptions, lopts.KernelBootOptions)
 
 		handleAnnotationPreferredRootFSType(ctx, s.Annotations, lopts)
 		handleAnnotationKernelDirectBoot(ctx, s.Annotations, lopts)

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/uvm/create_lcow.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/uvm/create_lcow.go
@@ -355,6 +355,7 @@ func CreateLCOW(ctx context.Context, opts *OptionsLCOW) (_ *UtilityVM, err error
 		kernelArgs += " panic=-1 quiet"
 	}
 
+	// Add Kernel Boot options
 	if opts.KernelBootOptions != "" {
 		kernelArgs += " " + opts.KernelBootOptions
 	}

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/uvm/security_policy.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/uvm/security_policy.go
@@ -24,6 +24,10 @@ func (uvm *UtilityVM) SetSecurityPolicy(ctx context.Context, policy string) erro
 		return errNotSupported
 	}
 
+	if policy == "" {
+		return nil
+	}
+
 	uvm.m.Lock()
 	defer uvm.m.Unlock()
 


### PR DESCRIPTION
Description:
=======
A new annotation "io.microsoft.virtualmachine.lcow.kernelbootoptions" support has been added, which lets one pass kernel boot options.

This will be used for an upcoming change to provide support for hugepages.

A sample usage:
==========
"io.microsoft.virtualmachine.lcow.kernelbootoptions" : "hugepagesz=2M hugepages=1024"

Behavior:
=====
Invalid options are ignored.

Verification:
=======
Pod comes up successfully with ""io.microsoft.virtualmachine.lcow.kernelbootoptions" : "hugepagesz=2M hugepages=1024"" setting.

Signed-off-by: vivekagg@microsoft.com