### PR TITLE
Add ci step to validate that modules have been vendored in

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,25 @@ jobs:
         with:
           version: v1.38.0
           args: --timeout=5m
+  verify-vendor:
+    runs-on: 'windows-2019'
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '^1.15.0'
+      - name: Validate main modules
+        shell: powershell
+        run: |
+          $currentPath = (Get-Location).Path
+          $process = Start-Process powershell.exe -PassThru -Verb runAs -Wait -ArgumentList $currentPath/scripts/Verify-GoModules.ps1, $currentPath
+          exit $process.ExitCode
+      - name: Validate test modules
+        shell: powershell
+        run: |
+          $currentPath = (Get-Location).Path
+          $process = Start-Process powershell.exe -PassThru -Verb runAs -Wait -ArgumentList $currentPath/scripts/Verify-GoModules.ps1, $currentPath, "test"
+          exit $process.ExitCode
 
   test:
     runs-on: 'windows-2019'

--- a/scripts/Verify-GoModules.ps1
+++ b/scripts/Verify-GoModules.ps1
@@ -1,0 +1,63 @@
+function newTemporaryDirectory {
+    $parent = [System.IO.Path]::GetTempPath()
+    [string] $name = [System.Guid]::NewGuid()
+    New-Item -ItemType Directory -Path (Join-Path $parent $name)
+}
+
+function updateVendor {
+    param (
+        [string]$path
+    )
+    $currentPath = (Get-Location).Path
+    Set-Location $path
+    go mod vendor
+    go mod tidy 
+    Set-Location $currentPath
+}
+
+function matchingHashes {
+    param (
+        [string]$rootPath,
+        [string]$tempPath
+    )
+    $rootHashes = Get-ChildItem -Recurse -Path $rootPath | foreach  {Get-FileHash -Path $_.FullName -Algorithm SHA256}
+    if (-not $?) {
+        return $false
+    }
+    $tempHashes = Get-ChildItem -Recurse -Path $tempPath | foreach  {Get-FileHash -Path $_.FullName -Algorithm SHA256}
+    if (-not $?) {
+        return $false
+    }
+    $diff = Compare-Object -ReferenceObject $rootHashes.Hash -DifferenceObject $tempHashes.Hash
+    if ($diff.Count -eq 0) {
+        return $true
+    }
+    return $false
+}
+
+$rootPath = $args[0]
+$subdir = $args[1]
+
+$tempDir = newTemporaryDirectory
+Copy-Item -Path $rootPath/* -Destination $tempDir -Recurse
+if (-not $?) {
+    Remove-Item $tempDir -Recurse
+    exit 1
+}
+
+updateVendor $tempDir/$subdir
+if (-not $?) {
+    Remove-Item $tempDir -Recurse
+    exit 1
+}
+
+$hashesMatch = matchingHashes $rootPath/$subdir/vendor $tempDir/$subdir/vendor
+if (-not $?) {
+    Remove-Item $tempDir -Recurse
+    exit 1
+}
+
+Remove-Item $tempDir -Recurse
+if ($hashesMatch -ne $true) {
+    exit 1
+}

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/uvm/security_policy.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/uvm/security_policy.go
@@ -24,6 +24,10 @@ func (uvm *UtilityVM) SetSecurityPolicy(ctx context.Context, policy string) erro
 		return errNotSupported
 	}
 
+	if policy == "" {
+		return nil
+	}
+
 	uvm.m.Lock()
 	defer uvm.m.Unlock()
 


### PR DESCRIPTION
This PR adds a new script `Verify-GoModules.ps1` that copies the contents of the repo into a temporary location and runs `go mod vendor` and `go mod tidy` in that temporary location. The file hashes of the vendor directories in the temporary location and in the repo's location are compared to determine difference. 

The script needs to be run as admin due to requirements of `Get-FileHash`. As a result, we cannot easily get the error messages from the script. 

Signed-off-by: Kathryn Baldauf <kabaldau@microsoft.com>