### PR TITLE
Job container path touchups + rework tests

### DIFF
--- a/internal/jobcontainers/jobcontainer.go
+++ b/internal/jobcontainers/jobcontainer.go
@@ -577,6 +577,6 @@ func systemProcessInformation() ([]*winapi.SYSTEM_PROCESS_INFORMATION, error) {
 
 // Takes a string and replaces any occurences of CONTAINER_SANDBOX_MOUNT_POINT with where the containers volume is mounted.
 func (c *JobContainer) replaceWithMountPoint(str string) string {
-	str = strings.ReplaceAll(str, "%"+sandboxMountPointEnvVar+"%", c.sandboxMount)
-	return strings.ReplaceAll(str, "$env:"+sandboxMountPointEnvVar, c.sandboxMount)
+	str = strings.ReplaceAll(str, "%"+sandboxMountPointEnvVar+"%", c.sandboxMount[:len(c.sandboxMount)-1])
+	return strings.ReplaceAll(str, "$env:"+sandboxMountPointEnvVar, c.sandboxMount[:len(c.sandboxMount)-1])
 }

--- a/internal/jobcontainers/path.go
+++ b/internal/jobcontainers/path.go
@@ -3,7 +3,6 @@ package jobcontainers
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/Microsoft/hcsshim/internal/winapi"
@@ -16,7 +15,7 @@ import (
 
 // getApplicationName resolves a given command line string and returns the path to the executable that should be launched, and
 // an adjusted commandline if needed. The resolution logic may appear overcomplicated but is designed to match the logic used by
-// standard Windows containers, as well as that used by CreateProcess (see notes for the lpApplicationName parameter).
+// Windows Server containers, as well as that used by CreateProcess (see notes for the lpApplicationName parameter).
 //
 // The logic follows this set of steps:
 // - Construct a list of searchable paths to find the application. This includes the standard Windows system paths
@@ -72,9 +71,6 @@ func getApplicationName(commandLine, workingDirectory, pathEnv string) (string, 
 		searchPath string
 		result     string
 	)
-
-	// Clean the path, to get rid of any . elements
-	commandLine = filepath.Clean(commandLine)
 
 	// First we get the system paths concatenated with semicolons (C:\windows;C:\windows\system32;C:\windows\system;)
 	// and use this as the basis for the directories to search for the application.
@@ -156,7 +152,7 @@ func getApplicationName(commandLine, workingDirectory, pathEnv string) (string, 
 	if quoteCmdLine {
 		trialName = "\"" + trialName + "\""
 		trialName += " " + strings.Join(args[argsIndex+1:], " ")
-		adjustedCommandLine = trialName
+		adjustedCommandLine = strings.TrimSpace(trialName) // Take off trailing space at beginning and end.
 	}
 
 	return result, adjustedCommandLine, nil


### PR DESCRIPTION
This change does a couple of things for the path resolution logic and tests. 

1. I was using `filepath.Clean` to remove any initial '.' paths in the command line. However it changes all forward slashes to backslashes, which hinders command lines like the following:

`"cmd /c ping 127.0.0.1"`

as the /c argument will be altered. Windows Server containers don't handle relative paths with a dot, so it doesn't seem necessary to support them for job containers either, so just get rid of the call entirely.

2. Remove empty spaces off the end of the cmdline if it's quoted. There was an empty space in this case as I was using strings.Join to join the arguments after the quoted element. This had no effects on actual usage/functionality, but to compare command lines for tests, this made things easier.

3. When replacing instances of %CONTAINER_SANDBOX_MOUNT_POINT% in the commandline, the path of the volume we were replacing it with had a trailing forward slash, so you'd end up with C:\C\12345678abcdefg\\\mybinary.exe (two forward slashes). This also didn't have much of an effect on anything, but just to clean things up.  

4. Lastly, this change also refactors the job container path tests as they were a bit unwieldy and were due for the t.Run treatment. This moves the tests to being run via t.Run and a slice of configs to test different path, working directory, env matrixes. Also adds some new test cases to try out.

Signed-off-by: Daniel Canter <dcanter@microsoft.com>