### PR TITLE
Hugepage support for LCOW

### DIFF
--- a/internal/guest/runtime/hcsv2/container.go
+++ b/internal/guest/runtime/hcsv2/container.go
@@ -125,6 +125,11 @@ func (c *Container) Delete(ctx context.Context) error {
 		if err := storage.UnmountAllInPath(ctx, getSandboxMountsDir(c.id), true); err != nil {
 			log.G(ctx).WithError(err).Error("failed to unmount sandbox mounts")
 		}
+
+		// remove hugepages mounts in sandbox container
+		if err := storage.UnmountAllInPath(ctx, getSandboxHugePageMountsDir(c.id), true); err != nil {
+			log.G(ctx).WithError(err).Error("failed to unmount hugepages mounts")
+		}
 	}
 	return c.container.Delete()
 }

--- a/internal/guest/runtime/hcsv2/sandbox_container.go
+++ b/internal/guest/runtime/hcsv2/sandbox_container.go
@@ -20,6 +20,10 @@ func getSandboxRootDir(id string) string {
 	return filepath.Join("/run/gcs/c", id)
 }
 
+func getSandboxHugePageMountsDir(id string) string {
+	return filepath.Join(getSandboxRootDir(id), "hugepages")
+}
+
 func getSandboxMountsDir(id string) string {
 	return filepath.Join(getSandboxRootDir(id), "sandboxMounts")
 }

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/hcsoci/resources_lcow.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/hcsoci/resources_lcow.go
@@ -116,9 +116,10 @@ func allocateLinuxResources(ctx context.Context, coi *createOptionsInternal, r *
 				uvmPathForFile = scsiMount.UVMPath
 				r.Add(scsiMount)
 				coi.Spec.Mounts[i].Type = "none"
-			} else if strings.HasPrefix(mount.Source, "sandbox://") {
+			} else if strings.HasPrefix(mount.Source, "sandbox://") || strings.HasPrefix(mount.Source, "hugepages://") {
 				// Mounts that map to a path in UVM are specified with 'sandbox://' prefix.
 				// example: sandbox:///a/dirInUvm destination:/b/dirInContainer
+				// Hugepages inside a container are backed by a mount created inside a UVM.
 				uvmPathForFile = mount.Source
 			} else {
 				st, err := os.Stat(hostPath)


### PR DESCRIPTION
This adds hugepages support for LCOW. 

A hugetlbfs drive can be mounted inside a LCOW. This is backed by a location in UVM. Currently, linux kernel shipped with containerd only supports hugepage size of 2M.

In order to specify a container path is a hugepage mount, hostpath needs to be specified as hugepages://2M. 

In order for container to use hugepage successfully, it is expected UVM will be created appropriate KernelOptions annotation.

_"io.microsoft.virtualmachine.lcow.kernelbootoptions" : "hugepagesz=2M hugepages=10"_

UVM also has to be created with sufficient memory to host desired number of hugepages.

Ex: 
 _"io.microsoft.virtualmachine.computetopology.memory.sizeinmb": "2048",
 "io.microsoft.virtualmachine.lcow.kernelbootoptions" : "hugepagesz=2M hugepages=10"_

In order to realize the performance of using hugepages inside the LCOW, memory backing the UVM has to ensured to use an approriate page size. The default page for physical memory backed UVM is 2MB. Hence, to ensure performance with using hugepage of size MB, UVM should be physcial memory backed.

_"io.microsoft.virtualmachine.fullyphysicallybacked": "true"_

Verification: Adhoc testing using updated containerd binaries/linux kernel /container image with a test app that tries to huge page.
Newly added functional test also passes.