### PR TITLE
Time synchronization inside LCOW UVM

### DIFF
--- a/cmd/gcs/main.go
+++ b/cmd/gcs/main.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/Microsoft/hcsshim/internal/guest/bridge"
+	"github.com/Microsoft/hcsshim/internal/guest/commonutils"
 	"github.com/Microsoft/hcsshim/internal/guest/kmsg"
 	"github.com/Microsoft/hcsshim/internal/guest/runtime/hcsv2"
 	"github.com/Microsoft/hcsshim/internal/guest/runtime/runc"
@@ -248,6 +249,12 @@ func main() {
 	oomFile := os.NewFile(oom, "cefd")
 	defer oomFile.Close()
 
+	// time synchronization service
+	err = commonutils.StartTimeSyncService()
+	if err != nil {
+		logrus.WithError(err).Fatal("failed to start time synchronization service")
+	}
+
 	go readMemoryEvents(startTime, gefdFile, "/gcs", int64(*gcsMemLimitBytes), gcsControl)
 	go readMemoryEvents(startTime, oomFile, "/containers", containersLimit, containersControl)
 	err = b.ListenAndServe(bridgeIn, bridgeOut)
@@ -256,4 +263,5 @@ func main() {
 			logrus.ErrorKey: err,
 		}).Fatal("failed to serve gcs service")
 	}
+
 }

--- a/cmd/gcs/main.go
+++ b/cmd/gcs/main.go
@@ -93,6 +93,7 @@ func main() {
 	v4 := flag.Bool("v4", false, "enable the v4 protocol support and v2 schema")
 	rootMemReserveBytes := flag.Uint64("root-mem-reserve-bytes", 75*1024*1024, "the amount of memory reserved for the orchestration, the rest will be assigned to containers")
 	gcsMemLimitBytes := flag.Uint64("gcs-mem-limit-bytes", 50*1024*1024, "the maximum amount of memory the gcs can use")
+	disableTimeSync := flag.Bool("disableTimeSync", false, "If true do not run chronyd time synchronization service inside the UVM")
 
 	flag.Usage = func() {
 		fmt.Fprintf(os.Stderr, "\nUsage of %s:\n", os.Args[0])
@@ -250,9 +251,11 @@ func main() {
 	defer oomFile.Close()
 
 	// time synchronization service
-	err = commonutils.StartTimeSyncService()
-	if err != nil {
-		logrus.WithError(err).Fatal("failed to start time synchronization service")
+	if !(*disableTimeSync) {
+		err = commonutils.StartTimeSyncService()
+		if err != nil {
+			logrus.WithError(err).Fatal("failed to start time synchronization service")
+		}
 	}
 
 	go readMemoryEvents(startTime, gefdFile, "/gcs", int64(*gcsMemLimitBytes), gcsControl)

--- a/cmd/gcs/main.go
+++ b/cmd/gcs/main.go
@@ -137,7 +137,7 @@ func startTimeSyncService() error {
 	for _, ptpDirPath = range ptpDirList {
 		clockNameFilePath := filepath.Join(ptpClassDir.Name(), ptpDirPath, "clock_name")
 		clockNameFile, err := os.Open(clockNameFilePath)
-		if err != nil {
+		if err != nil && !os.IsNotExist(err) {
 			return errors.Wrapf(err, "failed to open clock name file at %s", clockNameFilePath)
 		}
 		defer clockNameFile.Close()

--- a/cmd/gcs/main.go
+++ b/cmd/gcs/main.go
@@ -95,8 +95,7 @@ func runWithRestartMonitor(arg0 string, args ...string) {
 	backoffSettings.MaxElapsedTime = time.Minute * 10
 	for {
 		command := exec.Command(arg0, args...)
-		err := command.Run()
-		if err != nil {
+		if err := command.Run(); err != nil {
 			logrus.WithFields(logrus.Fields{
 				"error":   err,
 				"command": command.Args,

--- a/cmd/gcs/main.go
+++ b/cmd/gcs/main.go
@@ -162,8 +162,8 @@ func StartTimeSyncService() error {
 
 	// create chronyd config file
 	ptpDevPath := filepath.Join("/dev", filepath.Base(ptpDirPath))
-	chronydConfigString := fmt.Sprintf("refclock PHC %s poll 3 dpoll -2 offset 0\n", ptpDevPath)
-
+	// chronyd config file take from: https://docs.microsoft.com/en-us/azure/virtual-machines/linux/time-sync
+	chronydConfigString := fmt.Sprintf("refclock PHC %s poll 3 dpoll -2 offset 0 stratum 2\nmakestep 0.1 -1\n", ptpDevPath)
 	chronydConfPath := "/tmp/chronyd.conf"
 	err = ioutil.WriteFile(chronydConfPath, []byte(chronydConfigString), 0644)
 	if err != nil {
@@ -173,7 +173,7 @@ func StartTimeSyncService() error {
 	// start chronyd. Do NOT start chronyd as daemon because creating a daemon
 	// involves double forking the restart monitor will attempt to restart chornyd
 	// after the first fork child exits.
-	go runWithRestartMonitor("chronyd", "-d", "-f", chronydConfPath)
+	go runWithRestartMonitor("chronyd", "-n", "-f", chronydConfPath)
 	return nil
 }
 

--- a/internal/guest/commonutils/utilities.go
+++ b/internal/guest/commonutils/utilities.go
@@ -1,10 +1,19 @@
 package commonutils
 
 import (
+	"bufio"
 	"encoding/json"
+	"fmt"
 	"io"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
 
 	"github.com/Microsoft/hcsshim/internal/guest/gcserr"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 )
 
 // UnmarshalJSONWithHresult unmarshals the given data into the given interface, and
@@ -22,5 +31,76 @@ func DecodeJSONWithHresult(r io.Reader, v interface{}) error {
 	if err := json.NewDecoder(r).Decode(v); err != nil {
 		return gcserr.WrapHresult(err, gcserr.HrVmcomputeInvalidJSON)
 	}
+	return nil
+}
+
+// StartTimeSyncService starts the `chronyd` deamon to keep the UVM time synchronized.  We
+// use a PTP device provided by the hypervisor as a source of correct time (instead of
+// using a network server). We need to create a configuration file that configures chronyd
+// to use the PTP device.  The system can have multiple PTP devices so we identify the
+// correct PTP device by verifying that the `clock_name` of that device is `hyperv`.
+func StartTimeSyncService() error {
+	ptpClassDir, err := os.Open("/sys/class/ptp")
+	if err != nil {
+		return errors.Wrap(err, "failed to open PTP class directory")
+	}
+
+	ptpDirList, err := ptpClassDir.Readdirnames(-1)
+	if err != nil {
+		return errors.Wrap(err, "failed to list PTP class directory")
+	}
+
+	var ptpDirPath string
+	found := false
+	for _, ptpDirPath = range ptpDirList {
+		clockNameFilePath := filepath.Join(ptpClassDir.Name(), ptpDirPath, "clock_name")
+		clockNameFile, err := os.Open(clockNameFilePath)
+		if err != nil {
+			return errors.Wrapf(err, "failed to open clock name file at %s", clockNameFilePath)
+		}
+		// Expected clock name is `hyperv` so read first 6 chars and verify the
+		// name
+		expectedReadLen := len("hyperv")
+		buf := make([]byte, expectedReadLen)
+		fileReader := bufio.NewReader(clockNameFile)
+		nread, err := fileReader.Read(buf)
+		if err != nil {
+			return errors.Wrapf(err, "read file %s failed", clockNameFilePath)
+		} else if nread != expectedReadLen {
+			return errors.Wrapf(err, "read file %s returned %d bytes, expected %d", clockNameFilePath, nread, expectedReadLen)
+		}
+		clockName := string(buf)
+		if strings.EqualFold(clockName, "hyperv") {
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		return errors.Errorf("no PTP device found with name \"hyperv\"")
+	}
+
+	// create chronyd config file
+	ptpDevPath := filepath.Join("/dev", filepath.Base(ptpDirPath))
+	chronydConfigString := fmt.Sprintf("refclock PHC %s poll 3 dpoll -2 offset 0\n", ptpDevPath)
+
+	chronydConfPath := "/tmp/chronyd.conf"
+	err = ioutil.WriteFile(chronydConfPath, []byte(chronydConfigString), 0644)
+	if err != nil {
+		return errors.Wrapf(err, "failed to create chronyd conf file %s", chronydConfPath)
+	}
+
+	// start chronyd
+	chronydCmd := exec.Command("chronyd", "-f", chronydConfPath)
+	err = chronydCmd.Start()
+	if err != nil {
+		return errors.Wrap(err, "start chronyd command failed")
+	}
+	go func() {
+		waitErr := chronydCmd.Wait()
+		if waitErr != nil {
+			logrus.WithError(waitErr).Warn("chronyd command exited with error")
+		}
+	}()
 	return nil
 }

--- a/internal/guest/commonutils/utilities.go
+++ b/internal/guest/commonutils/utilities.go
@@ -52,6 +52,7 @@ func StartTimeSyncService() error {
 
 	var ptpDirPath string
 	found := false
+	expectedClockName := "hyperv"
 	for _, ptpDirPath = range ptpDirList {
 		clockNameFilePath := filepath.Join(ptpClassDir.Name(), ptpDirPath, "clock_name")
 		clockNameFile, err := os.Open(clockNameFilePath)
@@ -60,24 +61,21 @@ func StartTimeSyncService() error {
 		}
 		// Expected clock name is `hyperv` so read first 6 chars and verify the
 		// name
-		expectedReadLen := len("hyperv")
-		buf := make([]byte, expectedReadLen)
+		buf := make([]byte, len(expectedClockName))
 		fileReader := bufio.NewReader(clockNameFile)
-		nread, err := fileReader.Read(buf)
+		_, err = fileReader.Read(buf)
 		if err != nil {
 			return errors.Wrapf(err, "read file %s failed", clockNameFilePath)
-		} else if nread != expectedReadLen {
-			return errors.Wrapf(err, "read file %s returned %d bytes, expected %d", clockNameFilePath, nread, expectedReadLen)
 		}
 		clockName := string(buf)
-		if strings.EqualFold(clockName, "hyperv") {
+		if strings.EqualFold(clockName, expectedClockName) {
 			found = true
 			break
 		}
 	}
 
 	if !found {
-		return errors.Errorf("no PTP device found with name \"hyperv\"")
+		return errors.Errorf("no PTP device found with name \"%s\"", expectedClockName)
 	}
 
 	// create chronyd config file

--- a/internal/guest/commonutils/utilities.go
+++ b/internal/guest/commonutils/utilities.go
@@ -1,19 +1,10 @@
 package commonutils
 
 import (
-	"bufio"
 	"encoding/json"
-	"fmt"
 	"io"
-	"io/ioutil"
-	"os"
-	"os/exec"
-	"path/filepath"
-	"strings"
 
 	"github.com/Microsoft/hcsshim/internal/guest/gcserr"
-	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 )
 
 // UnmarshalJSONWithHresult unmarshals the given data into the given interface, and
@@ -31,74 +22,5 @@ func DecodeJSONWithHresult(r io.Reader, v interface{}) error {
 	if err := json.NewDecoder(r).Decode(v); err != nil {
 		return gcserr.WrapHresult(err, gcserr.HrVmcomputeInvalidJSON)
 	}
-	return nil
-}
-
-// StartTimeSyncService starts the `chronyd` deamon to keep the UVM time synchronized.  We
-// use a PTP device provided by the hypervisor as a source of correct time (instead of
-// using a network server). We need to create a configuration file that configures chronyd
-// to use the PTP device.  The system can have multiple PTP devices so we identify the
-// correct PTP device by verifying that the `clock_name` of that device is `hyperv`.
-func StartTimeSyncService() error {
-	ptpClassDir, err := os.Open("/sys/class/ptp")
-	if err != nil {
-		return errors.Wrap(err, "failed to open PTP class directory")
-	}
-
-	ptpDirList, err := ptpClassDir.Readdirnames(-1)
-	if err != nil {
-		return errors.Wrap(err, "failed to list PTP class directory")
-	}
-
-	var ptpDirPath string
-	found := false
-	expectedClockName := "hyperv"
-	for _, ptpDirPath = range ptpDirList {
-		clockNameFilePath := filepath.Join(ptpClassDir.Name(), ptpDirPath, "clock_name")
-		clockNameFile, err := os.Open(clockNameFilePath)
-		if err != nil {
-			return errors.Wrapf(err, "failed to open clock name file at %s", clockNameFilePath)
-		}
-		// Expected clock name is `hyperv` so read first 6 chars and verify the
-		// name
-		buf := make([]byte, len(expectedClockName))
-		fileReader := bufio.NewReader(clockNameFile)
-		_, err = fileReader.Read(buf)
-		if err != nil {
-			return errors.Wrapf(err, "read file %s failed", clockNameFilePath)
-		}
-		clockName := string(buf)
-		if strings.EqualFold(clockName, expectedClockName) {
-			found = true
-			break
-		}
-	}
-
-	if !found {
-		return errors.Errorf("no PTP device found with name \"%s\"", expectedClockName)
-	}
-
-	// create chronyd config file
-	ptpDevPath := filepath.Join("/dev", filepath.Base(ptpDirPath))
-	chronydConfigString := fmt.Sprintf("refclock PHC %s poll 3 dpoll -2 offset 0\n", ptpDevPath)
-
-	chronydConfPath := "/tmp/chronyd.conf"
-	err = ioutil.WriteFile(chronydConfPath, []byte(chronydConfigString), 0644)
-	if err != nil {
-		return errors.Wrapf(err, "failed to create chronyd conf file %s", chronydConfPath)
-	}
-
-	// start chronyd
-	chronydCmd := exec.Command("chronyd", "-f", chronydConfPath)
-	err = chronydCmd.Start()
-	if err != nil {
-		return errors.Wrap(err, "start chronyd command failed")
-	}
-	go func() {
-		waitErr := chronydCmd.Wait()
-		if waitErr != nil {
-			logrus.WithError(waitErr).Warn("chronyd command exited with error")
-		}
-	}()
 	return nil
 }

--- a/internal/oci/uvm.go
+++ b/internal/oci/uvm.go
@@ -358,7 +358,7 @@ func SpecToUVMCreateOpts(ctx context.Context, s *specs.Spec, id, owner string) (
 		lopts.SecurityPolicy = parseAnnotationsString(s.Annotations, annotations.SecurityPolicy, lopts.SecurityPolicy)
 		lopts.KernelBootOptions = parseAnnotationsString(s.Annotations, annotations.KernelBootOptions, lopts.KernelBootOptions)
 		lopts.ProcessDumpLocation = parseAnnotationsString(s.Annotations, annotations.ContainerProcessDumpLocation, lopts.ProcessDumpLocation)
-		lopts.DisableTimeSyncService = parseAnnotationsBool(s.Annotations, annotations.DisableLCOWTimeSyncService, lopts.DisableTimeSyncService)
+		lopts.DisableTimeSyncService = parseAnnotationsBool(ctx, s.Annotations, annotations.DisableLCOWTimeSyncService, lopts.DisableTimeSyncService)
 		handleAnnotationPreferredRootFSType(ctx, s.Annotations, lopts)
 		handleAnnotationKernelDirectBoot(ctx, s.Annotations, lopts)
 

--- a/internal/oci/uvm.go
+++ b/internal/oci/uvm.go
@@ -358,6 +358,7 @@ func SpecToUVMCreateOpts(ctx context.Context, s *specs.Spec, id, owner string) (
 		lopts.SecurityPolicy = parseAnnotationsString(s.Annotations, annotations.SecurityPolicy, lopts.SecurityPolicy)
 		lopts.KernelBootOptions = parseAnnotationsString(s.Annotations, annotations.KernelBootOptions, lopts.KernelBootOptions)
 		lopts.ProcessDumpLocation = parseAnnotationsString(s.Annotations, annotations.ContainerProcessDumpLocation, lopts.ProcessDumpLocation)
+		lopts.DisableTimeSyncService = parseAnnotationsBool(s.Annotations, annotations.DisableLCOWTimeSyncService, lopts.DisableTimeSyncService)
 		handleAnnotationPreferredRootFSType(ctx, s.Annotations, lopts)
 		handleAnnotationKernelDirectBoot(ctx, s.Annotations, lopts)
 

--- a/internal/uvm/create_lcow.go
+++ b/internal/uvm/create_lcow.go
@@ -103,6 +103,7 @@ type OptionsLCOW struct {
 	SecurityPolicyEnabled   bool                // Set when there is a security policy to apply on actual SNP hardware, use this rathen than checking the string length
 	UseGuestStateFile       bool                // Use a vmgs file that contains a kernel and initrd, required for SNP
 	GuestStateFile          string              // The vmgs file to load
+	DisableTimeSyncService  bool                // Disables the time synchronization service
 }
 
 // defaultLCOWOSBootFilesPath returns the default path used to locate the LCOW
@@ -152,6 +153,7 @@ func NewDefaultOptionsLCOW(id, owner string) *OptionsLCOW {
 		SecurityPolicyEnabled:   false,
 		SecurityPolicy:          "",
 		GuestStateFile:          "",
+		DisableTimeSyncService:  false,
 	}
 
 	if _, err := os.Stat(filepath.Join(opts.BootFilesPath, VhdFile)); err == nil {
@@ -649,6 +651,10 @@ func makeLCOWDoc(ctx context.Context, opts *OptionsLCOW, uvm *UtilityVM) (_ *hcs
 
 	if opts.ForwardStderr {
 		initArgs += fmt.Sprintf(" -e %d", linuxLogVsockPort)
+	}
+
+	if opts.DisableTimeSyncService {
+		opts.ExecCommandLine = fmt.Sprintf("%s --disableTimeSync", opts.ExecCommandLine)
 	}
 
 	initArgs += " " + opts.ExecCommandLine

--- a/internal/uvm/create_lcow.go
+++ b/internal/uvm/create_lcow.go
@@ -654,7 +654,7 @@ func makeLCOWDoc(ctx context.Context, opts *OptionsLCOW, uvm *UtilityVM) (_ *hcs
 	}
 
 	if opts.DisableTimeSyncService {
-		opts.ExecCommandLine = fmt.Sprintf("%s --disableTimeSync", opts.ExecCommandLine)
+		opts.ExecCommandLine = fmt.Sprintf("%s --disable-time-sync", opts.ExecCommandLine)
 	}
 
 	initArgs += " " + opts.ExecCommandLine

--- a/pkg/annotations/annotations.go
+++ b/pkg/annotations/annotations.go
@@ -257,4 +257,8 @@ const (
 
 	// GuestStateFile specifies the path of the vmgs file to use if required. Only applies in SNP mode.
 	GuestStateFile = "io.microsoft.virtualmachine.lcow.gueststatefile"
+
+	// AnnotationDisableLCOWTimeSyncService is used to disable the chronyd time
+	// synchronization service inside the LCOW UVM.
+	DisableLCOWTimeSyncService = "io.microsoft.virtualmachine.lcow.timesync.disable"
 )

--- a/test/cri-containerd/runpodsandbox_test.go
+++ b/test/cri-containerd/runpodsandbox_test.go
@@ -7,7 +7,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/Microsoft/hcsshim/pkg/annotations"
+	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -22,6 +22,7 @@ import (
 	"github.com/Microsoft/hcsshim/internal/processorinfo"
 	"github.com/Microsoft/hcsshim/internal/shimdiag"
 	"github.com/Microsoft/hcsshim/osversion"
+	"github.com/Microsoft/hcsshim/pkg/annotations"
 	testutilities "github.com/Microsoft/hcsshim/test/functional/utilities"
 	"github.com/containerd/containerd/log"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
@@ -1727,13 +1728,11 @@ func Test_RunPodSandbox_TimeSyncService(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	pullRequiredLcowImages(t, []string{imageLcowK8sPause})
+	pullRequiredLCOWImages(t, []string{imageLcowK8sPause})
 
 	request := getRunPodSandboxRequest(
 		t,
-		lcowRuntimeHandler,
-		map[string]string{},
-	)
+		lcowRuntimeHandler)
 
 	podID := runPodSandbox(t, client, ctx, request)
 	defer removePodSandbox(t, client, ctx, podID)
@@ -1772,14 +1771,15 @@ func Test_RunPodSandbox_DisableTimeSyncService(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	pullRequiredLcowImages(t, []string{imageLcowK8sPause})
+	pullRequiredLCOWImages(t, []string{imageLcowK8sPause})
 
 	request := getRunPodSandboxRequest(
 		t,
 		lcowRuntimeHandler,
-		map[string]string{
-			oci.AnnotationDisableLCOWTimeSyncService: "true",
-		},
+		WithSandboxAnnotations(
+			map[string]string{
+				annotations.DisableLCOWTimeSyncService: "true",
+			}),
 	)
 
 	podID := runPodSandbox(t, client, ctx, request)

--- a/test/cri-containerd/runpodsandbox_test.go
+++ b/test/cri-containerd/runpodsandbox_test.go
@@ -1708,3 +1708,18 @@ func Test_RunPodSandbox_KernelOptions_LCOW(t *testing.T) {
 		t.Fatalf("Expected number of hugepages to be 10. Got output instead: %d", numOfHugePages)
 	}
 }
+
+func Test_RunPodSandbox_TimeSyncService(t *testing.T) {
+	requireFeatures(t, featureLCOW)
+
+	pullRequiredLcowImages(t, []string{imageLcowK8sPause})
+
+	request := getRunPodSandboxRequest(
+		t,
+		lcowRuntimeHandler,
+		map[string]string{
+			oci.AnnotationDisableLCOWTimeSyncService: "true",
+		},
+	)
+	runPodSandboxTest(t, request)
+}

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/oci/uvm.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/oci/uvm.go
@@ -358,7 +358,7 @@ func SpecToUVMCreateOpts(ctx context.Context, s *specs.Spec, id, owner string) (
 		lopts.SecurityPolicy = parseAnnotationsString(s.Annotations, annotations.SecurityPolicy, lopts.SecurityPolicy)
 		lopts.KernelBootOptions = parseAnnotationsString(s.Annotations, annotations.KernelBootOptions, lopts.KernelBootOptions)
 		lopts.ProcessDumpLocation = parseAnnotationsString(s.Annotations, annotations.ContainerProcessDumpLocation, lopts.ProcessDumpLocation)
-		lopts.DisableTimeSyncService = parseAnnotationsBool(s.Annotations, annotations.DisableLCOWTimeSyncService, lopts.DisableTimeSyncService)
+		lopts.DisableTimeSyncService = parseAnnotationsBool(ctx, s.Annotations, annotations.DisableLCOWTimeSyncService, lopts.DisableTimeSyncService)
 		handleAnnotationPreferredRootFSType(ctx, s.Annotations, lopts)
 		handleAnnotationKernelDirectBoot(ctx, s.Annotations, lopts)
 

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/oci/uvm.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/oci/uvm.go
@@ -358,6 +358,7 @@ func SpecToUVMCreateOpts(ctx context.Context, s *specs.Spec, id, owner string) (
 		lopts.SecurityPolicy = parseAnnotationsString(s.Annotations, annotations.SecurityPolicy, lopts.SecurityPolicy)
 		lopts.KernelBootOptions = parseAnnotationsString(s.Annotations, annotations.KernelBootOptions, lopts.KernelBootOptions)
 		lopts.ProcessDumpLocation = parseAnnotationsString(s.Annotations, annotations.ContainerProcessDumpLocation, lopts.ProcessDumpLocation)
+		lopts.DisableTimeSyncService = parseAnnotationsBool(s.Annotations, annotations.DisableLCOWTimeSyncService, lopts.DisableTimeSyncService)
 		handleAnnotationPreferredRootFSType(ctx, s.Annotations, lopts)
 		handleAnnotationKernelDirectBoot(ctx, s.Annotations, lopts)
 

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/uvm/create_lcow.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/uvm/create_lcow.go
@@ -103,6 +103,7 @@ type OptionsLCOW struct {
 	SecurityPolicyEnabled   bool                // Set when there is a security policy to apply on actual SNP hardware, use this rathen than checking the string length
 	UseGuestStateFile       bool                // Use a vmgs file that contains a kernel and initrd, required for SNP
 	GuestStateFile          string              // The vmgs file to load
+	DisableTimeSyncService  bool                // Disables the time synchronization service
 }
 
 // defaultLCOWOSBootFilesPath returns the default path used to locate the LCOW
@@ -152,6 +153,7 @@ func NewDefaultOptionsLCOW(id, owner string) *OptionsLCOW {
 		SecurityPolicyEnabled:   false,
 		SecurityPolicy:          "",
 		GuestStateFile:          "",
+		DisableTimeSyncService:  false,
 	}
 
 	if _, err := os.Stat(filepath.Join(opts.BootFilesPath, VhdFile)); err == nil {
@@ -649,6 +651,10 @@ func makeLCOWDoc(ctx context.Context, opts *OptionsLCOW, uvm *UtilityVM) (_ *hcs
 
 	if opts.ForwardStderr {
 		initArgs += fmt.Sprintf(" -e %d", linuxLogVsockPort)
+	}
+
+	if opts.DisableTimeSyncService {
+		opts.ExecCommandLine = fmt.Sprintf("%s --disableTimeSync", opts.ExecCommandLine)
 	}
 
 	initArgs += " " + opts.ExecCommandLine

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/uvm/create_lcow.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/uvm/create_lcow.go
@@ -654,7 +654,7 @@ func makeLCOWDoc(ctx context.Context, opts *OptionsLCOW, uvm *UtilityVM) (_ *hcs
 	}
 
 	if opts.DisableTimeSyncService {
-		opts.ExecCommandLine = fmt.Sprintf("%s --disableTimeSync", opts.ExecCommandLine)
+		opts.ExecCommandLine = fmt.Sprintf("%s --disable-time-sync", opts.ExecCommandLine)
 	}
 
 	initArgs += " " + opts.ExecCommandLine

--- a/test/vendor/github.com/Microsoft/hcsshim/pkg/annotations/annotations.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/pkg/annotations/annotations.go
@@ -257,4 +257,8 @@ const (
 
 	// GuestStateFile specifies the path of the vmgs file to use if required. Only applies in SNP mode.
 	GuestStateFile = "io.microsoft.virtualmachine.lcow.gueststatefile"
+
+	// AnnotationDisableLCOWTimeSyncService is used to disable the chronyd time
+	// synchronization service inside the LCOW UVM.
+	DisableLCOWTimeSyncService = "io.microsoft.virtualmachine.lcow.timesync.disable"
 )


### PR DESCRIPTION
Currently LCOW UVM doesn't run any time synchronization service which causes a small amount of time lag after running the UVM for a long time (~10 days).

This change updates OpenGCS to start `chronyd` daemon as soon as gcs is started. It also adds a new annotation which can be used to disable this service inside the UVM.