### PR TITLE
[release/0.8] Cherry-pick PrepareLayer fixes

### DIFF
--- a/internal/layers/layers.go
+++ b/internal/layers/layers.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"time"
 
 	hcsschema "github.com/Microsoft/hcsshim/internal/hcs/schema2"
 	"github.com/Microsoft/hcsshim/internal/hcserror"
@@ -109,6 +110,9 @@ func MountContainerLayers(ctx context.Context, layerFolders []string, guestRoot 
 				// for ERROR_NOT_READY as well.
 				if hcserr, ok := lErr.(*hcserror.HcsError); ok {
 					if hcserr.Err == windows.ERROR_NOT_READY || hcserr.Err == windows.ERROR_DEVICE_NOT_CONNECTED {
+						// Sleep for a little before a re-attempt. A probable cause for these issues in the first place is events not getting
+						// reported in time so might be good to give some time for things to "cool down" or get back to a known state.
+						time.Sleep(time.Millisecond * 100)
 						continue
 					}
 				}


### PR DESCRIPTION
This PR cherry-picks some best effort fixes for the PrepareLayer call/layer setup. The errors that these try and fix have been observed in a couple of k8s scenarios.

From:

1. https://github.com/microsoft/hcsshim/pull/1091
2. https://github.com/microsoft/hcsshim/pull/1122