### PR TITLE
Rework how working directories function for job containers

### DIFF
--- a/internal/jobcontainers/jobcontainer.go
+++ b/internal/jobcontainers/jobcontainer.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"sync"
@@ -176,11 +177,38 @@ func (c *JobContainer) CreateProcess(ctx context.Context, config interface{}) (_
 
 	// Replace any occurences of the sandbox mount point env variable in the commandline.
 	// %CONTAINER_SANDBOX_MOUNTPOINT%\mybinary.exe -> C:\C\123456789\mybinary.exe
-	commandLine := c.replaceWithMountPoint(conf.CommandLine)
+	commandLine, _ := c.replaceWithMountPoint(conf.CommandLine)
+
+	removeDriveLetter := func(name string) string {
+		// If just the letter and colon (C:) then replace with a single backslash. Else just trim the drive letter and leave the rest of the
+		// path.
+		if len(name) == 2 && name[1] == ':' {
+			name = "\\"
+		} else if len(name) > 2 && name[1] == ':' {
+			name = name[2:]
+		}
+		return name
+	}
 
 	workDir := c.sandboxMount
 	if conf.WorkingDirectory != "" {
-		workDir = c.replaceWithMountPoint(conf.WorkingDirectory)
+		var changed bool
+		// For now, we join the working directory requested with where the sandbox volume is located. It's expected that the default behavior
+		// would be to treat all paths as relative to the volume.
+		//
+		// For example:
+		// A working directory of C:\ would become C:\C\12345678\
+		// A working directory of C:\work\dir would become C:\C\12345678\work\dir
+		//
+		// The below calls replaceWithMountPoint to replace any occurrences of the environment variable that points to where the container image
+		// volume is mounted.
+		workDir, changed = c.replaceWithMountPoint(conf.WorkingDirectory)
+		// If the working directory was changed, that means the user supplied %CONTAINER_SANDBOX_MOUNT_POINT%\\my\dir or something similar.
+		// In that case there's nothing left to do, as we don't want to join it with the mount point again.. If it *wasn't* changed, then we
+		// need to join it with the mount point, as it's some normal path.
+		if !changed {
+			workDir = filepath.Join(c.sandboxMount, removeDriveLetter(workDir))
+		}
 	}
 
 	// Reassign commandline here in case it needed to be quoted. For example if "foo bar baz" was supplied, and
@@ -575,8 +603,10 @@ func systemProcessInformation() ([]*winapi.SYSTEM_PROCESS_INFORMATION, error) {
 	return procInfos, nil
 }
 
-// Takes a string and replaces any occurences of CONTAINER_SANDBOX_MOUNT_POINT with where the containers volume is mounted.
-func (c *JobContainer) replaceWithMountPoint(str string) string {
-	str = strings.ReplaceAll(str, "%"+sandboxMountPointEnvVar+"%", c.sandboxMount[:len(c.sandboxMount)-1])
-	return strings.ReplaceAll(str, "$env:"+sandboxMountPointEnvVar, c.sandboxMount[:len(c.sandboxMount)-1])
+// Takes a string and replaces any occurences of CONTAINER_SANDBOX_MOUNT_POINT with where the containers volume is mounted, as well as returning
+// if the string actually contained the environment variable.
+func (c *JobContainer) replaceWithMountPoint(str string) (string, bool) {
+	newStr := strings.ReplaceAll(str, "%"+sandboxMountPointEnvVar+"%", c.sandboxMount[:len(c.sandboxMount)-1])
+	newStr = strings.ReplaceAll(newStr, "$env:"+sandboxMountPointEnvVar, c.sandboxMount[:len(c.sandboxMount)-1])
+	return newStr, str != newStr
 }

--- a/test/cri-containerd/main.go
+++ b/test/cri-containerd/main.go
@@ -45,15 +45,16 @@ const (
 	testVMServiceAddress = "C:\\ContainerPlat\\vmservice.sock"
 	testVMServiceBinary  = "C:\\Containerplat\\vmservice.exe"
 
-	lcowRuntimeHandler   = "runhcs-lcow"
-	imageLcowK8sPause    = "k8s.gcr.io/pause:3.1"
-	imageLcowAlpine      = "docker.io/library/alpine:latest"
-	imageLcowCosmos      = "cosmosarno/spark-master:2.4.1_2019-04-18_8e864ce"
-	imageJobContainerHNS = "cplatpublic.azurecr.io/jobcontainer_hns:latest"
-	imageJobContainerETW = "cplatpublic.azurecr.io/jobcontainer_etw:latest"
-	imageJobContainerVHD = "cplatpublic.azurecr.io/jobcontainer_vhd:latest"
-	alpineAspNet         = "mcr.microsoft.com/dotnet/core/aspnet:3.1-alpine3.11"
-	alpineAspnetUpgrade  = "mcr.microsoft.com/dotnet/core/aspnet:3.1.2-alpine3.11"
+	lcowRuntimeHandler       = "runhcs-lcow"
+	imageLcowK8sPause        = "k8s.gcr.io/pause:3.1"
+	imageLcowAlpine          = "docker.io/library/alpine:latest"
+	imageLcowCosmos          = "cosmosarno/spark-master:2.4.1_2019-04-18_8e864ce"
+	imageJobContainerHNS     = "cplatpublic.azurecr.io/jobcontainer_hns:latest"
+	imageJobContainerETW     = "cplatpublic.azurecr.io/jobcontainer_etw:latest"
+	imageJobContainerVHD     = "cplatpublic.azurecr.io/jobcontainer_vhd:latest"
+	imageJobContainerWorkDir = "cplatpublic.azurecr.io/jobcontainer_workdir:latest"
+	alpineAspNet             = "mcr.microsoft.com/dotnet/core/aspnet:3.1-alpine3.11"
+	alpineAspnetUpgrade      = "mcr.microsoft.com/dotnet/core/aspnet:3.1.2-alpine3.11"
 	// Default account name for use with GMSA related tests. This will not be
 	// present/you will not have access to the account on your machine unless
 	// your environment is configured properly.

--- a/test/cri-containerd/test-images/jobcontainer_createvhd/Dockerfile
+++ b/test/cri-containerd/test-images/jobcontainer_createvhd/Dockerfile
@@ -4,7 +4,7 @@ FROM golang:1.15.10-nanoserver-1809
 # Get administrator privileges
 USER containeradministrator
 
-WORKDIR /go/src/vhd
+WORKDIR C:\\go\\src\\vhd
 COPY main.go .
 
 RUN go get -d -v ./...

--- a/test/cri-containerd/test-images/jobcontainer_etw/Dockerfile
+++ b/test/cri-containerd/test-images/jobcontainer_etw/Dockerfile
@@ -4,7 +4,7 @@ FROM golang:1.15.10-nanoserver-1809
 # Get administrator privileges
 USER containeradministrator
 
-WORKDIR /go/src/etw
+WORKDIR C:\\go\\src\\etw
 COPY . .
 
 RUN go get -d -v ./...

--- a/test/cri-containerd/test-images/jobcontainer_workdir/Dockerfile
+++ b/test/cri-containerd/test-images/jobcontainer_workdir/Dockerfile
@@ -8,7 +8,7 @@ FROM golang:1.15.10-nanoserver-1809
 # Get administrator privileges
 USER containeradministrator
 
-WORKDIR C:\\go\\src\\hns
+WORKDIR C:\\go\\src\\workdir
 COPY main.go .
 
 RUN go get -d -v ./...

--- a/test/cri-containerd/test-images/jobcontainer_workdir/main.go
+++ b/test/cri-containerd/test-images/jobcontainer_workdir/main.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"fmt"
+	"time"
+)
+
+// The contents of the program are irrelevant. This binary will be placed in an image that is used for testing the working directory behavior
+// for job containers. So as long as the binary is launched is all that's being tested.
+func main() {
+	for {
+		fmt.Println("Hello world")
+		time.Sleep(time.Second * 5)
+	}
+}


### PR DESCRIPTION
Instead of taking the working directory as is, change to joining the working directory
requested with where the sandbox volume is located. It's expected that the default behavior
would be to treat all paths as relative to the volume as this would be equivalent to a
normal Windows Server Containers behavior.

For example:
A working directory of C:\ would become C:\C\12345678\
A working directory of C:\work\dir would become C:\C\12345678\work\dir

Signed-off-by: Daniel Canter <dcanter@microsoft.com>