### PR TITLE
Fix duplicate "failed" in HCS errors

### DIFF
--- a/hcn/hcnglobals.go
+++ b/hcn/hcnglobals.go
@@ -111,7 +111,7 @@ func hnsCall(method, path, request string, returnResponse interface{}) error {
 
 	err := _hnsCall(method, path, request, &responseBuffer)
 	if err != nil {
-		return hcserror.New(err, "hnsCall ", "")
+		return hcserror.New(err, "hnsCall", "")
 	}
 	response := interop.ConvertAndFreeCoTaskMemString(responseBuffer)
 

--- a/internal/wclayer/activatelayer.go
+++ b/internal/wclayer/activatelayer.go
@@ -21,7 +21,7 @@ func ActivateLayer(ctx context.Context, path string) (err error) {
 
 	err = activateLayer(&stdDriverInfo, path)
 	if err != nil {
-		return hcserror.New(err, title+" - failed", "")
+		return hcserror.New(err, title, "")
 	}
 	return nil
 }

--- a/internal/wclayer/createlayer.go
+++ b/internal/wclayer/createlayer.go
@@ -21,7 +21,7 @@ func CreateLayer(ctx context.Context, path, parent string) (err error) {
 
 	err = createLayer(&stdDriverInfo, path, parent)
 	if err != nil {
-		return hcserror.New(err, title+" - failed", "")
+		return hcserror.New(err, title, "")
 	}
 	return nil
 }

--- a/internal/wclayer/createscratchlayer.go
+++ b/internal/wclayer/createscratchlayer.go
@@ -28,7 +28,7 @@ func CreateScratchLayer(ctx context.Context, path string, parentLayerPaths []str
 
 	err = createSandboxLayer(&stdDriverInfo, path, 0, layers)
 	if err != nil {
-		return hcserror.New(err, title+" - failed", "")
+		return hcserror.New(err, title, "")
 	}
 	return nil
 }

--- a/internal/wclayer/destroylayer.go
+++ b/internal/wclayer/destroylayer.go
@@ -19,7 +19,7 @@ func DestroyLayer(ctx context.Context, path string) (err error) {
 
 	err = destroyLayer(&stdDriverInfo, path)
 	if err != nil {
-		return hcserror.New(err, title+" - failed", "")
+		return hcserror.New(err, title, "")
 	}
 	return nil
 }

--- a/internal/wclayer/expandscratchsize.go
+++ b/internal/wclayer/expandscratchsize.go
@@ -25,7 +25,7 @@ func ExpandScratchSize(ctx context.Context, path string, size uint64) (err error
 
 	err = expandSandboxSize(&stdDriverInfo, path, size)
 	if err != nil {
-		return hcserror.New(err, title+" - failed", "")
+		return hcserror.New(err, title, "")
 	}
 
 	// Manually expand the volume now in order to work around bugs in 19H1 and

--- a/internal/wclayer/exportlayer.go
+++ b/internal/wclayer/exportlayer.go
@@ -35,7 +35,7 @@ func ExportLayer(ctx context.Context, path string, exportFolderPath string, pare
 
 	err = exportLayer(&stdDriverInfo, path, exportFolderPath, layers)
 	if err != nil {
-		return hcserror.New(err, title+" - failed", "")
+		return hcserror.New(err, title, "")
 	}
 	return nil
 }

--- a/internal/wclayer/getlayermountpath.go
+++ b/internal/wclayer/getlayermountpath.go
@@ -27,7 +27,7 @@ func GetLayerMountPath(ctx context.Context, path string) (_ string, err error) {
 	log.G(ctx).Debug("Calling proc (1)")
 	err = getLayerMountPath(&stdDriverInfo, path, &mountPathLength, nil)
 	if err != nil {
-		return "", hcserror.New(err, title+" - failed", "(first call)")
+		return "", hcserror.New(err, title, "(first call)")
 	}
 
 	// Allocate a mount path of the returned length.
@@ -41,7 +41,7 @@ func GetLayerMountPath(ctx context.Context, path string) (_ string, err error) {
 	log.G(ctx).Debug("Calling proc (2)")
 	err = getLayerMountPath(&stdDriverInfo, path, &mountPathLength, &mountPathp[0])
 	if err != nil {
-		return "", hcserror.New(err, title+" - failed", "(second call)")
+		return "", hcserror.New(err, title, "(second call)")
 	}
 
 	mountPath := syscall.UTF16ToString(mountPathp[0:])

--- a/internal/wclayer/getsharedbaseimages.go
+++ b/internal/wclayer/getsharedbaseimages.go
@@ -21,7 +21,7 @@ func GetSharedBaseImages(ctx context.Context) (_ string, err error) {
 	var buffer *uint16
 	err = getBaseImages(&buffer)
 	if err != nil {
-		return "", hcserror.New(err, title+" - failed", "")
+		return "", hcserror.New(err, title, "")
 	}
 	imageData := interop.ConvertAndFreeCoTaskMemString(buffer)
 	span.AddAttributes(trace.StringAttribute("imageData", imageData))

--- a/internal/wclayer/grantvmaccess.go
+++ b/internal/wclayer/grantvmaccess.go
@@ -20,7 +20,7 @@ func GrantVmAccess(ctx context.Context, vmid string, filepath string) (err error
 
 	err = grantVmAccess(vmid, filepath)
 	if err != nil {
-		return hcserror.New(err, title+" - failed", "")
+		return hcserror.New(err, title, "")
 	}
 	return nil
 }

--- a/internal/wclayer/importlayer.go
+++ b/internal/wclayer/importlayer.go
@@ -36,7 +36,7 @@ func ImportLayer(ctx context.Context, path string, importFolderPath string, pare
 
 	err = importLayer(&stdDriverInfo, path, importFolderPath, layers)
 	if err != nil {
-		return hcserror.New(err, title+" - failed", "")
+		return hcserror.New(err, title, "")
 	}
 	return nil
 }

--- a/internal/wclayer/layerexists.go
+++ b/internal/wclayer/layerexists.go
@@ -21,7 +21,7 @@ func LayerExists(ctx context.Context, path string) (_ bool, err error) {
 	var exists uint32
 	err = layerExists(&stdDriverInfo, path, &exists)
 	if err != nil {
-		return false, hcserror.New(err, title+" - failed", "")
+		return false, hcserror.New(err, title, "")
 	}
 	span.AddAttributes(trace.BoolAttribute("layer-exists", exists != 0))
 	return exists != 0, nil

--- a/internal/wclayer/nametoguid.go
+++ b/internal/wclayer/nametoguid.go
@@ -22,7 +22,7 @@ func NameToGuid(ctx context.Context, name string) (_ guid.GUID, err error) {
 	var id guid.GUID
 	err = nameToGuid(name, &id)
 	if err != nil {
-		return guid.GUID{}, hcserror.New(err, title+" - failed", "")
+		return guid.GUID{}, hcserror.New(err, title, "")
 	}
 	span.AddAttributes(trace.StringAttribute("guid", id.String()))
 	return id, nil

--- a/internal/wclayer/preparelayer.go
+++ b/internal/wclayer/preparelayer.go
@@ -38,7 +38,7 @@ func PrepareLayer(ctx context.Context, path string, parentLayerPaths []string) (
 	defer prepareLayerLock.Unlock()
 	err = prepareLayer(&stdDriverInfo, path, layers)
 	if err != nil {
-		return hcserror.New(err, title+" - failed", "")
+		return hcserror.New(err, title, "")
 	}
 	return nil
 }

--- a/internal/wclayer/unpreparelayer.go
+++ b/internal/wclayer/unpreparelayer.go
@@ -19,7 +19,7 @@ func UnprepareLayer(ctx context.Context, path string) (err error) {
 
 	err = unprepareLayer(&stdDriverInfo, path)
 	if err != nil {
-		return hcserror.New(err, title+" - failed", "")
+		return hcserror.New(err, title, "")
 	}
 	return nil
 }


### PR DESCRIPTION
noticed this in https://github.com/moby/moby/issues/42743#issuecomment-907507159

HcsError.Error() already appends "failed" to the error message, which resulted in some uses to contain a duplicate "failed", for example:

    re-exec error: exit status 1: output: hcsshim::ImportLayer - failed failed in Win32: The system cannot find the path specified. (0x3)

