### PR TITLE
Add extra info about DCO check to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,10 @@ When you submit a pull request, a CLA-bot will automatically determine whether y
 a CLA and decorate the PR appropriately (e.g., label, comment). Simply follow the instructions
 provided by the bot. You will only need to do this once across all repos using our CLA.
 
-We also ask that contributors [sign their commits](https://git-scm.com/docs/git-commit) using `git commit -s` or `git commit --signoff` to certify they either authored the work themselves or otherwise have permission to use it in this project.
+We also require that contributors [sign their commits](https://git-scm.com/docs/git-commit) using `git commit -s` or `git commit --signoff` to
+certify they either authored the work themselves or otherwise have permission to use it in this project. Please see https://developercertificate.org/ for
+more info, as well as to make sure that you can attest to the rules listed. Our CI uses the [DCO Github app](https://github.com/apps/dco) to ensure
+that all commits in a given PR are signed-off.
 
 
 ## Code of Conduct


### PR DESCRIPTION
We recently added the DCO github app and it will get run on every PR. This change
adds a small blurb to our README to give more information on DCO for contributors.

Signed-off-by: Daniel Canter <dcanter@microsoft.com>