### PR TITLE
Fixup logic for sandbox and container cleanup on failure

### DIFF
--- a/internal/guest/runtime/hcsv2/sandbox_container.go
+++ b/internal/guest/runtime/hcsv2/sandbox_container.go
@@ -47,6 +47,11 @@ func setupSandboxContainerSpec(ctx context.Context, id string, spec *oci.Spec) (
 	if err := os.MkdirAll(rootDir, 0755); err != nil {
 		return errors.Wrapf(err, "failed to create sandbox root directory %q", rootDir)
 	}
+	defer func() {
+		if err != nil {
+			_ = os.RemoveAll(rootDir)
+		}
+	}()
 
 	// Write the hostname
 	hostname := spec.Hostname

--- a/internal/guest/runtime/hcsv2/standalone_container.go
+++ b/internal/guest/runtime/hcsv2/standalone_container.go
@@ -43,6 +43,11 @@ func setupStandaloneContainerSpec(ctx context.Context, id string, spec *oci.Spec
 	if err := os.MkdirAll(rootDir, 0755); err != nil {
 		return errors.Wrapf(err, "failed to create container root directory %q", rootDir)
 	}
+	defer func() {
+		if err != nil {
+			_ = os.RemoveAll(rootDir)
+		}
+	}()
 
 	hostname := spec.Hostname
 	if hostname == "" {


### PR DESCRIPTION
This PR fixes up some logic when creating sandboxes and container where we might overwrite the error from a previous call. 

Signed-off-by: Kathryn Baldauf <kabaldau@microsoft.com>