### PR TITLE
Adjust execed processes OCI spec for LCOW

### DIFF
--- a/internal/guest/runtime/hcsv2/container.go
+++ b/internal/guest/runtime/hcsv2/container.go
@@ -194,12 +194,10 @@ func adjustExecSpec(containerSpec *oci.Process, execSpec *oci.Process) {
 	// the container image on the host. A consequence of the user example is any exec will run as root instead of the user configured for
 	// the container which can be problematic.
 	//
-	// Currently through cri there's no way to set a user for an exec, so just assigning whatever user the container ran as to the execs spec
-	// is fine for that. However, for any other client that would end up here, that won't hold true. For that scenario, there's no easy way to tell if a
-	// client supplied root as the user for an exec explicitly or they simply just didn't fill in the spec, as uid 0 and gid 0 will be root and
-	// this is the default value for a uint32. To try and please as many camps as possible, if the uid/gid are changed at all and don't match
-	// whatever was set on the containers spec then just use whatever was received. If the exec spec is set to 0/0 for uid/gid, then just inherit
-	// the containers as we assume it just wasn't filled in.
+	// There is no way to tell if a client supplied root as the user for an exec explicitly or if they simply didn't fill in
+	// the spec, as the default values of uid 0 and gid 0 are also the uid & gid values of the root user. To try and cover as many
+	// use cases as possible, we check if the uid/gid are changed at all and if not we just copy whatever user was set in the
+	// container spec to the exec spec.
 	if execSpec.User.UID == 0 && execSpec.User.GID == 0 {
 		execSpec.User = containerSpec.User
 	}

--- a/test/cri-containerd/main.go
+++ b/test/cri-containerd/main.go
@@ -49,6 +49,7 @@ const (
 	imageLcowK8sPause    = "k8s.gcr.io/pause:3.1"
 	imageLcowAlpine      = "docker.io/library/alpine:latest"
 	imageLcowCosmos      = "cosmosarno/spark-master:2.4.1_2019-04-18_8e864ce"
+	imageLcowCustomUser  = "cplatpublic.azurecr.io/linux_custom_user:latest"
 	imageJobContainerHNS = "cplatpublic.azurecr.io/jobcontainer_hns:latest"
 	imageJobContainerETW = "cplatpublic.azurecr.io/jobcontainer_etw:latest"
 	imageJobContainerVHD = "cplatpublic.azurecr.io/jobcontainer_vhd:latest"

--- a/test/cri-containerd/test-images/lcow_custom_user/Dockerfile
+++ b/test/cri-containerd/test-images/lcow_custom_user/Dockerfile
@@ -1,0 +1,4 @@
+FROM ubuntu:latest
+
+RUN useradd -ms /bin/bash test
+USER test


### PR DESCRIPTION
In most places in Containerd an execed process gets assigned the process spec of the
container it’s getting launched in (so it will inherit anything set on the container
spec), but due to the nature of LCOW there’s some OCI spec fields we set in the UVM
instead as they’re not able to be handled on the host (in a clean manner at least).
One of these is the user for the container. On a Linux host, Containerd will check if
the user exists in the filesystem for the container before setting the user on the spec.
On LCOW we just have vhd’s with the contents of the layers when making the spec which makes
this a bit infeasible, so we defer that work until we’re in the guest and then edit the spec
if the user exists. This has the outcome that the user is never set on the containers spec on
the host for LCOW, but we do have the final amended spec in the UVM with whatever user was
requested (or was set in the image via USER and so on).

This change adds a function to adjust the execed processes spec to contain the user from
the container, but also leaves it open to add future fields that we may have to amend in the guest.

Signed-off-by: Daniel Canter <dcanter@microsoft.com>