### PR TITLE
add RecommendedVHDSizeGB constant

### DIFF
--- a/cmd/dmverity-vhd/main.go
+++ b/cmd/dmverity-vhd/main.go
@@ -27,7 +27,7 @@ const (
 	imageFlag     = "image"
 	verboseFlag   = "verbose"
 	outputDirFlag = "out-dir"
-	maxVHDSize    = 128 * 1024 * 1024 * 1024
+	maxVHDSize    = dmverity.RecommendedVHDSizeGB
 )
 
 func init() {

--- a/ext4/dmverity/dmverity.go
+++ b/ext4/dmverity/dmverity.go
@@ -16,8 +16,9 @@ import (
 
 const (
 	blockSize = compactext4.BlockSize
+	// RecommendedVHDSizeGB is the recommended size in GB for VHDs, which is not a hard limit. 
+	RecommendedVHDSizeGB = 128 * 1024 * 1024 * 1024
 )
-
 var salt = bytes.Repeat([]byte{0}, 32)
 
 var (

--- a/internal/tools/securitypolicy/main.go
+++ b/internal/tools/securitypolicy/main.go
@@ -150,7 +150,7 @@ func createPolicyFromConfig(config Config) (sp.SecurityPolicy, error) {
 
 			opts := []tar2ext4.Option{
 				tar2ext4.ConvertWhiteout,
-				tar2ext4.MaximumDiskSize(128 * 1024 * 1024 * 1024),
+				tar2ext4.MaximumDiskSize(dmverity.RecommendedVHDSizeGB),
 			}
 
 			err = tar2ext4.Convert(r, out, opts...)


### PR DESCRIPTION
Add Max disk size constant to eliminate hard code size. 
The size is synced with [max disk size in containrd](https://github.com/containerd/containerd/blob/main/diff/lcow/lcow.go#L47). In the future, this need to be upstreamed in containerd. 
