### PR TITLE
Add security policy enforcement of environment variables

### DIFF
--- a/internal/guest/runtime/hcsv2/uvm.go
+++ b/internal/guest/runtime/hcsv2/uvm.go
@@ -159,7 +159,8 @@ func (h *Host) CreateContainer(ctx context.Context, id string, settings *prot.VM
 		return nil, gcserr.NewHresultError(gcserr.HrVmcomputeSystemAlreadyExists)
 	}
 
-	err = h.securityPolicyEnforcer.EnforceCommandPolicy(id, settings.OCISpecification.Process.Args)
+	err = h.securityPolicyEnforcer.EnforceStartContainerPolicy(id, settings.OCISpecification.Process.Args, settings.OCISpecification.Process.Env)
+
 	if err != nil {
 		return nil, errors.Wrapf(err, "container creation denied due to policy")
 	}

--- a/internal/guest/storage/test/policy/mountmonitoringsecuritypolicyenforcer.go
+++ b/internal/guest/storage/test/policy/mountmonitoringsecuritypolicyenforcer.go
@@ -23,6 +23,6 @@ func (p *MountMonitoringSecurityPolicyEnforcer) EnforceOverlayMountPolicy(contai
 	return nil
 }
 
-func (p *MountMonitoringSecurityPolicyEnforcer) EnforceCommandPolicy(containerID string, argList []string) (err error) {
+func (p *MountMonitoringSecurityPolicyEnforcer) EnforceStartContainerPolicy(containerID string, argList []string, envList []string) (err error) {
 	return nil
 }

--- a/internal/tools/securitypolicy/README.md
+++ b/internal/tools/securitypolicy/README.md
@@ -20,6 +20,10 @@ be downloaded, turned into an ext4, and finally a dm-verity root hash calculated
 [[image]]
 name = "rust:1.52.1"
 command = ["rustc", "--help"]
+
+[[image.env_rule]]
+strategy = "re2"
+rule = "PREFIX_.+=.+"
 ```
 
 ### Converted to JSON
@@ -32,13 +36,54 @@ represented in JSON.
   "allow_all": false,
   "containers": [
     {
-      "command": ["/pause"],
+      "command": [
+        "/pause"
+      ],
+      "env_rules": [
+        {
+          "strategy": "string",
+          "rule": "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+        },
+        {
+          "strategy": "string",
+          "rule": "TERM=xterm"
+        }
+      ],
       "layers": [
         "16b514057a06ad665f92c02863aca074fd5976c755d26bff16365299169e8415"
       ]
     },
     {
-      "command": ["rustc", "--help"],
+      "command": [
+        "rustc",
+        "--help"
+      ],
+      "env_rules": [
+        {
+          "strategy": "re2",
+          "rule": "PREFIX_.+=.+"
+        },
+        {
+          "strategy": "string",
+          "rule": "TERM=xterm"
+        },
+        {
+          "strategy": "string",
+          "rule": "PATH=/usr/local/cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+        },
+        {
+          "strategy": "string",
+          "rule": "RUSTUP_HOME=/usr/local/rustup"
+        },
+        {
+          "strategy": "string",
+          "rule": "CARGO_HOME=/usr/local/cargo"
+        },
+        {
+          "strategy": "string",
+          "rule": "RUST_VERSION=1.52.1"
+        }
+      ],
       "layers": [
         "fe84c9d5bfddd07a2624d00333cf13c1a9c941f3a261f13ead44fc6a93bc0e7a",
         "4dedae42847c704da891a28c25d32201a1ae440bce2aecccfa8e6f03b97a6a6c",

--- a/pkg/securitypolicy/securitypolicy.go
+++ b/pkg/securitypolicy/securitypolicy.go
@@ -23,11 +23,18 @@ type SecurityPolicy struct {
 type SecurityPolicyContainer struct {
 	// The command that we will allow the container to execute
 	Command []string `json:"command"`
+	// The rules for determining if a given environment variable is allowed
+	EnvRules []SecurityPolicyEnvironmentVariableRule `json:"env_rules"`
 	// An ordered list of dm-verity root hashes for each layer that makes up
 	// "a container". Containers are constructed as an overlay file system. The
 	// order that the layers are overlayed is important and needs to be enforced
 	// as part of policy.
 	Layers []string `json:"layers"`
+}
+
+type SecurityPolicyEnvironmentVariableRule struct {
+	Strategy string `json:"strategy"`
+	Rule     string `json:"rule"`
 }
 
 // EncodedSecurityPolicy is a JSON representation of SecurityPolicy that has

--- a/test/go.sum
+++ b/test/go.sum
@@ -390,6 +390,7 @@ github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfn
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.5/go.mod h1:9r2w37qlBe7rQ6e1fg1S/9xpWHSnaqNdHD3WcMdbPDA=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/linuxkit/virtsock v0.0.0-20201010232012-f8cee7dfc7a3/go.mod h1:3r6x7q95whyfWQpmGZTu3gk3v2YkMi05HEzl7Tf7YEo=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
@@ -429,6 +430,7 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8m
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/ncw/swift v1.0.47/go.mod h1:23YIA4yWVnGwv2dQlN4bB7egfYX6YLn0Yo/S6zZO/ZM=
+github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
@@ -855,6 +857,7 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20141024133853-64131543e789/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f h1:BLraFXnmrev5lT+xlilqcH8XK9/i0At2xKjWk4p6zsU=
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/cheggaaa/pb.v1 v1.0.25/go.mod h1:V/YB90LKu/1FcN3WVnfiiE5oMCibMjukxqG/qStrOgw=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=

--- a/test/vendor/github.com/Microsoft/hcsshim/pkg/securitypolicy/securitypolicy.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/pkg/securitypolicy/securitypolicy.go
@@ -23,11 +23,18 @@ type SecurityPolicy struct {
 type SecurityPolicyContainer struct {
 	// The command that we will allow the container to execute
 	Command []string `json:"command"`
+	// The rules for determining if a given environment variable is allowed
+	EnvRules []SecurityPolicyEnvironmentVariableRule `json:"env_rules"`
 	// An ordered list of dm-verity root hashes for each layer that makes up
 	// "a container". Containers are constructed as an overlay file system. The
 	// order that the layers are overlayed is important and needs to be enforced
 	// as part of policy.
 	Layers []string `json:"layers"`
+}
+
+type SecurityPolicyEnvironmentVariableRule struct {
+	Strategy string `json:"strategy"`
+	Rule     string `json:"rule"`
 }
 
 // EncodedSecurityPolicy is a JSON representation of SecurityPolicy that has


### PR DESCRIPTION
Supports two different matching schemes:

- string

This is a direct string match. All characters must be equal.

- re2

The rule is an re2 regular expression that will be matched against the environment variable.

Environment variables are in the form "KEY=VALUE" as a single string.

The securitypolicy tool has been updated to automatically include any environment variables defined
in the image spec for an image to the allowed environment variables in the generated policy.

Signed-off-by: Sean T. Allen <seanallen@microsoft.com>