### PR TITLE
Switch JSON policy schema from using arrays to maps

### DIFF
--- a/internal/tools/securitypolicy/README.md
+++ b/internal/tools/securitypolicy/README.md
@@ -34,66 +34,73 @@ represented in JSON.
 ```json
 {
   "allow_all": false,
-  "containers": [
-    {
-      "command": [
-        "/pause"
-      ],
-      "env_rules": [
-        {
-          "strategy": "string",
-          "rule": "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
-        },
-        {
-          "strategy": "string",
-          "rule": "TERM=xterm"
-        }
-      ],
-      "layers": [
-        "16b514057a06ad665f92c02863aca074fd5976c755d26bff16365299169e8415"
-      ]
-    },
-    {
-      "command": [
-        "rustc",
-        "--help"
-      ],
-      "env_rules": [
-        {
-          "strategy": "re2",
-          "rule": "PREFIX_.+=.+"
-        },
-        {
-          "strategy": "string",
-          "rule": "TERM=xterm"
-        },
-        {
+  "num_containers": 2,
+  "containers": {
+    "0": {
+      "num_commands": 2,
+      "command": {
+        "0": "rustc",
+        "1": "--help"
+      },
+      "num_env_rules": 6,
+      "env_rules": {
+        "0": {
           "strategy": "string",
           "rule": "PATH=/usr/local/cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
         },
-        {
+        "1": {
           "strategy": "string",
           "rule": "RUSTUP_HOME=/usr/local/rustup"
         },
-        {
+        "2": {
           "strategy": "string",
           "rule": "CARGO_HOME=/usr/local/cargo"
         },
-        {
+        "3": {
           "strategy": "string",
           "rule": "RUST_VERSION=1.52.1"
+        },
+        "4": {
+          "strategy": "string",
+          "rule": "TERM=xterm"
+        },
+        "5": {
+          "strategy": "re2",
+          "rule": "PREFIX_.+=.+"
         }
-      ],
-      "layers": [
-        "fe84c9d5bfddd07a2624d00333cf13c1a9c941f3a261f13ead44fc6a93bc0e7a",
-        "4dedae42847c704da891a28c25d32201a1ae440bce2aecccfa8e6f03b97a6a6c",
-        "41d64cdeb347bf236b4c13b7403b633ff11f1cf94dbc7cf881a44d6da88c5156",
-        "eb36921e1f82af46dfe248ef8f1b3afb6a5230a64181d960d10237a08cd73c79",
-        "e769d7487cc314d3ee748a4440805317c19262c7acd2fdbdb0d47d2e4613a15c",
-        "1b80f120dbd88e4355d6241b519c3e25290215c469516b49dece9cf07175a766"
-      ]
+      },
+      "num_layers": 6,
+      "layers": {
+        "0": "fe84c9d5bfddd07a2624d00333cf13c1a9c941f3a261f13ead44fc6a93bc0e7a",
+        "1": "4dedae42847c704da891a28c25d32201a1ae440bce2aecccfa8e6f03b97a6a6c",
+        "2": "41d64cdeb347bf236b4c13b7403b633ff11f1cf94dbc7cf881a44d6da88c5156",
+        "3": "eb36921e1f82af46dfe248ef8f1b3afb6a5230a64181d960d10237a08cd73c79",
+        "4": "e769d7487cc314d3ee748a4440805317c19262c7acd2fdbdb0d47d2e4613a15c",
+        "5": "1b80f120dbd88e4355d6241b519c3e25290215c469516b49dece9cf07175a766"
+      }
+    },
+    "1": {
+      "num_commands": 1,
+      "command": {
+        "0": "/pause"
+      },
+      "num_env_rules": 2,
+      "env_rules": {
+        "0": {
+          "strategy": "string",
+          "rule": "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+        },
+        "1": {
+          "strategy": "string",
+          "rule": "TERM=xterm"
+        }
+      },
+      "num_layers": 1,
+      "layers": {
+        "0": "16b514057a06ad665f92c02863aca074fd5976c755d26bff16365299169e8415"
+      }
     }
-  ]
+  }
 }
 ```
 

--- a/pkg/securitypolicy/securitypolicy.go
+++ b/pkg/securitypolicy/securitypolicy.go
@@ -1,6 +1,47 @@
 package securitypolicy
 
-// SecurityPolicy is the user supplied security policy to enforce.
+import (
+	"encoding/base64"
+	"encoding/json"
+
+	"github.com/pkg/errors"
+)
+
+// Internal version of SecurityPolicyContainer
+type securityPolicyContainer struct {
+	// The command that we will allow the container to execute
+	Command []string `json:"command"`
+	// The rules for determining if a given environment variable is allowed
+	EnvRules []securityPolicyEnvironmentVariableRule `json:"env_rules"`
+	// An ordered list of dm-verity root hashes for each layer that makes up
+	// "a container". Containers are constructed as an overlay file system. The
+	// order that the layers are overlayed is important and needs to be enforced
+	// as part of policy.
+	Layers []string `json:"layers"`
+}
+
+// Internal versino of SecurityPolicyEnvironmentVariableRule
+type securityPolicyEnvironmentVariableRule struct {
+	Strategy string `json:"type"`
+	Rule     string `json:"rule"`
+}
+
+// SecurityPolicyState is a structure that holds user supplied policy to enforce
+// we keep both the encoded representation and the unmarshalled representation
+// because different components need to have access to either of these
+type SecurityPolicyState struct {
+	EncodedSecurityPolicy EncodedSecurityPolicy `json:"EncodedSecurityPolicy,omitempty"`
+	SecurityPolicy        `json:"SecurityPolicy,omitempty"`
+}
+
+// EncodedSecurityPolicy is a JSON representation of SecurityPolicy that has
+// been base64 encoded for storage in an annotation embedded within another
+// JSON configuration
+type EncodedSecurityPolicy struct {
+	SecurityPolicy string `json:"SecurityPolicy,omitempty"`
+}
+
+// JSON transport version
 type SecurityPolicy struct {
 	// Flag that when set to true allows for all checks to pass. Currently used
 	// to run with security policy enforcement "running dark"; checks can be in
@@ -9,8 +50,10 @@ type SecurityPolicy struct {
 	// standpoint. Policy enforcement isn't actually off as the policy is "allow
 	// everything:.
 	AllowAll bool `json:"allow_all"`
+	// Total number of containers in our map
+	NumContainers int `json:"num_containers"`
 	// One or more containers that are allowed to run
-	Containers []SecurityPolicyContainer `json:"containers"`
+	Containers map[string]SecurityPolicyContainer `json:"containers"`
 }
 
 // SecurityPolicyContainer contains information about a container that should be
@@ -21,15 +64,22 @@ type SecurityPolicy struct {
 // entries. Once that overlay creation is allowed, the command could not match
 // policy and running the command would be rejected.
 type SecurityPolicyContainer struct {
+	// Number of entries that should be in the "Command" map
+	NumCommands int `json:"num_commands"`
 	// The command that we will allow the container to execute
-	Command []string `json:"command"`
+	Command map[string]string `json:"command"`
+	// Number of entries that should be in the "EnvRules" map
+	NumEnvRules int `json:"num_env_rules"`
 	// The rules for determining if a given environment variable is allowed
-	EnvRules []SecurityPolicyEnvironmentVariableRule `json:"env_rules"`
-	// An ordered list of dm-verity root hashes for each layer that makes up
+	EnvRules map[string]SecurityPolicyEnvironmentVariableRule `json:"env_rules"`
+	// Number of entries that should in the "Layers" map
+	NumLayers int `json:"num_layers"`
+	// An "ordered list" of dm-verity root hashes for each layer that makes up
 	// "a container". Containers are constructed as an overlay file system. The
 	// order that the layers are overlayed is important and needs to be enforced
-	// as part of policy.
-	Layers []string `json:"layers"`
+	// as part of policy. The map is interpreted as an ordered list by arranging
+	// the keys of the map as indexes like 0,1,2,3 to establish the order.
+	Layers map[string]string `json:"layers"`
 }
 
 type SecurityPolicyEnvironmentVariableRule struct {
@@ -37,9 +87,36 @@ type SecurityPolicyEnvironmentVariableRule struct {
 	Rule     string `json:"rule"`
 }
 
-// EncodedSecurityPolicy is a JSON representation of SecurityPolicy that has
-// been base64 encoded for storage in an annotation embedded within another
-// JSON configuration
-type EncodedSecurityPolicy struct {
-	SecurityPolicy string `json:"SecurityPolicy,omitempty"`
+// Constructs SecurityPolicyState from base64Policy string. It first decodes
+// base64 policy and returns the structs security policy struct and encoded
+// security policy for given policy. The security policy is transmitted as json
+// in an annotation, so we first have to remove the base64 encoding that allows
+// the JSON based policy to be passed as a string. From there, we decode the
+// JSONand setup our security policy struct
+func NewSecurityPolicyState(base64Policy string) (*SecurityPolicyState, error) {
+	// construct an encoded security policy that holds the base64 representation
+	encodedSecurityPolicy := EncodedSecurityPolicy{
+		SecurityPolicy: base64Policy,
+	}
+
+	// base64 decode the incoming policy string
+	// its base64 encoded because it is coming from an annotation
+	// annotations are a map of string to string
+	// we want to store a complex json object so.... base64 it is
+	jsonPolicy, err := base64.StdEncoding.DecodeString(base64Policy)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to decode policy from Base64 format")
+	}
+
+	// json unmarshall the decoded to a SecurityPolicy
+	securityPolicy := SecurityPolicy{}
+	err = json.Unmarshal(jsonPolicy, &securityPolicy)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to unmarshal JSON policy")
+	}
+
+	return &SecurityPolicyState{
+		SecurityPolicy:        securityPolicy,
+		EncodedSecurityPolicy: encodedSecurityPolicy,
+	}, nil
 }

--- a/test/vendor/github.com/Microsoft/hcsshim/pkg/securitypolicy/securitypolicy.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/pkg/securitypolicy/securitypolicy.go
@@ -1,6 +1,47 @@
 package securitypolicy
 
-// SecurityPolicy is the user supplied security policy to enforce.
+import (
+	"encoding/base64"
+	"encoding/json"
+
+	"github.com/pkg/errors"
+)
+
+// Internal version of SecurityPolicyContainer
+type securityPolicyContainer struct {
+	// The command that we will allow the container to execute
+	Command []string `json:"command"`
+	// The rules for determining if a given environment variable is allowed
+	EnvRules []securityPolicyEnvironmentVariableRule `json:"env_rules"`
+	// An ordered list of dm-verity root hashes for each layer that makes up
+	// "a container". Containers are constructed as an overlay file system. The
+	// order that the layers are overlayed is important and needs to be enforced
+	// as part of policy.
+	Layers []string `json:"layers"`
+}
+
+// Internal versino of SecurityPolicyEnvironmentVariableRule
+type securityPolicyEnvironmentVariableRule struct {
+	Strategy string `json:"type"`
+	Rule     string `json:"rule"`
+}
+
+// SecurityPolicyState is a structure that holds user supplied policy to enforce
+// we keep both the encoded representation and the unmarshalled representation
+// because different components need to have access to either of these
+type SecurityPolicyState struct {
+	EncodedSecurityPolicy EncodedSecurityPolicy `json:"EncodedSecurityPolicy,omitempty"`
+	SecurityPolicy        `json:"SecurityPolicy,omitempty"`
+}
+
+// EncodedSecurityPolicy is a JSON representation of SecurityPolicy that has
+// been base64 encoded for storage in an annotation embedded within another
+// JSON configuration
+type EncodedSecurityPolicy struct {
+	SecurityPolicy string `json:"SecurityPolicy,omitempty"`
+}
+
+// JSON transport version
 type SecurityPolicy struct {
 	// Flag that when set to true allows for all checks to pass. Currently used
 	// to run with security policy enforcement "running dark"; checks can be in
@@ -9,8 +50,10 @@ type SecurityPolicy struct {
 	// standpoint. Policy enforcement isn't actually off as the policy is "allow
 	// everything:.
 	AllowAll bool `json:"allow_all"`
+	// Total number of containers in our map
+	NumContainers int `json:"num_containers"`
 	// One or more containers that are allowed to run
-	Containers []SecurityPolicyContainer `json:"containers"`
+	Containers map[string]SecurityPolicyContainer `json:"containers"`
 }
 
 // SecurityPolicyContainer contains information about a container that should be
@@ -21,15 +64,22 @@ type SecurityPolicy struct {
 // entries. Once that overlay creation is allowed, the command could not match
 // policy and running the command would be rejected.
 type SecurityPolicyContainer struct {
+	// Number of entries that should be in the "Command" map
+	NumCommands int `json:"num_commands"`
 	// The command that we will allow the container to execute
-	Command []string `json:"command"`
+	Command map[string]string `json:"command"`
+	// Number of entries that should be in the "EnvRules" map
+	NumEnvRules int `json:"num_env_rules"`
 	// The rules for determining if a given environment variable is allowed
-	EnvRules []SecurityPolicyEnvironmentVariableRule `json:"env_rules"`
-	// An ordered list of dm-verity root hashes for each layer that makes up
+	EnvRules map[string]SecurityPolicyEnvironmentVariableRule `json:"env_rules"`
+	// Number of entries that should in the "Layers" map
+	NumLayers int `json:"num_layers"`
+	// An "ordered list" of dm-verity root hashes for each layer that makes up
 	// "a container". Containers are constructed as an overlay file system. The
 	// order that the layers are overlayed is important and needs to be enforced
-	// as part of policy.
-	Layers []string `json:"layers"`
+	// as part of policy. The map is interpreted as an ordered list by arranging
+	// the keys of the map as indexes like 0,1,2,3 to establish the order.
+	Layers map[string]string `json:"layers"`
 }
 
 type SecurityPolicyEnvironmentVariableRule struct {
@@ -37,9 +87,36 @@ type SecurityPolicyEnvironmentVariableRule struct {
 	Rule     string `json:"rule"`
 }
 
-// EncodedSecurityPolicy is a JSON representation of SecurityPolicy that has
-// been base64 encoded for storage in an annotation embedded within another
-// JSON configuration
-type EncodedSecurityPolicy struct {
-	SecurityPolicy string `json:"SecurityPolicy,omitempty"`
+// Constructs SecurityPolicyState from base64Policy string. It first decodes
+// base64 policy and returns the structs security policy struct and encoded
+// security policy for given policy. The security policy is transmitted as json
+// in an annotation, so we first have to remove the base64 encoding that allows
+// the JSON based policy to be passed as a string. From there, we decode the
+// JSONand setup our security policy struct
+func NewSecurityPolicyState(base64Policy string) (*SecurityPolicyState, error) {
+	// construct an encoded security policy that holds the base64 representation
+	encodedSecurityPolicy := EncodedSecurityPolicy{
+		SecurityPolicy: base64Policy,
+	}
+
+	// base64 decode the incoming policy string
+	// its base64 encoded because it is coming from an annotation
+	// annotations are a map of string to string
+	// we want to store a complex json object so.... base64 it is
+	jsonPolicy, err := base64.StdEncoding.DecodeString(base64Policy)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to decode policy from Base64 format")
+	}
+
+	// json unmarshall the decoded to a SecurityPolicy
+	securityPolicy := SecurityPolicy{}
+	err = json.Unmarshal(jsonPolicy, &securityPolicy)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to unmarshal JSON policy")
+	}
+
+	return &SecurityPolicyState{
+		SecurityPolicy:        securityPolicy,
+		EncodedSecurityPolicy: encodedSecurityPolicy,
+	}, nil
 }


### PR DESCRIPTION
The existing array based policy  doesn't work with managed HSMs query language, so, we have switched
it up to using maps instead of arrays. Map keys correspond to the array index that an entry would have.
This allows us to keep ordering.

Signed-off-by: Sean T. Allen <seanallen@microsoft.com>