### PR TITLE
Update windowsbuilds.go

### DIFF
--- a/osversion/windowsbuilds.go
+++ b/osversion/windowsbuilds.go
@@ -38,4 +38,7 @@ const (
 
 	// V21H1 corresponds to Windows Server 21H1 (semi-annual channel).
 	V21H1 = 19043
+
+	// V21H2 corresponds to Windows Server 2022 (ltsc2022).
+	V21H2 = 20348
 )

--- a/test/vendor/github.com/Microsoft/hcsshim/osversion/windowsbuilds.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/osversion/windowsbuilds.go
@@ -38,4 +38,7 @@ const (
 
 	// V21H1 corresponds to Windows Server 21H1 (semi-annual channel).
 	V21H1 = 19043
+
+	// V21H2 corresponds to Windows Server 2022 (ltsc2022).
+	V21H2 = 20348
 )


### PR DESCRIPTION
Updates windowsbuilds to include build number for Windows Server 2022 and corresponding Windows 10 version.