### PR TITLE
Add ws2022 image/build to cri-containerd tests

### DIFF
--- a/test/cri-containerd/main_test.go
+++ b/test/cri-containerd/main_test.go
@@ -159,6 +159,13 @@ func requireBinary(t *testing.T, binary string) string {
 }
 
 func getWindowsNanoserverImage(build uint16) string {
+	// Due to some efforts in improving down-level compatibility for Windows containers (see
+	// https://techcommunity.microsoft.com/t5/containers/windows-server-2022-and-beyond-for-containers/ba-p/2712487)
+	// the ltsc2022 image should continue to work on builds ws2022 and onwards. The panic for "unsupported build"
+	// should only be triggered if the user is on a build older than RS5 or 21h1 now.
+	if build > osversion.V21H2 {
+		build = osversion.V21H2
+	}
 	switch build {
 	case osversion.RS5:
 		return "mcr.microsoft.com/windows/nanoserver:1809"
@@ -170,23 +177,27 @@ func getWindowsNanoserverImage(build uint16) string {
 		return "mcr.microsoft.com/windows/nanoserver:2004"
 	case osversion.V20H2:
 		return "mcr.microsoft.com/windows/nanoserver:2009"
+	case osversion.V21H2:
+		return "mcr.microsoft.com/windows/nanoserver:ltsc2022"
 	default:
 		panic("unsupported build")
 	}
 }
 
 func getWindowsServerCoreImage(build uint16) string {
-	switch build {
-	case osversion.RS5:
+	switch b := build; {
+	case b == osversion.RS5:
 		return "mcr.microsoft.com/windows/servercore:1809"
-	case osversion.V19H1:
+	case b == osversion.V19H1:
 		return "mcr.microsoft.com/windows/servercore:1903"
-	case osversion.V19H2:
+	case b == osversion.V19H2:
 		return "mcr.microsoft.com/windows/servercore:1909"
-	case osversion.V20H1:
+	case b == osversion.V20H1:
 		return "mcr.microsoft.com/windows/servercore:2004"
-	case osversion.V20H2:
+	case b == osversion.V20H2:
 		return "mcr.microsoft.com/windows/servercore:2009"
+	case b >= osversion.V21H2:
+		return "mcr.microsoft.com/windows/servercore:ltsc2022"
 	default:
 		panic("unsupported build")
 	}

--- a/test/cri-containerd/main_test.go
+++ b/test/cri-containerd/main_test.go
@@ -159,13 +159,6 @@ func requireBinary(t *testing.T, binary string) string {
 }
 
 func getWindowsNanoserverImage(build uint16) string {
-	// Due to some efforts in improving down-level compatibility for Windows containers (see
-	// https://techcommunity.microsoft.com/t5/containers/windows-server-2022-and-beyond-for-containers/ba-p/2712487)
-	// the ltsc2022 image should continue to work on builds ws2022 and onwards. The panic for "unsupported build"
-	// should only be triggered if the user is on 21h1 or a build older than RS5 now.
-	if build > osversion.V21H2Server {
-		build = osversion.V21H2Server
-	}
 	switch build {
 	case osversion.RS5:
 		return "mcr.microsoft.com/windows/nanoserver:1809"
@@ -180,6 +173,13 @@ func getWindowsNanoserverImage(build uint16) string {
 	case osversion.V21H2Server:
 		return "mcr.microsoft.com/windows/nanoserver:ltsc2022"
 	default:
+		// Due to some efforts in improving down-level compatibility for Windows containers (see
+		// https://techcommunity.microsoft.com/t5/containers/windows-server-2022-and-beyond-for-containers/ba-p/2712487)
+		// the ltsc2022 image should continue to work on builds ws2022 and onwards. With this in mind,
+		// if there's no mapping for the host build, just use the Windows Server 2022 image.
+		if build > osversion.V21H2Server {
+			return "mcr.microsoft.com/windows/nanoserver:ltsc2022"
+		}
 		panic("unsupported build")
 	}
 }
@@ -206,6 +206,13 @@ func getWindowsServerCoreImage(build uint16) string {
 	case osversion.V21H2Server:
 		return "mcr.microsoft.com/windows/servercore:ltsc2022"
 	default:
+		// Due to some efforts in improving down-level compatibility for Windows containers (see
+		// https://techcommunity.microsoft.com/t5/containers/windows-server-2022-and-beyond-for-containers/ba-p/2712487)
+		// the ltsc2022 image should continue to work on builds ws2022 and onwards. With this in mind,
+		// if there's no mapping for the host build, just use the Windows Server 2022 image.
+		if build > osversion.V21H2Server {
+			return "mcr.microsoft.com/windows/servercore:ltsc2022"
+		}
 		panic("unsupported build")
 	}
 }

--- a/test/cri-containerd/main_test.go
+++ b/test/cri-containerd/main_test.go
@@ -185,13 +185,6 @@ func getWindowsNanoserverImage(build uint16) string {
 }
 
 func getWindowsServerCoreImage(build uint16) string {
-	// Due to some efforts in improving down-level compatibility for Windows containers (see
-	// https://techcommunity.microsoft.com/t5/containers/windows-server-2022-and-beyond-for-containers/ba-p/2712487)
-	// the ltsc2022 image should continue to work on builds ws2022 and onwards. The panic for "unsupported build"
-	// should only be triggered if the user is on 21h1 or a build older than RS5 now.
-	if build > osversion.V21H2Server {
-		build = osversion.V21H2Server
-	}
 	switch build {
 	case osversion.RS5:
 		return "mcr.microsoft.com/windows/servercore:1809"

--- a/test/cri-containerd/main_test.go
+++ b/test/cri-containerd/main_test.go
@@ -163,8 +163,8 @@ func getWindowsNanoserverImage(build uint16) string {
 	// https://techcommunity.microsoft.com/t5/containers/windows-server-2022-and-beyond-for-containers/ba-p/2712487)
 	// the ltsc2022 image should continue to work on builds ws2022 and onwards. The panic for "unsupported build"
 	// should only be triggered if the user is on 21h1 or a build older than RS5 now.
-	if build > osversion.V21H2 {
-		build = osversion.V21H2
+	if build > osversion.V21H2Server {
+		build = osversion.V21H2Server
 	}
 	switch build {
 	case osversion.RS5:
@@ -177,7 +177,7 @@ func getWindowsNanoserverImage(build uint16) string {
 		return "mcr.microsoft.com/windows/nanoserver:2004"
 	case osversion.V20H2:
 		return "mcr.microsoft.com/windows/nanoserver:2009"
-	case osversion.V21H2:
+	case osversion.V21H2Server:
 		return "mcr.microsoft.com/windows/nanoserver:ltsc2022"
 	default:
 		panic("unsupported build")
@@ -185,18 +185,25 @@ func getWindowsNanoserverImage(build uint16) string {
 }
 
 func getWindowsServerCoreImage(build uint16) string {
-	switch b := build; {
-	case b == osversion.RS5:
+	// Due to some efforts in improving down-level compatibility for Windows containers (see
+	// https://techcommunity.microsoft.com/t5/containers/windows-server-2022-and-beyond-for-containers/ba-p/2712487)
+	// the ltsc2022 image should continue to work on builds ws2022 and onwards. The panic for "unsupported build"
+	// should only be triggered if the user is on 21h1 or a build older than RS5 now.
+	if build > osversion.V21H2Server {
+		build = osversion.V21H2Server
+	}
+	switch build {
+	case osversion.RS5:
 		return "mcr.microsoft.com/windows/servercore:1809"
-	case b == osversion.V19H1:
+	case osversion.V19H1:
 		return "mcr.microsoft.com/windows/servercore:1903"
-	case b == osversion.V19H2:
+	case osversion.V19H2:
 		return "mcr.microsoft.com/windows/servercore:1909"
-	case b == osversion.V20H1:
+	case osversion.V20H1:
 		return "mcr.microsoft.com/windows/servercore:2004"
-	case b == osversion.V20H2:
+	case osversion.V20H2:
 		return "mcr.microsoft.com/windows/servercore:2009"
-	case b >= osversion.V21H2:
+	case osversion.V21H2Server:
 		return "mcr.microsoft.com/windows/servercore:ltsc2022"
 	default:
 		panic("unsupported build")

--- a/test/cri-containerd/main_test.go
+++ b/test/cri-containerd/main_test.go
@@ -162,7 +162,7 @@ func getWindowsNanoserverImage(build uint16) string {
 	// Due to some efforts in improving down-level compatibility for Windows containers (see
 	// https://techcommunity.microsoft.com/t5/containers/windows-server-2022-and-beyond-for-containers/ba-p/2712487)
 	// the ltsc2022 image should continue to work on builds ws2022 and onwards. The panic for "unsupported build"
-	// should only be triggered if the user is on a build older than RS5 or 21h1 now.
+	// should only be triggered if the user is on 21h1 or a build older than RS5 now.
 	if build > osversion.V21H2 {
 		build = osversion.V21H2
 	}


### PR DESCRIPTION
This change adds a new case to the getWindowsServerCoreImage and
getWindowsNanoserverImage functions to return ws2022 on a ws2022 or higher
build. The higher case is because of some recent efforts to improve down-level
compatability for Windows container images. For reference, the ltsc2022 image
works on a win11 host without hypervisor isolation.

Signed-off-by: Daniel Canter <dcanter@microsoft.com>