### PR TITLE
Update securitypolicy tool to support multiple registries

### DIFF
--- a/internal/tools/securitypolicy/README.md
+++ b/internal/tools/securitypolicy/README.md
@@ -114,13 +114,26 @@ TOML configuration file to process (required)
 
 output raw JSON in addition to the Base64 encoded version
 
-- -u
+## Authorization
 
-username to use to login to remote container services (defaults to anonymous)
+Some images will be pulled from registries that require authorization. To add
+authorization information for a given image, you would add an `[auth]` object
+to the TOML definiton for that image. For example:
 
-- -p
+```toml
+[[image]]
+name = "rust:1.52.1"
+command = ["rustc", "--help"]
 
-password to use to login to remote container services (defaults to anonymous)
+[auth]
+username = "my username"
+password = "my password"
+```
+
+Authorization information needs added on a per-image basis as it can vary from
+image to image and their respective registries.
+
+To pull an image using anonymous access, no `[auth]` object is required.
 
 ## Pause container
 


### PR DESCRIPTION
Before this change, the securitypolicy tool could authorize with a registry
by providing a username and password as command-line options.

This approach worked fine as long as all images were being pulled from the
same registry. It doesn't work if you need to access multiple registries.

After this change, authorization is provided in the policy.toml on a per-image
basis. This allows for mixing and matching different registries together as
part of a pod.

Signed-off-by: Sean T. Allen <seanallen@microsoft.com>