### PR TITLE
Enforce security policy at unmount

### DIFF
--- a/internal/guest/runtime/hcsv2/uvm.go
+++ b/internal/guest/runtime/hcsv2/uvm.go
@@ -437,7 +437,7 @@ func modifyMappedVirtualDisk(ctx context.Context, rt prot.ModifyRequestType, mvd
 		return nil
 	case prot.MreqtRemove:
 		if mvd.MountPath != "" {
-			if err := scsi.Unmount(ctx, mvd.Controller, mvd.Lun, mvd.MountPath, mvd.Encrypted); err != nil {
+			if err := scsi.Unmount(ctx, mvd.Controller, mvd.Lun, mvd.MountPath, mvd.Encrypted, mvd.VerityInfo, securityPolicy); err != nil {
 				return err
 			}
 		}

--- a/internal/guest/storage/pmem/pmem.go
+++ b/internal/guest/storage/pmem/pmem.go
@@ -128,6 +128,10 @@ func Unmount(ctx context.Context, devNumber uint32, target string, mappingInfo *
 		trace.Int64Attribute("device", int64(devNumber)),
 		trace.StringAttribute("target", target))
 
+	if err := securityPolicy.EnforceDeviceUnmountPolicy(target); err != nil {
+		return errors.Wrapf(err, "unmounting pmem device from %s denied by policy", target)
+	}
+
 	if err := storage.UnmountPath(ctx, target, true); err != nil {
 		return errors.Wrapf(err, "failed to unmount target: %s", target)
 	}

--- a/internal/guest/storage/pmem/pmem_test.go
+++ b/internal/guest/storage/pmem/pmem_test.go
@@ -227,7 +227,7 @@ func Test_Mount_Valid_Data(t *testing.T) {
 	}
 }
 
-func Test_Security_Policy_Enforcement(t *testing.T) {
+func Test_Security_Policy_Enforcement_Mount_Calls(t *testing.T) {
 	clearTestDependencies()
 
 	osMkdirAll = func(path string, perm os.FileMode) error {
@@ -247,6 +247,49 @@ func Test_Security_Policy_Enforcement(t *testing.T) {
 	expectedDeviceMountCalls := 1
 	if enforcer.DeviceMountCalls != expectedDeviceMountCalls {
 		t.Fatalf("expected %d attempt at pmem mount enforcement, got %d", expectedDeviceMountCalls, enforcer.DeviceMountCalls)
+	}
+
+	expectedDeviceUnmountCalls := 0
+	if enforcer.DeviceUnmountCalls != expectedDeviceUnmountCalls {
+		t.Fatalf("expected %d attempt at pmem mount enforcement, got %d", expectedDeviceUnmountCalls, enforcer.DeviceUnmountCalls)
+	}
+
+	expectedOverlay := 0
+	if enforcer.OverlayMountCalls != expectedOverlay {
+		t.Fatalf("expected %d attempts at overlay mount enforcement, got %d", expectedOverlay, enforcer.OverlayMountCalls)
+	}
+}
+
+func Test_Security_Policy_Enforcement_Unmount_Calls(t *testing.T) {
+	clearTestDependencies()
+
+	osMkdirAll = func(path string, perm os.FileMode) error {
+		return nil
+	}
+
+	unixMount = func(source string, target string, fstype string, flags uintptr, data string) error {
+		return nil
+	}
+
+	enforcer := mountMonitoringSecurityPolicyEnforcer()
+	err := Mount(context.Background(), 0, "/fake/path", nil, nil, enforcer)
+	if err != nil {
+		t.Fatalf("expected nil err, got: %v", err)
+	}
+
+	err = Unmount(context.Background(), 0, "/fake/path", nil, nil, enforcer)
+	if err != nil {
+		t.Fatalf("expected nil err, got: %v", err)
+	}
+
+	expectedDeviceMountCalls := 1
+	if enforcer.DeviceMountCalls != expectedDeviceMountCalls {
+		t.Fatalf("expected %d attempt at pmem mount enforcement, got %d", expectedDeviceMountCalls, enforcer.DeviceMountCalls)
+	}
+
+	expectedDeviceUnmountCalls := 1
+	if enforcer.DeviceUnmountCalls != expectedDeviceUnmountCalls {
+		t.Fatalf("expected %d attempt at pmem mount enforcement, got %d", expectedDeviceUnmountCalls, enforcer.DeviceUnmountCalls)
 	}
 
 	expectedOverlay := 0

--- a/internal/guest/storage/test/policy/mountmonitoringsecuritypolicyenforcer.go
+++ b/internal/guest/storage/test/policy/mountmonitoringsecuritypolicyenforcer.go
@@ -7,14 +7,20 @@ import (
 // For testing. Records the number of calls to each method so we can verify
 // the expected interactions took place.
 type MountMonitoringSecurityPolicyEnforcer struct {
-	DeviceMountCalls  int
-	OverlayMountCalls int
+	DeviceMountCalls   int
+	DeviceUnmountCalls int
+	OverlayMountCalls  int
 }
 
 var _ securitypolicy.SecurityPolicyEnforcer = (*MountMonitoringSecurityPolicyEnforcer)(nil)
 
 func (p *MountMonitoringSecurityPolicyEnforcer) EnforceDeviceMountPolicy(target string, deviceHash string) (err error) {
 	p.DeviceMountCalls++
+	return nil
+}
+
+func (p *MountMonitoringSecurityPolicyEnforcer) EnforceDeviceUnmountPolicy(target string) (err error) {
+	p.DeviceUnmountCalls++
 	return nil
 }
 


### PR DESCRIPTION
This is the first iteration of policy enforcement at unmount. There is an additional set
of functionality that will come as part of a larger change in the near future.

With this commit, we record that a device has been unmounted such that it isn't eligible to
be used in any overlay after unmounting.

In a future commit, I will be adding disallowing unmounting a device that is being used by a
running container.

Signed-off-by: Sean T. Allen <seanallen@microsoft.com>