### PR TITLE
Make policy environment variable rules consts

### DIFF
--- a/internal/tools/securitypolicy/main.go
+++ b/internal/tools/securitypolicy/main.go
@@ -79,8 +79,8 @@ func main() {
 }
 
 type EnvironmentVariableRule struct {
-	Strategy string `toml:"strategy"`
-	Rule     string `toml:"rule"`
+	Strategy sp.EnvVarRule `toml:"strategy"`
+	Rule     string        `toml:"rule"`
 }
 
 type Image struct {
@@ -205,7 +205,7 @@ func createPolicyFromConfig(config Config) (sp.SecurityPolicy, error) {
 		}
 		for _, env := range config.Config.Env {
 			rule := sp.SecurityPolicyEnvironmentVariableRule{
-				Strategy: "string",
+				Strategy: sp.EnvVarRuleString,
 				Rule:     env,
 			}
 
@@ -215,7 +215,7 @@ func createPolicyFromConfig(config Config) (sp.SecurityPolicy, error) {
 		// cri adds TERM=xterm for all workload containers. we add to all containers
 		// to prevent any possble erroring
 		rule := sp.SecurityPolicyEnvironmentVariableRule{
-			Strategy: "string",
+			Strategy: sp.EnvVarRuleString,
 			Rule:     "TERM=xterm",
 		}
 
@@ -233,7 +233,7 @@ func createPolicyFromConfig(config Config) (sp.SecurityPolicy, error) {
 func validateEnvRules(rules []EnvironmentVariableRule) error {
 	for _, rule := range rules {
 		switch rule.Strategy {
-		case "re2":
+		case sp.EnvVarRuleRegex:
 			_, err := regexp.Compile(rule.Rule)
 			if err != nil {
 				return err

--- a/pkg/securitypolicy/securitypolicy.go
+++ b/pkg/securitypolicy/securitypolicy.go
@@ -7,6 +7,13 @@ import (
 	"github.com/pkg/errors"
 )
 
+type EnvVarRule string
+
+const (
+	EnvVarRuleString EnvVarRule = "string"
+	EnvVarRuleRegex  EnvVarRule = "re2"
+)
+
 // Internal version of SecurityPolicyContainer
 type securityPolicyContainer struct {
 	// The command that we will allow the container to execute
@@ -22,8 +29,8 @@ type securityPolicyContainer struct {
 
 // Internal versino of SecurityPolicyEnvironmentVariableRule
 type securityPolicyEnvironmentVariableRule struct {
-	Strategy string `json:"type"`
-	Rule     string `json:"rule"`
+	Strategy EnvVarRule `json:"type"`
+	Rule     string     `json:"rule"`
 }
 
 // SecurityPolicyState is a structure that holds user supplied policy to enforce
@@ -83,8 +90,8 @@ type SecurityPolicyContainer struct {
 }
 
 type SecurityPolicyEnvironmentVariableRule struct {
-	Strategy string `json:"strategy"`
-	Rule     string `json:"rule"`
+	Strategy EnvVarRule `json:"strategy"`
+	Rule     string     `json:"rule"`
 }
 
 // Constructs SecurityPolicyState from base64Policy string. It first decodes

--- a/pkg/securitypolicy/securitypolicy_test.go
+++ b/pkg/securitypolicy/securitypolicy_test.go
@@ -569,7 +569,7 @@ func Test_EnforceEnvironmentVariablePolicy_Re2Match(t *testing.T) {
 	container := generateContainersContainer(r, 1)
 	// add a rule to re2 match
 	re2MatchRule := securityPolicyEnvironmentVariableRule{
-		Strategy: "re2",
+		Strategy: EnvVarRuleRegex,
 		Rule:     "PREFIX_.+=.+"}
 	container.EnvRules = append(container.EnvRules, re2MatchRule)
 	p.containers = append(p.containers, container)

--- a/test/vendor/github.com/Microsoft/hcsshim/pkg/securitypolicy/securitypolicy.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/pkg/securitypolicy/securitypolicy.go
@@ -7,6 +7,13 @@ import (
 	"github.com/pkg/errors"
 )
 
+type EnvVarRule string
+
+const (
+	EnvVarRuleString EnvVarRule = "string"
+	EnvVarRuleRegex  EnvVarRule = "re2"
+)
+
 // Internal version of SecurityPolicyContainer
 type securityPolicyContainer struct {
 	// The command that we will allow the container to execute
@@ -22,8 +29,8 @@ type securityPolicyContainer struct {
 
 // Internal versino of SecurityPolicyEnvironmentVariableRule
 type securityPolicyEnvironmentVariableRule struct {
-	Strategy string `json:"type"`
-	Rule     string `json:"rule"`
+	Strategy EnvVarRule `json:"type"`
+	Rule     string     `json:"rule"`
 }
 
 // SecurityPolicyState is a structure that holds user supplied policy to enforce
@@ -83,8 +90,8 @@ type SecurityPolicyContainer struct {
 }
 
 type SecurityPolicyEnvironmentVariableRule struct {
-	Strategy string `json:"strategy"`
-	Rule     string `json:"rule"`
+	Strategy EnvVarRule `json:"strategy"`
+	Rule     string     `json:"rule"`
 }
 
 // Constructs SecurityPolicyState from base64Policy string. It first decodes


### PR DESCRIPTION
This was a small change that came up in the initial code review that we put
off "for a later date".

The valid strategy strings are now shared between the policy tool and gcs
so they can't end up with a mismatch.

Signed-off-by: Sean T. Allen <seanallen@microsoft.com>