### PR TITLE
Update naming in internal security policy tool

### DIFF
--- a/internal/tools/securitypolicy/README.md
+++ b/internal/tools/securitypolicy/README.md
@@ -17,11 +17,11 @@ be downloaded, turned into an ext4, and finally a dm-verity root hash calculated
 ## Example TOML configuration file
 
 ```toml
-[[image]]
+[[container]]
 name = "rust:1.52.1"
 command = ["rustc", "--help"]
 
-[[image.env_rule]]
+[[container.env_rule]]
 strategy = "re2"
 rule = "PREFIX_.+=.+"
 ```


### PR DESCRIPTION
Maksim pointed out that when we added information beyond the image of an image
that the "image" entries in a TOML policy generation file weren't describing
images; the describe containers.

The addition of command line, environment variables, and what not to allow
is a description of a container that should be allowed to be created. The
only image specific bit is the name.

Signed-off-by: Sean T. Allen <seanallen@microsoft.com>