### PR TITLE
fix vmAccess param usage in AddSCSI

### DIFF
--- a/internal/uvm/scsi.go
+++ b/internal/uvm/scsi.go
@@ -266,7 +266,7 @@ func (uvm *UtilityVM) AddSCSI(ctx context.Context, hostPath string, uvmPath stri
 		attachmentType: "VirtualDisk",
 		readOnly:       readOnly,
 		guestOptions:   guestOptions,
-		vmAccess:       VMAccessTypeIndividual,
+		vmAccess:       vmAccess,
 	}
 	return uvm.addSCSIActual(ctx, addReq)
 }

--- a/test/vendor/github.com/Microsoft/hcsshim/ext4/dmverity/dmverity.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/ext4/dmverity/dmverity.go
@@ -16,8 +16,9 @@ import (
 
 const (
 	blockSize = compactext4.BlockSize
+	// RecommendedVHDSizeGB is the recommended size in GB for VHDs, which is not a hard limit. 
+	RecommendedVHDSizeGB = 128 * 1024 * 1024 * 1024
 )
-
 var salt = bytes.Repeat([]byte{0}, 32)
 
 var (

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/uvm/scsi.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/uvm/scsi.go
@@ -266,7 +266,7 @@ func (uvm *UtilityVM) AddSCSI(ctx context.Context, hostPath string, uvmPath stri
 		attachmentType: "VirtualDisk",
 		readOnly:       readOnly,
 		guestOptions:   guestOptions,
-		vmAccess:       VMAccessTypeIndividual,
+		vmAccess:       vmAccess,
 	}
 	return uvm.addSCSIActual(ctx, addReq)
 }

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/uvm/vpmem_mapped.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/uvm/vpmem_mapped.go
@@ -79,13 +79,11 @@ func newMappedVPMemModifyRequest(ctx context.Context, rType string, deviceNumber
 	if verity, err := readVeritySuperBlock(ctx, md.hostPath); err != nil {
 		log.G(ctx).WithError(err).WithField("hostPath", md.hostPath).Debug("unable to read dm-verity information from VHD")
 	} else {
-		if verity != nil {
-			log.G(ctx).WithFields(logrus.Fields{
-				"hostPath":   md.hostPath,
-				"rootDigest": verity.RootDigest,
-			}).Debug("adding multi-mapped VPMem with dm-verity")
-			guestSettings.VerityInfo = verity
-		}
+		log.G(ctx).WithFields(logrus.Fields{
+			"hostPath":   md.hostPath,
+			"rootDigest": verity.RootDigest,
+		}).Debug("adding multi-mapped VPMem with dm-verity")
+		guestSettings.VerityInfo = verity
 	}
 
 	request := &hcsschema.ModifySettingRequest{


### PR DESCRIPTION
AddSCSI wasn't using vmAccess parameter when making addSCSIRequest

Signed-off-by: Maksim An <maksiman@microsoft.com>