### PR TITLE
Change internal data structure in SecurityPolicyEnforcer

### DIFF
--- a/pkg/securitypolicy/securitypolicy_test.go
+++ b/pkg/securitypolicy/securitypolicy_test.go
@@ -487,7 +487,7 @@ func Test_EnforceCommandPolicy_NarrowingMatches(t *testing.T) {
 		if len(containerOneMapping) != 2 {
 			return false
 		}
-		for _, id := range containerOneMapping {
+		for id := range containerOneMapping {
 			if (id != testContainerOneID) && (id != testContainerTwoID) {
 				return false
 			}
@@ -497,7 +497,7 @@ func Test_EnforceCommandPolicy_NarrowingMatches(t *testing.T) {
 		if len(containerTwoMapping) != 2 {
 			return false
 		}
-		for _, id := range containerTwoMapping {
+		for id := range containerTwoMapping {
 			if (id != testContainerOneID) && (id != testContainerTwoID) {
 				return false
 			}
@@ -516,7 +516,7 @@ func Test_EnforceCommandPolicy_NarrowingMatches(t *testing.T) {
 		if len(updatedMapping) != 1 {
 			return false
 		}
-		for _, id := range updatedMapping {
+		for id := range updatedMapping {
 			if id != testContainerTwoID {
 				return false
 			}
@@ -686,7 +686,7 @@ func Test_EnforceEnvironmentVariablePolicy_NarrowingMatches(t *testing.T) {
 		if len(containerOneMapping) != 2 {
 			return false
 		}
-		for _, id := range containerOneMapping {
+		for id := range containerOneMapping {
 			if (id != testContainerOneID) && (id != testContainerTwoID) {
 				return false
 			}
@@ -696,7 +696,7 @@ func Test_EnforceEnvironmentVariablePolicy_NarrowingMatches(t *testing.T) {
 		if len(containerTwoMapping) != 2 {
 			return false
 		}
-		for _, id := range containerTwoMapping {
+		for id := range containerTwoMapping {
 			if (id != testContainerOneID) && (id != testContainerTwoID) {
 				return false
 			}
@@ -716,7 +716,7 @@ func Test_EnforceEnvironmentVariablePolicy_NarrowingMatches(t *testing.T) {
 		if len(updatedMapping) != 1 {
 			return false
 		}
-		for _, id := range updatedMapping {
+		for id := range updatedMapping {
 			if id != testContainerTwoID {
 				return false
 			}


### PR DESCRIPTION
This commit changes the data structure that we use to track possible
GCS container ids for a given security policy container from an array
to a set.

Set is the correct data structure to represent our constraint of "id
should only appear once".

Additionally, it makes this tricky bit of code slightly easier to understand.

Signed-off-by: Sean T. Allen <seanallen@microsoft.com>