### PR TITLE
Update kernel driver annotation for accuracy

### DIFF
--- a/internal/hcsoci/devices.go
+++ b/internal/hcsoci/devices.go
@@ -21,10 +21,10 @@ import (
 
 const deviceUtilExeName = "device-util.exe"
 
-// getAssignedDeviceKernelDrivers gets any device drivers specified on the spec.
+// getSpecKernelDrivers gets any device drivers specified on the spec.
 // Drivers are optional, therefore do not return an error if none are on the spec.
-func getAssignedDeviceKernelDrivers(annotations map[string]string) ([]string, error) {
-	drivers := oci.ParseAnnotationCommaSeparated(oci.AnnotationAssignedDeviceKernelDrivers, annotations)
+func getSpecKernelDrivers(annotations map[string]string) ([]string, error) {
+	drivers := oci.ParseAnnotationCommaSeparated(oci.AnnotationVirtualMachineKernelDrivers, annotations)
 	for _, driver := range drivers {
 		if _, err := os.Stat(driver); err != nil {
 			return nil, errors.Wrapf(err, "failed to find path to drivers at %s", driver)

--- a/internal/hcsoci/resources_wcow.go
+++ b/internal/hcsoci/resources_wcow.go
@@ -105,7 +105,7 @@ func allocateWindowsResources(ctx context.Context, coi *createOptionsInternal, r
 
 	if coi.HostingSystem != nil {
 		// get the spec specified kernel drivers and install them on the UVM
-		drivers, err := getAssignedDeviceKernelDrivers(coi.Spec.Annotations)
+		drivers, err := getSpecKernelDrivers(coi.Spec.Annotations)
 		if err != nil {
 			return err
 		}

--- a/internal/oci/annotations.go
+++ b/internal/oci/annotations.go
@@ -73,11 +73,12 @@ const (
 	// AnnotationGPUVHDPath overrides the default path to search for the gpu vhd
 	AnnotationGPUVHDPath = "io.microsoft.lcow.gpuvhdpath"
 
-	// AnnotationAssignedDeviceKernelDrivers indicates what drivers to install in the pod during device
-	// assignment. This value should contain a list of comma separated directories containing all
-	// files and information needed to install given driver(s). This may include .sys,
-	// .inf, .cer, and/or other files used during standard installation with pnputil.
-	AnnotationAssignedDeviceKernelDrivers = "io.microsoft.assigneddevice.kerneldrivers"
+	// AnnotationVirtualMachineKernelDrivers indicates what drivers to install in the pod.
+	// This value should contain a list of comma separated directories containing all
+	// files and information needed to install given driver(s). For windows, this may
+	// include .sys, .inf, .cer, and/or other files used during standard installation with pnputil.
+	// For LCOW, this may include a vhd file that contains kernel modules as *.ko files.
+	AnnotationVirtualMachineKernelDrivers = "io.microsoft.virtualmachine.kerneldrivers"
 
 	// AnnotationDeviceExtensions contains a comma separated list of full paths to device extension files.
 	// The content of these are added to a container's hcs create document.

--- a/test/cri-containerd/container_virtual_device_test.go
+++ b/test/cri-containerd/container_virtual_device_test.go
@@ -179,7 +179,7 @@ func getGPUContainerRequestWCOW(t *testing.T, podID string, podConfig *runtime.P
 				},
 			},
 			Annotations: map[string]string{
-				oci.AnnotationAssignedDeviceKernelDrivers: testDriversPath,
+				oci.AnnotationVirtualMachineKernelDrivers: testDriversPath,
 			},
 		},
 		PodSandboxId:  podID,

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/hcsoci/devices.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/hcsoci/devices.go
@@ -21,10 +21,10 @@ import (
 
 const deviceUtilExeName = "device-util.exe"
 
-// getAssignedDeviceKernelDrivers gets any device drivers specified on the spec.
+// getSpecKernelDrivers gets any device drivers specified on the spec.
 // Drivers are optional, therefore do not return an error if none are on the spec.
-func getAssignedDeviceKernelDrivers(annotations map[string]string) ([]string, error) {
-	drivers := oci.ParseAnnotationCommaSeparated(oci.AnnotationAssignedDeviceKernelDrivers, annotations)
+func getSpecKernelDrivers(annotations map[string]string) ([]string, error) {
+	drivers := oci.ParseAnnotationCommaSeparated(oci.AnnotationVirtualMachineKernelDrivers, annotations)
 	for _, driver := range drivers {
 		if _, err := os.Stat(driver); err != nil {
 			return nil, errors.Wrapf(err, "failed to find path to drivers at %s", driver)

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/hcsoci/resources_wcow.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/hcsoci/resources_wcow.go
@@ -105,7 +105,7 @@ func allocateWindowsResources(ctx context.Context, coi *createOptionsInternal, r
 
 	if coi.HostingSystem != nil {
 		// get the spec specified kernel drivers and install them on the UVM
-		drivers, err := getAssignedDeviceKernelDrivers(coi.Spec.Annotations)
+		drivers, err := getSpecKernelDrivers(coi.Spec.Annotations)
 		if err != nil {
 			return err
 		}

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/oci/annotations.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/oci/annotations.go
@@ -73,11 +73,12 @@ const (
 	// AnnotationGPUVHDPath overrides the default path to search for the gpu vhd
 	AnnotationGPUVHDPath = "io.microsoft.lcow.gpuvhdpath"
 
-	// AnnotationAssignedDeviceKernelDrivers indicates what drivers to install in the pod during device
-	// assignment. This value should contain a list of comma separated directories containing all
-	// files and information needed to install given driver(s). This may include .sys,
-	// .inf, .cer, and/or other files used during standard installation with pnputil.
-	AnnotationAssignedDeviceKernelDrivers = "io.microsoft.assigneddevice.kerneldrivers"
+	// AnnotationVirtualMachineKernelDrivers indicates what drivers to install in the pod.
+	// This value should contain a list of comma separated directories containing all
+	// files and information needed to install given driver(s). For windows, this may
+	// include .sys, .inf, .cer, and/or other files used during standard installation with pnputil.
+	// For LCOW, this may include a vhd file that contains kernel modules as *.ko files.
+	AnnotationVirtualMachineKernelDrivers = "io.microsoft.virtualmachine.kerneldrivers"
 
 	// AnnotationDeviceExtensions contains a comma separated list of full paths to device extension files.
 	// The content of these are added to a container's hcs create document.


### PR DESCRIPTION
This annotation is not being used in prod currently, so updating it to be more accurate since adding drivers don't need to be tied to assigning a device from the spec.  

Signed-off-by: Kathryn Baldauf <kabaldau@microsoft.com>