### PR TITLE
Update json format for security policy

### DIFF
--- a/internal/tools/securitypolicy/README.md
+++ b/internal/tools/securitypolicy/README.md
@@ -34,70 +34,84 @@ represented in JSON.
 ```json
 {
   "allow_all": false,
-  "num_containers": 2,
   "containers": {
-    "0": {
-      "num_commands": 2,
-      "command": {
-        "0": "rustc",
-        "1": "--help"
-      },
-      "num_env_rules": 6,
-      "env_rules": {
-        "0": {
-          "strategy": "string",
-          "rule": "PATH=/usr/local/cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+    "length": 2,
+    "elements": {
+      "0": {
+        "command": {
+          "length": 2,
+          "elements": {
+            "0": "rustc",
+            "1": "--help"
+          }
         },
-        "1": {
-          "strategy": "string",
-          "rule": "RUSTUP_HOME=/usr/local/rustup"
+        "env_rules": {
+          "length": 6,
+          "elements": {
+            "0": {
+              "strategy": "re2",
+              "rule": "PREFIX_.+=.+"
+            },
+            "1": {
+              "strategy": "string",
+              "rule": "PATH=/usr/local/cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+            },
+            "2": {
+              "strategy": "string",
+              "rule": "RUSTUP_HOME=/usr/local/rustup"
+            },
+            "3": {
+              "strategy": "string",
+              "rule": "CARGO_HOME=/usr/local/cargo"
+            },
+            "4": {
+              "strategy": "string",
+              "rule": "RUST_VERSION=1.52.1"
+            },
+            "5": {
+              "strategy": "string",
+              "rule": "TERM=xterm"
+            }
+          }
         },
-        "2": {
-          "strategy": "string",
-          "rule": "CARGO_HOME=/usr/local/cargo"
-        },
-        "3": {
-          "strategy": "string",
-          "rule": "RUST_VERSION=1.52.1"
-        },
-        "4": {
-          "strategy": "string",
-          "rule": "TERM=xterm"
-        },
-        "5": {
-          "strategy": "re2",
-          "rule": "PREFIX_.+=.+"
+        "layers": {
+          "length": 6,
+          "elements": {
+            "0": "fe84c9d5bfddd07a2624d00333cf13c1a9c941f3a261f13ead44fc6a93bc0e7a",
+            "1": "4dedae42847c704da891a28c25d32201a1ae440bce2aecccfa8e6f03b97a6a6c",
+            "2": "41d64cdeb347bf236b4c13b7403b633ff11f1cf94dbc7cf881a44d6da88c5156",
+            "3": "eb36921e1f82af46dfe248ef8f1b3afb6a5230a64181d960d10237a08cd73c79",
+            "4": "e769d7487cc314d3ee748a4440805317c19262c7acd2fdbdb0d47d2e4613a15c",
+            "5": "1b80f120dbd88e4355d6241b519c3e25290215c469516b49dece9cf07175a766"
+          }
         }
       },
-      "num_layers": 6,
-      "layers": {
-        "0": "fe84c9d5bfddd07a2624d00333cf13c1a9c941f3a261f13ead44fc6a93bc0e7a",
-        "1": "4dedae42847c704da891a28c25d32201a1ae440bce2aecccfa8e6f03b97a6a6c",
-        "2": "41d64cdeb347bf236b4c13b7403b633ff11f1cf94dbc7cf881a44d6da88c5156",
-        "3": "eb36921e1f82af46dfe248ef8f1b3afb6a5230a64181d960d10237a08cd73c79",
-        "4": "e769d7487cc314d3ee748a4440805317c19262c7acd2fdbdb0d47d2e4613a15c",
-        "5": "1b80f120dbd88e4355d6241b519c3e25290215c469516b49dece9cf07175a766"
-      }
-    },
-    "1": {
-      "num_commands": 1,
-      "command": {
-        "0": "/pause"
-      },
-      "num_env_rules": 2,
-      "env_rules": {
-        "0": {
-          "strategy": "string",
-          "rule": "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+      "1": {
+        "command": {
+          "length": 1,
+          "elements": {
+            "0": "/pause"
+          }
         },
-        "1": {
-          "strategy": "string",
-          "rule": "TERM=xterm"
+        "env_rules": {
+          "length": 2,
+          "elements": {
+            "0": {
+              "strategy": "string",
+              "rule": "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+            },
+            "1": {
+              "strategy": "string",
+              "rule": "TERM=xterm"
+            }
+          }
+        },
+        "layers": {
+          "length": 1,
+          "elements": {
+            "0": "16b514057a06ad665f92c02863aca074fd5976c755d26bff16365299169e8415"
+          }
         }
-      },
-      "num_layers": 1,
-      "layers": {
-        "0": "16b514057a06ad665f92c02863aca074fd5976c755d26bff16365299169e8415"
       }
     }
   }

--- a/pkg/securitypolicy/securitypolicy.go
+++ b/pkg/securitypolicy/securitypolicy.go
@@ -48,52 +48,6 @@ type EncodedSecurityPolicy struct {
 	SecurityPolicy string `json:"SecurityPolicy,omitempty"`
 }
 
-// JSON transport version
-type SecurityPolicy struct {
-	// Flag that when set to true allows for all checks to pass. Currently used
-	// to run with security policy enforcement "running dark"; checks can be in
-	// place but the default policy that is created on startup has AllowAll set
-	// to true, thus making policy enforcement effectively "off" from a logical
-	// standpoint. Policy enforcement isn't actually off as the policy is "allow
-	// everything:.
-	AllowAll bool `json:"allow_all"`
-	// Total number of containers in our map
-	NumContainers int `json:"num_containers"`
-	// One or more containers that are allowed to run
-	Containers map[string]SecurityPolicyContainer `json:"containers"`
-}
-
-// SecurityPolicyContainer contains information about a container that should be
-// allowed to run. "Allowed to run" is a bit of misnomer. For example, we
-// enforce that when an overlay file system is constructed that it must be a
-// an ordering of layers (as seen through dm-verity root hashes of devices)
-// that match a listing from Layers in one of any valid SecurityPolicyContainer
-// entries. Once that overlay creation is allowed, the command could not match
-// policy and running the command would be rejected.
-type SecurityPolicyContainer struct {
-	// Number of entries that should be in the "Command" map
-	NumCommands int `json:"num_commands"`
-	// The command that we will allow the container to execute
-	Command map[string]string `json:"command"`
-	// Number of entries that should be in the "EnvRules" map
-	NumEnvRules int `json:"num_env_rules"`
-	// The rules for determining if a given environment variable is allowed
-	EnvRules map[string]SecurityPolicyEnvironmentVariableRule `json:"env_rules"`
-	// Number of entries that should in the "Layers" map
-	NumLayers int `json:"num_layers"`
-	// An "ordered list" of dm-verity root hashes for each layer that makes up
-	// "a container". Containers are constructed as an overlay file system. The
-	// order that the layers are overlayed is important and needs to be enforced
-	// as part of policy. The map is interpreted as an ordered list by arranging
-	// the keys of the map as indexes like 0,1,2,3 to establish the order.
-	Layers map[string]string `json:"layers"`
-}
-
-type SecurityPolicyEnvironmentVariableRule struct {
-	Strategy EnvVarRule `json:"strategy"`
-	Rule     string     `json:"rule"`
-}
-
 // Constructs SecurityPolicyState from base64Policy string. It first decodes
 // base64 policy and returns the structs security policy struct and encoded
 // security policy for given policy. The security policy is transmitted as json
@@ -126,4 +80,95 @@ func NewSecurityPolicyState(base64Policy string) (*SecurityPolicyState, error) {
 		SecurityPolicy:        securityPolicy,
 		EncodedSecurityPolicy: encodedSecurityPolicy,
 	}, nil
+}
+
+type SecurityPolicy struct {
+	// Flag that when set to true allows for all checks to pass. Currently used
+	// to run with security policy enforcement "running dark"; checks can be in
+	// place but the default policy that is created on startup has AllowAll set
+	// to true, thus making policy enforcement effectively "off" from a logical
+	// standpoint. Policy enforcement isn't actually off as the policy is "allow
+	// everything:.
+	AllowAll bool `json:"allow_all"`
+	// One or more containers that are allowed to run
+	Containers Containers `json:"containers"`
+}
+
+type Containers struct {
+	Length   int                  `json:"length"`
+	Elements map[string]Container `json:"elements"`
+}
+
+type Container struct {
+	Command  CommandArgs `json:"command"`
+	EnvRules EnvRules    `json:"env_rules"`
+	Layers   Layers      `json:"layers"`
+}
+
+type Layers struct {
+	Length int `json:"length"`
+	// an ordered list of args where the key is in the index for ordering
+	Elements map[string]string `json:"elements"`
+}
+
+type CommandArgs struct {
+	Length int `json:"length"`
+	// an ordered list of args where the key is in the index for ordering
+	Elements map[string]string `json:"elements"`
+}
+
+type EnvRules struct {
+	Length   int                `json:"length"`
+	Elements map[string]EnvRule `json:"elements"`
+}
+
+type EnvRule struct {
+	Strategy EnvVarRule `json:"strategy"`
+	Rule     string     `json:"rule"`
+}
+
+// Custom JSON marshalling to add `lenth` field that matches the number of
+// elements present in the `elements` field.
+func (c Containers) MarshalJSON() ([]byte, error) {
+	type Alias Containers
+	return json.Marshal(&struct {
+		Length int `json:"length"`
+		*Alias
+	}{
+		Length: len(c.Elements),
+		Alias:  (*Alias)(&c),
+	})
+}
+
+func (l Layers) MarshalJSON() ([]byte, error) {
+	type Alias Layers
+	return json.Marshal(&struct {
+		Length int `json:"length"`
+		*Alias
+	}{
+		Length: len(l.Elements),
+		Alias:  (*Alias)(&l),
+	})
+}
+
+func (c CommandArgs) MarshalJSON() ([]byte, error) {
+	type Alias CommandArgs
+	return json.Marshal(&struct {
+		Length int `json:"length"`
+		*Alias
+	}{
+		Length: len(c.Elements),
+		Alias:  (*Alias)(&c),
+	})
+}
+
+func (e EnvRules) MarshalJSON() ([]byte, error) {
+	type Alias EnvRules
+	return json.Marshal(&struct {
+		Length int `json:"length"`
+		*Alias
+	}{
+		Length: len(e.Elements),
+		Alias:  (*Alias)(&e),
+	})
 }

--- a/pkg/securitypolicy/securitypolicyenforcer.go
+++ b/pkg/securitypolicy/securitypolicyenforcer.go
@@ -21,7 +21,7 @@ func NewSecurityPolicyEnforcer(state SecurityPolicyState) (SecurityPolicyEnforce
 	if state.SecurityPolicy.AllowAll {
 		return &OpenDoorSecurityPolicyEnforcer{}, nil
 	} else {
-		containers, err := toInternal(&state.SecurityPolicy)
+		containers, err := state.SecurityPolicy.Containers.toInternal()
 		if err != nil {
 			return nil, err
 		}
@@ -121,57 +121,83 @@ func NewStandardSecurityPolicyEnforcer(containers []securityPolicyContainer, enc
 	}
 }
 
-func toInternal(external *SecurityPolicy) ([]securityPolicyContainer, error) {
-	containerMapLength := len(external.Containers)
-	if external.NumContainers != containerMapLength {
-		errmsg := fmt.Sprintf("container numbers don't match in policy. expected: %d, actual: %d", external.NumContainers, containerMapLength)
-		return nil, errors.New(errmsg)
+func (c Containers) toInternal() ([]securityPolicyContainer, error) {
+	containerMapLength := len(c.Elements)
+	if c.Length != containerMapLength {
+		return nil, fmt.Errorf("container numbers don't match in policy. expected: %d, actual: %d", c.Length, containerMapLength)
 	}
 
 	internal := make([]securityPolicyContainer, containerMapLength)
 
 	for i := 0; i < containerMapLength; i++ {
-		iContainer := securityPolicyContainer{}
-
-		eContainer := external.Containers[strconv.Itoa(i)]
-
-		// Command conversion
-		if eContainer.NumCommands != len(eContainer.Command) {
-			errmsg := fmt.Sprintf("command argument numbers don't match in policy. expected: %d, actual: %d", eContainer.NumCommands, len(eContainer.Command))
-			return nil, errors.New(errmsg)
+		iContainer, err := c.Elements[strconv.Itoa(i)].toInternal()
+		if err != nil {
+			return nil, err
 		}
-		iContainer.Command = stringMapToStringArray(eContainer.Command)
-
-		// Layers conversion
-		if eContainer.NumLayers != len(eContainer.Layers) {
-			errmsg := fmt.Sprintf("layer numbers don't match in policy. expected: %d, actual: %d", eContainer.NumLayers, len(eContainer.Layers))
-			return nil, errors.New(errmsg)
-		}
-		iContainer.Layers = stringMapToStringArray(eContainer.Layers)
-
-		// EnvRules conversion
-		envRulesMapLength := len(eContainer.EnvRules)
-		if eContainer.NumEnvRules != envRulesMapLength {
-			errmsg := fmt.Sprintf("env rule numbers don't match in policy. expected: %d, actual: %d", eContainer.NumEnvRules, envRulesMapLength)
-			return nil, errors.New(errmsg)
-		}
-
-		envRules := make([]securityPolicyEnvironmentVariableRule, envRulesMapLength)
-		for i := 0; i < envRulesMapLength; i++ {
-			eIndex := strconv.Itoa(i)
-			rule := securityPolicyEnvironmentVariableRule{
-				Strategy: eContainer.EnvRules[eIndex].Strategy,
-				Rule:     eContainer.EnvRules[eIndex].Rule,
-			}
-			envRules[i] = rule
-		}
-		iContainer.EnvRules = envRules
 
 		// save off new container
 		internal[i] = iContainer
 	}
 
 	return internal, nil
+}
+
+func (c Container) toInternal() (securityPolicyContainer, error) {
+	command, err := c.Command.toInternal()
+	if err != nil {
+		return securityPolicyContainer{}, err
+	}
+
+	envRules, err := c.EnvRules.toInternal()
+	if err != nil {
+		return securityPolicyContainer{}, err
+	}
+
+	layers, err := c.Layers.toInternal()
+	if err != nil {
+		return securityPolicyContainer{}, err
+	}
+
+	return securityPolicyContainer{
+		Command:  command,
+		EnvRules: envRules,
+		Layers:   layers,
+	}, nil
+}
+
+func (c CommandArgs) toInternal() ([]string, error) {
+	if c.Length != len(c.Elements) {
+		return nil, fmt.Errorf("command argument numbers don't match in policy. expected: %d, actual: %d", c.Length, len(c.Elements))
+	}
+
+	return stringMapToStringArray(c.Elements), nil
+}
+
+func (e EnvRules) toInternal() ([]securityPolicyEnvironmentVariableRule, error) {
+	envRulesMapLength := len(e.Elements)
+	if e.Length != envRulesMapLength {
+		return nil, fmt.Errorf("env rule numbers don't match in policy. expected: %d, actual: %d", e.Length, envRulesMapLength)
+	}
+
+	envRules := make([]securityPolicyEnvironmentVariableRule, envRulesMapLength)
+	for i := 0; i < envRulesMapLength; i++ {
+		eIndex := strconv.Itoa(i)
+		rule := securityPolicyEnvironmentVariableRule{
+			Strategy: e.Elements[eIndex].Strategy,
+			Rule:     e.Elements[eIndex].Rule,
+		}
+		envRules[i] = rule
+	}
+
+	return envRules, nil
+}
+
+func (l Layers) toInternal() ([]string, error) {
+	if l.Length != len(l.Elements) {
+		return nil, fmt.Errorf("layer numbers don't match in policy. expected: %d, actual: %d", l.Length, len(l.Elements))
+	}
+
+	return stringMapToStringArray(l.Elements), nil
 }
 
 func stringMapToStringArray(in map[string]string) []string {

--- a/test/vendor/github.com/Microsoft/hcsshim/pkg/securitypolicy/securitypolicy.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/pkg/securitypolicy/securitypolicy.go
@@ -48,52 +48,6 @@ type EncodedSecurityPolicy struct {
 	SecurityPolicy string `json:"SecurityPolicy,omitempty"`
 }
 
-// JSON transport version
-type SecurityPolicy struct {
-	// Flag that when set to true allows for all checks to pass. Currently used
-	// to run with security policy enforcement "running dark"; checks can be in
-	// place but the default policy that is created on startup has AllowAll set
-	// to true, thus making policy enforcement effectively "off" from a logical
-	// standpoint. Policy enforcement isn't actually off as the policy is "allow
-	// everything:.
-	AllowAll bool `json:"allow_all"`
-	// Total number of containers in our map
-	NumContainers int `json:"num_containers"`
-	// One or more containers that are allowed to run
-	Containers map[string]SecurityPolicyContainer `json:"containers"`
-}
-
-// SecurityPolicyContainer contains information about a container that should be
-// allowed to run. "Allowed to run" is a bit of misnomer. For example, we
-// enforce that when an overlay file system is constructed that it must be a
-// an ordering of layers (as seen through dm-verity root hashes of devices)
-// that match a listing from Layers in one of any valid SecurityPolicyContainer
-// entries. Once that overlay creation is allowed, the command could not match
-// policy and running the command would be rejected.
-type SecurityPolicyContainer struct {
-	// Number of entries that should be in the "Command" map
-	NumCommands int `json:"num_commands"`
-	// The command that we will allow the container to execute
-	Command map[string]string `json:"command"`
-	// Number of entries that should be in the "EnvRules" map
-	NumEnvRules int `json:"num_env_rules"`
-	// The rules for determining if a given environment variable is allowed
-	EnvRules map[string]SecurityPolicyEnvironmentVariableRule `json:"env_rules"`
-	// Number of entries that should in the "Layers" map
-	NumLayers int `json:"num_layers"`
-	// An "ordered list" of dm-verity root hashes for each layer that makes up
-	// "a container". Containers are constructed as an overlay file system. The
-	// order that the layers are overlayed is important and needs to be enforced
-	// as part of policy. The map is interpreted as an ordered list by arranging
-	// the keys of the map as indexes like 0,1,2,3 to establish the order.
-	Layers map[string]string `json:"layers"`
-}
-
-type SecurityPolicyEnvironmentVariableRule struct {
-	Strategy EnvVarRule `json:"strategy"`
-	Rule     string     `json:"rule"`
-}
-
 // Constructs SecurityPolicyState from base64Policy string. It first decodes
 // base64 policy and returns the structs security policy struct and encoded
 // security policy for given policy. The security policy is transmitted as json
@@ -126,4 +80,95 @@ func NewSecurityPolicyState(base64Policy string) (*SecurityPolicyState, error) {
 		SecurityPolicy:        securityPolicy,
 		EncodedSecurityPolicy: encodedSecurityPolicy,
 	}, nil
+}
+
+type SecurityPolicy struct {
+	// Flag that when set to true allows for all checks to pass. Currently used
+	// to run with security policy enforcement "running dark"; checks can be in
+	// place but the default policy that is created on startup has AllowAll set
+	// to true, thus making policy enforcement effectively "off" from a logical
+	// standpoint. Policy enforcement isn't actually off as the policy is "allow
+	// everything:.
+	AllowAll bool `json:"allow_all"`
+	// One or more containers that are allowed to run
+	Containers Containers `json:"containers"`
+}
+
+type Containers struct {
+	Length   int                  `json:"length"`
+	Elements map[string]Container `json:"elements"`
+}
+
+type Container struct {
+	Command  CommandArgs `json:"command"`
+	EnvRules EnvRules    `json:"env_rules"`
+	Layers   Layers      `json:"layers"`
+}
+
+type Layers struct {
+	Length int `json:"length"`
+	// an ordered list of args where the key is in the index for ordering
+	Elements map[string]string `json:"elements"`
+}
+
+type CommandArgs struct {
+	Length int `json:"length"`
+	// an ordered list of args where the key is in the index for ordering
+	Elements map[string]string `json:"elements"`
+}
+
+type EnvRules struct {
+	Length   int                `json:"length"`
+	Elements map[string]EnvRule `json:"elements"`
+}
+
+type EnvRule struct {
+	Strategy EnvVarRule `json:"strategy"`
+	Rule     string     `json:"rule"`
+}
+
+// Custom JSON marshalling to add `lenth` field that matches the number of
+// elements present in the `elements` field.
+func (c Containers) MarshalJSON() ([]byte, error) {
+	type Alias Containers
+	return json.Marshal(&struct {
+		Length int `json:"length"`
+		*Alias
+	}{
+		Length: len(c.Elements),
+		Alias:  (*Alias)(&c),
+	})
+}
+
+func (l Layers) MarshalJSON() ([]byte, error) {
+	type Alias Layers
+	return json.Marshal(&struct {
+		Length int `json:"length"`
+		*Alias
+	}{
+		Length: len(l.Elements),
+		Alias:  (*Alias)(&l),
+	})
+}
+
+func (c CommandArgs) MarshalJSON() ([]byte, error) {
+	type Alias CommandArgs
+	return json.Marshal(&struct {
+		Length int `json:"length"`
+		*Alias
+	}{
+		Length: len(c.Elements),
+		Alias:  (*Alias)(&c),
+	})
+}
+
+func (e EnvRules) MarshalJSON() ([]byte, error) {
+	type Alias EnvRules
+	return json.Marshal(&struct {
+		Length int `json:"length"`
+		*Alias
+	}{
+		Length: len(e.Elements),
+		Alias:  (*Alias)(&e),
+	})
 }

--- a/test/vendor/github.com/Microsoft/hcsshim/pkg/securitypolicy/securitypolicyenforcer.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/pkg/securitypolicy/securitypolicyenforcer.go
@@ -21,7 +21,7 @@ func NewSecurityPolicyEnforcer(state SecurityPolicyState) (SecurityPolicyEnforce
 	if state.SecurityPolicy.AllowAll {
 		return &OpenDoorSecurityPolicyEnforcer{}, nil
 	} else {
-		containers, err := toInternal(&state.SecurityPolicy)
+		containers, err := state.SecurityPolicy.Containers.toInternal()
 		if err != nil {
 			return nil, err
 		}
@@ -121,57 +121,83 @@ func NewStandardSecurityPolicyEnforcer(containers []securityPolicyContainer, enc
 	}
 }
 
-func toInternal(external *SecurityPolicy) ([]securityPolicyContainer, error) {
-	containerMapLength := len(external.Containers)
-	if external.NumContainers != containerMapLength {
-		errmsg := fmt.Sprintf("container numbers don't match in policy. expected: %d, actual: %d", external.NumContainers, containerMapLength)
-		return nil, errors.New(errmsg)
+func (c Containers) toInternal() ([]securityPolicyContainer, error) {
+	containerMapLength := len(c.Elements)
+	if c.Length != containerMapLength {
+		return nil, fmt.Errorf("container numbers don't match in policy. expected: %d, actual: %d", c.Length, containerMapLength)
 	}
 
 	internal := make([]securityPolicyContainer, containerMapLength)
 
 	for i := 0; i < containerMapLength; i++ {
-		iContainer := securityPolicyContainer{}
-
-		eContainer := external.Containers[strconv.Itoa(i)]
-
-		// Command conversion
-		if eContainer.NumCommands != len(eContainer.Command) {
-			errmsg := fmt.Sprintf("command argument numbers don't match in policy. expected: %d, actual: %d", eContainer.NumCommands, len(eContainer.Command))
-			return nil, errors.New(errmsg)
+		iContainer, err := c.Elements[strconv.Itoa(i)].toInternal()
+		if err != nil {
+			return nil, err
 		}
-		iContainer.Command = stringMapToStringArray(eContainer.Command)
-
-		// Layers conversion
-		if eContainer.NumLayers != len(eContainer.Layers) {
-			errmsg := fmt.Sprintf("layer numbers don't match in policy. expected: %d, actual: %d", eContainer.NumLayers, len(eContainer.Layers))
-			return nil, errors.New(errmsg)
-		}
-		iContainer.Layers = stringMapToStringArray(eContainer.Layers)
-
-		// EnvRules conversion
-		envRulesMapLength := len(eContainer.EnvRules)
-		if eContainer.NumEnvRules != envRulesMapLength {
-			errmsg := fmt.Sprintf("env rule numbers don't match in policy. expected: %d, actual: %d", eContainer.NumEnvRules, envRulesMapLength)
-			return nil, errors.New(errmsg)
-		}
-
-		envRules := make([]securityPolicyEnvironmentVariableRule, envRulesMapLength)
-		for i := 0; i < envRulesMapLength; i++ {
-			eIndex := strconv.Itoa(i)
-			rule := securityPolicyEnvironmentVariableRule{
-				Strategy: eContainer.EnvRules[eIndex].Strategy,
-				Rule:     eContainer.EnvRules[eIndex].Rule,
-			}
-			envRules[i] = rule
-		}
-		iContainer.EnvRules = envRules
 
 		// save off new container
 		internal[i] = iContainer
 	}
 
 	return internal, nil
+}
+
+func (c Container) toInternal() (securityPolicyContainer, error) {
+	command, err := c.Command.toInternal()
+	if err != nil {
+		return securityPolicyContainer{}, err
+	}
+
+	envRules, err := c.EnvRules.toInternal()
+	if err != nil {
+		return securityPolicyContainer{}, err
+	}
+
+	layers, err := c.Layers.toInternal()
+	if err != nil {
+		return securityPolicyContainer{}, err
+	}
+
+	return securityPolicyContainer{
+		Command:  command,
+		EnvRules: envRules,
+		Layers:   layers,
+	}, nil
+}
+
+func (c CommandArgs) toInternal() ([]string, error) {
+	if c.Length != len(c.Elements) {
+		return nil, fmt.Errorf("command argument numbers don't match in policy. expected: %d, actual: %d", c.Length, len(c.Elements))
+	}
+
+	return stringMapToStringArray(c.Elements), nil
+}
+
+func (e EnvRules) toInternal() ([]securityPolicyEnvironmentVariableRule, error) {
+	envRulesMapLength := len(e.Elements)
+	if e.Length != envRulesMapLength {
+		return nil, fmt.Errorf("env rule numbers don't match in policy. expected: %d, actual: %d", e.Length, envRulesMapLength)
+	}
+
+	envRules := make([]securityPolicyEnvironmentVariableRule, envRulesMapLength)
+	for i := 0; i < envRulesMapLength; i++ {
+		eIndex := strconv.Itoa(i)
+		rule := securityPolicyEnvironmentVariableRule{
+			Strategy: e.Elements[eIndex].Strategy,
+			Rule:     e.Elements[eIndex].Rule,
+		}
+		envRules[i] = rule
+	}
+
+	return envRules, nil
+}
+
+func (l Layers) toInternal() ([]string, error) {
+	if l.Length != len(l.Elements) {
+		return nil, fmt.Errorf("layer numbers don't match in policy. expected: %d, actual: %d", l.Length, len(l.Elements))
+	}
+
+	return stringMapToStringArray(l.Elements), nil
 }
 
 func stringMapToStringArray(in map[string]string) []string {


### PR DESCRIPTION
These changes come by way of a suggestion from Maksim who noted that this
new format keeps the same information as the previous format, but organizes
it in a way that makes it easier to maintain the creation code and can
allow for the usage of a custom JSON marshaller to remove a source
of possible bugs in keeping the number of elements and the field that
is the length of said elements in sync,

Signed-off-by: Sean T. Allen <seanallen@microsoft.com>