### PR TITLE
Also run tests on Windows Server 2022 GitHub Runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,10 @@ jobs:
           exit $process.ExitCode
 
   test:
-    runs-on: 'windows-2019'
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [windows-2019, windows-2022]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
@@ -84,7 +87,7 @@ jobs:
 
       - uses: actions/upload-artifact@v2
         with:
-          name: test_binaries
+          name: test_binaries_${{ matrix.os }}
           path: |
             test/containerd-shim-runhcs-v1.test.exe
             test/cri-containerd.test.exe


### PR DESCRIPTION
Low-hanging fruit, but nice to have in place while things like #1160 are in-flight.

Outstanding thoughts:
- [x] Make this a matrix job? Is it worth it for the two versions we care about until the mid-2020's?
- [ ] While I'm on the topic, we probably should either test or explicitly declaim Server 2016 support. The README currently points to a [system requirements doc](https://docs.microsoft.com/en-us/virtualization/windowscontainers/deploy-containers/system-requirements) that includes Server 2016... this solves itself in less than 4 months anyway.