### PR TITLE
Refactor pod config generation in tests

### DIFF
--- a/test/cri-containerd/container_downlevel_test.go
+++ b/test/cri-containerd/container_downlevel_test.go
@@ -16,7 +16,7 @@ func Test_CreateContainer_DownLevel_WCOW_Hypervisor(t *testing.T) {
 
 	pullRequiredImages(t, []string{imageWindowsNanoserver17763})
 
-	sandboxRequest := getRunPodSandboxRequest(t, wcowHypervisor17763RuntimeHandler, nil)
+	sandboxRequest := getRunPodSandboxRequest(t, wcowHypervisor17763RuntimeHandler)
 
 	request := &runtime.CreateContainerRequest{
 		Config: &runtime.ContainerConfig{

--- a/test/cri-containerd/container_layers_packing_test.go
+++ b/test/cri-containerd/container_layers_packing_test.go
@@ -83,7 +83,7 @@ func Test_Container_Layer_Packing_On_VPMem(t *testing.T) {
 	requireFeatures(t, featureLCOW)
 
 	// use ubuntu to make sure that multiple container layers will be mapped properly
-	pullRequiredLcowImages(t, []string{imageLcowK8sPause, ubuntu1804})
+	pullRequiredLCOWImages(t, []string{imageLcowK8sPause, ubuntu1804})
 
 	type config struct {
 		rootfsType   string
@@ -137,7 +137,7 @@ func Test_Many_Container_Layers_Supported_On_VPMem(t *testing.T) {
 
 	requireFeatures(t, featureLCOW)
 
-	pullRequiredLcowImages(t, []string{imageLcowK8sPause, alpine70ExtraLayers, ubuntu70ExtraLayers})
+	pullRequiredLCOWImages(t, []string{imageLcowK8sPause, alpine70ExtraLayers, ubuntu70ExtraLayers})
 
 	podReq := getRunPodSandboxRequest(t, lcowRuntimeHandler)
 	podID := runPodSandbox(t, client, ctx, podReq)
@@ -168,7 +168,7 @@ func Test_Annotation_Disable_Multi_Mapping(t *testing.T) {
 
 	requireFeatures(t, featureLCOW)
 
-	pullRequiredLcowImages(t, []string{imageLcowK8sPause, alpine70ExtraLayers})
+	pullRequiredLCOWImages(t, []string{imageLcowK8sPause, alpine70ExtraLayers})
 
 	annotations := map[string]string{
 		oci.AnnotationVPMemNoMultiMapping: "true",

--- a/test/cri-containerd/container_layers_packing_test.go
+++ b/test/cri-containerd/container_layers_packing_test.go
@@ -104,7 +104,7 @@ func Test_Container_Layer_Packing_On_VPMem(t *testing.T) {
 			annotations := map[string]string{
 				oci.AnnotationPreferredRootFSType: scenario.rootfsType,
 			}
-			podReq := getRunPodSandboxRequest(t, lcowRuntimeHandler, annotations)
+			podReq := getRunPodSandboxRequest(t, lcowRuntimeHandler, WithSandboxAnnotations(annotations))
 			podID := runPodSandbox(t, client, ctx, podReq)
 			defer removePodSandbox(t, client, ctx, podID)
 
@@ -139,7 +139,7 @@ func Test_Many_Container_Layers_Supported_On_VPMem(t *testing.T) {
 
 	pullRequiredLcowImages(t, []string{imageLcowK8sPause, alpine70ExtraLayers, ubuntu70ExtraLayers})
 
-	podReq := getRunPodSandboxRequest(t, lcowRuntimeHandler, nil)
+	podReq := getRunPodSandboxRequest(t, lcowRuntimeHandler)
 	podID := runPodSandbox(t, client, ctx, podReq)
 	defer removePodSandbox(t, client, ctx, podID)
 
@@ -173,7 +173,7 @@ func Test_Annotation_Disable_Multi_Mapping(t *testing.T) {
 	annotations := map[string]string{
 		oci.AnnotationVPMemNoMultiMapping: "true",
 	}
-	podReq := getRunPodSandboxRequest(t, lcowRuntimeHandler, annotations)
+	podReq := getRunPodSandboxRequest(t, lcowRuntimeHandler, WithSandboxAnnotations(annotations))
 	podID := runPodSandbox(t, client, ctx, podReq)
 	defer removePodSandbox(t, client, ctx, podID)
 

--- a/test/cri-containerd/container_network_test.go
+++ b/test/cri-containerd/container_network_test.go
@@ -18,7 +18,7 @@ import (
 func Test_Container_Network_LCOW(t *testing.T) {
 	requireFeatures(t, featureLCOW)
 
-	pullRequiredLcowImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
+	pullRequiredLCOWImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
 
 	// create a directory and log file
 	dir, err := ioutil.TempDir("", "")
@@ -132,7 +132,7 @@ func Test_Container_Network_Hostname(t *testing.T) {
 			requireFeatures(t, test.requiredFeatures...)
 
 			if test.runtimeHandler == lcowRuntimeHandler {
-				pullRequiredLcowImages(t, []string{test.sandboxImage, test.containerImage})
+				pullRequiredLCOWImages(t, []string{test.sandboxImage, test.containerImage})
 			} else {
 				pullRequiredImages(t, []string{test.sandboxImage, test.containerImage})
 			}

--- a/test/cri-containerd/container_network_test.go
+++ b/test/cri-containerd/container_network_test.go
@@ -32,7 +32,7 @@ func Test_Container_Network_LCOW(t *testing.T) {
 	}()
 	log := filepath.Join(dir, "ping.txt")
 
-	sandboxRequest := getRunPodSandboxRequest(t, lcowRuntimeHandler, nil)
+	sandboxRequest := getRunPodSandboxRequest(t, lcowRuntimeHandler)
 
 	client := newTestRuntimeClient(t)
 	ctx, cancel := context.WithCancel(context.Background())
@@ -137,7 +137,7 @@ func Test_Container_Network_Hostname(t *testing.T) {
 				pullRequiredImages(t, []string{test.sandboxImage, test.containerImage})
 			}
 
-			sandboxRequest := getRunPodSandboxRequest(t, test.runtimeHandler, nil)
+			sandboxRequest := getRunPodSandboxRequest(t, test.runtimeHandler)
 			sandboxRequest.Config.Hostname = "TestHost"
 
 			client := newTestRuntimeClient(t)

--- a/test/cri-containerd/container_test.go
+++ b/test/cri-containerd/container_test.go
@@ -78,7 +78,7 @@ func Test_RotateLogs_LCOW(t *testing.T) {
 	log := filepath.Join(dir, "log.txt")
 	logArchive := filepath.Join(dir, "log-archive.txt")
 
-	pullRequiredLcowImages(t, []string{imageLcowK8sPause, image})
+	pullRequiredLCOWImages(t, []string{imageLcowK8sPause, image})
 	logrus.SetLevel(logrus.DebugLevel)
 
 	sandboxRequest := getRunPodSandboxRequest(t, lcowRuntimeHandler)
@@ -136,7 +136,7 @@ func Test_RotateLogs_LCOW(t *testing.T) {
 func Test_RunContainer_Events_LCOW(t *testing.T) {
 	requireFeatures(t, featureLCOW)
 
-	pullRequiredLcowImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
+	pullRequiredLCOWImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
 	client := newTestRuntimeClient(t)
 
 	podctx, podcancel := context.WithCancel(context.Background())
@@ -207,7 +207,7 @@ func Test_RunContainer_Events_LCOW(t *testing.T) {
 func Test_RunContainer_ForksThenExits_ShowsAsExited_LCOW(t *testing.T) {
 	requireFeatures(t, featureLCOW)
 
-	pullRequiredLcowImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
+	pullRequiredLCOWImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
 	client := newTestRuntimeClient(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 	defer cancel()
@@ -258,7 +258,7 @@ func Test_RunContainer_ForksThenExits_ShowsAsExited_LCOW(t *testing.T) {
 func Test_RunContainer_ZeroVPMEM_LCOW(t *testing.T) {
 	requireFeatures(t, featureLCOW)
 
-	pullRequiredLcowImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
+	pullRequiredLCOWImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
 
 	client := newTestRuntimeClient(t)
 	ctx, cancel := context.WithCancel(context.Background())
@@ -300,7 +300,7 @@ func Test_RunContainer_ZeroVPMEM_LCOW(t *testing.T) {
 func Test_RunContainer_ZeroVPMEM_Multiple_LCOW(t *testing.T) {
 	requireFeatures(t, featureLCOW)
 
-	pullRequiredLcowImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
+	pullRequiredLCOWImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
 
 	client := newTestRuntimeClient(t)
 	ctx, cancel := context.WithCancel(context.Background())
@@ -479,7 +479,7 @@ func Test_RunContainer_GMSA_WCOW_Hypervisor(t *testing.T) {
 func Test_RunContainer_SandboxDevice_LCOW(t *testing.T) {
 	requireFeatures(t, featureLCOW)
 
-	pullRequiredLcowImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
+	pullRequiredLCOWImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
 
 	client := newTestRuntimeClient(t)
 	ctx, cancel := context.WithCancel(context.Background())
@@ -549,7 +549,7 @@ func Test_RunContainer_NonDefault_User(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	pullRequiredLcowImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
+	pullRequiredLCOWImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
 
 	podReq := getRunPodSandboxRequest(t, lcowRuntimeHandler)
 	podID := runPodSandbox(t, client, ctx, podReq)
@@ -605,7 +605,7 @@ func Test_RunContainer_NonDefault_User(t *testing.T) {
 func Test_RunContainer_ShareScratch_LCOW(t *testing.T) {
 	requireFeatures(t, featureLCOW)
 
-	pullRequiredLcowImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
+	pullRequiredLCOWImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
 
 	client := newTestRuntimeClient(t)
 	ctx, cancel := context.WithCancel(context.Background())
@@ -695,7 +695,7 @@ func findOverlaySize(t *testing.T, ctx context.Context, client runtime.RuntimeSe
 func Test_RunContainer_ShareScratch_CheckSize_LCOW(t *testing.T) {
 	requireFeatures(t, featureLCOW)
 
-	pullRequiredLcowImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
+	pullRequiredLCOWImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
 
 	client := newTestRuntimeClient(t)
 	ctx, cancel := context.WithCancel(context.Background())
@@ -779,7 +779,7 @@ func Test_RunContainer_ShareScratch_CheckSize_LCOW(t *testing.T) {
 func Test_CreateContainer_DevShmSize(t *testing.T) {
 	requireFeatures(t, featureLCOW)
 
-	pullRequiredLcowImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
+	pullRequiredLCOWImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
 
 	client := newTestRuntimeClient(t)
 	ctx, cancel := context.WithCancel(context.Background())
@@ -834,7 +834,7 @@ func Test_CreateContainer_HugePageMount_LCOW(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	pullRequiredLcowImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
+	pullRequiredLCOWImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
 
 	annotations := map[string]string{
 		oci.AnnotationFullyPhysicallyBacked: "true",

--- a/test/cri-containerd/container_test.go
+++ b/test/cri-containerd/container_test.go
@@ -81,7 +81,7 @@ func Test_RotateLogs_LCOW(t *testing.T) {
 	pullRequiredLcowImages(t, []string{imageLcowK8sPause, image})
 	logrus.SetLevel(logrus.DebugLevel)
 
-	sandboxRequest := getRunPodSandboxRequest(t, lcowRuntimeHandler, nil)
+	sandboxRequest := getRunPodSandboxRequest(t, lcowRuntimeHandler)
 
 	request := &runtime.CreateContainerRequest{
 		Config: &runtime.ContainerConfig{
@@ -143,7 +143,7 @@ func Test_RunContainer_Events_LCOW(t *testing.T) {
 	defer podcancel()
 	targetNamespace := "k8s.io"
 
-	sandboxRequest := getRunPodSandboxRequest(t, lcowRuntimeHandler, nil)
+	sandboxRequest := getRunPodSandboxRequest(t, lcowRuntimeHandler)
 
 	podID := runPodSandbox(t, client, podctx, sandboxRequest)
 	defer removePodSandbox(t, client, podctx, podID)
@@ -212,7 +212,7 @@ func Test_RunContainer_ForksThenExits_ShowsAsExited_LCOW(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 	defer cancel()
 
-	podRequest := getRunPodSandboxRequest(t, lcowRuntimeHandler, nil)
+	podRequest := getRunPodSandboxRequest(t, lcowRuntimeHandler)
 	podID := runPodSandbox(t, client, ctx, podRequest)
 	defer removePodSandbox(t, client, ctx, podID)
 	defer stopPodSandbox(t, client, ctx, podID)
@@ -267,10 +267,10 @@ func Test_RunContainer_ZeroVPMEM_LCOW(t *testing.T) {
 	sandboxRequest := getRunPodSandboxRequest(
 		t,
 		lcowRuntimeHandler,
-		map[string]string{
+		WithSandboxAnnotations(map[string]string{
 			oci.AnnotationPreferredRootFSType: "initrd",
 			oci.AnnotationVPMemCount:          "0",
-		},
+		}),
 	)
 
 	podID := runPodSandbox(t, client, ctx, sandboxRequest)
@@ -309,10 +309,10 @@ func Test_RunContainer_ZeroVPMEM_Multiple_LCOW(t *testing.T) {
 	sandboxRequest := getRunPodSandboxRequest(
 		t,
 		lcowRuntimeHandler,
-		map[string]string{
+		WithSandboxAnnotations(map[string]string{
 			oci.AnnotationPreferredRootFSType: "initrd",
 			oci.AnnotationVPMemCount:          "0",
-		},
+		}),
 	)
 
 	podID := runPodSandbox(t, client, ctx, sandboxRequest)
@@ -357,7 +357,7 @@ func Test_RunContainer_GMSA_WCOW_Process(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	sandboxRequest := getRunPodSandboxRequest(t, wcowProcessRuntimeHandler, nil)
+	sandboxRequest := getRunPodSandboxRequest(t, wcowProcessRuntimeHandler)
 
 	podID := runPodSandbox(t, client, ctx, sandboxRequest)
 	defer removePodSandbox(t, client, ctx, podID)
@@ -421,7 +421,7 @@ func Test_RunContainer_GMSA_WCOW_Hypervisor(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	sandboxRequest := getRunPodSandboxRequest(t, wcowHypervisorRuntimeHandler, nil)
+	sandboxRequest := getRunPodSandboxRequest(t, wcowHypervisorRuntimeHandler)
 
 	podID := runPodSandbox(t, client, ctx, sandboxRequest)
 	defer removePodSandbox(t, client, ctx, podID)
@@ -485,7 +485,7 @@ func Test_RunContainer_SandboxDevice_LCOW(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	sandboxRequest := getRunPodSandboxRequest(t, lcowRuntimeHandler, nil)
+	sandboxRequest := getRunPodSandboxRequest(t, lcowRuntimeHandler)
 	sandboxRequest.Config.Linux = &runtime.LinuxPodSandboxConfig{
 		SecurityContext: &runtime.LinuxSandboxSecurityContext{
 			Privileged: true,
@@ -551,7 +551,7 @@ func Test_RunContainer_NonDefault_User(t *testing.T) {
 
 	pullRequiredLcowImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
 
-	podReq := getRunPodSandboxRequest(t, lcowRuntimeHandler, nil)
+	podReq := getRunPodSandboxRequest(t, lcowRuntimeHandler)
 	podID := runPodSandbox(t, client, ctx, podReq)
 	defer removePodSandbox(t, client, ctx, podID)
 	defer stopPodSandbox(t, client, ctx, podID)
@@ -611,7 +611,7 @@ func Test_RunContainer_ShareScratch_LCOW(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	sandboxRequest := getRunPodSandboxRequest(t, lcowRuntimeHandler, nil)
+	sandboxRequest := getRunPodSandboxRequest(t, lcowRuntimeHandler)
 
 	podID := runPodSandbox(t, client, ctx, sandboxRequest)
 	defer removePodSandbox(t, client, ctx, podID)
@@ -701,7 +701,7 @@ func Test_RunContainer_ShareScratch_CheckSize_LCOW(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	sandboxRequest := getRunPodSandboxRequest(t, lcowRuntimeHandler, nil)
+	sandboxRequest := getRunPodSandboxRequest(t, lcowRuntimeHandler)
 
 	podID := runPodSandbox(t, client, ctx, sandboxRequest)
 	defer removePodSandbox(t, client, ctx, podID)
@@ -785,7 +785,7 @@ func Test_CreateContainer_DevShmSize(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	podReq := getRunPodSandboxRequest(t, lcowRuntimeHandler, nil)
+	podReq := getRunPodSandboxRequest(t, lcowRuntimeHandler)
 	podID := runPodSandbox(t, client, ctx, podReq)
 	defer removePodSandbox(t, client, ctx, podID)
 
@@ -841,7 +841,7 @@ func Test_CreateContainer_HugePageMount_LCOW(t *testing.T) {
 		oci.AnnotationMemorySizeInMB:        "2048",
 		oci.AnnotationKernelBootOptions:     "hugepagesz=2M hugepages=10",
 	}
-	sandboxRequest := getRunPodSandboxRequest(t, lcowRuntimeHandler, annotations)
+	sandboxRequest := getRunPodSandboxRequest(t, lcowRuntimeHandler, WithSandboxAnnotations(annotations))
 
 	podID := runPodSandbox(t, client, ctx, sandboxRequest)
 	defer removePodSandbox(t, client, ctx, podID)

--- a/test/cri-containerd/container_update_test.go
+++ b/test/cri-containerd/container_update_test.go
@@ -72,7 +72,7 @@ func Test_Container_UpdateResources_CPUShare(t *testing.T) {
 			requireFeatures(t, test.requiredFeatures...)
 
 			if test.runtimeHandler == lcowRuntimeHandler {
-				pullRequiredLcowImages(t, []string{test.sandboxImage})
+				pullRequiredLCOWImages(t, []string{test.sandboxImage})
 			} else if test.runtimeHandler == wcowHypervisorRuntimeHandler {
 				pullRequiredImages(t, []string{test.sandboxImage})
 			}
@@ -179,7 +179,7 @@ func Test_Container_UpdateResources_CPUShare_NotRunning(t *testing.T) {
 			requireFeatures(t, test.requiredFeatures...)
 
 			if test.runtimeHandler == lcowRuntimeHandler {
-				pullRequiredLcowImages(t, []string{test.sandboxImage})
+				pullRequiredLCOWImages(t, []string{test.sandboxImage})
 			} else if test.runtimeHandler == wcowHypervisorRuntimeHandler {
 				pullRequiredImages(t, []string{test.sandboxImage})
 			}
@@ -286,7 +286,7 @@ func Test_Container_UpdateResources_Memory(t *testing.T) {
 			requireFeatures(t, test.requiredFeatures...)
 
 			if test.runtimeHandler == lcowRuntimeHandler {
-				pullRequiredLcowImages(t, []string{test.sandboxImage})
+				pullRequiredLCOWImages(t, []string{test.sandboxImage})
 			} else if test.runtimeHandler == wcowHypervisorRuntimeHandler {
 				pullRequiredImages(t, []string{test.sandboxImage})
 			}

--- a/test/cri-containerd/container_update_test.go
+++ b/test/cri-containerd/container_update_test.go
@@ -77,15 +77,7 @@ func Test_Container_UpdateResources_CPUShare(t *testing.T) {
 				pullRequiredImages(t, []string{test.sandboxImage})
 			}
 
-			podRequest := &runtime.RunPodSandboxRequest{
-				Config: &runtime.PodSandboxConfig{
-					Metadata: &runtime.PodSandboxMetadata{
-						Name:      t.Name(),
-						Namespace: testNamespace,
-					},
-				},
-				RuntimeHandler: test.runtimeHandler,
-			}
+			podRequest := getRunPodSandboxRequest(t, test.runtimeHandler)
 
 			client := newTestRuntimeClient(t)
 			ctx, cancel := context.WithCancel(context.Background())
@@ -192,15 +184,7 @@ func Test_Container_UpdateResources_CPUShare_NotRunning(t *testing.T) {
 				pullRequiredImages(t, []string{test.sandboxImage})
 			}
 
-			podRequest := &runtime.RunPodSandboxRequest{
-				Config: &runtime.PodSandboxConfig{
-					Metadata: &runtime.PodSandboxMetadata{
-						Name:      t.Name(),
-						Namespace: testNamespace,
-					},
-				},
-				RuntimeHandler: test.runtimeHandler,
-			}
+			podRequest := getRunPodSandboxRequest(t, test.runtimeHandler)
 
 			client := newTestRuntimeClient(t)
 			ctx, cancel := context.WithCancel(context.Background())
@@ -307,15 +291,7 @@ func Test_Container_UpdateResources_Memory(t *testing.T) {
 				pullRequiredImages(t, []string{test.sandboxImage})
 			}
 
-			podRequest := &runtime.RunPodSandboxRequest{
-				Config: &runtime.PodSandboxConfig{
-					Metadata: &runtime.PodSandboxMetadata{
-						Name:      t.Name(),
-						Namespace: testNamespace,
-					},
-				},
-				RuntimeHandler: test.runtimeHandler,
-			}
+			podRequest := getRunPodSandboxRequest(t, test.runtimeHandler)
 
 			client := newTestRuntimeClient(t)
 			ctx, cancel := context.WithCancel(context.Background())

--- a/test/cri-containerd/container_virtual_device_test.go
+++ b/test/cri-containerd/container_virtual_device_test.go
@@ -202,7 +202,7 @@ func Test_RunContainer_VirtualDevice_GPU_LCOW(t *testing.T) {
 		t.Fatal("skipping test, host has no assignable nvidia gpu devices")
 	}
 
-	pullRequiredLcowImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
+	pullRequiredLCOWImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
 	client := newTestRuntimeClient(t)
 
 	podctx := context.Background()
@@ -247,7 +247,7 @@ func Test_RunContainer_VirtualDevice_GPU_Multiple_LCOW(t *testing.T) {
 		t.Fatal("skipping test, host has no assignable nvidia gpu devices")
 	}
 
-	pullRequiredLcowImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
+	pullRequiredLCOWImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
 	client := newTestRuntimeClient(t)
 
 	podctx := context.Background()
@@ -299,7 +299,7 @@ func Test_RunContainer_VirtualDevice_GPU_and_NoGPU_LCOW(t *testing.T) {
 		t.Fatal("skipping test, host has no assignable nvidia gpu devices")
 	}
 
-	pullRequiredLcowImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
+	pullRequiredLCOWImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
 	client := newTestRuntimeClient(t)
 
 	podctx := context.Background()
@@ -372,7 +372,7 @@ func Test_RunContainer_VirtualDevice_GPU_Multiple_Removal_LCOW(t *testing.T) {
 		t.Fatal("skipping test, host has no assignable nvidia gpu devices")
 	}
 
-	pullRequiredLcowImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
+	pullRequiredLCOWImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
 	client := newTestRuntimeClient(t)
 
 	podctx := context.Background()

--- a/test/cri-containerd/container_virtual_device_test.go
+++ b/test/cri-containerd/container_virtual_device_test.go
@@ -209,7 +209,7 @@ func Test_RunContainer_VirtualDevice_GPU_LCOW(t *testing.T) {
 	sandboxRequest := getRunPodSandboxRequest(
 		t,
 		lcowRuntimeHandler,
-		lcowPodGPUAnnotations,
+		WithSandboxAnnotations(lcowPodGPUAnnotations),
 	)
 
 	podID := runPodSandbox(t, client, podctx, sandboxRequest)
@@ -254,7 +254,7 @@ func Test_RunContainer_VirtualDevice_GPU_Multiple_LCOW(t *testing.T) {
 	sandboxRequest := getRunPodSandboxRequest(
 		t,
 		lcowRuntimeHandler,
-		lcowPodGPUAnnotations,
+		WithSandboxAnnotations(lcowPodGPUAnnotations),
 	)
 
 	podID := runPodSandbox(t, client, podctx, sandboxRequest)
@@ -306,7 +306,7 @@ func Test_RunContainer_VirtualDevice_GPU_and_NoGPU_LCOW(t *testing.T) {
 	sandboxRequest := getRunPodSandboxRequest(
 		t,
 		lcowRuntimeHandler,
-		lcowPodGPUAnnotations,
+		WithSandboxAnnotations(lcowPodGPUAnnotations),
 	)
 
 	podID := runPodSandbox(t, client, podctx, sandboxRequest)
@@ -379,7 +379,7 @@ func Test_RunContainer_VirtualDevice_GPU_Multiple_Removal_LCOW(t *testing.T) {
 	sandboxRequest := getRunPodSandboxRequest(
 		t,
 		lcowRuntimeHandler,
-		lcowPodGPUAnnotations,
+		WithSandboxAnnotations(lcowPodGPUAnnotations),
 	)
 
 	podID := runPodSandbox(t, client, podctx, sandboxRequest)
@@ -426,7 +426,7 @@ func Test_RunContainer_VirtualDevice_LocationPath_WCOW_Process(t *testing.T) {
 	client := newTestRuntimeClient(t)
 
 	podctx := context.Background()
-	sandboxRequest := getRunPodSandboxRequest(t, wcowProcessRuntimeHandler, nil)
+	sandboxRequest := getRunPodSandboxRequest(t, wcowProcessRuntimeHandler)
 
 	podID := runPodSandbox(t, client, podctx, sandboxRequest)
 	defer removePodSandbox(t, client, podctx, podID)
@@ -467,7 +467,7 @@ func Test_RunContainer_VirtualDevice_ClassGUID_WCOW_Process(t *testing.T) {
 	client := newTestRuntimeClient(t)
 
 	podctx := context.Background()
-	sandboxRequest := getRunPodSandboxRequest(t, wcowProcessRuntimeHandler, nil)
+	sandboxRequest := getRunPodSandboxRequest(t, wcowProcessRuntimeHandler)
 
 	podID := runPodSandbox(t, client, podctx, sandboxRequest)
 	defer removePodSandbox(t, client, podctx, podID)
@@ -511,9 +511,9 @@ func Test_RunContainer_VirtualDevice_GPU_WCOW_Hypervisor(t *testing.T) {
 	sandboxRequest := getRunPodSandboxRequest(
 		t,
 		wcowHypervisorRuntimeHandler,
-		map[string]string{
+		WithSandboxAnnotations(map[string]string{
 			oci.AnnotationFullyPhysicallyBacked: "true",
-		},
+		}),
 	)
 
 	podID := runPodSandbox(t, client, podctx, sandboxRequest)
@@ -559,9 +559,9 @@ func Test_RunContainer_VirtualDevice_GPU_and_NoGPU_WCOW_Hypervisor(t *testing.T)
 	sandboxRequest := getRunPodSandboxRequest(
 		t,
 		wcowHypervisorRuntimeHandler,
-		map[string]string{
+		WithSandboxAnnotations(map[string]string{
 			oci.AnnotationFullyPhysicallyBacked: "true",
-		},
+		}),
 	)
 
 	podID := runPodSandbox(t, client, podctx, sandboxRequest)
@@ -624,9 +624,9 @@ func Test_RunContainer_VirtualDevice_GPU_Multiple_WCOW_Hypervisor(t *testing.T) 
 	sandboxRequest := getRunPodSandboxRequest(
 		t,
 		wcowHypervisorRuntimeHandler,
-		map[string]string{
+		WithSandboxAnnotations(map[string]string{
 			oci.AnnotationFullyPhysicallyBacked: "true",
-		},
+		}),
 	)
 
 	podID := runPodSandbox(t, client, podctx, sandboxRequest)
@@ -679,9 +679,9 @@ func Test_RunContainer_VirtualDevice_GPU_Multiple_Removal_WCOW_Hypervisor(t *tes
 	sandboxRequest := getRunPodSandboxRequest(
 		t,
 		wcowHypervisorRuntimeHandler,
-		map[string]string{
+		WithSandboxAnnotations(map[string]string{
 			oci.AnnotationFullyPhysicallyBacked: "true",
-		},
+		}),
 	)
 
 	podID := runPodSandbox(t, client, podctx, sandboxRequest)

--- a/test/cri-containerd/createcontainer_test.go
+++ b/test/cri-containerd/createcontainer_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func runCreateContainerTest(t *testing.T, runtimeHandler string, request *runtime.CreateContainerRequest) {
-	sandboxRequest := getRunPodSandboxRequest(t, runtimeHandler, nil)
+	sandboxRequest := getRunPodSandboxRequest(t, runtimeHandler)
 	runCreateContainerTestWithSandbox(t, sandboxRequest, request)
 }
 
@@ -189,7 +189,7 @@ func Test_CreateContainer_LCOW_Privileged(t *testing.T) {
 
 	pullRequiredLcowImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
 
-	sandboxRequest := getRunPodSandboxRequest(t, lcowRuntimeHandler, nil)
+	sandboxRequest := getRunPodSandboxRequest(t, lcowRuntimeHandler)
 	sandboxRequest.Config.Linux = &runtime.LinuxPodSandboxConfig{
 		SecurityContext: &runtime.LinuxSandboxSecurityContext{
 			Privileged: true,
@@ -223,7 +223,7 @@ func Test_CreateContainer_SandboxDevice_LCOW(t *testing.T) {
 
 	pullRequiredLcowImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
 
-	sandboxRequest := getRunPodSandboxRequest(t, lcowRuntimeHandler, nil)
+	sandboxRequest := getRunPodSandboxRequest(t, lcowRuntimeHandler)
 	sandboxRequest.Config.Linux = &runtime.LinuxPodSandboxConfig{
 		SecurityContext: &runtime.LinuxSandboxSecurityContext{
 			Privileged: true,
@@ -1228,7 +1228,7 @@ func Test_Mount_ReadOnlyDirReuse_WCOW(t *testing.T) {
 	}
 	defer os.RemoveAll(tempDir)
 
-	sandboxRequest := getRunPodSandboxRequest(t, wcowHypervisorRuntimeHandler, nil)
+	sandboxRequest := getRunPodSandboxRequest(t, wcowHypervisorRuntimeHandler)
 
 	podID := runPodSandbox(t, client, ctx, sandboxRequest)
 	defer removePodSandbox(t, client, ctx, podID)

--- a/test/cri-containerd/createcontainer_test.go
+++ b/test/cri-containerd/createcontainer_test.go
@@ -96,7 +96,7 @@ func Test_CreateContainer_WCOW_Hypervisor(t *testing.T) {
 func Test_CreateContainer_LCOW(t *testing.T) {
 	requireFeatures(t, featureLCOW)
 
-	pullRequiredLcowImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
+	pullRequiredLCOWImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
 
 	request := &runtime.CreateContainerRequest{
 		Config: &runtime.ContainerConfig{
@@ -164,7 +164,7 @@ func Test_CreateContainer_WCOW_Hypervisor_Tty(t *testing.T) {
 func Test_CreateContainer_LCOW_Tty(t *testing.T) {
 	requireFeatures(t, featureLCOW)
 
-	pullRequiredLcowImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
+	pullRequiredLCOWImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
 
 	request := &runtime.CreateContainerRequest{
 		Config: &runtime.ContainerConfig{
@@ -187,7 +187,7 @@ func Test_CreateContainer_LCOW_Tty(t *testing.T) {
 func Test_CreateContainer_LCOW_Privileged(t *testing.T) {
 	requireFeatures(t, featureLCOW)
 
-	pullRequiredLcowImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
+	pullRequiredLCOWImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
 
 	sandboxRequest := getRunPodSandboxRequest(t, lcowRuntimeHandler)
 	sandboxRequest.Config.Linux = &runtime.LinuxPodSandboxConfig{
@@ -221,7 +221,7 @@ func Test_CreateContainer_LCOW_Privileged(t *testing.T) {
 func Test_CreateContainer_SandboxDevice_LCOW(t *testing.T) {
 	requireFeatures(t, featureLCOW)
 
-	pullRequiredLcowImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
+	pullRequiredLCOWImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
 
 	sandboxRequest := getRunPodSandboxRequest(t, lcowRuntimeHandler)
 	sandboxRequest.Config.Linux = &runtime.LinuxPodSandboxConfig{
@@ -375,7 +375,7 @@ func Test_CreateContainer_MemorySize_Annotation_WCOW_Hypervisor(t *testing.T) {
 func Test_CreateContainer_MemorySize_LCOW(t *testing.T) {
 	requireFeatures(t, featureLCOW)
 
-	pullRequiredLcowImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
+	pullRequiredLCOWImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
 
 	request := &runtime.CreateContainerRequest{
 		Config: &runtime.ContainerConfig{
@@ -522,7 +522,7 @@ func Test_CreateContainer_CPUCount_Annotation_WCOW_Hypervisor(t *testing.T) {
 func Test_CreateContainer_CPUCount_LCOW(t *testing.T) {
 	requireFeatures(t, featureLCOW)
 
-	pullRequiredLcowImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
+	pullRequiredLCOWImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
 
 	request := &runtime.CreateContainerRequest{
 		Config: &runtime.ContainerConfig{
@@ -669,7 +669,7 @@ func Test_CreateContainer_CPULimit_Annotation_WCOW_Hypervisor(t *testing.T) {
 func Test_CreateContainer_CPUQuota_LCOW(t *testing.T) {
 	requireFeatures(t, featureLCOW)
 
-	pullRequiredLcowImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
+	pullRequiredLCOWImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
 
 	request := &runtime.CreateContainerRequest{
 		Config: &runtime.ContainerConfig{
@@ -817,7 +817,7 @@ func Test_CreateContainer_CPUWeight_Annotation_WCOW_Hypervisor(t *testing.T) {
 func Test_CreateContainer_CPUShares_LCOW(t *testing.T) {
 	requireFeatures(t, featureLCOW)
 
-	pullRequiredLcowImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
+	pullRequiredLCOWImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
 
 	request := &runtime.CreateContainerRequest{
 		Config: &runtime.ContainerConfig{
@@ -845,7 +845,7 @@ func Test_CreateContainer_Mount_File_LCOW(t *testing.T) {
 	requireFeatures(t, featureLCOW)
 	testutilities.RequiresBuild(t, osversion.V19H1)
 
-	pullRequiredLcowImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
+	pullRequiredLCOWImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
 
 	tempFile, err := ioutil.TempFile("", "test")
 
@@ -890,7 +890,7 @@ func Test_CreateContainer_Mount_ReadOnlyFile_LCOW(t *testing.T) {
 	requireFeatures(t, featureLCOW)
 	testutilities.RequiresBuild(t, osversion.V19H1)
 
-	pullRequiredLcowImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
+	pullRequiredLCOWImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
 
 	tempFile, err := ioutil.TempFile("", "test")
 
@@ -935,7 +935,7 @@ func Test_CreateContainer_Mount_ReadOnlyFile_LCOW(t *testing.T) {
 func Test_CreateContainer_Mount_Dir_LCOW(t *testing.T) {
 	requireFeatures(t, featureLCOW)
 
-	pullRequiredLcowImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
+	pullRequiredLCOWImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
 
 	tempDir, err := ioutil.TempDir("", "")
 	if err != nil {
@@ -971,7 +971,7 @@ func Test_CreateContainer_Mount_Dir_LCOW(t *testing.T) {
 func Test_CreateContainer_Mount_ReadOnlyDir_LCOW(t *testing.T) {
 	requireFeatures(t, featureLCOW)
 
-	pullRequiredLcowImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
+	pullRequiredLCOWImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
 
 	tempDir, err := ioutil.TempDir("", "")
 	if err != nil {

--- a/test/cri-containerd/execcontainer_test.go
+++ b/test/cri-containerd/execcontainer_test.go
@@ -34,7 +34,7 @@ func runexecContainerTestWithSandbox(t *testing.T, sandboxRequest *runtime.RunPo
 }
 
 func execContainerLCOW(t *testing.T, uid int64, cmd []string) *runtime.ExecSyncResponse {
-	pullRequiredLcowImages(t, []string{imageLcowK8sPause, imageLcowCosmos})
+	pullRequiredLCOWImages(t, []string{imageLcowK8sPause, imageLcowCosmos})
 
 	// run podsandbox request
 	sandboxRequest := getRunPodSandboxRequest(t, lcowRuntimeHandler)

--- a/test/cri-containerd/execcontainer_test.go
+++ b/test/cri-containerd/execcontainer_test.go
@@ -37,7 +37,7 @@ func execContainerLCOW(t *testing.T, uid int64, cmd []string) *runtime.ExecSyncR
 	pullRequiredLcowImages(t, []string{imageLcowK8sPause, imageLcowCosmos})
 
 	// run podsandbox request
-	sandboxRequest := getRunPodSandboxRequest(t, lcowRuntimeHandler, nil)
+	sandboxRequest := getRunPodSandboxRequest(t, lcowRuntimeHandler)
 	sandboxRequest.Config.Linux = &runtime.LinuxPodSandboxConfig{
 		SecurityContext: &runtime.LinuxSandboxSecurityContext{
 			Privileged: true,

--- a/test/cri-containerd/jobcontainer_test.go
+++ b/test/cri-containerd/jobcontainer_test.go
@@ -20,18 +20,13 @@ import (
 )
 
 func getJobContainerPodRequestWCOW(t *testing.T) *runtime.RunPodSandboxRequest {
-	return &runtime.RunPodSandboxRequest{
-		Config: &runtime.PodSandboxConfig{
-			Metadata: &runtime.PodSandboxMetadata{
-				Name:      t.Name(),
-				Namespace: testNamespace,
-			},
-			Annotations: map[string]string{
-				oci.AnnotationHostProcessContainer: "true",
-			},
-		},
-		RuntimeHandler: wcowProcessRuntimeHandler,
-	}
+	return getRunPodSandboxRequest(
+		t,
+		wcowProcessRuntimeHandler,
+		WithSandboxAnnotations(map[string]string{
+			oci.AnnotationHostProcessContainer: "true",
+		}),
+	)
 }
 
 func getJobContainerRequestWCOW(t *testing.T, podID string, podConfig *runtime.PodSandboxConfig, image string, mounts []*runtime.Mount) *runtime.CreateContainerRequest {

--- a/test/cri-containerd/logging_binary_test.go
+++ b/test/cri-containerd/logging_binary_test.go
@@ -80,7 +80,7 @@ func Test_Run_Container_With_Binary_Logger(t *testing.T) {
 
 			requiredImages := []string{test.sandboxImage, test.containerImage}
 			if test.runtimeHandler == lcowRuntimeHandler {
-				pullRequiredLcowImages(t, requiredImages)
+				pullRequiredLCOWImages(t, requiredImages)
 			} else {
 				pullRequiredImages(t, requiredImages)
 			}
@@ -118,7 +118,7 @@ func Test_Run_Container_With_Binary_Logger(t *testing.T) {
 
 			requiredImages := []string{test.sandboxImage, test.containerImage}
 			if test.runtimeHandler == lcowRuntimeHandler {
-				pullRequiredLcowImages(t, requiredImages)
+				pullRequiredLCOWImages(t, requiredImages)
 			} else {
 				pullRequiredImages(t, requiredImages)
 			}

--- a/test/cri-containerd/logging_binary_test.go
+++ b/test/cri-containerd/logging_binary_test.go
@@ -85,7 +85,7 @@ func Test_Run_Container_With_Binary_Logger(t *testing.T) {
 				pullRequiredImages(t, requiredImages)
 			}
 
-			podReq := getRunPodSandboxRequest(t, test.runtimeHandler, nil)
+			podReq := getRunPodSandboxRequest(t, test.runtimeHandler)
 			podID := runPodSandbox(t, client, ctx, podReq)
 			defer removePodSandbox(t, client, ctx, podID)
 
@@ -123,7 +123,7 @@ func Test_Run_Container_With_Binary_Logger(t *testing.T) {
 				pullRequiredImages(t, requiredImages)
 			}
 
-			podReq := getRunPodSandboxRequest(t, test.runtimeHandler, nil)
+			podReq := getRunPodSandboxRequest(t, test.runtimeHandler)
 			podID := runPodSandbox(t, client, ctx, podReq)
 			defer removePodSandbox(t, client, ctx, podID)
 

--- a/test/cri-containerd/main.go
+++ b/test/cri-containerd/main.go
@@ -287,7 +287,7 @@ func pullRequiredImagesWithOptions(t *testing.T, images []string, opts ...Sandbo
 	sb := &runtime.PodSandboxConfig{}
 	for _, o := range opts {
 		if err := o(sb); err != nil {
-			t.Errorf("failed to apply PodSandboxConfig option: %s", err)
+			t.Fatalf("failed to apply PodSandboxConfig option: %s", err)
 		}
 	}
 

--- a/test/cri-containerd/main.go
+++ b/test/cri-containerd/main.go
@@ -261,19 +261,21 @@ func convertEvent(e *types.Any) (string, interface{}, error) {
 	return id, evt, nil
 }
 
-func pullRequiredImages(t *testing.T, images []string) {
-	pullRequiredImagesWithLabels(t, images, map[string]string{
+func pullRequiredImages(t *testing.T, images []string, opts ...SandboxConfigOpt) {
+	opts = append(opts, WithSandboxLabels(map[string]string{
 		"sandbox-platform": "windows/amd64", // Not required for Windows but makes the test safer depending on defaults in the config.
-	})
+	}))
+	pullRequiredImagesWithOptions(t, images, opts...)
 }
 
-func pullRequiredLcowImages(t *testing.T, images []string) {
-	pullRequiredImagesWithLabels(t, images, map[string]string{
+func pullRequiredLcowImages(t *testing.T, images []string, opts ...SandboxConfigOpt) {
+	opts = append(opts, WithSandboxLabels(map[string]string{
 		"sandbox-platform": "linux/amd64",
-	})
+	}))
+	pullRequiredImagesWithOptions(t, images, opts...)
 }
 
-func pullRequiredImagesWithLabels(t *testing.T, images []string, labels map[string]string) {
+func pullRequiredImagesWithOptions(t *testing.T, images []string, opts ...SandboxConfigOpt) {
 	if len(images) < 1 {
 		return
 	}
@@ -282,9 +284,13 @@ func pullRequiredImagesWithLabels(t *testing.T, images []string, labels map[stri
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	sb := &runtime.PodSandboxConfig{
-		Labels: labels,
+	sb := &runtime.PodSandboxConfig{}
+	for _, o := range opts {
+		if err := o(sb); err != nil {
+			t.Errorf("failed to apply PodSandboxConfig option: %s", err)
+		}
 	}
+
 	for _, image := range images {
 		_, err := client.PullImage(ctx, &runtime.PullImageRequest{
 			Image: &runtime.ImageSpec{

--- a/test/cri-containerd/main.go
+++ b/test/cri-containerd/main.go
@@ -268,7 +268,7 @@ func pullRequiredImages(t *testing.T, images []string, opts ...SandboxConfigOpt)
 	pullRequiredImagesWithOptions(t, images, opts...)
 }
 
-func pullRequiredLcowImages(t *testing.T, images []string, opts ...SandboxConfigOpt) {
+func pullRequiredLCOWImages(t *testing.T, images []string, opts ...SandboxConfigOpt) {
 	opts = append(opts, WithSandboxLabels(map[string]string{
 		"sandbox-platform": "linux/amd64",
 	}))

--- a/test/cri-containerd/pod_update_test.go
+++ b/test/cri-containerd/pod_update_test.go
@@ -38,7 +38,7 @@ func Test_Pod_UpdateResources_Memory(t *testing.T) {
 			requireFeatures(t, test.requiredFeatures...)
 
 			if test.runtimeHandler == lcowRuntimeHandler {
-				pullRequiredLcowImages(t, []string{test.sandboxImage})
+				pullRequiredLCOWImages(t, []string{test.sandboxImage})
 			} else {
 				pullRequiredImages(t, []string{test.sandboxImage})
 			}
@@ -109,7 +109,7 @@ func Test_Pod_UpdateResources_Memory_PA(t *testing.T) {
 			requireFeatures(t, test.requiredFeatures...)
 
 			if test.runtimeHandler == lcowRuntimeHandler {
-				pullRequiredLcowImages(t, []string{test.sandboxImage})
+				pullRequiredLCOWImages(t, []string{test.sandboxImage})
 			} else {
 				pullRequiredImages(t, []string{test.sandboxImage})
 			}
@@ -181,7 +181,7 @@ func Test_Pod_UpdateResources_CPUShares(t *testing.T) {
 			requireFeatures(t, test.requiredFeatures...)
 
 			if test.runtimeHandler == lcowRuntimeHandler {
-				pullRequiredLcowImages(t, []string{test.sandboxImage})
+				pullRequiredLCOWImages(t, []string{test.sandboxImage})
 			} else {
 				pullRequiredImages(t, []string{test.sandboxImage})
 			}

--- a/test/cri-containerd/pod_update_test.go
+++ b/test/cri-containerd/pod_update_test.go
@@ -43,18 +43,13 @@ func Test_Pod_UpdateResources_Memory(t *testing.T) {
 				pullRequiredImages(t, []string{test.sandboxImage})
 			}
 			var startingMemorySize int64 = 768 * 1024 * 1024
-			podRequest := &runtime.RunPodSandboxRequest{
-				Config: &runtime.PodSandboxConfig{
-					Metadata: &runtime.PodSandboxMetadata{
-						Name:      t.Name(),
-						Namespace: testNamespace,
-					},
-					Annotations: map[string]string{
-						oci.AnnotationContainerMemorySizeInMB: fmt.Sprintf("%d", startingMemorySize),
-					},
-				},
-				RuntimeHandler: test.runtimeHandler,
-			}
+			podRequest := getRunPodSandboxRequest(
+				t,
+				test.runtimeHandler,
+				WithSandboxAnnotations(map[string]string{
+					oci.AnnotationContainerMemorySizeInMB: fmt.Sprintf("%d", startingMemorySize),
+				}),
+			)
 
 			client := newTestRuntimeClient(t)
 			ctx, cancel := context.WithCancel(context.Background())
@@ -119,19 +114,14 @@ func Test_Pod_UpdateResources_Memory_PA(t *testing.T) {
 				pullRequiredImages(t, []string{test.sandboxImage})
 			}
 			var startingMemorySize int64 = 200 * 1024 * 1024
-			podRequest := &runtime.RunPodSandboxRequest{
-				Config: &runtime.PodSandboxConfig{
-					Metadata: &runtime.PodSandboxMetadata{
-						Name:      t.Name(),
-						Namespace: testNamespace,
-					},
-					Annotations: map[string]string{
-						oci.AnnotationFullyPhysicallyBacked:   "true",
-						oci.AnnotationContainerMemorySizeInMB: fmt.Sprintf("%d", startingMemorySize),
-					},
-				},
-				RuntimeHandler: test.runtimeHandler,
-			}
+			podRequest := getRunPodSandboxRequest(
+				t,
+				test.runtimeHandler,
+				WithSandboxAnnotations(map[string]string{
+					oci.AnnotationFullyPhysicallyBacked:   "true",
+					oci.AnnotationContainerMemorySizeInMB: fmt.Sprintf("%d", startingMemorySize),
+				}),
+			)
 
 			client := newTestRuntimeClient(t)
 			ctx, cancel := context.WithCancel(context.Background())
@@ -195,15 +185,7 @@ func Test_Pod_UpdateResources_CPUShares(t *testing.T) {
 			} else {
 				pullRequiredImages(t, []string{test.sandboxImage})
 			}
-			podRequest := &runtime.RunPodSandboxRequest{
-				Config: &runtime.PodSandboxConfig{
-					Metadata: &runtime.PodSandboxMetadata{
-						Name:      t.Name(),
-						Namespace: testNamespace,
-					},
-				},
-				RuntimeHandler: test.runtimeHandler,
-			}
+			podRequest := getRunPodSandboxRequest(t, test.runtimeHandler)
 
 			client := newTestRuntimeClient(t)
 			ctx, cancel := context.WithCancel(context.Background())

--- a/test/cri-containerd/pullimage_test.go
+++ b/test/cri-containerd/pullimage_test.go
@@ -44,7 +44,7 @@ func Test_PullImageTimestamps(t *testing.T) {
 	pullRequiredImages(t, []string{imageWindowsNanoserverTestImage})
 	defer removeImages(t, []string{imageWindowsNanoserverTestImage})
 
-	sandboxRequest := getRunPodSandboxRequest(t, wcowHypervisor18362RuntimeHandler, nil)
+	sandboxRequest := getRunPodSandboxRequest(t, wcowHypervisor18362RuntimeHandler)
 
 	podID := runPodSandbox(t, client, ctx, sandboxRequest)
 	defer removePodSandbox(t, client, ctx, podID)

--- a/test/cri-containerd/removepodsandbox_test.go
+++ b/test/cri-containerd/removepodsandbox_test.go
@@ -107,7 +107,7 @@ func Test_RunPodSandbox_Without_Sandbox_Stop(t *testing.T) {
 			requireFeatures(t, test.requiredFeatures...)
 
 			if test.runtimeHandler == lcowRuntimeHandler {
-				pullRequiredLcowImages(t, []string{test.sandboxImage})
+				pullRequiredLCOWImages(t, []string{test.sandboxImage})
 			} else {
 				pullRequiredImages(t, []string{test.sandboxImage})
 			}
@@ -154,7 +154,7 @@ func Test_RunContainer_Without_Sandbox_Stop(t *testing.T) {
 			requireFeatures(t, test.requiredFeatures...)
 
 			if test.runtimeHandler == lcowRuntimeHandler {
-				pullRequiredLcowImages(t, []string{test.sandboxImage, test.containerImage})
+				pullRequiredLCOWImages(t, []string{test.sandboxImage, test.containerImage})
 			} else {
 				pullRequiredImages(t, []string{test.sandboxImage, test.containerImage})
 			}

--- a/test/cri-containerd/removepodsandbox_test.go
+++ b/test/cri-containerd/removepodsandbox_test.go
@@ -42,7 +42,7 @@ func runPodSandboxTestWithoutPodStop(t *testing.T, request *runtime.RunPodSandbo
 
 // Utility function to start sandbox with one container and make sure that sandbox is removed in the end
 func runPodWithContainer(t *testing.T, client runtime.RuntimeServiceClient, ctx context.Context, tc *TestConfig) (string, string) {
-	request := getRunPodSandboxRequest(t, tc.runtimeHandler, nil)
+	request := getRunPodSandboxRequest(t, tc.runtimeHandler)
 	podID := runPodSandbox(t, client, ctx, request)
 	defer removePodSandbox(t, client, ctx, podID)
 
@@ -112,7 +112,7 @@ func Test_RunPodSandbox_Without_Sandbox_Stop(t *testing.T) {
 				pullRequiredImages(t, []string{test.sandboxImage})
 			}
 
-			request := getRunPodSandboxRequest(t, test.runtimeHandler, nil)
+			request := getRunPodSandboxRequest(t, test.runtimeHandler)
 			runPodSandboxTestWithoutPodStop(t, request)
 		})
 	}

--- a/test/cri-containerd/runpodsandbox_test.go
+++ b/test/cri-containerd/runpodsandbox_test.go
@@ -39,7 +39,7 @@ func Test_RunPodSandbox_WCOW_Process(t *testing.T) {
 
 	pullRequiredImages(t, []string{imageWindowsNanoserver})
 
-	request := getRunPodSandboxRequest(t, wcowProcessRuntimeHandler, nil)
+	request := getRunPodSandboxRequest(t, wcowProcessRuntimeHandler)
 	runPodSandboxTest(t, request)
 }
 
@@ -48,7 +48,7 @@ func Test_RunPodSandbox_WCOW_Hypervisor(t *testing.T) {
 
 	pullRequiredImages(t, []string{imageWindowsNanoserver})
 
-	request := getRunPodSandboxRequest(t, wcowHypervisorRuntimeHandler, nil)
+	request := getRunPodSandboxRequest(t, wcowHypervisorRuntimeHandler)
 	runPodSandboxTest(t, request)
 }
 
@@ -57,7 +57,7 @@ func Test_RunPodSandbox_LCOW(t *testing.T) {
 
 	pullRequiredLcowImages(t, []string{imageLcowK8sPause})
 
-	request := getRunPodSandboxRequest(t, lcowRuntimeHandler, nil)
+	request := getRunPodSandboxRequest(t, lcowRuntimeHandler)
 	runPodSandboxTest(t, request)
 }
 
@@ -72,7 +72,7 @@ func Test_RunPodSandbox_Events_LCOW(t *testing.T) {
 
 	pullRequiredLcowImages(t, []string{imageLcowK8sPause})
 
-	request := getRunPodSandboxRequest(t, lcowRuntimeHandler, nil)
+	request := getRunPodSandboxRequest(t, lcowRuntimeHandler)
 
 	topicNames, filters := getTargetRunTopics()
 	targetNamespace := "k8s.io"
@@ -120,9 +120,9 @@ func Test_RunPodSandbox_VirtualMemory_WCOW_Hypervisor(t *testing.T) {
 	request := getRunPodSandboxRequest(
 		t,
 		wcowHypervisorRuntimeHandler,
-		map[string]string{
+		WithSandboxAnnotations(map[string]string{
 			oci.AnnotationAllowOvercommit: "true",
-		},
+		}),
 	)
 	runPodSandboxTest(t, request)
 }
@@ -135,9 +135,9 @@ func Test_RunPodSandbox_VirtualMemory_LCOW(t *testing.T) {
 	request := getRunPodSandboxRequest(
 		t,
 		lcowRuntimeHandler,
-		map[string]string{
+		WithSandboxAnnotations(map[string]string{
 			oci.AnnotationAllowOvercommit: "true",
-		},
+		}),
 	)
 	runPodSandboxTest(t, request)
 }
@@ -150,10 +150,10 @@ func Test_RunPodSandbox_VirtualMemory_DeferredCommit_WCOW_Hypervisor(t *testing.
 	request := getRunPodSandboxRequest(
 		t,
 		wcowHypervisorRuntimeHandler,
-		map[string]string{
+		WithSandboxAnnotations(map[string]string{
 			oci.AnnotationAllowOvercommit:      "true",
 			oci.AnnotationEnableDeferredCommit: "true",
-		},
+		}),
 	)
 	runPodSandboxTest(t, request)
 }
@@ -166,10 +166,10 @@ func Test_RunPodSandbox_VirtualMemory_DeferredCommit_LCOW(t *testing.T) {
 	request := getRunPodSandboxRequest(
 		t,
 		lcowRuntimeHandler,
-		map[string]string{
+		WithSandboxAnnotations(map[string]string{
 			oci.AnnotationAllowOvercommit:      "true",
 			oci.AnnotationEnableDeferredCommit: "true",
-		},
+		}),
 	)
 	runPodSandboxTest(t, request)
 }
@@ -182,9 +182,9 @@ func Test_RunPodSandbox_PhysicalMemory_WCOW_Hypervisor(t *testing.T) {
 	request := getRunPodSandboxRequest(
 		t,
 		wcowHypervisorRuntimeHandler,
-		map[string]string{
+		WithSandboxAnnotations(map[string]string{
 			oci.AnnotationAllowOvercommit: "false",
-		},
+		}),
 	)
 	runPodSandboxTest(t, request)
 }
@@ -197,9 +197,9 @@ func Test_RunPodSandbox_FullyPhysicallyBacked_WCOW_Hypervisor(t *testing.T) {
 	request := getRunPodSandboxRequest(
 		t,
 		wcowHypervisorRuntimeHandler,
-		map[string]string{
+		WithSandboxAnnotations(map[string]string{
 			oci.AnnotationFullyPhysicallyBacked: "true",
-		},
+		}),
 	)
 	runPodSandboxTest(t, request)
 }
@@ -212,9 +212,9 @@ func Test_RunPodSandbox_VSMBNoDirectMap_WCOW_Hypervisor(t *testing.T) {
 	request := getRunPodSandboxRequest(
 		t,
 		wcowHypervisorRuntimeHandler,
-		map[string]string{
+		WithSandboxAnnotations(map[string]string{
 			oci.AnnotationVSMBNoDirectMap: "true",
-		},
+		}),
 	)
 	runPodSandboxTest(t, request)
 }
@@ -227,9 +227,9 @@ func Test_RunPodSandbox_PhysicalMemory_LCOW(t *testing.T) {
 	request := getRunPodSandboxRequest(
 		t,
 		lcowRuntimeHandler,
-		map[string]string{
+		WithSandboxAnnotations(map[string]string{
 			oci.AnnotationAllowOvercommit: "false",
-		},
+		}),
 	)
 	runPodSandboxTest(t, request)
 }
@@ -242,9 +242,9 @@ func Test_RunPodSandbox_FullyPhysicallyBacked_LCOW(t *testing.T) {
 	request := getRunPodSandboxRequest(
 		t,
 		lcowRuntimeHandler,
-		map[string]string{
+		WithSandboxAnnotations(map[string]string{
 			oci.AnnotationFullyPhysicallyBacked: "true",
-		},
+		}),
 	)
 	runPodSandboxTest(t, request)
 }
@@ -257,9 +257,9 @@ func Test_RunPodSandbox_MemorySize_WCOW_Process(t *testing.T) {
 	request := getRunPodSandboxRequest(
 		t,
 		wcowProcessRuntimeHandler,
-		map[string]string{
+		WithSandboxAnnotations(map[string]string{
 			oci.AnnotationContainerMemorySizeInMB: "128",
-		},
+		}),
 	)
 	runPodSandboxTest(t, request)
 }
@@ -272,9 +272,9 @@ func Test_RunPodSandbox_MemorySize_WCOW_Hypervisor(t *testing.T) {
 	request := getRunPodSandboxRequest(
 		t,
 		wcowHypervisorRuntimeHandler,
-		map[string]string{
+		WithSandboxAnnotations(map[string]string{
 			oci.AnnotationMemorySizeInMB: "768", // 128 is too small for WCOW. It is really slow boot.
-		},
+		}),
 	)
 	runPodSandboxTest(t, request)
 }
@@ -287,9 +287,9 @@ func Test_RunPodSandbox_MemorySize_LCOW(t *testing.T) {
 	request := getRunPodSandboxRequest(
 		t,
 		lcowRuntimeHandler,
-		map[string]string{
+		WithSandboxAnnotations(map[string]string{
 			oci.AnnotationMemorySizeInMB: "200",
-		},
+		}),
 	)
 	runPodSandboxTest(t, request)
 }
@@ -305,11 +305,11 @@ func Test_RunPodSandbox_MMIO_WCOW_Process(t *testing.T) {
 	request := getRunPodSandboxRequest(
 		t,
 		wcowProcessRuntimeHandler,
-		map[string]string{
+		WithSandboxAnnotations(map[string]string{
 			oci.AnnotationMemoryLowMMIOGapInMB:   "100",
 			oci.AnnotationMemoryHighMMIOBaseInMB: "100",
 			oci.AnnotationMemoryHighMMIOGapInMB:  "100",
-		},
+		}),
 	)
 	runPodSandboxTest(t, request)
 }
@@ -325,11 +325,11 @@ func Test_RunPodSandbox_MMIO_WCOW_Hypervisor(t *testing.T) {
 	request := getRunPodSandboxRequest(
 		t,
 		wcowHypervisorRuntimeHandler,
-		map[string]string{
+		WithSandboxAnnotations(map[string]string{
 			oci.AnnotationMemoryLowMMIOGapInMB:   "100",
 			oci.AnnotationMemoryHighMMIOBaseInMB: "100",
 			oci.AnnotationMemoryHighMMIOGapInMB:  "100",
-		},
+		}),
 	)
 	runPodSandboxTest(t, request)
 }
@@ -345,11 +345,11 @@ func Test_RunPodSandbox_MMIO_LCOW(t *testing.T) {
 	request := getRunPodSandboxRequest(
 		t,
 		lcowRuntimeHandler,
-		map[string]string{
+		WithSandboxAnnotations(map[string]string{
 			oci.AnnotationMemoryLowMMIOGapInMB:   "100",
 			oci.AnnotationMemoryHighMMIOBaseInMB: "100",
 			oci.AnnotationMemoryHighMMIOGapInMB:  "100",
-		},
+		}),
 	)
 	runPodSandboxTest(t, request)
 }
@@ -362,9 +362,9 @@ func Test_RunPodSandbox_CPUCount_WCOW_Process(t *testing.T) {
 	request := getRunPodSandboxRequest(
 		t,
 		wcowProcessRuntimeHandler,
-		map[string]string{
+		WithSandboxAnnotations(map[string]string{
 			oci.AnnotationContainerProcessorCount: "1",
-		},
+		}),
 	)
 	runPodSandboxTest(t, request)
 }
@@ -377,9 +377,9 @@ func Test_RunPodSandbox_CPUCount_WCOW_Hypervisor(t *testing.T) {
 	request := getRunPodSandboxRequest(
 		t,
 		wcowHypervisorRuntimeHandler,
-		map[string]string{
+		WithSandboxAnnotations(map[string]string{
 			oci.AnnotationProcessorCount: "1",
-		},
+		}),
 	)
 	runPodSandboxTest(t, request)
 }
@@ -392,9 +392,9 @@ func Test_RunPodSandbox_CPUCount_LCOW(t *testing.T) {
 	request := getRunPodSandboxRequest(
 		t,
 		lcowRuntimeHandler,
-		map[string]string{
+		WithSandboxAnnotations(map[string]string{
 			oci.AnnotationProcessorCount: "1",
-		},
+		}),
 	)
 	runPodSandboxTest(t, request)
 }
@@ -407,9 +407,9 @@ func Test_RunPodSandbox_CPULimit_WCOW_Process(t *testing.T) {
 	request := getRunPodSandboxRequest(
 		t,
 		wcowProcessRuntimeHandler,
-		map[string]string{
+		WithSandboxAnnotations(map[string]string{
 			oci.AnnotationContainerProcessorLimit: "9000",
-		},
+		}),
 	)
 	runPodSandboxTest(t, request)
 }
@@ -422,9 +422,9 @@ func Test_RunPodSandbox_CPULimit_WCOW_Hypervisor(t *testing.T) {
 	request := getRunPodSandboxRequest(
 		t,
 		wcowHypervisorRuntimeHandler,
-		map[string]string{
+		WithSandboxAnnotations(map[string]string{
 			oci.AnnotationProcessorLimit: "90000",
-		},
+		}),
 	)
 	runPodSandboxTest(t, request)
 }
@@ -437,9 +437,9 @@ func Test_RunPodSandbox_CPULimit_LCOW(t *testing.T) {
 	request := getRunPodSandboxRequest(
 		t,
 		lcowRuntimeHandler,
-		map[string]string{
+		WithSandboxAnnotations(map[string]string{
 			oci.AnnotationProcessorLimit: "90000",
-		},
+		}),
 	)
 	runPodSandboxTest(t, request)
 }
@@ -452,9 +452,9 @@ func Test_RunPodSandbox_CPUWeight_WCOW_Process(t *testing.T) {
 	request := getRunPodSandboxRequest(
 		t,
 		wcowProcessRuntimeHandler,
-		map[string]string{
+		WithSandboxAnnotations(map[string]string{
 			oci.AnnotationContainerProcessorWeight: "500",
-		},
+		}),
 	)
 	runPodSandboxTest(t, request)
 }
@@ -467,9 +467,9 @@ func Test_RunPodSandbox_CPUWeight_WCOW_Hypervisor(t *testing.T) {
 	request := getRunPodSandboxRequest(
 		t,
 		wcowHypervisorRuntimeHandler,
-		map[string]string{
+		WithSandboxAnnotations(map[string]string{
 			oci.AnnotationContainerProcessorWeight: "500",
-		},
+		}),
 	)
 	runPodSandboxTest(t, request)
 }
@@ -482,9 +482,9 @@ func Test_RunPodSandbox_CPUWeight_LCOW(t *testing.T) {
 	request := getRunPodSandboxRequest(
 		t,
 		lcowRuntimeHandler,
-		map[string]string{
+		WithSandboxAnnotations(map[string]string{
 			oci.AnnotationProcessorWeight: "500",
-		},
+		}),
 	)
 	runPodSandboxTest(t, request)
 }
@@ -497,9 +497,9 @@ func Test_RunPodSandbox_StorageQoSBandwithMax_WCOW_Process(t *testing.T) {
 	request := getRunPodSandboxRequest(
 		t,
 		wcowProcessRuntimeHandler,
-		map[string]string{
+		WithSandboxAnnotations(map[string]string{
 			oci.AnnotationContainerStorageQoSBandwidthMaximum: fmt.Sprintf("%d", 1024*1024), // 1MB/s
-		},
+		}),
 	)
 	runPodSandboxTest(t, request)
 }
@@ -512,9 +512,9 @@ func Test_RunPodSandbox_StorageQoSBandwithMax_WCOW_Hypervisor(t *testing.T) {
 	request := getRunPodSandboxRequest(
 		t,
 		wcowHypervisorRuntimeHandler,
-		map[string]string{
+		WithSandboxAnnotations(map[string]string{
 			oci.AnnotationStorageQoSBandwidthMaximum: fmt.Sprintf("%d", 1024*1024), // 1MB/s
-		},
+		}),
 	)
 	runPodSandboxTest(t, request)
 }
@@ -527,9 +527,9 @@ func Test_RunPodSandbox_StorageQoSBandwithMax_LCOW(t *testing.T) {
 	request := getRunPodSandboxRequest(
 		t,
 		lcowRuntimeHandler,
-		map[string]string{
+		WithSandboxAnnotations(map[string]string{
 			oci.AnnotationStorageQoSBandwidthMaximum: fmt.Sprintf("%d", 1024*1024), // 1MB/s
-		},
+		}),
 	)
 	runPodSandboxTest(t, request)
 }
@@ -542,9 +542,9 @@ func Test_RunPodSandbox_StorageQoSIopsMax_WCOW_Process(t *testing.T) {
 	request := getRunPodSandboxRequest(
 		t,
 		wcowProcessRuntimeHandler,
-		map[string]string{
+		WithSandboxAnnotations(map[string]string{
 			oci.AnnotationContainerStorageQoSIopsMaximum: "300",
-		},
+		}),
 	)
 	runPodSandboxTest(t, request)
 }
@@ -557,9 +557,9 @@ func Test_RunPodSandbox_StorageQoSIopsMax_WCOW_Hypervisor(t *testing.T) {
 	request := getRunPodSandboxRequest(
 		t,
 		wcowHypervisorRuntimeHandler,
-		map[string]string{
+		WithSandboxAnnotations(map[string]string{
 			oci.AnnotationStorageQoSIopsMaximum: "300",
-		},
+		}),
 	)
 	runPodSandboxTest(t, request)
 }
@@ -572,9 +572,9 @@ func Test_RunPodSandbox_StorageQoSIopsMax_LCOW(t *testing.T) {
 	request := getRunPodSandboxRequest(
 		t,
 		lcowRuntimeHandler,
-		map[string]string{
+		WithSandboxAnnotations(map[string]string{
 			oci.AnnotationStorageQoSIopsMaximum: "300",
-		},
+		}),
 	)
 	runPodSandboxTest(t, request)
 }
@@ -587,9 +587,9 @@ func Test_RunPodSandbox_InitrdBoot_LCOW(t *testing.T) {
 	request := getRunPodSandboxRequest(
 		t,
 		lcowRuntimeHandler,
-		map[string]string{
+		WithSandboxAnnotations(map[string]string{
 			oci.AnnotationPreferredRootFSType: "initrd",
-		},
+		}),
 	)
 	runPodSandboxTest(t, request)
 }
@@ -602,9 +602,9 @@ func Test_RunPodSandbox_RootfsVhdBoot_LCOW(t *testing.T) {
 	request := getRunPodSandboxRequest(
 		t,
 		lcowRuntimeHandler,
-		map[string]string{
+		WithSandboxAnnotations(map[string]string{
 			oci.AnnotationPreferredRootFSType: "vhd",
-		},
+		}),
 	)
 	runPodSandboxTest(t, request)
 }
@@ -617,9 +617,9 @@ func Test_RunPodSandbox_VPCIEnabled_LCOW(t *testing.T) {
 	request := getRunPodSandboxRequest(
 		t,
 		lcowRuntimeHandler,
-		map[string]string{
+		WithSandboxAnnotations(map[string]string{
 			oci.AnnotationVPCIEnabled: "true",
-		},
+		}),
 	)
 	runPodSandboxTest(t, request)
 }
@@ -632,9 +632,9 @@ func Test_RunPodSandbox_UEFIBoot_LCOW(t *testing.T) {
 	request := getRunPodSandboxRequest(
 		t,
 		lcowRuntimeHandler,
-		map[string]string{
+		WithSandboxAnnotations(map[string]string{
 			oci.AnnotationKernelDirectBoot: "false",
-		},
+		}),
 	)
 	runPodSandboxTest(t, request)
 }
@@ -644,7 +644,7 @@ func Test_RunPodSandbox_DnsConfig_WCOW_Process(t *testing.T) {
 
 	pullRequiredImages(t, []string{imageWindowsNanoserver})
 
-	request := getRunPodSandboxRequest(t, wcowProcessRuntimeHandler, nil)
+	request := getRunPodSandboxRequest(t, wcowProcessRuntimeHandler)
 	request.Config.DnsConfig = &runtime.DNSConfig{
 		Searches: []string{"8.8.8.8", "8.8.4.4"},
 	}
@@ -659,7 +659,7 @@ func Test_RunPodSandbox_DnsConfig_WCOW_Hypervisor(t *testing.T) {
 
 	pullRequiredImages(t, []string{imageWindowsNanoserver})
 
-	request := getRunPodSandboxRequest(t, wcowHypervisorRuntimeHandler, nil)
+	request := getRunPodSandboxRequest(t, wcowHypervisorRuntimeHandler)
 	request.Config.DnsConfig = &runtime.DNSConfig{
 		Searches: []string{"8.8.8.8", "8.8.4.4"},
 	}
@@ -674,7 +674,7 @@ func Test_RunPodSandbox_DnsConfig_LCOW(t *testing.T) {
 
 	pullRequiredLcowImages(t, []string{imageLcowK8sPause})
 
-	request := getRunPodSandboxRequest(t, lcowRuntimeHandler, nil)
+	request := getRunPodSandboxRequest(t, lcowRuntimeHandler)
 	request.Config.DnsConfig = &runtime.DNSConfig{
 		Searches: []string{"8.8.8.8", "8.8.4.4"},
 	}
@@ -689,7 +689,7 @@ func Test_RunPodSandbox_PortMappings_WCOW_Process(t *testing.T) {
 
 	pullRequiredImages(t, []string{imageWindowsNanoserver})
 
-	request := getRunPodSandboxRequest(t, wcowProcessRuntimeHandler, nil)
+	request := getRunPodSandboxRequest(t, wcowProcessRuntimeHandler)
 	request.Config.PortMappings = []*runtime.PortMapping{
 		{
 			Protocol:      runtime.Protocol_TCP,
@@ -705,7 +705,7 @@ func Test_RunPodSandbox_PortMappings_WCOW_Hypervisor(t *testing.T) {
 
 	pullRequiredImages(t, []string{imageWindowsNanoserver})
 
-	request := getRunPodSandboxRequest(t, wcowHypervisorRuntimeHandler, nil)
+	request := getRunPodSandboxRequest(t, wcowHypervisorRuntimeHandler)
 	request.Config.PortMappings = []*runtime.PortMapping{
 		{
 			Protocol:      runtime.Protocol_TCP,
@@ -721,7 +721,7 @@ func Test_RunPodSandbox_PortMappings_LCOW(t *testing.T) {
 
 	pullRequiredLcowImages(t, []string{imageLcowK8sPause})
 
-	request := getRunPodSandboxRequest(t, lcowRuntimeHandler, nil)
+	request := getRunPodSandboxRequest(t, lcowRuntimeHandler)
 	request.Config.PortMappings = []*runtime.PortMapping{
 		{
 			Protocol:      runtime.Protocol_TCP,
@@ -861,7 +861,7 @@ func Test_RunPodSandbox_Mount_SandboxDir_WCOW(t *testing.T) {
 	client := newTestRuntimeClient(t)
 	ctx := context.Background()
 
-	sbRequest := getRunPodSandboxRequest(t, wcowHypervisorRuntimeHandler, nil)
+	sbRequest := getRunPodSandboxRequest(t, wcowHypervisorRuntimeHandler)
 	podID := runPodSandbox(t, client, ctx, sbRequest)
 	defer removePodSandbox(t, client, ctx, podID)
 	defer stopPodSandbox(t, client, ctx, podID)
@@ -929,7 +929,7 @@ func Test_RunPodSandbox_Mount_SandboxDir_NoShare_WCOW(t *testing.T) {
 	client := newTestRuntimeClient(t)
 	ctx := context.Background()
 
-	sbRequest := getRunPodSandboxRequest(t, wcowHypervisorRuntimeHandler, nil)
+	sbRequest := getRunPodSandboxRequest(t, wcowHypervisorRuntimeHandler)
 	podID := runPodSandbox(t, client, ctx, sbRequest)
 	defer removePodSandbox(t, client, ctx, podID)
 	defer stopPodSandbox(t, client, ctx, podID)
@@ -1089,7 +1089,7 @@ func Test_RunPodSandbox_MultipleContainersSameVhd_LCOW(t *testing.T) {
 		},
 	}
 
-	sbRequest := getRunPodSandboxRequest(t, lcowRuntimeHandler, annotations)
+	sbRequest := getRunPodSandboxRequest(t, lcowRuntimeHandler, WithSandboxAnnotations(annotations))
 
 	podID := runPodSandbox(t, client, ctx, sbRequest)
 	defer removePodSandbox(t, client, ctx, podID)
@@ -1149,7 +1149,7 @@ func Test_RunPodSandbox_MultipleContainersSameVhd_RShared_LCOW(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	sbRequest := getRunPodSandboxRequest(t, lcowRuntimeHandler, nil)
+	sbRequest := getRunPodSandboxRequest(t, lcowRuntimeHandler)
 	sbRequest.Config.Linux = &runtime.LinuxPodSandboxConfig{
 		SecurityContext: &runtime.LinuxSandboxSecurityContext{
 			Privileged: true,
@@ -1305,7 +1305,7 @@ func Test_RunPodSandbox_MultipleContainersSameVhd_WCOW(t *testing.T) {
 		},
 	}
 
-	sbRequest := getRunPodSandboxRequest(t, wcowHypervisorRuntimeHandler, annotations)
+	sbRequest := getRunPodSandboxRequest(t, wcowHypervisorRuntimeHandler, WithSandboxAnnotations(annotations))
 
 	podID := runPodSandbox(t, client, ctx, sbRequest)
 	defer removePodSandbox(t, client, ctx, podID)
@@ -1370,9 +1370,13 @@ func Test_RunPodSandbox_ProcessDump_LCOW(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	sbRequest := getRunPodSandboxRequest(t, lcowRuntimeHandler, map[string]string{
-		oci.AnnotationContainerProcessDumpLocation: "/coredumps/core",
-	})
+	sbRequest := getRunPodSandboxRequest(
+		t,
+		lcowRuntimeHandler,
+		WithSandboxAnnotations(map[string]string{
+			oci.AnnotationContainerProcessDumpLocation: "/coredumps/core",
+		}),
+	)
 
 	podID := runPodSandbox(t, client, ctx, sbRequest)
 	defer removePodSandbox(t, client, ctx, podID)
@@ -1477,9 +1481,13 @@ func Test_RunPodSandbox_ProcessDump_WCOW_Hypervisor(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	sbRequest := getRunPodSandboxRequest(t, wcowHypervisor19041RuntimeHandler, map[string]string{
-		oci.AnnotationContainerProcessDumpLocation: "C:\\processdump",
-	})
+	sbRequest := getRunPodSandboxRequest(
+		t,
+		wcowHypervisor19041RuntimeHandler,
+		WithSandboxAnnotations(map[string]string{
+			oci.AnnotationContainerProcessDumpLocation: "C:\\processdump",
+		}),
+	)
 
 	podID := runPodSandbox(t, client, ctx, sbRequest)
 	defer removePodSandbox(t, client, ctx, podID)
@@ -1620,7 +1628,7 @@ func createSandboxContainerAndExec(t *testing.T, annotations map[string]string, 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	sbRequest := getRunPodSandboxRequest(t, lcowRuntimeHandler, annotations)
+	sbRequest := getRunPodSandboxRequest(t, lcowRuntimeHandler, WithSandboxAnnotations(annotations))
 
 	podID := runPodSandbox(t, client, ctx, sbRequest)
 	defer removePodSandbox(t, client, ctx, podID)

--- a/test/cri-containerd/runpodsandbox_test.go
+++ b/test/cri-containerd/runpodsandbox_test.go
@@ -55,7 +55,7 @@ func Test_RunPodSandbox_WCOW_Hypervisor(t *testing.T) {
 func Test_RunPodSandbox_LCOW(t *testing.T) {
 	requireFeatures(t, featureLCOW)
 
-	pullRequiredLcowImages(t, []string{imageLcowK8sPause})
+	pullRequiredLCOWImages(t, []string{imageLcowK8sPause})
 
 	request := getRunPodSandboxRequest(t, lcowRuntimeHandler)
 	runPodSandboxTest(t, request)
@@ -70,7 +70,7 @@ func Test_RunPodSandbox_Events_LCOW(t *testing.T) {
 	podctx, podcancel := context.WithCancel(context.Background())
 	defer podcancel()
 
-	pullRequiredLcowImages(t, []string{imageLcowK8sPause})
+	pullRequiredLCOWImages(t, []string{imageLcowK8sPause})
 
 	request := getRunPodSandboxRequest(t, lcowRuntimeHandler)
 
@@ -130,7 +130,7 @@ func Test_RunPodSandbox_VirtualMemory_WCOW_Hypervisor(t *testing.T) {
 func Test_RunPodSandbox_VirtualMemory_LCOW(t *testing.T) {
 	requireFeatures(t, featureLCOW)
 
-	pullRequiredLcowImages(t, []string{imageLcowK8sPause})
+	pullRequiredLCOWImages(t, []string{imageLcowK8sPause})
 
 	request := getRunPodSandboxRequest(
 		t,
@@ -161,7 +161,7 @@ func Test_RunPodSandbox_VirtualMemory_DeferredCommit_WCOW_Hypervisor(t *testing.
 func Test_RunPodSandbox_VirtualMemory_DeferredCommit_LCOW(t *testing.T) {
 	requireFeatures(t, featureLCOW)
 
-	pullRequiredLcowImages(t, []string{imageLcowK8sPause})
+	pullRequiredLCOWImages(t, []string{imageLcowK8sPause})
 
 	request := getRunPodSandboxRequest(
 		t,
@@ -222,7 +222,7 @@ func Test_RunPodSandbox_VSMBNoDirectMap_WCOW_Hypervisor(t *testing.T) {
 func Test_RunPodSandbox_PhysicalMemory_LCOW(t *testing.T) {
 	requireFeatures(t, featureLCOW)
 
-	pullRequiredLcowImages(t, []string{imageLcowK8sPause})
+	pullRequiredLCOWImages(t, []string{imageLcowK8sPause})
 
 	request := getRunPodSandboxRequest(
 		t,
@@ -237,7 +237,7 @@ func Test_RunPodSandbox_PhysicalMemory_LCOW(t *testing.T) {
 func Test_RunPodSandbox_FullyPhysicallyBacked_LCOW(t *testing.T) {
 	requireFeatures(t, featureLCOW)
 
-	pullRequiredLcowImages(t, []string{imageLcowK8sPause})
+	pullRequiredLCOWImages(t, []string{imageLcowK8sPause})
 
 	request := getRunPodSandboxRequest(
 		t,
@@ -282,7 +282,7 @@ func Test_RunPodSandbox_MemorySize_WCOW_Hypervisor(t *testing.T) {
 func Test_RunPodSandbox_MemorySize_LCOW(t *testing.T) {
 	requireFeatures(t, featureLCOW)
 
-	pullRequiredLcowImages(t, []string{imageLcowK8sPause})
+	pullRequiredLCOWImages(t, []string{imageLcowK8sPause})
 
 	request := getRunPodSandboxRequest(
 		t,
@@ -340,7 +340,7 @@ func Test_RunPodSandbox_MMIO_LCOW(t *testing.T) {
 	if osversion.Build() < osversion.V20H1 {
 		t.Skip("Requires build +20H1")
 	}
-	pullRequiredLcowImages(t, []string{imageLcowK8sPause})
+	pullRequiredLCOWImages(t, []string{imageLcowK8sPause})
 
 	request := getRunPodSandboxRequest(
 		t,
@@ -387,7 +387,7 @@ func Test_RunPodSandbox_CPUCount_WCOW_Hypervisor(t *testing.T) {
 func Test_RunPodSandbox_CPUCount_LCOW(t *testing.T) {
 	requireFeatures(t, featureLCOW)
 
-	pullRequiredLcowImages(t, []string{imageLcowK8sPause})
+	pullRequiredLCOWImages(t, []string{imageLcowK8sPause})
 
 	request := getRunPodSandboxRequest(
 		t,
@@ -432,7 +432,7 @@ func Test_RunPodSandbox_CPULimit_WCOW_Hypervisor(t *testing.T) {
 func Test_RunPodSandbox_CPULimit_LCOW(t *testing.T) {
 	requireFeatures(t, featureLCOW)
 
-	pullRequiredLcowImages(t, []string{imageLcowK8sPause})
+	pullRequiredLCOWImages(t, []string{imageLcowK8sPause})
 
 	request := getRunPodSandboxRequest(
 		t,
@@ -477,7 +477,7 @@ func Test_RunPodSandbox_CPUWeight_WCOW_Hypervisor(t *testing.T) {
 func Test_RunPodSandbox_CPUWeight_LCOW(t *testing.T) {
 	requireFeatures(t, featureLCOW)
 
-	pullRequiredLcowImages(t, []string{imageLcowK8sPause})
+	pullRequiredLCOWImages(t, []string{imageLcowK8sPause})
 
 	request := getRunPodSandboxRequest(
 		t,
@@ -522,7 +522,7 @@ func Test_RunPodSandbox_StorageQoSBandwithMax_WCOW_Hypervisor(t *testing.T) {
 func Test_RunPodSandbox_StorageQoSBandwithMax_LCOW(t *testing.T) {
 	requireFeatures(t, featureLCOW)
 
-	pullRequiredLcowImages(t, []string{imageLcowK8sPause})
+	pullRequiredLCOWImages(t, []string{imageLcowK8sPause})
 
 	request := getRunPodSandboxRequest(
 		t,
@@ -567,7 +567,7 @@ func Test_RunPodSandbox_StorageQoSIopsMax_WCOW_Hypervisor(t *testing.T) {
 func Test_RunPodSandbox_StorageQoSIopsMax_LCOW(t *testing.T) {
 	requireFeatures(t, featureLCOW)
 
-	pullRequiredLcowImages(t, []string{imageLcowK8sPause})
+	pullRequiredLCOWImages(t, []string{imageLcowK8sPause})
 
 	request := getRunPodSandboxRequest(
 		t,
@@ -582,7 +582,7 @@ func Test_RunPodSandbox_StorageQoSIopsMax_LCOW(t *testing.T) {
 func Test_RunPodSandbox_InitrdBoot_LCOW(t *testing.T) {
 	requireFeatures(t, featureLCOW)
 
-	pullRequiredLcowImages(t, []string{imageLcowK8sPause})
+	pullRequiredLCOWImages(t, []string{imageLcowK8sPause})
 
 	request := getRunPodSandboxRequest(
 		t,
@@ -597,7 +597,7 @@ func Test_RunPodSandbox_InitrdBoot_LCOW(t *testing.T) {
 func Test_RunPodSandbox_RootfsVhdBoot_LCOW(t *testing.T) {
 	requireFeatures(t, featureLCOW)
 
-	pullRequiredLcowImages(t, []string{imageLcowK8sPause})
+	pullRequiredLCOWImages(t, []string{imageLcowK8sPause})
 
 	request := getRunPodSandboxRequest(
 		t,
@@ -612,7 +612,7 @@ func Test_RunPodSandbox_RootfsVhdBoot_LCOW(t *testing.T) {
 func Test_RunPodSandbox_VPCIEnabled_LCOW(t *testing.T) {
 	requireFeatures(t, featureLCOW)
 
-	pullRequiredLcowImages(t, []string{imageLcowK8sPause})
+	pullRequiredLCOWImages(t, []string{imageLcowK8sPause})
 
 	request := getRunPodSandboxRequest(
 		t,
@@ -627,7 +627,7 @@ func Test_RunPodSandbox_VPCIEnabled_LCOW(t *testing.T) {
 func Test_RunPodSandbox_UEFIBoot_LCOW(t *testing.T) {
 	requireFeatures(t, featureLCOW)
 
-	pullRequiredLcowImages(t, []string{imageLcowK8sPause})
+	pullRequiredLCOWImages(t, []string{imageLcowK8sPause})
 
 	request := getRunPodSandboxRequest(
 		t,
@@ -672,7 +672,7 @@ func Test_RunPodSandbox_DnsConfig_WCOW_Hypervisor(t *testing.T) {
 func Test_RunPodSandbox_DnsConfig_LCOW(t *testing.T) {
 	requireFeatures(t, featureLCOW)
 
-	pullRequiredLcowImages(t, []string{imageLcowK8sPause})
+	pullRequiredLCOWImages(t, []string{imageLcowK8sPause})
 
 	request := getRunPodSandboxRequest(t, lcowRuntimeHandler)
 	request.Config.DnsConfig = &runtime.DNSConfig{
@@ -719,7 +719,7 @@ func Test_RunPodSandbox_PortMappings_WCOW_Hypervisor(t *testing.T) {
 func Test_RunPodSandbox_PortMappings_LCOW(t *testing.T) {
 	requireFeatures(t, featureLCOW)
 
-	pullRequiredLcowImages(t, []string{imageLcowK8sPause})
+	pullRequiredLCOWImages(t, []string{imageLcowK8sPause})
 
 	request := getRunPodSandboxRequest(t, lcowRuntimeHandler)
 	request.Config.PortMappings = []*runtime.PortMapping{
@@ -735,7 +735,7 @@ func Test_RunPodSandbox_PortMappings_LCOW(t *testing.T) {
 func Test_RunPodSandbox_CustomizableScratchDefaultSize_LCOW(t *testing.T) {
 	requireFeatures(t, featureLCOW)
 
-	pullRequiredLcowImages(t, []string{imageLcowK8sPause})
+	pullRequiredLCOWImages(t, []string{imageLcowK8sPause})
 
 	annotations := map[string]string{
 		oci.AnnotationAllowOvercommit: "true",
@@ -779,7 +779,7 @@ func Test_RunPodSandbox_CustomizableScratchDefaultSize_LCOW(t *testing.T) {
 func Test_RunPodSandbox_CustomizableScratchCustomSize_LCOW(t *testing.T) {
 	requireFeatures(t, featureLCOW)
 
-	pullRequiredLcowImages(t, []string{imageLcowK8sPause})
+	pullRequiredLCOWImages(t, []string{imageLcowK8sPause})
 
 	annotations := map[string]string{
 		oci.AnnotationAllowOvercommit:                                          "true",
@@ -826,7 +826,7 @@ func Test_RunPodSandbox_CustomizableScratchCustomSize_LCOW(t *testing.T) {
 func Test_RunPodSandbox_Mount_SandboxDir_LCOW(t *testing.T) {
 	requireFeatures(t, featureLCOW)
 
-	pullRequiredLcowImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
+	pullRequiredLCOWImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
 
 	annotations := map[string]string{
 		oci.AnnotationAllowOvercommit: "true",
@@ -1027,7 +1027,7 @@ func Test_RunPodSandbox_CPUGroup(t *testing.T) {
 	for _, test := range tests {
 		requireFeatures(t, test.requiredFeatures...)
 		if test.runtimeHandler == lcowRuntimeHandler {
-			pullRequiredLcowImages(t, []string{test.sandboxImage})
+			pullRequiredLCOWImages(t, []string{test.sandboxImage})
 		} else {
 			pullRequiredImages(t, []string{test.sandboxImage})
 		}
@@ -1061,7 +1061,7 @@ func createExt4VHD(ctx context.Context, t *testing.T, path string) {
 func Test_RunPodSandbox_MultipleContainersSameVhd_LCOW(t *testing.T) {
 	requireFeatures(t, featureLCOW)
 
-	pullRequiredLcowImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
+	pullRequiredLCOWImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
 
 	client := newTestRuntimeClient(t)
 	ctx, cancel := context.WithCancel(context.Background())
@@ -1143,7 +1143,7 @@ func Test_RunPodSandbox_MultipleContainersSameVhd_LCOW(t *testing.T) {
 func Test_RunPodSandbox_MultipleContainersSameVhd_RShared_LCOW(t *testing.T) {
 	requireFeatures(t, featureLCOW)
 
-	pullRequiredLcowImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
+	pullRequiredLCOWImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
 
 	client := newTestRuntimeClient(t)
 	ctx, cancel := context.WithCancel(context.Background())
@@ -1364,7 +1364,7 @@ func Test_RunPodSandbox_MultipleContainersSameVhd_WCOW(t *testing.T) {
 func Test_RunPodSandbox_ProcessDump_LCOW(t *testing.T) {
 	requireFeatures(t, featureLCOW)
 
-	pullRequiredLcowImages(t, []string{imageLcowK8sPause, imageLcowAlpineCoreDump})
+	pullRequiredLCOWImages(t, []string{imageLcowK8sPause, imageLcowAlpineCoreDump})
 
 	client := newTestRuntimeClient(t)
 	ctx, cancel := context.WithCancel(context.Background())
@@ -1683,7 +1683,7 @@ func createSandboxContainerAndExec(t *testing.T, annotations map[string]string, 
 func Test_RunPodSandbox_KernelOptions_LCOW(t *testing.T) {
 	requireFeatures(t, featureLCOW)
 
-	pullRequiredLcowImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
+	pullRequiredLCOWImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
 
 	annotations := map[string]string{
 		oci.AnnotationFullyPhysicallyBacked: "true",

--- a/test/cri-containerd/sandbox.go
+++ b/test/cri-containerd/sandbox.go
@@ -85,7 +85,7 @@ func getTestSandboxConfig(t *testing.T, opts ...SandboxConfigOpt) *runtime.PodSa
 
 	for _, o := range opts {
 		if err := o(c); err != nil {
-			t.Errorf("failed to apply PodSandboxConfig option: %s", err)
+			t.Fatalf("failed to apply PodSandboxConfig option: %s", err)
 		}
 	}
 	return c

--- a/test/cri-containerd/sandbox.go
+++ b/test/cri-containerd/sandbox.go
@@ -71,16 +71,15 @@ func getTestSandboxConfig(t *testing.T, opts ...SandboxConfigOpt) *runtime.PodSa
 	}
 
 	if *flagVirtstack != "" {
+		vmServicePath := testVMServiceBinary
+		if *flagVMServiceBinary != "" {
+			vmServicePath = *flagVMServiceBinary
+		}
 		opts = append(opts, WithSandboxAnnotations(map[string]string{
 			"io.microsoft.virtualmachine.vmsource":          *flagVirtstack,
 			"io.microsoft.virtualmachine.vmservice.address": testVMServiceAddress,
-			"io.microsoft.virtualmachine.vmservice.path":    testVMServiceBinary,
+			"io.microsoft.virtualmachine.vmservice.path":    vmServicePath,
 		}))
-		if *flagVMServiceBinary != "" {
-			opts = append(opts, WithSandboxAnnotations(map[string]string{
-				"io.microsoft.virtualmachine.vmservice.path": *flagVMServiceBinary,
-			}))
-		}
 	}
 
 	for _, o := range opts {

--- a/test/cri-containerd/sandbox.go
+++ b/test/cri-containerd/sandbox.go
@@ -9,6 +9,33 @@ import (
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 )
 
+type SandboxConfigOpt func(*runtime.PodSandboxConfig) error
+
+func WithSandboxAnnotations(annotations map[string]string) SandboxConfigOpt {
+	return func(config *runtime.PodSandboxConfig) error {
+		if config.Annotations == nil {
+			config.Annotations = make(map[string]string)
+		}
+		for k, v := range annotations {
+			config.Annotations[k] = v
+		}
+		return nil
+	}
+}
+
+func WithSandboxLabels(labels map[string]string) SandboxConfigOpt {
+	return func(config *runtime.PodSandboxConfig) error {
+		if config.Labels == nil {
+			config.Labels = make(map[string]string)
+		}
+
+		for k, v := range labels {
+			config.Labels[k] = v
+		}
+		return nil
+	}
+}
+
 func runPodSandbox(t *testing.T, client runtime.RuntimeServiceClient, ctx context.Context, request *runtime.RunPodSandboxRequest) string {
 	response, err := client.RunPodSandbox(ctx, request)
 	if err != nil {
@@ -35,28 +62,38 @@ func removePodSandbox(t *testing.T, client runtime.RuntimeServiceClient, ctx con
 	}
 }
 
-func getRunPodSandboxRequest(t *testing.T, runtimeHandler string, annotations map[string]string) *runtime.RunPodSandboxRequest {
-	req := &runtime.RunPodSandboxRequest{
-		Config: &runtime.PodSandboxConfig{
-			Metadata: &runtime.PodSandboxMetadata{
-				Name:      t.Name(),
-				Namespace: testNamespace,
-			},
-			Annotations: annotations,
+func getTestSandboxConfig(t *testing.T, opts ...SandboxConfigOpt) *runtime.PodSandboxConfig {
+	c := &runtime.PodSandboxConfig{
+		Metadata: &runtime.PodSandboxMetadata{
+			Name:      t.Name(),
+			Namespace: testNamespace,
 		},
-		RuntimeHandler: runtimeHandler,
 	}
 
 	if *flagVirtstack != "" {
-		if req.Config.Annotations == nil {
-			req.Config.Annotations = make(map[string]string)
-		}
-		req.Config.Annotations["io.microsoft.virtualmachine.vmsource"] = *flagVirtstack
-		req.Config.Annotations["io.microsoft.virtualmachine.vmservice.address"] = testVMServiceAddress
-		req.Config.Annotations["io.microsoft.virtualmachine.vmservice.path"] = testVMServiceBinary
+		opts = append(opts, WithSandboxAnnotations(map[string]string{
+			"io.microsoft.virtualmachine.vmsource":          *flagVirtstack,
+			"io.microsoft.virtualmachine.vmservice.address": testVMServiceAddress,
+			"io.microsoft.virtualmachine.vmservice.path":    testVMServiceBinary,
+		}))
 		if *flagVMServiceBinary != "" {
-			req.Config.Annotations["io.microsoft.virtualmachine.vmservice.path"] = *flagVMServiceBinary
+			opts = append(opts, WithSandboxAnnotations(map[string]string{
+				"io.microsoft.virtualmachine.vmservice.path": *flagVMServiceBinary,
+			}))
 		}
 	}
-	return req
+
+	for _, o := range opts {
+		if err := o(c); err != nil {
+			t.Errorf("failed to apply PodSandboxConfig option: %s", err)
+		}
+	}
+	return c
+}
+
+func getRunPodSandboxRequest(t *testing.T, runtimeHandler string, sandboxOpts ...SandboxConfigOpt) *runtime.RunPodSandboxRequest {
+	return &runtime.RunPodSandboxRequest{
+		Config:         getTestSandboxConfig(t, sandboxOpts...),
+		RuntimeHandler: runtimeHandler,
+	}
 }

--- a/test/cri-containerd/scale_cpu_limits_to_sandbox_test.go
+++ b/test/cri-containerd/scale_cpu_limits_to_sandbox_test.go
@@ -23,7 +23,7 @@ func Test_Scale_CPU_Limits_To_Sandbox(t *testing.T) {
 	defer cancel()
 
 	client := newTestRuntimeClient(t)
-	podReq := getRunPodSandboxRequest(t, wcowHypervisor17763RuntimeHandler, nil)
+	podReq := getRunPodSandboxRequest(t, wcowHypervisor17763RuntimeHandler)
 	podID := runPodSandbox(t, client, ctx, podReq)
 	defer removePodSandbox(t, client, ctx, podID)
 

--- a/test/cri-containerd/stats_test.go
+++ b/test/cri-containerd/stats_test.go
@@ -87,7 +87,7 @@ func verifyPhysicallyBackedWorkingSet(t *testing.T, num uint64, stat *runtime.Co
 func Test_SandboxStats_Single_LCOW(t *testing.T) {
 	requireFeatures(t, featureLCOW)
 
-	pullRequiredLcowImages(t, []string{imageLcowK8sPause})
+	pullRequiredLCOWImages(t, []string{imageLcowK8sPause})
 
 	request := getRunPodSandboxRequest(t, lcowRuntimeHandler)
 
@@ -115,7 +115,7 @@ func Test_SandboxStats_Single_LCOW(t *testing.T) {
 func Test_SandboxStats_List_ContainerID_LCOW(t *testing.T) {
 	requireFeatures(t, featureLCOW)
 
-	pullRequiredLcowImages(t, []string{imageLcowK8sPause})
+	pullRequiredLCOWImages(t, []string{imageLcowK8sPause})
 
 	request := getRunPodSandboxRequest(t, lcowRuntimeHandler)
 
@@ -148,7 +148,7 @@ func Test_SandboxStats_List_ContainerID_LCOW(t *testing.T) {
 func Test_SandboxStats_List_PodID_LCOW(t *testing.T) {
 	requireFeatures(t, featureLCOW)
 
-	pullRequiredLcowImages(t, []string{imageLcowK8sPause})
+	pullRequiredLCOWImages(t, []string{imageLcowK8sPause})
 
 	request := getRunPodSandboxRequest(t, lcowRuntimeHandler)
 
@@ -219,7 +219,7 @@ func Test_ContainerStats_ContainerID(t *testing.T) {
 			requireFeatures(t, test.requiredFeatures...)
 
 			if test.runtimeHandler == lcowRuntimeHandler {
-				pullRequiredLcowImages(t, []string{test.sandboxImage, test.containerImage})
+				pullRequiredLCOWImages(t, []string{test.sandboxImage, test.containerImage})
 			} else {
 				pullRequiredImages(t, []string{test.sandboxImage, test.containerImage})
 			}
@@ -294,7 +294,7 @@ func Test_ContainerStats_List_ContainerID(t *testing.T) {
 			requireFeatures(t, test.requiredFeatures...)
 
 			if test.runtimeHandler == lcowRuntimeHandler {
-				pullRequiredLcowImages(t, []string{test.sandboxImage, test.containerImage})
+				pullRequiredLCOWImages(t, []string{test.sandboxImage, test.containerImage})
 			} else {
 				pullRequiredImages(t, []string{test.sandboxImage, test.containerImage})
 			}
@@ -354,7 +354,7 @@ func Test_SandboxStats_WorkingSet_PhysicallyBacked(t *testing.T) {
 			requireFeatures(t, test.requiredFeatures...)
 
 			if test.runtimeHandler == lcowRuntimeHandler {
-				pullRequiredLcowImages(t, []string{test.sandboxImage})
+				pullRequiredLCOWImages(t, []string{test.sandboxImage})
 			} else {
 				pullRequiredImages(t, []string{test.sandboxImage})
 			}

--- a/test/cri-containerd/stats_test.go
+++ b/test/cri-containerd/stats_test.go
@@ -89,7 +89,7 @@ func Test_SandboxStats_Single_LCOW(t *testing.T) {
 
 	pullRequiredLcowImages(t, []string{imageLcowK8sPause})
 
-	request := getRunPodSandboxRequest(t, lcowRuntimeHandler, nil)
+	request := getRunPodSandboxRequest(t, lcowRuntimeHandler)
 
 	client := newTestRuntimeClient(t)
 	ctx, cancel := context.WithCancel(context.Background())
@@ -117,7 +117,7 @@ func Test_SandboxStats_List_ContainerID_LCOW(t *testing.T) {
 
 	pullRequiredLcowImages(t, []string{imageLcowK8sPause})
 
-	request := getRunPodSandboxRequest(t, lcowRuntimeHandler, nil)
+	request := getRunPodSandboxRequest(t, lcowRuntimeHandler)
 
 	client := newTestRuntimeClient(t)
 	ctx, cancel := context.WithCancel(context.Background())
@@ -150,7 +150,7 @@ func Test_SandboxStats_List_PodID_LCOW(t *testing.T) {
 
 	pullRequiredLcowImages(t, []string{imageLcowK8sPause})
 
-	request := getRunPodSandboxRequest(t, lcowRuntimeHandler, nil)
+	request := getRunPodSandboxRequest(t, lcowRuntimeHandler)
 
 	client := newTestRuntimeClient(t)
 	ctx, cancel := context.WithCancel(context.Background())
@@ -224,7 +224,7 @@ func Test_ContainerStats_ContainerID(t *testing.T) {
 				pullRequiredImages(t, []string{test.sandboxImage, test.containerImage})
 			}
 
-			podRequest := getRunPodSandboxRequest(t, test.runtimeHandler, nil)
+			podRequest := getRunPodSandboxRequest(t, test.runtimeHandler)
 
 			client := newTestRuntimeClient(t)
 			ctx, cancel := context.WithCancel(context.Background())
@@ -299,7 +299,7 @@ func Test_ContainerStats_List_ContainerID(t *testing.T) {
 				pullRequiredImages(t, []string{test.sandboxImage, test.containerImage})
 			}
 
-			podRequest := getRunPodSandboxRequest(t, test.runtimeHandler, nil)
+			podRequest := getRunPodSandboxRequest(t, test.runtimeHandler)
 
 			client := newTestRuntimeClient(t)
 			ctx, cancel := context.WithCancel(context.Background())
@@ -368,11 +368,11 @@ func Test_SandboxStats_WorkingSet_PhysicallyBacked(t *testing.T) {
 			podRequest := getRunPodSandboxRequest(
 				t,
 				test.runtimeHandler,
-				map[string]string{
+				WithSandboxAnnotations(map[string]string{
 					oci.AnnotationAllowOvercommit:      "false",
 					oci.AnnotationEnableDeferredCommit: "false",
 					oci.AnnotationMemorySizeInMB:       sizeInMBStr,
-				},
+				}),
 			)
 
 			client := newTestRuntimeClient(t)

--- a/test/cri-containerd/stopcontainer_test.go
+++ b/test/cri-containerd/stopcontainer_test.go
@@ -12,7 +12,7 @@ import (
 func Test_StopContainer_LCOW(t *testing.T) {
 	requireFeatures(t, featureLCOW)
 
-	pullRequiredLcowImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
+	pullRequiredLCOWImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
 
 	client := newTestRuntimeClient(t)
 	ctx, cancel := context.WithCancel(context.Background())
@@ -50,7 +50,7 @@ func Test_StopContainer_LCOW(t *testing.T) {
 func Test_StopContainer_WithTimeout_LCOW(t *testing.T) {
 	requireFeatures(t, featureLCOW)
 
-	pullRequiredLcowImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
+	pullRequiredLCOWImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
 
 	client := newTestRuntimeClient(t)
 	ctx, cancel := context.WithCancel(context.Background())
@@ -88,7 +88,7 @@ func Test_StopContainer_WithTimeout_LCOW(t *testing.T) {
 func Test_StopContainer_WithExec_LCOW(t *testing.T) {
 	requireFeatures(t, featureLCOW)
 
-	pullRequiredLcowImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
+	pullRequiredLCOWImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
 
 	client := newTestRuntimeClient(t)
 	ctx, cancel := context.WithCancel(context.Background())
@@ -134,7 +134,7 @@ func Test_StopContainer_WithExec_LCOW(t *testing.T) {
 func Test_StopContainer_ReusePod_LCOW(t *testing.T) {
 	requireFeatures(t, featureLCOW)
 
-	pullRequiredLcowImages(t, []string{alpineAspNet, alpineAspnetUpgrade})
+	pullRequiredLCOWImages(t, []string{alpineAspNet, alpineAspnetUpgrade})
 
 	client := newTestRuntimeClient(t)
 	ctx, cancel := context.WithCancel(context.Background())

--- a/test/cri-containerd/stopcontainer_test.go
+++ b/test/cri-containerd/stopcontainer_test.go
@@ -18,7 +18,7 @@ func Test_StopContainer_LCOW(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	sandboxRequest := getRunPodSandboxRequest(t, lcowRuntimeHandler, nil)
+	sandboxRequest := getRunPodSandboxRequest(t, lcowRuntimeHandler)
 
 	podID := runPodSandbox(t, client, ctx, sandboxRequest)
 	defer removePodSandbox(t, client, ctx, podID)
@@ -56,7 +56,7 @@ func Test_StopContainer_WithTimeout_LCOW(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	sandboxRequest := getRunPodSandboxRequest(t, lcowRuntimeHandler, nil)
+	sandboxRequest := getRunPodSandboxRequest(t, lcowRuntimeHandler)
 
 	podID := runPodSandbox(t, client, ctx, sandboxRequest)
 	defer removePodSandbox(t, client, ctx, podID)
@@ -94,7 +94,7 @@ func Test_StopContainer_WithExec_LCOW(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	sandboxRequest := getRunPodSandboxRequest(t, lcowRuntimeHandler, nil)
+	sandboxRequest := getRunPodSandboxRequest(t, lcowRuntimeHandler)
 
 	podID := runPodSandbox(t, client, ctx, sandboxRequest)
 	defer removePodSandbox(t, client, ctx, podID)
@@ -140,7 +140,7 @@ func Test_StopContainer_ReusePod_LCOW(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	sandboxRequest := getRunPodSandboxRequest(t, lcowRuntimeHandler, nil)
+	sandboxRequest := getRunPodSandboxRequest(t, lcowRuntimeHandler)
 
 	podID := runPodSandbox(t, client, ctx, sandboxRequest)
 	defer removePodSandbox(t, client, ctx, podID)


### PR DESCRIPTION
Add SandboxConfigOpt func type, which enables pluggable configuration
of PodSandboxConfig.

Signed-off-by: Maksim An <maksiman@microsoft.com>