### PR TITLE
Remove unused definitions in winapi

### DIFF
--- a/internal/winapi/memory.go
+++ b/internal/winapi/memory.go
@@ -1,27 +1,4 @@
 package winapi
 
-// VOID RtlMoveMemory(
-// 	_Out_       VOID UNALIGNED *Destination,
-// 	_In_  const VOID UNALIGNED *Source,
-// 	_In_        SIZE_T         Length
-// );
-//sys RtlMoveMemory(destination *byte, source *byte, length uintptr) (err error) = kernel32.RtlMoveMemory
-
 //sys LocalAlloc(flags uint32, size int) (ptr uintptr) = kernel32.LocalAlloc
 //sys LocalFree(ptr uintptr) = kernel32.LocalFree
-
-// BOOL QueryWorkingSet(
-//	HANDLE hProcess,
-//	PVOID  pv,
-//	DWORD  cb
-// );
-//sys QueryWorkingSet(handle windows.Handle, pv uintptr, cb uint32) (err error) = psapi.QueryWorkingSet
-
-type PSAPI_WORKING_SET_INFORMATION struct {
-	NumberOfEntries uintptr
-	WorkingSetInfo  [1]PSAPI_WORKING_SET_BLOCK
-}
-
-type PSAPI_WORKING_SET_BLOCK struct {
-	Flags uintptr
-}

--- a/internal/winapi/zsyscall_windows.go
+++ b/internal/winapi/zsyscall_windows.go
@@ -41,7 +41,6 @@ var (
 	modiphlpapi = windows.NewLazySystemDLL("iphlpapi.dll")
 	modkernel32 = windows.NewLazySystemDLL("kernel32.dll")
 	modadvapi32 = windows.NewLazySystemDLL("advapi32.dll")
-	modpsapi    = windows.NewLazySystemDLL("psapi.dll")
 	modcfgmgr32 = windows.NewLazySystemDLL("cfgmgr32.dll")
 
 	procNtQuerySystemInformation               = modntdll.NewProc("NtQuerySystemInformation")
@@ -57,10 +56,8 @@ var (
 	procNtOpenJobObject                        = modntdll.NewProc("NtOpenJobObject")
 	procNtCreateJobObject                      = modntdll.NewProc("NtCreateJobObject")
 	procLogonUserW                             = modadvapi32.NewProc("LogonUserW")
-	procRtlMoveMemory                          = modkernel32.NewProc("RtlMoveMemory")
 	procLocalAlloc                             = modkernel32.NewProc("LocalAlloc")
 	procLocalFree                              = modkernel32.NewProc("LocalFree")
-	procQueryWorkingSet                        = modpsapi.NewProc("QueryWorkingSet")
 	procGetProcessImageFileNameW               = modkernel32.NewProc("GetProcessImageFileNameW")
 	procGetActiveProcessorCount                = modkernel32.NewProc("GetActiveProcessorCount")
 	procCM_Get_Device_ID_List_SizeA            = modcfgmgr32.NewProc("CM_Get_Device_ID_List_SizeA")
@@ -219,18 +216,6 @@ func LogonUser(username *uint16, domain *uint16, password *uint16, logonType uin
 	return
 }
 
-func RtlMoveMemory(destination *byte, source *byte, length uintptr) (err error) {
-	r1, _, e1 := syscall.Syscall(procRtlMoveMemory.Addr(), 3, uintptr(unsafe.Pointer(destination)), uintptr(unsafe.Pointer(source)), uintptr(length))
-	if r1 == 0 {
-		if e1 != 0 {
-			err = errnoErr(e1)
-		} else {
-			err = syscall.EINVAL
-		}
-	}
-	return
-}
-
 func LocalAlloc(flags uint32, size int) (ptr uintptr) {
 	r0, _, _ := syscall.Syscall(procLocalAlloc.Addr(), 2, uintptr(flags), uintptr(size), 0)
 	ptr = uintptr(r0)
@@ -239,18 +224,6 @@ func LocalAlloc(flags uint32, size int) (ptr uintptr) {
 
 func LocalFree(ptr uintptr) {
 	syscall.Syscall(procLocalFree.Addr(), 1, uintptr(ptr), 0, 0)
-	return
-}
-
-func QueryWorkingSet(handle windows.Handle, pv uintptr, cb uint32) (err error) {
-	r1, _, e1 := syscall.Syscall(procQueryWorkingSet.Addr(), 3, uintptr(handle), uintptr(pv), uintptr(cb))
-	if r1 == 0 {
-		if e1 != 0 {
-			err = errnoErr(e1)
-		} else {
-			err = syscall.EINVAL
-		}
-	}
 	return
 }
 

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/winapi/memory.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/winapi/memory.go
@@ -1,27 +1,4 @@
 package winapi
 
-// VOID RtlMoveMemory(
-// 	_Out_       VOID UNALIGNED *Destination,
-// 	_In_  const VOID UNALIGNED *Source,
-// 	_In_        SIZE_T         Length
-// );
-//sys RtlMoveMemory(destination *byte, source *byte, length uintptr) (err error) = kernel32.RtlMoveMemory
-
 //sys LocalAlloc(flags uint32, size int) (ptr uintptr) = kernel32.LocalAlloc
 //sys LocalFree(ptr uintptr) = kernel32.LocalFree
-
-// BOOL QueryWorkingSet(
-//	HANDLE hProcess,
-//	PVOID  pv,
-//	DWORD  cb
-// );
-//sys QueryWorkingSet(handle windows.Handle, pv uintptr, cb uint32) (err error) = psapi.QueryWorkingSet
-
-type PSAPI_WORKING_SET_INFORMATION struct {
-	NumberOfEntries uintptr
-	WorkingSetInfo  [1]PSAPI_WORKING_SET_BLOCK
-}
-
-type PSAPI_WORKING_SET_BLOCK struct {
-	Flags uintptr
-}

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/winapi/zsyscall_windows.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/winapi/zsyscall_windows.go
@@ -41,7 +41,6 @@ var (
 	modiphlpapi = windows.NewLazySystemDLL("iphlpapi.dll")
 	modkernel32 = windows.NewLazySystemDLL("kernel32.dll")
 	modadvapi32 = windows.NewLazySystemDLL("advapi32.dll")
-	modpsapi    = windows.NewLazySystemDLL("psapi.dll")
 	modcfgmgr32 = windows.NewLazySystemDLL("cfgmgr32.dll")
 
 	procNtQuerySystemInformation               = modntdll.NewProc("NtQuerySystemInformation")
@@ -57,10 +56,8 @@ var (
 	procNtOpenJobObject                        = modntdll.NewProc("NtOpenJobObject")
 	procNtCreateJobObject                      = modntdll.NewProc("NtCreateJobObject")
 	procLogonUserW                             = modadvapi32.NewProc("LogonUserW")
-	procRtlMoveMemory                          = modkernel32.NewProc("RtlMoveMemory")
 	procLocalAlloc                             = modkernel32.NewProc("LocalAlloc")
 	procLocalFree                              = modkernel32.NewProc("LocalFree")
-	procQueryWorkingSet                        = modpsapi.NewProc("QueryWorkingSet")
 	procGetProcessImageFileNameW               = modkernel32.NewProc("GetProcessImageFileNameW")
 	procGetActiveProcessorCount                = modkernel32.NewProc("GetActiveProcessorCount")
 	procCM_Get_Device_ID_List_SizeA            = modcfgmgr32.NewProc("CM_Get_Device_ID_List_SizeA")
@@ -219,18 +216,6 @@ func LogonUser(username *uint16, domain *uint16, password *uint16, logonType uin
 	return
 }
 
-func RtlMoveMemory(destination *byte, source *byte, length uintptr) (err error) {
-	r1, _, e1 := syscall.Syscall(procRtlMoveMemory.Addr(), 3, uintptr(unsafe.Pointer(destination)), uintptr(unsafe.Pointer(source)), uintptr(length))
-	if r1 == 0 {
-		if e1 != 0 {
-			err = errnoErr(e1)
-		} else {
-			err = syscall.EINVAL
-		}
-	}
-	return
-}
-
 func LocalAlloc(flags uint32, size int) (ptr uintptr) {
 	r0, _, _ := syscall.Syscall(procLocalAlloc.Addr(), 2, uintptr(flags), uintptr(size), 0)
 	ptr = uintptr(r0)
@@ -239,18 +224,6 @@ func LocalAlloc(flags uint32, size int) (ptr uintptr) {
 
 func LocalFree(ptr uintptr) {
 	syscall.Syscall(procLocalFree.Addr(), 1, uintptr(ptr), 0, 0)
-	return
-}
-
-func QueryWorkingSet(handle windows.Handle, pv uintptr, cb uint32) (err error) {
-	r1, _, e1 := syscall.Syscall(procQueryWorkingSet.Addr(), 3, uintptr(handle), uintptr(pv), uintptr(cb))
-	if r1 == 0 {
-		if e1 != 0 {
-			err = errnoErr(e1)
-		} else {
-			err = syscall.EINVAL
-		}
-	}
 	return
 }
 


### PR DESCRIPTION
This change removes some unused memory related definitions in internal/winapi.
They were originally going to be used for stats for host process contaienrs
but NtQuerySystemInformation was used instead.

Signed-off-by: Daniel Canter <dcanter@microsoft.com>