### PR TITLE
tests: Fix tests that used old pullRequiredLCOWImages func name

### DIFF
--- a/test/cri-containerd/container_test.go
+++ b/test/cri-containerd/container_test.go
@@ -897,7 +897,7 @@ func Test_CreateContainer_HugePageMount_LCOW(t *testing.T) {
 func Test_RunContainer_ExecUser_LCOW(t *testing.T) {
 	requireFeatures(t, featureLCOW)
 
-	pullRequiredLcowImages(t, []string{imageLcowK8sPause, imageLcowCustomUser})
+	pullRequiredLCOWImages(t, []string{imageLcowK8sPause, imageLcowCustomUser})
 
 	client := newTestRuntimeClient(t)
 	ctx, cancel := context.WithCancel(context.Background())
@@ -950,7 +950,7 @@ func Test_RunContainer_ExecUser_LCOW(t *testing.T) {
 func Test_RunContainer_ExecUser_Root_LCOW(t *testing.T) {
 	requireFeatures(t, featureLCOW)
 
-	pullRequiredLcowImages(t, []string{imageLcowK8sPause, imageLcowCustomUser})
+	pullRequiredLCOWImages(t, []string{imageLcowK8sPause, imageLcowCustomUser})
 
 	client := newTestRuntimeClient(t)
 	ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
Lack of rebase when merging
https://github.com/microsoft/hcsshim/pull/1180 resulted in some
test files being out of date and containing old helper function
name

Signed-off-by: Maksim An <maksiman@microsoft.com>