### PR TITLE
tests: Fix ExecUser LCOW tests using old function signature

### DIFF
--- a/test/cri-containerd/container_test.go
+++ b/test/cri-containerd/container_test.go
@@ -903,7 +903,7 @@ func Test_RunContainer_ExecUser_LCOW(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	sandboxRequest := getRunPodSandboxRequest(t, lcowRuntimeHandler, nil)
+	sandboxRequest := getRunPodSandboxRequest(t, lcowRuntimeHandler)
 
 	podID := runPodSandbox(t, client, ctx, sandboxRequest)
 	defer removePodSandbox(t, client, ctx, podID)
@@ -956,7 +956,7 @@ func Test_RunContainer_ExecUser_Root_LCOW(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	sandboxRequest := getRunPodSandboxRequest(t, lcowRuntimeHandler, nil)
+	sandboxRequest := getRunPodSandboxRequest(t, lcowRuntimeHandler)
 
 	podID := runPodSandbox(t, client, ctx, sandboxRequest)
 	defer removePodSandbox(t, client, ctx, podID)


### PR DESCRIPTION
Signed-off-by: Maksim An <maksiman@microsoft.com>