### PR TITLE
Revert V21H2 osversion definition

### DIFF
--- a/osversion/windowsbuilds.go
+++ b/osversion/windowsbuilds.go
@@ -38,7 +38,4 @@ const (
 
 	// V21H1 corresponds to Windows Server 21H1 (semi-annual channel).
 	V21H1 = 19043
-
-	// V21H2 corresponds to Windows Server 2022 (ltsc2022).
-	V21H2 = 20348
 )

--- a/test/vendor/github.com/Microsoft/hcsshim/osversion/windowsbuilds.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/osversion/windowsbuilds.go
@@ -38,7 +38,4 @@ const (
 
 	// V21H1 corresponds to Windows Server 21H1 (semi-annual channel).
 	V21H1 = 19043
-
-	// V21H2 corresponds to Windows Server 2022 (ltsc2022).
-	V21H2 = 20348
 )


### PR DESCRIPTION
This reverts commit 7b6e3dac2b3b0c2e06ab5d0bf2a0665fb80ae511 that added 
a windows server 2022 build number. The reason
for this is because the tag 21h2 actually refers to a couple different
Windows builds now unfortunately. It's the tag for the latest Windows 10
update, for Windows 11, and Windows Server 2022. We're looking into how
best to actually name these going forward if we're going to account for an
event like this again.