### PR TITLE
Add support for finding net adapters that were assigned with vpci

### DIFF
--- a/internal/guest/network/network_test.go
+++ b/internal/guest/network/network_test.go
@@ -5,6 +5,7 @@ package network
 import (
 	"context"
 	"io/fs"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -197,7 +198,7 @@ func (t *testFileInfo) Sys() interface{} {
 	return nil
 }
 
-var _ = (fs.FileInfo)(&testFileInfo{})
+var _ = (os.FileInfo)(&testFileInfo{})
 
 func Test_InstanceIDToName(t *testing.T) {
 	ctx, _ := context.WithTimeout(context.Background(), 5*time.Second)
@@ -205,8 +206,8 @@ func Test_InstanceIDToName(t *testing.T) {
 	vmBusGUID := "1111-2222-3333-4444"
 	testIfName := "test-eth0"
 
-	vmbusWaitForDevicePath = func(_ context.Context, vmbusGUIDPattern string) (string, error) {
-		vmBusPath := filepath.Join("/sys/bus/vmbus/devices", vmbusGUIDPattern)
+	vmbusWaitForDevicePath = func(_ context.Context, vmBusGUIDPattern string) (string, error) {
+		vmBusPath := filepath.Join("/sys/bus/vmbus/devices", vmBusGUIDPattern)
 		return vmBusPath, nil
 	}
 
@@ -214,7 +215,7 @@ func Test_InstanceIDToName(t *testing.T) {
 		return pattern, nil
 	}
 
-	ioutilReadDir = func(dirname string) ([]fs.FileInfo, error) {
+	ioutilReadDir = func(dirname string) ([]os.FileInfo, error) {
 		info := &testFileInfo{
 			FileName:    testIfName,
 			IsDirectory: false,
@@ -244,12 +245,12 @@ func Test_InstanceIDToName_VPCI(t *testing.T) {
 		return pattern, nil
 	}
 
-	ioutilReadDir = func(dirname string) ([]fs.FileInfo, error) {
+	ioutilReadDir = func(dirname string) ([]os.FileInfo, error) {
 		info := &testFileInfo{
 			FileName:    testIfName,
 			IsDirectory: false,
 		}
-		return []fs.FileInfo{info}, nil
+		return []os.FileInfo{info}, nil
 	}
 	actualIfName, err := InstanceIDToName(ctx, vmBusGUID, true)
 	if err != nil {

--- a/internal/guest/network/network_test.go
+++ b/internal/guest/network/network_test.go
@@ -4,7 +4,10 @@ package network
 
 import (
 	"context"
+	"io/fs"
+	"path/filepath"
 	"testing"
+	"time"
 )
 
 func Test_GenerateResolvConfContent(t *testing.T) {
@@ -163,5 +166,96 @@ ff02::2 ip6-allrouters
 				t.Fatalf("expected content: %q got: %q", tc.expectedContent, c)
 			}
 		})
+	}
+}
+
+// create a test FileInfo so we can return back a value to ReadDir
+type testFileInfo struct {
+	FileName    string
+	IsDirectory bool
+}
+
+func (t *testFileInfo) Name() string {
+	return t.FileName
+}
+func (t *testFileInfo) Size() int64 {
+	return 0
+}
+func (t *testFileInfo) Mode() fs.FileMode {
+	if t.IsDirectory {
+		return fs.ModeDir
+	}
+	return 0
+}
+func (t *testFileInfo) ModTime() time.Time {
+	return time.Now()
+}
+func (t *testFileInfo) IsDir() bool {
+	return t.IsDirectory
+}
+func (t *testFileInfo) Sys() interface{} {
+	return nil
+}
+
+var _ = (fs.FileInfo)(&testFileInfo{})
+
+func Test_InstanceIDToName(t *testing.T) {
+	ctx, _ := context.WithTimeout(context.Background(), 5*time.Second)
+
+	vmBusGUID := "1111-2222-3333-4444"
+	testIfName := "test-eth0"
+
+	vmbusWaitForDevicePath = func(_ context.Context, vmbusGUIDPattern string) (string, error) {
+		vmBusPath := filepath.Join("/sys/bus/vmbus/devices", vmbusGUIDPattern)
+		return vmBusPath, nil
+	}
+
+	storageWaitForFileMatchingPattern = func(_ context.Context, pattern string) (string, error) {
+		return pattern, nil
+	}
+
+	ioutilReadDir = func(dirname string) ([]fs.FileInfo, error) {
+		info := &testFileInfo{
+			FileName:    testIfName,
+			IsDirectory: false,
+		}
+		return []fs.FileInfo{info}, nil
+	}
+	actualIfName, err := InstanceIDToName(ctx, vmBusGUID, false)
+	if err != nil {
+		t.Fatalf("expected no error, instead got %v", err)
+	}
+	if actualIfName != testIfName {
+		t.Fatalf("expected to get %v ifname, instead got %v", testIfName, actualIfName)
+	}
+}
+
+func Test_InstanceIDToName_VPCI(t *testing.T) {
+	ctx, _ := context.WithTimeout(context.Background(), 5*time.Second)
+
+	vmBusGUID := "1111-2222-3333-4444"
+	testIfName := "test-eth0-vpci"
+
+	pciFindDeviceFullPath = func(_ context.Context, vmBusGUID string) (string, error) {
+		return filepath.Join("/sys/bus/vmbus/devices", vmBusGUID), nil
+	}
+
+	storageWaitForFileMatchingPattern = func(_ context.Context, pattern string) (string, error) {
+		return pattern, nil
+	}
+
+	ioutilReadDir = func(dirname string) ([]fs.FileInfo, error) {
+		info := &testFileInfo{
+			FileName:    testIfName,
+			IsDirectory: false,
+		}
+		return []fs.FileInfo{info}, nil
+	}
+	actualIfName, err := InstanceIDToName(ctx, vmBusGUID, true)
+	if err != nil {
+		t.Fatalf("expected no error, instead got %v", err)
+	}
+	if actualIfName != testIfName {
+		t.Fatalf("expected to get %v ifname, instead got %v", testIfName, actualIfName)
 	}
 }

--- a/internal/guest/prot/protocol.go
+++ b/internal/guest/prot/protocol.go
@@ -754,6 +754,7 @@ type NetworkAdapterV2 struct {
 	DNSServerList   string `json:",omitempty"`
 	EnableLowMetric bool   `json:",omitempty"`
 	EncapOverhead   uint16 `json:",omitempty"`
+	VPCIAssigned    bool   `json:",omitempty"`
 }
 
 // MappedVirtualDisk represents a disk on the host which is mapped into a

--- a/internal/guest/runtime/hcsv2/network.go
+++ b/internal/guest/runtime/hcsv2/network.go
@@ -162,7 +162,7 @@ func (n *namespace) AddAdapter(ctx context.Context, adp *prot.NetworkAdapterV2) 
 
 	resolveCtx, cancel := context.WithTimeout(ctx, time.Second*5)
 	defer cancel()
-	ifname, err := networkInstanceIDToName(resolveCtx, adp.ID)
+	ifname, err := networkInstanceIDToName(resolveCtx, adp.ID, adp.VPCIAssigned)
 	if err != nil {
 		return err
 	}

--- a/internal/guest/runtime/hcsv2/network_test.go
+++ b/internal/guest/runtime/hcsv2/network_test.go
@@ -97,7 +97,7 @@ func Test_removeNetworkNamespace_HasAdapters(t *testing.T) {
 
 	ns := getOrAddNetworkNamespace(t.Name())
 
-	networkInstanceIDToName = func(ctx context.Context, id string) (string, error) {
+	networkInstanceIDToName = func(ctx context.Context, id string, _ bool) (string, error) {
 		return "/dev/sdz", nil
 	}
 	err := ns.AddAdapter(context.Background(), &prot.NetworkAdapterV2{ID: "test"})

--- a/internal/guest/storage/pci/pci.go
+++ b/internal/guest/storage/pci/pci.go
@@ -41,12 +41,7 @@ func FindDeviceFullPath(ctx context.Context, vmBusGUID string) (string, error) {
 		return "", err
 	}
 
-	pciDevicePath, err := findVMBusPCIDevice(ctx, pciDir)
-	if err != nil {
-		return "", err
-	}
-
-	return pciDevicePath, nil
+	return findVMBusPCIDevice(ctx, pciDir)
 }
 
 // findVMBusPCIDir waits for the pci bus directory matching pattern

--- a/internal/guestrequest/types.go
+++ b/internal/guestrequest/types.go
@@ -102,6 +102,7 @@ type LCOWNetworkAdapter struct {
 	DNSServerList   string `json:",omitempty"`
 	EnableLowMetric bool   `json:",omitempty"`
 	EncapOverhead   uint16 `json:",omitempty"`
+	VPCIAssigned    bool   `json:",omitempty"`
 }
 
 type LCOWContainerConstraints struct {

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/guestrequest/types.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/guestrequest/types.go
@@ -102,6 +102,7 @@ type LCOWNetworkAdapter struct {
 	DNSServerList   string `json:",omitempty"`
 	EnableLowMetric bool   `json:",omitempty"`
 	EncapOverhead   uint16 `json:",omitempty"`
+	VPCIAssigned    bool   `json:",omitempty"`
 }
 
 type LCOWContainerConstraints struct {


### PR DESCRIPTION
This PR adds support in the linux GCS for using network adapters that have been assigned into the guest via vpci. 

Signed-off-by: Kathryn Baldauf <kabaldau@microsoft.com>