### PR TITLE
Add retries when removing device mapper target

### DIFF
--- a/internal/guest/storage/devicemapper/devicemapper.go
+++ b/internal/guest/storage/devicemapper/devicemapper.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"strings"
 	"time"
 	"unsafe"
 
@@ -284,7 +285,7 @@ func RemoveDevice(name string) (err error) {
 	// This is workaround for "device or resource busy" error, which occasionally happens after the device mapper
 	// target has been unmounted.
 	for i := 0; i < 10; i++ {
-		if err = rm(); err != nil {
+		if err = rm(); err != nil && strings.Contains(err.Error(), "device or resource busy") {
 			time.Sleep(10 * time.Millisecond)
 			continue
 		}

--- a/internal/guest/storage/devicemapper/devicemapper.go
+++ b/internal/guest/storage/devicemapper/devicemapper.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path"
-	"strings"
+	"syscall"
 	"time"
 	"unsafe"
 
@@ -290,7 +290,7 @@ func RemoveDevice(name string) (err error) {
 	// This is workaround for "device or resource busy" error, which occasionally happens after the device mapper
 	// target has been unmounted.
 	for i := 0; i < 10; i++ {
-		if err = rm(); err != nil && strings.Contains(err.Error(), "device or resource busy") {
+		if err = rm(); err != nil && err == syscall.EBUSY {
 			time.Sleep(10 * time.Millisecond)
 			continue
 		}

--- a/internal/guest/storage/devicemapper/devicemapper.go
+++ b/internal/guest/storage/devicemapper/devicemapper.go
@@ -290,7 +290,10 @@ func RemoveDevice(name string) (err error) {
 	// This is workaround for "device or resource busy" error, which occasionally happens after the device mapper
 	// target has been unmounted.
 	for i := 0; i < 10; i++ {
-		if err = rm(); err == syscall.EBUSY {
+		if err = rm(); err != nil {
+			if e, ok := err.(*dmError); !ok || e.Err != syscall.EBUSY {
+				break
+			}
 			time.Sleep(10 * time.Millisecond)
 			continue
 		}

--- a/internal/guest/storage/devicemapper/devicemapper.go
+++ b/internal/guest/storage/devicemapper/devicemapper.go
@@ -290,7 +290,7 @@ func RemoveDevice(name string) (err error) {
 	// This is workaround for "device or resource busy" error, which occasionally happens after the device mapper
 	// target has been unmounted.
 	for i := 0; i < 10; i++ {
-		if err = rm(); err != nil && err == syscall.EBUSY {
+		if err = rm(); err == syscall.EBUSY {
 			time.Sleep(10 * time.Millisecond)
 			continue
 		}

--- a/internal/guest/storage/devicemapper/devicemapper_test.go
+++ b/internal/guest/storage/devicemapper/devicemapper_test.go
@@ -4,7 +4,6 @@ package devicemapper
 
 import (
 	"flag"
-	"fmt"
 	"io/ioutil"
 	"os"
 	"syscall"
@@ -167,7 +166,10 @@ func TestRemoveDeviceRetriesOnSyscallEBUSY(t *testing.T) {
 	removeDeviceWrapper = func(_ *os.File, _ string) error {
 		if !rmDeviceCalled {
 			rmDeviceCalled = true
-			return syscall.EBUSY
+			return &dmError{
+				Op:  1,
+				Err: syscall.EBUSY,
+			}
 		}
 		if !retryDone {
 			retryDone = true
@@ -190,7 +192,10 @@ func TestRemoveDeviceRetriesOnSyscallEBUSY(t *testing.T) {
 func TestRemoveDeviceFailsOnNonSyscallEBUSY(t *testing.T) {
 	clearTestDependencies()
 
-	expectedError := fmt.Errorf("non syscall.BUSY error")
+	expectedError := &dmError{
+		Op:  0,
+		Err: syscall.EACCES,
+	}
 	rmDeviceCalled := false
 	retryDone := false
 	openMapperWrapper = func() (*os.File, error) {

--- a/internal/guest/storage/devicemapper/devicemapper_test.go
+++ b/internal/guest/storage/devicemapper/devicemapper_test.go
@@ -4,9 +4,9 @@ package devicemapper
 
 import (
 	"flag"
-	"fmt"
 	"io/ioutil"
 	"os"
+	"syscall"
 	"testing"
 	"unsafe"
 
@@ -170,7 +170,7 @@ func TestRemoveDeviceRetries(t *testing.T) {
 	removeDeviceWrapper = func(_ *os.File, name string) error {
 		if !rmDeviceCalled {
 			rmDeviceCalled = true
-			return fmt.Errorf("device-mapper device remove: device or resource busy")
+			return syscall.EBUSY
 		}
 		if !retryCalled {
 			retryCalled = true

--- a/internal/guest/storage/pmem/pmem.go
+++ b/internal/guest/storage/pmem/pmem.go
@@ -143,14 +143,16 @@ func Unmount(ctx context.Context, devNumber uint32, target string, mappingInfo *
 	if verityInfo != nil {
 		dmVerityName := fmt.Sprintf(verityDeviceFmt, devNumber, verityInfo.RootDigest)
 		if err := dm.RemoveDevice(dmVerityName); err != nil {
-			return errors.Wrapf(err, "failed to remove dm verity target: %s", dmVerityName)
+			// The target is already unmounted at this point, ignore potential errors
+			log.G(ctx).WithError(err).Debugf("failed to remove dm verity target: %s", dmVerityName)
 		}
 	}
 
 	if mappingInfo != nil {
 		dmLinearName := fmt.Sprintf(linearDeviceFmt, devNumber, mappingInfo.DeviceOffsetInBytes, mappingInfo.DeviceSizeInBytes)
 		if err := dm.RemoveDevice(dmLinearName); err != nil {
-			return errors.Wrapf(err, "failed to remove dm linear target: %s", dmLinearName)
+			// The target is already unmounted at this point, ignore potential errors
+			log.G(ctx).WithError(err).Debugf("failed to remove dm linear target: %s", dmLinearName)
 		}
 	}
 


### PR DESCRIPTION
Additionally ignore the error from device mapper if target removal
still fails. The corresponding layer path is already unmounted
at that point and this avoids having an inconsistent state.

Signed-off-by: Maksim An <maksiman@microsoft.com>