### PR TITLE
Support updating cpugroup membership

### DIFF
--- a/internal/hcs/schema2/cpu_group_property.go
+++ b/internal/hcs/schema2/cpu_group_property.go
@@ -9,6 +9,14 @@
 
 package hcsschema
 
+type CPUGroupPropertyCode uint32
+
+const (
+	CPUCapacityProperty           = 0x00010000
+	CPUSchedulingPriorityProperty = 0x00020000
+	IdleLPReserveProperty         = 0x00030000
+)
+
 type CpuGroupProperty struct {
 	PropertyCode  uint32 `json:"PropertyCode,omitempty"`
 	PropertyValue uint32 `json:"PropertyValue,omitempty"`

--- a/internal/uvm/cpugroups.go
+++ b/internal/uvm/cpugroups.go
@@ -8,12 +8,10 @@ import (
 	"github.com/Microsoft/hcsshim/internal/cpugroup"
 	"github.com/Microsoft/hcsshim/internal/hcs/resourcepaths"
 	hcsschema "github.com/Microsoft/hcsshim/internal/hcs/schema2"
+	"github.com/Microsoft/hcsshim/osversion"
 )
 
-// Build that assigning a cpu group on creation of a vm is supported
-const cpuGroupCreateBuild = 20124
-
-var errCPUGroupCreateNotSupported = fmt.Errorf("cpu group assignment on create requires a build of %d or higher", cpuGroupCreateBuild)
+var errCPUGroupCreateNotSupported = fmt.Errorf("cpu group assignment on create requires a build of %d or higher", osversion.V21H1)
 
 // ReleaseCPUGroup unsets the cpugroup from the VM
 func (uvm *UtilityVM) ReleaseCPUGroup(ctx context.Context) error {

--- a/internal/uvm/create_lcow.go
+++ b/internal/uvm/create_lcow.go
@@ -216,7 +216,7 @@ func CreateLCOW(ctx context.Context, opts *OptionsLCOW) (_ *UtilityVM, err error
 	}
 	// We can set a cpu group for the VM at creation time in recent builds.
 	if opts.CPUGroupID != "" {
-		if osversion.Build() < cpuGroupCreateBuild {
+		if osversion.Build() < osversion.V21H1 {
 			return nil, errCPUGroupCreateNotSupported
 		}
 		processor.CpuGroup = &hcsschema.CpuGroup{Id: opts.CPUGroupID}

--- a/internal/uvm/create_wcow.go
+++ b/internal/uvm/create_wcow.go
@@ -160,7 +160,7 @@ func prepareConfigDoc(ctx context.Context, uvm *UtilityVM, opts *OptionsWCOW, uv
 	}
 	// We can set a cpu group for the VM at creation time in recent builds.
 	if opts.CPUGroupID != "" {
-		if osversion.Build() < cpuGroupCreateBuild {
+		if osversion.Build() < osversion.V21H1 {
 			return nil, errCPUGroupCreateNotSupported
 		}
 		processor.CpuGroup = &hcsschema.CpuGroup{Id: opts.CPUGroupID}

--- a/internal/uvm/update_uvm.go
+++ b/internal/uvm/update_uvm.go
@@ -4,10 +4,11 @@ import (
 	"context"
 
 	hcsschema "github.com/Microsoft/hcsshim/internal/hcs/schema2"
+	"github.com/Microsoft/hcsshim/pkg/annotations"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 )
 
-func (uvm *UtilityVM) UpdateConstraints(ctx context.Context, data interface{}, annotations map[string]string) error {
+func (uvm *UtilityVM) UpdateConstraints(ctx context.Context, data interface{}, annots map[string]string) error {
 	var memoryLimitInBytes *uint64
 	var processorLimits *hcsschema.ProcessorLimits
 
@@ -48,6 +49,13 @@ func (uvm *UtilityVM) UpdateConstraints(ctx context.Context, data interface{}, a
 	}
 	if processorLimits != nil {
 		if err := uvm.UpdateCPULimits(ctx, processorLimits); err != nil {
+			return err
+		}
+	}
+
+	// Check if an annotation was sent to update cpugroup membership
+	if cpuGroupID, ok := annots[annotations.CPUGroupID]; ok {
+		if err := uvm.SetCPUGroup(ctx, cpuGroupID); err != nil {
 			return err
 		}
 	}

--- a/test/cri-containerd/runpodsandbox_test.go
+++ b/test/cri-containerd/runpodsandbox_test.go
@@ -978,7 +978,7 @@ func Test_RunPodSandbox_Mount_SandboxDir_NoShare_WCOW(t *testing.T) {
 }
 
 func Test_RunPodSandbox_CPUGroup(t *testing.T) {
-	testutilities.RequiresBuild(t, 20124)
+	testutilities.RequiresBuild(t, osversion.V21H1)
 	ctx := context.Background()
 	presentID := "FA22A12C-36B3-486D-A3E9-BC526C2B450B"
 

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/hcs/schema2/cpu_group_property.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/hcs/schema2/cpu_group_property.go
@@ -9,6 +9,14 @@
 
 package hcsschema
 
+type CPUGroupPropertyCode uint32
+
+const (
+	CPUCapacityProperty           = 0x00010000
+	CPUSchedulingPriorityProperty = 0x00020000
+	IdleLPReserveProperty         = 0x00030000
+)
+
 type CpuGroupProperty struct {
 	PropertyCode  uint32 `json:"PropertyCode,omitempty"`
 	PropertyValue uint32 `json:"PropertyValue,omitempty"`

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/uvm/cpugroups.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/uvm/cpugroups.go
@@ -8,12 +8,10 @@ import (
 	"github.com/Microsoft/hcsshim/internal/cpugroup"
 	"github.com/Microsoft/hcsshim/internal/hcs/resourcepaths"
 	hcsschema "github.com/Microsoft/hcsshim/internal/hcs/schema2"
+	"github.com/Microsoft/hcsshim/osversion"
 )
 
-// Build that assigning a cpu group on creation of a vm is supported
-const cpuGroupCreateBuild = 20124
-
-var errCPUGroupCreateNotSupported = fmt.Errorf("cpu group assignment on create requires a build of %d or higher", cpuGroupCreateBuild)
+var errCPUGroupCreateNotSupported = fmt.Errorf("cpu group assignment on create requires a build of %d or higher", osversion.V21H1)
 
 // ReleaseCPUGroup unsets the cpugroup from the VM
 func (uvm *UtilityVM) ReleaseCPUGroup(ctx context.Context) error {

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/uvm/create_lcow.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/uvm/create_lcow.go
@@ -216,7 +216,7 @@ func CreateLCOW(ctx context.Context, opts *OptionsLCOW) (_ *UtilityVM, err error
 	}
 	// We can set a cpu group for the VM at creation time in recent builds.
 	if opts.CPUGroupID != "" {
-		if osversion.Build() < cpuGroupCreateBuild {
+		if osversion.Build() < osversion.V21H1 {
 			return nil, errCPUGroupCreateNotSupported
 		}
 		processor.CpuGroup = &hcsschema.CpuGroup{Id: opts.CPUGroupID}

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/uvm/create_wcow.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/uvm/create_wcow.go
@@ -160,7 +160,7 @@ func prepareConfigDoc(ctx context.Context, uvm *UtilityVM, opts *OptionsWCOW, uv
 	}
 	// We can set a cpu group for the VM at creation time in recent builds.
 	if opts.CPUGroupID != "" {
-		if osversion.Build() < cpuGroupCreateBuild {
+		if osversion.Build() < osversion.V21H1 {
 			return nil, errCPUGroupCreateNotSupported
 		}
 		processor.CpuGroup = &hcsschema.CpuGroup{Id: opts.CPUGroupID}

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/uvm/update_uvm.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/uvm/update_uvm.go
@@ -4,10 +4,11 @@ import (
 	"context"
 
 	hcsschema "github.com/Microsoft/hcsshim/internal/hcs/schema2"
+	"github.com/Microsoft/hcsshim/pkg/annotations"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 )
 
-func (uvm *UtilityVM) UpdateConstraints(ctx context.Context, data interface{}, annotations map[string]string) error {
+func (uvm *UtilityVM) UpdateConstraints(ctx context.Context, data interface{}, annots map[string]string) error {
 	var memoryLimitInBytes *uint64
 	var processorLimits *hcsschema.ProcessorLimits
 
@@ -48,6 +49,13 @@ func (uvm *UtilityVM) UpdateConstraints(ctx context.Context, data interface{}, a
 	}
 	if processorLimits != nil {
 		if err := uvm.UpdateCPULimits(ctx, processorLimits); err != nil {
+			return err
+		}
+	}
+
+	// Check if an annotation was sent to update cpugroup membership
+	if cpuGroupID, ok := annots[annotations.CPUGroupID]; ok {
+		if err := uvm.SetCPUGroup(ctx, cpuGroupID); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
This PR adds support for passing an annotation to update the cpugroup ID for a UVM. 

Signed-off-by: Kathryn Baldauf <kabaldau@microsoft.com>