### PR TITLE
Fix LayerData not being usable for ComputeStorage package

### DIFF
--- a/computestorage/export.go
+++ b/computestorage/export.go
@@ -28,17 +28,17 @@ func ExportLayer(ctx context.Context, layerPath, exportFolderPath string, layerD
 		trace.StringAttribute("exportFolderPath", exportFolderPath),
 	)
 
-	ldbytes, err := json.Marshal(layerData)
+	ldBytes, err := json.Marshal(layerData)
 	if err != nil {
 		return err
 	}
 
-	obytes, err := json.Marshal(options)
+	oBytes, err := json.Marshal(options)
 	if err != nil {
 		return err
 	}
 
-	err = hcsExportLayer(layerPath, exportFolderPath, string(ldbytes), string(obytes))
+	err = hcsExportLayer(layerPath, exportFolderPath, string(ldBytes), string(oBytes))
 	if err != nil {
 		return errors.Wrap(err, "failed to export layer")
 	}

--- a/computestorage/storage.go
+++ b/computestorage/storage.go
@@ -20,10 +20,13 @@ import (
 //sys hcsGetLayerVhdMountPath(vhdHandle windows.Handle, mountPath **uint16) (hr error) = computestorage.HcsGetLayerVhdMountPath?
 //sys hcsSetupBaseOSVolume(layerPath string, volumePath string, options string) (hr error) = computestorage.HcsSetupBaseOSVolume?
 
+type Version = hcsschema.Version
+type Layer = hcsschema.Layer
+
 // LayerData is the data used to describe parent layer information.
 type LayerData struct {
-	SchemaVersion hcsschema.Version `json:"SchemaVersion,omitempty"`
-	Layers        []hcsschema.Layer `json:"Layers,omitempty"`
+	SchemaVersion Version `json:"SchemaVersion,omitempty"`
+	Layers        []Layer `json:"Layers,omitempty"`
 }
 
 // ExportLayerOptions are the set of options that are used with the `computestorage.HcsExportLayer` syscall.

--- a/test/vendor/github.com/Microsoft/hcsshim/computestorage/export.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/computestorage/export.go
@@ -28,17 +28,17 @@ func ExportLayer(ctx context.Context, layerPath, exportFolderPath string, layerD
 		trace.StringAttribute("exportFolderPath", exportFolderPath),
 	)
 
-	ldbytes, err := json.Marshal(layerData)
+	ldBytes, err := json.Marshal(layerData)
 	if err != nil {
 		return err
 	}
 
-	obytes, err := json.Marshal(options)
+	oBytes, err := json.Marshal(options)
 	if err != nil {
 		return err
 	}
 
-	err = hcsExportLayer(layerPath, exportFolderPath, string(ldbytes), string(obytes))
+	err = hcsExportLayer(layerPath, exportFolderPath, string(ldBytes), string(oBytes))
 	if err != nil {
 		return errors.Wrap(err, "failed to export layer")
 	}

--- a/test/vendor/github.com/Microsoft/hcsshim/computestorage/storage.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/computestorage/storage.go
@@ -20,10 +20,13 @@ import (
 //sys hcsGetLayerVhdMountPath(vhdHandle windows.Handle, mountPath **uint16) (hr error) = computestorage.HcsGetLayerVhdMountPath?
 //sys hcsSetupBaseOSVolume(layerPath string, volumePath string, options string) (hr error) = computestorage.HcsSetupBaseOSVolume?
 
+type Version = hcsschema.Version
+type Layer = hcsschema.Layer
+
 // LayerData is the data used to describe parent layer information.
 type LayerData struct {
-	SchemaVersion hcsschema.Version `json:"SchemaVersion,omitempty"`
-	Layers        []hcsschema.Layer `json:"Layers,omitempty"`
+	SchemaVersion Version `json:"SchemaVersion,omitempty"`
+	Layers        []Layer `json:"Layers,omitempty"`
 }
 
 // ExportLayerOptions are the set of options that are used with the `computestorage.HcsExportLayer` syscall.


### PR DESCRIPTION
Previously the LayerData structure in the computestorage package used
definitions from the hcs schema from /internal so it was not actually possible
to create a LayerData structure for an outside caller.

This just creates local type aliases for hcsschema.Version and hcsschema.Layer
so a client can create the structure now using computestorage.Version and
computestorage.Layer respectively.

Signed-off-by: Daniel Canter <dcanter@microsoft.com>