### PR TITLE
Add 21H2 definitions to osversion package

### DIFF
--- a/osversion/windowsbuilds.go
+++ b/osversion/windowsbuilds.go
@@ -39,12 +39,12 @@ const (
 	// V21H1 corresponds to Windows Server 21H1 (semi-annual channel).
 	V21H1 = 19043
 
-	// Win10V21H2 corresponds to Windows 10 (November 2021 Update).
-	Win10V21H2 = 19044
+	// V21H2Win10 corresponds to Windows 10 (November 2021 Update).
+	V21H2Win10 = 19044
 
-	// WinServerV21H2 corresponds to Windows Server 2022 (ltsc2022).
-	WinServerV21H2 = 20348
+	// V21H2Server corresponds to Windows Server 2022 (ltsc2022).
+	V21H2Server = 20348
 
-	// Win11V21H2 corresponds to Windows 11 (original release).
-	Win11V21H2 = 22000
+	// V21H2Win11 corresponds to Windows 11 (original release).
+	V21H2Win11 = 22000
 )

--- a/osversion/windowsbuilds.go
+++ b/osversion/windowsbuilds.go
@@ -38,4 +38,13 @@ const (
 
 	// V21H1 corresponds to Windows Server 21H1 (semi-annual channel).
 	V21H1 = 19043
+
+	// Win10V21H2 corresponds to Windows 10 (November 2021 Update).
+	Win10V21H2 = 19044
+
+	// WinServerV21H2 corresponds to Windows Server 2022 (ltsc2022).
+	WinServerV21H2 = 20348
+
+	// Win11V21H2 corresponds to Windows 11 (original release).
+	Win11V21H2 = 22000
 )

--- a/test/vendor/github.com/Microsoft/hcsshim/osversion/windowsbuilds.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/osversion/windowsbuilds.go
@@ -39,12 +39,12 @@ const (
 	// V21H1 corresponds to Windows Server 21H1 (semi-annual channel).
 	V21H1 = 19043
 
-	// Win10V21H2 corresponds to Windows 10 (November 2021 Update).
-	Win10V21H2 = 19044
+	// V21H2Win10 corresponds to Windows 10 (November 2021 Update).
+	V21H2Win10 = 19044
 
-	// WinServerV21H2 corresponds to Windows Server 2022 (ltsc2022).
-	WinServerV21H2 = 20348
+	// V21H2Server corresponds to Windows Server 2022 (ltsc2022).
+	V21H2Server = 20348
 
-	// Win11V21H2 corresponds to Windows 11 (original release).
-	Win11V21H2 = 22000
+	// V21H2Win11 corresponds to Windows 11 (original release).
+	V21H2Win11 = 22000
 )

--- a/test/vendor/github.com/Microsoft/hcsshim/osversion/windowsbuilds.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/osversion/windowsbuilds.go
@@ -38,4 +38,13 @@ const (
 
 	// V21H1 corresponds to Windows Server 21H1 (semi-annual channel).
 	V21H1 = 19043
+
+	// Win10V21H2 corresponds to Windows 10 (November 2021 Update).
+	Win10V21H2 = 19044
+
+	// WinServerV21H2 corresponds to Windows Server 2022 (ltsc2022).
+	WinServerV21H2 = 20348
+
+	// Win11V21H2 corresponds to Windows 11 (original release).
+	Win11V21H2 = 22000
 )


### PR DESCRIPTION
This change adds three new definitions to the osversion package. All
three definitions are all of the 21H2 builds across Windows 10, Windows Server
and Windows 11, which all have different build numbers.

The approach taken was to prefix the definitions with Win10, WinServer and
Win11 respectively.

Signed-off-by: Daniel Canter <dcanter@microsoft.com>