### PR TITLE
Rework merkle tree implementation to use io.Reader instead of byte array

### DIFF
--- a/cmd/dmverity-vhd/main.go
+++ b/cmd/dmverity-vhd/main.go
@@ -217,7 +217,7 @@ var rootHashVHDCommand = cli.Command{
 			if err != nil {
 				return errors.Wrap(err, "failed to compute root hash")
 			}
-			fmt.Fprintf(os.Stdout, "Layer %d\nroot hash: %x\n", layerNumber, hash)
+			fmt.Fprintf(os.Stdout, "Layer %d\nroot hash: %s\n", layerNumber, hash)
 		}
 		return nil
 	},

--- a/cmd/dmverity-vhd/main.go
+++ b/cmd/dmverity-vhd/main.go
@@ -213,9 +213,9 @@ var rootHashVHDCommand = cli.Command{
 				return errors.Wrapf(err, "failed to uncompress layer %s", diffID.String())
 			}
 
-			hash, err := tar2ext4.ConvertAndRootDigest(rc)
+			hash, err := tar2ext4.ConvertAndComputeRootDigest(rc)
 			if err != nil {
-				return errors.Wrapf(err, "failed to compute root hash")
+				return errors.Wrap(err, "failed to compute root hash")
 			}
 			fmt.Fprintf(os.Stdout, "Layer %d\nroot hash: %x\n", layerNumber, hash)
 		}

--- a/ext4/dmverity/dmverity.go
+++ b/ext4/dmverity/dmverity.go
@@ -73,10 +73,10 @@ type VerityInfo struct {
 	Version       uint32
 }
 
-// MerkleTree constructs dm-verity hash-tree for a given bufio.Reader with a fixed salt (0-byte) and algorithm (sha256).
-func MerkleTree(br *bufio.Reader) ([]byte, error) {
+// MerkleTree constructs dm-verity hash-tree for a given io.Reader with a fixed salt (0-byte) and algorithm (sha256).
+func MerkleTree(r io.Reader) ([]byte, error) {
 	layers := make([][]byte, 0)
-	var currentLevel io.Reader = br
+	currentLevel := r
 
 	for {
 		nextLevel := bytes.NewBuffer(make([]byte, 0))

--- a/ext4/tar2ext4/tar2ext4.go
+++ b/ext4/tar2ext4/tar2ext4.go
@@ -194,7 +194,7 @@ func Convert(r io.Reader, w io.ReadWriteSeeker, options ...Option) error {
 			return err
 		}
 
-		merkleTree, err := dmverity.MerkleTreeWithReader(w)
+		merkleTree, err := dmverity.MerkleTree(bufio.NewReaderSize(w, dmverity.MerkleTreeBufioSize))
 		if err != nil {
 			return errors.Wrap(err, "failed to build merkle tree")
 		}
@@ -269,10 +269,10 @@ func ReadExt4SuperBlock(vhdPath string) (*format.SuperBlock, error) {
 	return &sb, nil
 }
 
-// ConvertAndRootDigest writes a compact ext4 file system image that contains the files in the
+// ConvertAndComputeRootDigest writes a compact ext4 file system image that contains the files in the
 // input tar stream, computes and returns its cryptographic digest. Convert is called with minimal
 // options: ConvertWhiteout and MaximumDiskSize set to dmverity.RecommendedVHDSizeGB.
-func ConvertAndRootDigest(r io.Reader) (string, error) {
+func ConvertAndComputeRootDigest(r io.Reader) (string, error) {
 	out, err := ioutil.TempFile("", "")
 	if err != nil {
 		return "", fmt.Errorf("failed to create temporary file: %s", err)
@@ -294,7 +294,7 @@ func ConvertAndRootDigest(r io.Reader) (string, error) {
 		return "", fmt.Errorf("failed to seek start on temp file when creating merkle tree: %s", err)
 	}
 
-	tree, err := dmverity.MerkleTreeWithReader(r)
+	tree, err := dmverity.MerkleTree(bufio.NewReaderSize(out, dmverity.MerkleTreeBufioSize))
 	if err != nil {
 		return "", fmt.Errorf("failed to create merkle tree: %s", err)
 	}

--- a/internal/tools/securitypolicy/main.go
+++ b/internal/tools/securitypolicy/main.go
@@ -167,7 +167,7 @@ func createPolicyFromConfig(config Config) (securitypolicy.SecurityPolicy, error
 				return p, err
 			}
 
-			hashString, err := tar2ext4.ConvertAndRootDigest(r)
+			hashString, err := tar2ext4.ConvertAndComputeRootDigest(r)
 			if err != nil {
 				return p, err
 			}

--- a/internal/tools/securitypolicy/main.go
+++ b/internal/tools/securitypolicy/main.go
@@ -11,7 +11,6 @@ import (
 	"strconv"
 
 	"github.com/BurntSushi/toml"
-	"github.com/Microsoft/hcsshim/ext4/dmverity"
 	"github.com/Microsoft/hcsshim/ext4/tar2ext4"
 	"github.com/Microsoft/hcsshim/pkg/securitypolicy"
 	"github.com/google/go-containerregistry/pkg/authn"
@@ -168,43 +167,20 @@ func createPolicyFromConfig(config Config) (securitypolicy.SecurityPolicy, error
 				return p, err
 			}
 
-			out, err := ioutil.TempFile("", "")
+			hashString, err := tar2ext4.ConvertAndRootDigest(r)
 			if err != nil {
 				return p, err
 			}
-			defer os.Remove(out.Name())
-
-			opts := []tar2ext4.Option{
-				tar2ext4.ConvertWhiteout,
-				tar2ext4.MaximumDiskSize(dmverity.RecommendedVHDSizeGB),
-			}
-
-			err = tar2ext4.Convert(r, out, opts...)
-			if err != nil {
-				return p, err
-			}
-
-			data, err := ioutil.ReadFile(out.Name())
-			if err != nil {
-				return p, err
-			}
-
-			tree, err := dmverity.MerkleTree(data)
-			if err != nil {
-				return p, err
-			}
-			hash := dmverity.RootHash(tree)
-			hashString := fmt.Sprintf("%x", hash)
 			addLayer(&container.Layers, hashString)
 		}
 
 		// add rules for all known environment variables from the configuration
 		// these are in addition to "other rules" from the policy definition file
-		config, err := img.ConfigFile()
+		imgConfig, err := img.ConfigFile()
 		if err != nil {
 			return p, err
 		}
-		for _, env := range config.Config.Env {
+		for _, env := range imgConfig.Config.Env {
 			rule := securitypolicy.EnvRule{
 				Strategy: securitypolicy.EnvVarRuleString,
 				Rule:     env,
@@ -214,7 +190,7 @@ func createPolicyFromConfig(config Config) (securitypolicy.SecurityPolicy, error
 		}
 
 		// cri adds TERM=xterm for all workload containers. we add to all containers
-		// to prevent any possble erroring
+		// to prevent any possible error
 		rule := securitypolicy.EnvRule{
 			Strategy: securitypolicy.EnvVarRuleString,
 			Rule:     "TERM=xterm",
@@ -243,19 +219,19 @@ func validateEnvRules(rules []EnvironmentVariableRule) error {
 }
 
 func convertCommand(toml []string) securitypolicy.CommandArgs {
-	json := map[string]string{}
+	jsn := map[string]string{}
 
 	for i, arg := range toml {
-		json[strconv.Itoa(i)] = arg
+		jsn[strconv.Itoa(i)] = arg
 	}
 
 	return securitypolicy.CommandArgs{
-		Elements: json,
+		Elements: jsn,
 	}
 }
 
 func convertEnvironmentVariableRules(toml []EnvironmentVariableRule) securitypolicy.EnvRules {
-	json := map[string]securitypolicy.EnvRule{}
+	jsn := map[string]securitypolicy.EnvRule{}
 
 	for i, rule := range toml {
 		jsonRule := securitypolicy.EnvRule{
@@ -263,11 +239,11 @@ func convertEnvironmentVariableRules(toml []EnvironmentVariableRule) securitypol
 			Rule:     rule.Rule,
 		}
 
-		json[strconv.Itoa(i)] = jsonRule
+		jsn[strconv.Itoa(i)] = jsonRule
 	}
 
 	return securitypolicy.EnvRules{
-		Elements: json,
+		Elements: jsn,
 	}
 }
 

--- a/test/vendor/github.com/Microsoft/hcsshim/ext4/dmverity/dmverity.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/ext4/dmverity/dmverity.go
@@ -73,10 +73,10 @@ type VerityInfo struct {
 	Version       uint32
 }
 
-// MerkleTree constructs dm-verity hash-tree for a given bufio.Reader with a fixed salt (0-byte) and algorithm (sha256).
-func MerkleTree(br *bufio.Reader) ([]byte, error) {
+// MerkleTree constructs dm-verity hash-tree for a given io.Reader with a fixed salt (0-byte) and algorithm (sha256).
+func MerkleTree(r io.Reader) ([]byte, error) {
 	layers := make([][]byte, 0)
-	var currentLevel io.Reader = br
+	currentLevel := r
 
 	for {
 		nextLevel := bytes.NewBuffer(make([]byte, 0))

--- a/test/vendor/github.com/Microsoft/hcsshim/ext4/tar2ext4/tar2ext4.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/ext4/tar2ext4/tar2ext4.go
@@ -194,7 +194,7 @@ func Convert(r io.Reader, w io.ReadWriteSeeker, options ...Option) error {
 			return err
 		}
 
-		merkleTree, err := dmverity.MerkleTreeWithReader(w)
+		merkleTree, err := dmverity.MerkleTree(bufio.NewReaderSize(w, dmverity.MerkleTreeBufioSize))
 		if err != nil {
 			return errors.Wrap(err, "failed to build merkle tree")
 		}
@@ -269,10 +269,10 @@ func ReadExt4SuperBlock(vhdPath string) (*format.SuperBlock, error) {
 	return &sb, nil
 }
 
-// ConvertAndRootDigest writes a compact ext4 file system image that contains the files in the
+// ConvertAndComputeRootDigest writes a compact ext4 file system image that contains the files in the
 // input tar stream, computes and returns its cryptographic digest. Convert is called with minimal
 // options: ConvertWhiteout and MaximumDiskSize set to dmverity.RecommendedVHDSizeGB.
-func ConvertAndRootDigest(r io.Reader) (string, error) {
+func ConvertAndComputeRootDigest(r io.Reader) (string, error) {
 	out, err := ioutil.TempFile("", "")
 	if err != nil {
 		return "", fmt.Errorf("failed to create temporary file: %s", err)
@@ -294,7 +294,7 @@ func ConvertAndRootDigest(r io.Reader) (string, error) {
 		return "", fmt.Errorf("failed to seek start on temp file when creating merkle tree: %s", err)
 	}
 
-	tree, err := dmverity.MerkleTreeWithReader(r)
+	tree, err := dmverity.MerkleTree(bufio.NewReaderSize(out, dmverity.MerkleTreeBufioSize))
 	if err != nil {
 		return "", fmt.Errorf("failed to create merkle tree: %s", err)
 	}


### PR DESCRIPTION
MerkleTree implementation requires the entire content of ext4 file
system to be read into a byte array when computing cryptographic digest.

This PR reworks the existing implementation to work with io.Reader
interface instead.

Additionally update the existing usages of MerkleTree with the new
MerkleTreeWithReader implementation.

Signed-off-by: Maksim An <maksiman@microsoft.com>