### PR TITLE
Exporting Out of Memory (OOM) events from Linux Guest UVM to Host

### DIFF
--- a/cmd/gcs/main.go
+++ b/cmd/gcs/main.go
@@ -260,8 +260,7 @@ func main() {
 
 	h := hcsv2.NewHost(rtime, tport)
 	b, err := bridge.NewBridge(bridge.WithHost(h),
-		bridge.WithV4Enabled(*v4),
-		bridge.WithCgroupVersion(1))
+		bridge.WithV4Enabled(*v4))
 	if err != nil {
 		logrus.WithError(err).Fatal("could not create bridge")
 	}

--- a/container.go
+++ b/container.go
@@ -60,7 +60,7 @@ type container struct {
 	waitCh   chan struct{}
 }
 
-// createComputeSystemAdditionalJSON is read from the environment at initialisation
+// createContainerAdditionalJSON is read from the environment at initialization
 // time. It allows an environment variable to define additional JSON which
 // is merged in the CreateComputeSystem call to HCS.
 var createContainerAdditionalJSON []byte

--- a/internal/cow/cow.go
+++ b/internal/cow/cow.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/Microsoft/hcsshim/internal/hcs/schema1"
 	hcsschema "github.com/Microsoft/hcsshim/internal/hcs/schema2"
+	"github.com/Microsoft/hcsshim/internal/queue"
 )
 
 // Process is the interface for an OS process running in a container or utility VM.
@@ -88,4 +89,7 @@ type Container interface {
 	Wait() error
 	// Modify sends a request to modify container resources
 	Modify(ctx context.Context, config interface{}) error
+	// Notification returns a MessageQueue of `notifications.Notification` raised
+	// for the container. Currently, only supported for OOM events in LCOW
+	Notifications() (*queue.MessageQueue, error)
 }

--- a/internal/cow/cow.go
+++ b/internal/cow/cow.go
@@ -89,7 +89,7 @@ type Container interface {
 	Wait() error
 	// Modify sends a request to modify container resources
 	Modify(ctx context.Context, config interface{}) error
-	// Notification returns a MessageQueue of `notifications.Notification` raised
+	// Notifications returns a MessageQueue of `notifications.Message` raised
 	// for the container. Currently, only supported for OOM events in LCOW
 	Notifications() (*queue.MessageQueue, error)
 }

--- a/internal/gcs/container.go
+++ b/internal/gcs/container.go
@@ -30,7 +30,7 @@ type Container struct {
 	waitError error
 	closeOnce sync.Once
 	// communication channels with the guest connection
-	notifyChs     notifyChans
+	notifyChs     *notifyChans
 	notifications *queue.MessageQueue
 }
 

--- a/internal/gcs/guestconnection_test.go
+++ b/internal/gcs/guestconnection_test.go
@@ -128,6 +128,7 @@ func simpleGcsLoop(t *testing.T, rw io.ReadWriter) error {
 				requestBase: requestBase{
 					ContainerID: req.ContainerID,
 				},
+				Type: "ForcedExit",
 			})
 			if err != nil {
 				return err

--- a/internal/guest/bridge/publisher.go
+++ b/internal/guest/bridge/publisher.go
@@ -1,0 +1,68 @@
+//go:build linux
+
+package bridge
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Microsoft/hcsshim/internal/guest/prot"
+	log "github.com/Microsoft/hcsshim/internal/log"
+	eventstypes "github.com/containerd/containerd/api/events"
+	"github.com/containerd/containerd/events"
+	"github.com/containerd/containerd/runtime"
+	"github.com/containerd/containerd/runtime/v2/shim"
+	"github.com/pkg/errors"
+)
+
+const emptyActivityID = "00000000-0000-0000-0000-000000000000"
+
+// wraps `bridge.PublishNotification` to conform to `shim.Publish`, so that it can
+// be used by containerd's `oom.Watcher` (github.com/containerd/containerd/pkg/oom)
+type BridgePublisherFunc func(*prot.ContainerNotification)
+
+var _ shim.Publisher = BridgePublisherFunc(func(_ *prot.ContainerNotification) {})
+
+func (bp BridgePublisherFunc) Close() error {
+	// noop
+	return nil
+}
+
+func (bp BridgePublisherFunc) Publish(ctx context.Context, topic string, event events.Event) error {
+	n, err := mapEventToNotification(topic, event)
+	if err != nil {
+		return errors.Wrapf(err, "could not handle topic %q and event %+v", topic, event)
+	}
+
+	log.G(ctx).WithField("event", fmt.Sprintf("%+v", event)).WithField("eventTopic", topic).Debug("publishing event over notification channel")
+
+	bp(n)
+	return nil
+}
+
+// may want to expand this to other events if they are sent over a shim.Publisher interface
+func mapEventToNotification(topic string, event events.Event) (*prot.ContainerNotification, error) {
+	switch topic {
+	case runtime.TaskOOMEventTopic:
+		e, ok := event.(*eventstypes.TaskOOM)
+		if !ok {
+			return nil, fmt.Errorf("unsupported event type %T", e)
+		}
+
+		notification := prot.ContainerNotification{
+			MessageBase: prot.MessageBase{
+				ActivityID:  emptyActivityID,
+				ContainerID: e.ContainerID,
+			},
+			Type:       prot.NtOomEvent,
+			Operation:  prot.AoNone,
+			Result:     0,
+			ResultInfo: "",
+		}
+
+		return &notification, nil
+	default:
+		return nil, fmt.Errorf("unsupported event topic %q", topic)
+	}
+
+}

--- a/internal/guest/prot/protocol.go
+++ b/internal/guest/prot/protocol.go
@@ -350,6 +350,9 @@ const (
 	NtUnexpectedExit = NotificationType("UnexpectedExit")
 	// NtReboot indicates a reboot notification to be sent back to the HCS
 	NtReboot = NotificationType("Reboot")
+	// NtOomEvent indicates an Out of Memory (OOM) notification to be sent back to the
+	// HCS
+	NtOomEvent = NotificationType("OOM")
 	// NtConstructed indicates a constructed notification to be sent back to the
 	// HCS
 	NtConstructed = NotificationType("Constructed")

--- a/internal/hcs/system.go
+++ b/internal/hcs/system.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Microsoft/hcsshim/internal/hcs/schema1"
 	hcsschema "github.com/Microsoft/hcsshim/internal/hcs/schema2"
 	"github.com/Microsoft/hcsshim/internal/log"
+	"github.com/Microsoft/hcsshim/internal/notifications"
 	"github.com/Microsoft/hcsshim/internal/oc"
 	"github.com/Microsoft/hcsshim/internal/timeout"
 	"github.com/Microsoft/hcsshim/internal/vmcompute"
@@ -29,7 +30,11 @@ type System struct {
 	waitError      error
 	exitError      error
 	os, typ        string
+
+	notifications.NullNotifications
 }
+
+var _ cow.Container = &(System{})
 
 func newSystem(id string) *System {
 	return &System{

--- a/internal/jobcontainers/jobcontainer.go
+++ b/internal/jobcontainers/jobcontainer.go
@@ -21,6 +21,7 @@ import (
 	"github.com/Microsoft/hcsshim/internal/jobobject"
 	"github.com/Microsoft/hcsshim/internal/layers"
 	"github.com/Microsoft/hcsshim/internal/log"
+	"github.com/Microsoft/hcsshim/internal/notifications"
 	"github.com/Microsoft/hcsshim/internal/queue"
 	"github.com/Microsoft/hcsshim/internal/resources"
 	"github.com/Microsoft/hcsshim/internal/winapi"
@@ -66,6 +67,8 @@ type JobContainer struct {
 	exited           chan struct{}
 	waitBlock        chan struct{}
 	waitError        error
+
+	notifications.NullNotifications
 }
 
 var _ cow.ProcessHost = &JobContainer{}

--- a/internal/logfields/fields.go
+++ b/internal/logfields/fields.go
@@ -6,6 +6,7 @@ const (
 	ContainerID = "cid"
 	UVMID       = "uvm-id"
 	ProcessID   = "pid"
+	TaskID      = "tid"
 
 	// Common Misc
 

--- a/internal/notifications/notifications.go
+++ b/internal/notifications/notifications.go
@@ -1,0 +1,80 @@
+// Notifications that `cow.Containers` can raise and Notify clients about
+//
+// generalized from `internal/gcs/protocol.go` and `internal/guest/prot/protocol.go`
+package notifications
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/Microsoft/hcsshim/internal/queue"
+)
+
+type MessageType string
+
+type Message interface {
+	fmt.Stringer
+	Type() MessageType
+}
+
+// trivial implementation, with no extra info
+type message string
+
+// todo (helsaawy): evalute string overhead is more than `iota` with "const" LUT from into to string
+const (
+	// None indicates a no-op notification
+	None = message("None")
+	// Unknown indicates an unknown notification
+	Unknown = message("Unknown")
+	// GracefulExit indicates a graceful container exit notification
+	GracefulExit = message("GracefulExit")
+	// ForcedExit indicates a forced container exit notification
+	ForcedExit = message("ForcedExit")
+	// UnexpectedExit indicates an unexpected container exit notification
+	UnexpectedExit = message("UnexpectedExit")
+	// Reboot indicates a container reboot notification
+	Reboot = message("Reboot")
+	// OomEvent indicates an Out of Memory (OOM) notification
+	Oom = message("OOM")
+	// Constructed indicates a constructed notification
+	Constructed = message("Constructed") // todo (helsaawy): what is this used for? inherited from HCS?
+	// Creates indicates a container creation notification
+	Created = message("Created")
+	//ExecCreated indicated an exec creation notification
+	ExecCreated = message("ExecCreated")
+	// Started indicates a container started notification
+	Started = message("Started")
+	// ExceStarted indicates an exec started within a container
+	ExecStarted = message("ExecStarted")
+	// Deleted indicated a container deleted notification
+	Deleted = message("Deleted")
+	// Paused indicates a container paused notification
+	Paused = message("Paused")
+	// Checkpoint indicates a notification of a container checkpoint
+	Checkpoint = message("Checkpoint")
+)
+
+func (n message) String() string {
+	return string(n)
+}
+
+func (n message) Type() MessageType {
+	return MessageType(n)
+}
+
+func FromString(n string) Message {
+	if len(n) == 0 {
+		return None
+	}
+	return message(n)
+}
+
+var ErrNotificationsNotSupported = errors.New("notifications not supported")
+
+// No-Op implementation of Notifications for the cow.Containers interface
+type NullNotifications struct{}
+
+func (*NullNotifications) Notifications() (*queue.MessageQueue, error) {
+	// pointer receiver to match most cow.Container implementations
+	return nil, ErrNotificationsNotSupported
+}

--- a/test/cri-containerd/container.go
+++ b/test/cri-containerd/container.go
@@ -67,11 +67,15 @@ func getCreateContainerRequest(podID string, name string, image string, command 
 }
 
 func getContainerStatus(t *testing.T, client runtime.RuntimeServiceClient, ctx context.Context, containerID string) runtime.ContainerState {
+	return getContainerStatusFull(t, client, ctx, containerID).State
+}
+
+func getContainerStatusFull(t *testing.T, client runtime.RuntimeServiceClient, ctx context.Context, containerID string) *runtime.ContainerStatus {
 	response, err := client.ContainerStatus(ctx, &runtime.ContainerStatusRequest{
 		ContainerId: containerID,
 	})
 	if err != nil {
 		t.Fatalf("failed ContainerStatus request for container: %s, with: %v", containerID, err)
 	}
-	return response.Status.State
+	return response.Status
 }

--- a/test/vendor/github.com/Microsoft/hcsshim/container.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/container.go
@@ -60,7 +60,7 @@ type container struct {
 	waitCh   chan struct{}
 }
 
-// createComputeSystemAdditionalJSON is read from the environment at initialisation
+// createContainerAdditionalJSON is read from the environment at initialization
 // time. It allows an environment variable to define additional JSON which
 // is merged in the CreateComputeSystem call to HCS.
 var createContainerAdditionalJSON []byte

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/cow/cow.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/cow/cow.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/Microsoft/hcsshim/internal/hcs/schema1"
 	hcsschema "github.com/Microsoft/hcsshim/internal/hcs/schema2"
+	"github.com/Microsoft/hcsshim/internal/queue"
 )
 
 // Process is the interface for an OS process running in a container or utility VM.
@@ -88,4 +89,7 @@ type Container interface {
 	Wait() error
 	// Modify sends a request to modify container resources
 	Modify(ctx context.Context, config interface{}) error
+	// Notification returns a MessageQueue of `notifications.Notification` raised
+	// for the container. Currently, only supported for OOM events in LCOW
+	Notifications() (*queue.MessageQueue, error)
 }

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/cow/cow.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/cow/cow.go
@@ -89,7 +89,7 @@ type Container interface {
 	Wait() error
 	// Modify sends a request to modify container resources
 	Modify(ctx context.Context, config interface{}) error
-	// Notification returns a MessageQueue of `notifications.Notification` raised
+	// Notifications returns a MessageQueue of `notifications.Message` raised
 	// for the container. Currently, only supported for OOM events in LCOW
 	Notifications() (*queue.MessageQueue, error)
 }

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/gcs/container.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/gcs/container.go
@@ -30,7 +30,7 @@ type Container struct {
 	waitError error
 	closeOnce sync.Once
 	// communication channels with the guest connection
-	notifyChs     notifyChans
+	notifyChs     *notifyChans
 	notifications *queue.MessageQueue
 }
 

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/hcs/system.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/hcs/system.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Microsoft/hcsshim/internal/hcs/schema1"
 	hcsschema "github.com/Microsoft/hcsshim/internal/hcs/schema2"
 	"github.com/Microsoft/hcsshim/internal/log"
+	"github.com/Microsoft/hcsshim/internal/notifications"
 	"github.com/Microsoft/hcsshim/internal/oc"
 	"github.com/Microsoft/hcsshim/internal/timeout"
 	"github.com/Microsoft/hcsshim/internal/vmcompute"
@@ -29,7 +30,11 @@ type System struct {
 	waitError      error
 	exitError      error
 	os, typ        string
+
+	notifications.NullNotifications
 }
+
+var _ cow.Container = &(System{})
 
 func newSystem(id string) *System {
 	return &System{

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/logfields/fields.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/logfields/fields.go
@@ -6,6 +6,7 @@ const (
 	ContainerID = "cid"
 	UVMID       = "uvm-id"
 	ProcessID   = "pid"
+	TaskID      = "tid"
 
 	// Common Misc
 

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/notifications/notifications.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/notifications/notifications.go
@@ -1,0 +1,80 @@
+// Notifications that `cow.Containers` can raise and Notify clients about
+//
+// generalized from `internal/gcs/protocol.go` and `internal/guest/prot/protocol.go`
+package notifications
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/Microsoft/hcsshim/internal/queue"
+)
+
+type MessageType string
+
+type Message interface {
+	fmt.Stringer
+	Type() MessageType
+}
+
+// trivial implementation, with no extra info
+type message string
+
+// todo (helsaawy): evalute string overhead is more than `iota` with "const" LUT from into to string
+const (
+	// None indicates a no-op notification
+	None = message("None")
+	// Unknown indicates an unknown notification
+	Unknown = message("Unknown")
+	// GracefulExit indicates a graceful container exit notification
+	GracefulExit = message("GracefulExit")
+	// ForcedExit indicates a forced container exit notification
+	ForcedExit = message("ForcedExit")
+	// UnexpectedExit indicates an unexpected container exit notification
+	UnexpectedExit = message("UnexpectedExit")
+	// Reboot indicates a container reboot notification
+	Reboot = message("Reboot")
+	// OomEvent indicates an Out of Memory (OOM) notification
+	Oom = message("OOM")
+	// Constructed indicates a constructed notification
+	Constructed = message("Constructed") // todo (helsaawy): what is this used for? inherited from HCS?
+	// Creates indicates a container creation notification
+	Created = message("Created")
+	//ExecCreated indicated an exec creation notification
+	ExecCreated = message("ExecCreated")
+	// Started indicates a container started notification
+	Started = message("Started")
+	// ExceStarted indicates an exec started within a container
+	ExecStarted = message("ExecStarted")
+	// Deleted indicated a container deleted notification
+	Deleted = message("Deleted")
+	// Paused indicates a container paused notification
+	Paused = message("Paused")
+	// Checkpoint indicates a notification of a container checkpoint
+	Checkpoint = message("Checkpoint")
+)
+
+func (n message) String() string {
+	return string(n)
+}
+
+func (n message) Type() MessageType {
+	return MessageType(n)
+}
+
+func FromString(n string) Message {
+	if len(n) == 0 {
+		return None
+	}
+	return message(n)
+}
+
+var ErrNotificationsNotSupported = errors.New("notifications not supported")
+
+// No-Op implementation of Notifications for the cow.Containers interface
+type NullNotifications struct{}
+
+func (*NullNotifications) Notifications() (*queue.MessageQueue, error) {
+	// pointer receiver to match most cow.Container implementations
+	return nil, ErrNotificationsNotSupported
+}

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/queue/mq.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/queue/mq.go
@@ -1,0 +1,111 @@
+package queue
+
+import (
+	"errors"
+	"sync"
+)
+
+var (
+	ErrQueueClosed = errors.New("the queue is closed for reading and writing")
+	ErrQueueEmpty  = errors.New("the queue is empty")
+)
+
+// MessageQueue represents a threadsafe message queue to be used to retrieve or
+// write messages to.
+type MessageQueue struct {
+	m        *sync.RWMutex
+	c        *sync.Cond
+	messages []interface{}
+	closed   bool
+}
+
+// NewMessageQueue returns a new MessageQueue.
+func NewMessageQueue() *MessageQueue {
+	m := &sync.RWMutex{}
+	return &MessageQueue{
+		m:        m,
+		c:        sync.NewCond(m),
+		messages: []interface{}{},
+	}
+}
+
+// Write writes `msg` to the queue.
+func (mq *MessageQueue) Write(msg interface{}) error {
+	mq.m.Lock()
+	defer mq.m.Unlock()
+
+	if mq.closed {
+		return ErrQueueClosed
+	}
+	mq.messages = append(mq.messages, msg)
+	// Signal a waiter that there is now a value available in the queue.
+	mq.c.Signal()
+	return nil
+}
+
+// Read will read a value from the queue if available, otherwise return an error.
+func (mq *MessageQueue) Read() (interface{}, error) {
+	mq.m.Lock()
+	defer mq.m.Unlock()
+	if mq.closed {
+		return nil, ErrQueueClosed
+	}
+	if mq.isEmpty() {
+		return nil, ErrQueueEmpty
+	}
+	val := mq.messages[0]
+	mq.messages[0] = nil
+	mq.messages = mq.messages[1:]
+	return val, nil
+}
+
+// ReadOrWait will read a value from the queue if available, else it will wait for a
+// value to become available. This will block forever if nothing gets written or until
+// the queue gets closed.
+func (mq *MessageQueue) ReadOrWait() (interface{}, error) {
+	mq.m.Lock()
+	if mq.closed {
+		mq.m.Unlock()
+		return nil, ErrQueueClosed
+	}
+	if mq.isEmpty() {
+		for !mq.closed && mq.isEmpty() {
+			mq.c.Wait()
+		}
+		mq.m.Unlock()
+		return mq.Read()
+	}
+	val := mq.messages[0]
+	mq.messages[0] = nil
+	mq.messages = mq.messages[1:]
+	mq.m.Unlock()
+	return val, nil
+}
+
+// IsEmpty returns if the queue is empty
+func (mq *MessageQueue) IsEmpty() bool {
+	mq.m.RLock()
+	defer mq.m.RUnlock()
+	return len(mq.messages) == 0
+}
+
+// Nonexported empty check that doesn't lock so we can call this in Read and Write.
+func (mq *MessageQueue) isEmpty() bool {
+	return len(mq.messages) == 0
+}
+
+// Close closes the queue for future writes or reads. Any attempts to read or write from the
+// queue after close will return ErrQueueClosed. This is safe to call multiple times.
+func (mq *MessageQueue) Close() {
+	mq.m.Lock()
+	defer mq.m.Unlock()
+	// Already closed
+	if mq.closed {
+		return
+	}
+	mq.messages = nil
+	mq.closed = true
+	// If there's anybody currently waiting on a value from ReadOrWait, we need to
+	// broadcast so the read(s) can return ErrQueueClosed.
+	mq.c.Broadcast()
+}

--- a/test/vendor/modules.txt
+++ b/test/vendor/modules.txt
@@ -47,12 +47,14 @@ github.com/Microsoft/hcsshim/internal/memory
 github.com/Microsoft/hcsshim/internal/mergemaps
 github.com/Microsoft/hcsshim/internal/ncproxy/networking
 github.com/Microsoft/hcsshim/internal/ncproxyttrpc
+github.com/Microsoft/hcsshim/internal/notifications
 github.com/Microsoft/hcsshim/internal/oc
 github.com/Microsoft/hcsshim/internal/oci
 github.com/Microsoft/hcsshim/internal/ospath
 github.com/Microsoft/hcsshim/internal/processorinfo
 github.com/Microsoft/hcsshim/internal/protocol/guestrequest
 github.com/Microsoft/hcsshim/internal/protocol/guestresource
+github.com/Microsoft/hcsshim/internal/queue
 github.com/Microsoft/hcsshim/internal/regstate
 github.com/Microsoft/hcsshim/internal/resources
 github.com/Microsoft/hcsshim/internal/runhcs

--- a/vendor/github.com/containerd/containerd/pkg/oom/oom.go
+++ b/vendor/github.com/containerd/containerd/pkg/oom/oom.go
@@ -1,0 +1,30 @@
+// +build linux
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package oom
+
+import (
+	"context"
+)
+
+// Watcher watches OOM events
+type Watcher interface {
+	Close() error
+	Run(ctx context.Context)
+	Add(id string, cg interface{}) error
+}

--- a/vendor/github.com/containerd/containerd/pkg/oom/v1/v1.go
+++ b/vendor/github.com/containerd/containerd/pkg/oom/v1/v1.go
@@ -1,0 +1,141 @@
+// +build linux
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package v1
+
+import (
+	"context"
+	"sync"
+
+	"github.com/containerd/cgroups"
+	eventstypes "github.com/containerd/containerd/api/events"
+	"github.com/containerd/containerd/pkg/oom"
+	"github.com/containerd/containerd/runtime"
+	"github.com/containerd/containerd/runtime/v2/shim"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/sys/unix"
+)
+
+// New returns an epoll implementation that listens to OOM events
+// from a container's cgroups.
+func New(publisher shim.Publisher) (oom.Watcher, error) {
+	fd, err := unix.EpollCreate1(unix.EPOLL_CLOEXEC)
+	if err != nil {
+		return nil, err
+	}
+	return &epoller{
+		fd:        fd,
+		publisher: publisher,
+		set:       make(map[uintptr]*item),
+	}, nil
+}
+
+// epoller implementation for handling OOM events from a container's cgroup
+type epoller struct {
+	mu sync.Mutex
+
+	fd        int
+	publisher shim.Publisher
+	set       map[uintptr]*item
+}
+
+type item struct {
+	id string
+	cg cgroups.Cgroup
+}
+
+// Close the epoll fd
+func (e *epoller) Close() error {
+	return unix.Close(e.fd)
+}
+
+// Run the epoll loop
+func (e *epoller) Run(ctx context.Context) {
+	var events [128]unix.EpollEvent
+	for {
+		select {
+		case <-ctx.Done():
+			e.Close()
+			return
+		default:
+			n, err := unix.EpollWait(e.fd, events[:], -1)
+			if err != nil {
+				if err == unix.EINTR {
+					continue
+				}
+				logrus.WithError(err).Error("cgroups: epoll wait")
+			}
+			for i := 0; i < n; i++ {
+				e.process(ctx, uintptr(events[i].Fd))
+			}
+		}
+	}
+}
+
+// Add cgroups.Cgroup to the epoll monitor
+func (e *epoller) Add(id string, cgx interface{}) error {
+	cg, ok := cgx.(cgroups.Cgroup)
+	if !ok {
+		return errors.Errorf("expected cgroups.Cgroup, got: %T", cgx)
+	}
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	fd, err := cg.OOMEventFD()
+	if err != nil {
+		return err
+	}
+	e.set[fd] = &item{
+		id: id,
+		cg: cg,
+	}
+	event := unix.EpollEvent{
+		Fd:     int32(fd),
+		Events: unix.EPOLLHUP | unix.EPOLLIN | unix.EPOLLERR,
+	}
+	return unix.EpollCtl(e.fd, unix.EPOLL_CTL_ADD, int(fd), &event)
+}
+
+func (e *epoller) process(ctx context.Context, fd uintptr) {
+	flush(fd)
+	e.mu.Lock()
+	i, ok := e.set[fd]
+	if !ok {
+		e.mu.Unlock()
+		return
+	}
+	e.mu.Unlock()
+	if i.cg.State() == cgroups.Deleted {
+		e.mu.Lock()
+		delete(e.set, fd)
+		e.mu.Unlock()
+		unix.Close(int(fd))
+		return
+	}
+	if err := e.publisher.Publish(ctx, runtime.TaskOOMEventTopic, &eventstypes.TaskOOM{
+		ContainerID: i.id,
+	}); err != nil {
+		logrus.WithError(err).Error("publish OOM event")
+	}
+}
+
+func flush(fd uintptr) error {
+	var buf [8]byte
+	_, err := unix.Read(int(fd), buf[:])
+	return err
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -34,6 +34,8 @@ github.com/containerd/containerd/log
 github.com/containerd/containerd/mount
 github.com/containerd/containerd/namespaces
 github.com/containerd/containerd/pkg/dialer
+github.com/containerd/containerd/pkg/oom
+github.com/containerd/containerd/pkg/oom/v1
 github.com/containerd/containerd/pkg/ttrpcutil
 github.com/containerd/containerd/pkg/userns
 github.com/containerd/containerd/runtime


### PR DESCRIPTION
Added ability to publish Out of Memory (OOM) events (`TaskOOM`) to containerd's events pub/sub (to `TaskOOMEventTopic`) that originated in Linux containers on a guest UVM.

Created notification queue that containers can publish events on; added OOM monitoring on the Linux UVM (via containerd's OOM watcher, which leverages cgroup notification API and Linux epolls); updated Linux guest bridge to publish OOM events to host; and added monitoring to host shim to forward notifications to containderd.

Previously, `gcs.Container` (which abstracted a container created on a uVM) held two channels:
1. `notifyCh`, which was used by `gcs.GuestConnection` to notify of container exit on the guest uVM. 
2. `closeCh`, which is waited on in `GuestConnection.Wait()` but never closed or used anywhere.
 
The notification comes from `gcs.bridge`, which (in `bridge.recvLoop`) waits for any notifications from the guest and passes them to the `GuestConnection`, which, in turn, assumes it is a notification of container exit and proceeds to mark the container as terminated.

This PR leverages that existing framework to make notifications from the guest (namely OOM errors) available to the shim, which can then pass them to containerd's event queue.

A `waitBlock` channel was added to `gcs.Container` for all calls to `Wait()` to block on, decoupling waits from the `GuestConnection` signaling. A go routine `waitBackground`, is launched at container creation to close `waitBlock` when the container is marked as closed via `closeCh`. 
The `GuestConnection` now uses `closeCh` to signal that the container has terminated, and `notifyCh` was used to pass along any notifications that `gcs.bridge` receives from the guest. Since events are sent to containerd for container exit elsewhere in the code, so those notifications from the guest are used to mark the container as terminated but are not sent along the notifications channel. 
An additional go routine, `publishNotifications`, launched at container creation, is used to read notifications off of `notifyCh` and write them to a queue.

A `Notifications()` function was added to the `cow.Container` interface that returns a queue on which raised notifications can be read off of. `gcs.Container` returns the queue it populates with the OOM notifications (and potentially others in the future), and other implementations of `cow.Container` return an error reporting that they do not support notifications. 

Finally, within the runhcs shim, creating and cloning an `hcsTask` also launches a `publishNotifications` goroutine that reads notifications from the queue returned by `cow.Containers.Notifications()` and publishes them to the events publisher that containerd consumes. 

Signed-off-by: Hamza El-Saawy <hamzaelsaawy@microsoft.com>