### PR TITLE
Handling of out-of-order whiteout files during tar expansion

### DIFF
--- a/ext4/internal/compactext4/compact.go
+++ b/ext4/internal/compactext4/compact.go
@@ -414,6 +414,9 @@ func (w *Writer) makeInode(f *File, node *inode) (*inode, error) {
 	node.Devmajor = f.Devmajor
 	node.Devminor = f.Devminor
 	node.Data = nil
+	if f.Xattrs == nil {
+		f.Xattrs = make(map[string][]byte)
+	}
 
 	// copy over existing xattrs first, we need to merge existing xattrs and the passed xattrs.
 	existingXattrs := make(map[string][]byte)

--- a/ext4/internal/compactext4/compact.go
+++ b/ext4/internal/compactext4/compact.go
@@ -414,6 +414,12 @@ func (w *Writer) makeInode(f *File, node *inode) (*inode, error) {
 	node.Devmajor = f.Devmajor
 	node.Devminor = f.Devminor
 	node.Data = nil
+
+	// copy over existing xattrs first, we need to merge existing xattrs and the passed xattrs.
+	existingXattrs := make(map[string][]byte)
+	if len(node.XattrInline) > 0 {
+		getXattrs(node.XattrInline[4:], existingXattrs, 0)
+	}
 	node.XattrInline = nil
 
 	var xstate xattrState
@@ -450,6 +456,13 @@ func (w *Writer) makeInode(f *File, node *inode) (*inode, error) {
 	case format.S_IFDIR, format.S_IFIFO, format.S_IFSOCK, format.S_IFCHR, format.S_IFBLK:
 	default:
 		return nil, fmt.Errorf("invalid mode %o", mode)
+	}
+
+	// merge xattrs but prefer currently passed over existing
+	for name, data := range existingXattrs {
+		if _, ok := f.Xattrs[name]; !ok {
+			f.Xattrs[name] = data
+		}
 	}
 
 	// Accumulate the extended attributes.
@@ -514,15 +527,16 @@ func (w *Writer) lookup(name string, mustExist bool) (*inode, *inode, string, er
 	return dir, child, childname, nil
 }
 
-// CreateWithParents adds a file to the file system creating the parent directories in the path if
-// they don't exist (like `mkdir -p`). These non existing parent directories are created
+// MakeParents ensures that all the parent directories in the path specified by `name` exists. If
+// they don't exist it creates them (like `mkdir -p`). These non existing parent directories are created
 // with the same permissions as that of it's parent directory. It is expected that the a
 // call to make these parent directories will be made at a later point with the correct
 // permissions, at that time the permissions of these directories will be updated.
-func (w *Writer) CreateWithParents(name string, f *File) error {
+func (w *Writer) MakeParents(name string) error {
 	if err := w.finishInode(); err != nil {
 		return err
 	}
+
 	// go through the directories in the path one by one and create the
 	// parent directories if they don't exist.
 	cleanname := path.Clean("/" + name)[1:]
@@ -553,7 +567,7 @@ func (w *Writer) CreateWithParents(name string, f *File) error {
 		}
 		root = root.Children[dirname]
 	}
-	return w.Create(name, f)
+	return nil
 }
 
 // Create adds a file to the file system.

--- a/ext4/tar2ext4/tar2ext4_test.go
+++ b/ext4/tar2ext4/tar2ext4_test.go
@@ -28,10 +28,11 @@ func Test_UnorderedTarExpansion(t *testing.T) {
 	var files = []struct {
 		path, body string
 	}{
-		{"foo/bar.txt", "inside bar.txt"},
+		{"foo/.wh.bar.txt", "inside bar.txt"},
 		{"data/", ""},
 		{"root.txt", "inside root.txt"},
 		{"foo/", ""},
+		{"A/.wh..wh..opq", ""},
 		{"A/B/b.txt", "inside b.txt"},
 		{"A/a.txt", "inside a.txt"},
 		{"A/", ""},

--- a/test/vendor/github.com/Microsoft/hcsshim/ext4/internal/compactext4/compact.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/ext4/internal/compactext4/compact.go
@@ -414,6 +414,9 @@ func (w *Writer) makeInode(f *File, node *inode) (*inode, error) {
 	node.Devmajor = f.Devmajor
 	node.Devminor = f.Devminor
 	node.Data = nil
+	if f.Xattrs == nil {
+		f.Xattrs = make(map[string][]byte)
+	}
 
 	// copy over existing xattrs first, we need to merge existing xattrs and the passed xattrs.
 	existingXattrs := make(map[string][]byte)

--- a/test/vendor/github.com/Microsoft/hcsshim/ext4/internal/compactext4/compact.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/ext4/internal/compactext4/compact.go
@@ -414,6 +414,12 @@ func (w *Writer) makeInode(f *File, node *inode) (*inode, error) {
 	node.Devmajor = f.Devmajor
 	node.Devminor = f.Devminor
 	node.Data = nil
+
+	// copy over existing xattrs first, we need to merge existing xattrs and the passed xattrs.
+	existingXattrs := make(map[string][]byte)
+	if len(node.XattrInline) > 0 {
+		getXattrs(node.XattrInline[4:], existingXattrs, 0)
+	}
 	node.XattrInline = nil
 
 	var xstate xattrState
@@ -450,6 +456,13 @@ func (w *Writer) makeInode(f *File, node *inode) (*inode, error) {
 	case format.S_IFDIR, format.S_IFIFO, format.S_IFSOCK, format.S_IFCHR, format.S_IFBLK:
 	default:
 		return nil, fmt.Errorf("invalid mode %o", mode)
+	}
+
+	// merge xattrs but prefer currently passed over existing
+	for name, data := range existingXattrs {
+		if _, ok := f.Xattrs[name]; !ok {
+			f.Xattrs[name] = data
+		}
 	}
 
 	// Accumulate the extended attributes.
@@ -514,15 +527,16 @@ func (w *Writer) lookup(name string, mustExist bool) (*inode, *inode, string, er
 	return dir, child, childname, nil
 }
 
-// CreateWithParents adds a file to the file system creating the parent directories in the path if
-// they don't exist (like `mkdir -p`). These non existing parent directories are created
+// MakeParents ensures that all the parent directories in the path specified by `name` exists. If
+// they don't exist it creates them (like `mkdir -p`). These non existing parent directories are created
 // with the same permissions as that of it's parent directory. It is expected that the a
 // call to make these parent directories will be made at a later point with the correct
 // permissions, at that time the permissions of these directories will be updated.
-func (w *Writer) CreateWithParents(name string, f *File) error {
+func (w *Writer) MakeParents(name string) error {
 	if err := w.finishInode(); err != nil {
 		return err
 	}
+
 	// go through the directories in the path one by one and create the
 	// parent directories if they don't exist.
 	cleanname := path.Clean("/" + name)[1:]
@@ -553,7 +567,7 @@ func (w *Writer) CreateWithParents(name string, f *File) error {
 		}
 		root = root.Children[dirname]
 	}
-	return w.Create(name, f)
+	return nil
 }
 
 // Create adds a file to the file system.


### PR DESCRIPTION
When extracting a container image layer tar, some files can show in an out of order
fashion (i.e the file shows up first before its parent directory shows up). We already
handle this by creating these parent directories if they don't already exist. However,
that handling didn't apply to whiteout files. This commit fixes that.

Signed-off-by: Amit Barve <ambarve@microsoft.com>