### PR TITLE
security policy appended to container's environment variables 

### DIFF
--- a/internal/guest/runtime/hcsv2/uvm.go
+++ b/internal/guest/runtime/hcsv2/uvm.go
@@ -218,8 +218,8 @@ func (h *Host) CreateContainer(ctx context.Context, id string, settings *prot.VM
 	// We append the variable after the security policy enforcing logic completes so as to bypass it; the
 	// security policy variable cannot be included in the security policy as its value is not available
 	// security policy construction time.
-	policyEnforcer, ok := (h.securityPolicyEnforcer).(*securitypolicy.StandardSecurityPolicyEnforcer)
-	if ok {
+
+	if policyEnforcer, ok := (h.securityPolicyEnforcer).(*securitypolicy.StandardSecurityPolicyEnforcer); ok {
 		secPolicyEnv := fmt.Sprintf("SECURITY_POLICY=%s", policyEnforcer.EncodedSecurityPolicy)
 		settings.OCISpecification.Process.Env = append(settings.OCISpecification.Process.Env, secPolicyEnv)
 	}

--- a/internal/guest/runtime/hcsv2/uvm.go
+++ b/internal/guest/runtime/hcsv2/uvm.go
@@ -210,10 +210,8 @@ func (h *Host) CreateContainer(ctx context.Context, id string, settings *prot.VM
 	}
 
 	// Export security policy as one of the process's environment variables so that application and sidecar
-	// containers can have access to it. security policy is required by attestation containers which need to
-	// verify the attestation report feched from the PSP and extract init-time attestation claims found in
-	// the security policy. In doing so, an attestation container needs to confirm that the hash digest of
-	// the report's host_data attribute matches the hash digest of the security policy.
+	// containers can have access to it. The security policy is required by containers which need to extract
+	// init-time claims found in the security policy.
 	//
 	// We append the variable after the security policy enforcing logic completes so as to bypass it; the
 	// security policy variable cannot be included in the security policy as its value is not available


### PR DESCRIPTION
Attestation sidecar containers need to have access to the security policy so they can extract the init-time claims of the utility VM as presented in the security policy.