### PR TITLE
Update readme to list accurate go version

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additio
 
 ## Dependencies
 
-This project requires Golang 1.9 or newer to build.
+This project requires Golang 1.13 or newer to build.
 
 For system requirements to run this project, see the Microsoft docs on [Windows Container requirements](https://docs.microsoft.com/en-us/virtualization/windowscontainers/deploy-containers/system-requirements).
 

--- a/test/vendor/github.com/Microsoft/hcsshim/README.md
+++ b/test/vendor/github.com/Microsoft/hcsshim/README.md
@@ -101,7 +101,7 @@ contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additio
 
 ## Dependencies
 
-This project requires Golang 1.9 or newer to build.
+This project requires Golang 1.13 or newer to build.
 
 For system requirements to run this project, see the Microsoft docs on [Windows Container requirements](https://docs.microsoft.com/en-us/virtualization/windowscontainers/deploy-containers/system-requirements).
 


### PR DESCRIPTION
Our README stated that you'd need go 1.9 or newer to build. Our go.mod
currently lists 1.13 however.

Signed-off-by: Daniel Canter <dcanter@microsoft.com>