### PR TITLE
[release/0.9] Fix commandline double quoting for job containers

### DIFF
--- a/internal/jobcontainers/jobcontainer.go
+++ b/internal/jobcontainers/jobcontainer.go
@@ -253,12 +253,12 @@ func (c *JobContainer) CreateProcess(ctx context.Context, config interface{}) (_
 		Env:  env,
 		Dir:  workDir,
 		Path: absPath,
-		Args: splitArgs(commandLine),
 		SysProcAttr: &syscall.SysProcAttr{
 			// CREATE_BREAKAWAY_FROM_JOB to make sure that we're not inheriting the job object (and by extension its limits)
 			// from whatever process is going to launch the container.
 			CreationFlags: windows.CREATE_NEW_PROCESS_GROUP | windows.CREATE_BREAKAWAY_FROM_JOB,
 			Token:         syscall.Token(token),
+			CmdLine:       commandLine,
 		},
 	}
 	process := newProcess(cmd)

--- a/test/cri-containerd/main.go
+++ b/test/cri-containerd/main.go
@@ -1,3 +1,4 @@
+//go:build functional
 // +build functional
 
 package cri_containerd
@@ -55,6 +56,7 @@ const (
 	imageJobContainerHNS     = "cplatpublic.azurecr.io/jobcontainer_hns:latest"
 	imageJobContainerETW     = "cplatpublic.azurecr.io/jobcontainer_etw:latest"
 	imageJobContainerVHD     = "cplatpublic.azurecr.io/jobcontainer_vhd:latest"
+	imageJobContainerCmdline = "cplatpublic.azurecr.io/jobcontainer_cmdline:latest"
 	imageJobContainerWorkDir = "cplatpublic.azurecr.io/jobcontainer_workdir:latest"
 	alpineAspNet             = "mcr.microsoft.com/dotnet/core/aspnet:3.1-alpine3.11"
 	alpineAspnetUpgrade      = "mcr.microsoft.com/dotnet/core/aspnet:3.1.2-alpine3.11"

--- a/test/cri-containerd/test-images/jobcontainer_cmdline/dockerfile
+++ b/test/cri-containerd/test-images/jobcontainer_cmdline/dockerfile
@@ -1,0 +1,11 @@
+# Irrelevant what image version we use for job containers as there's no container <-> host OS version restraint.
+FROM golang:1.15.10-nanoserver-1809
+
+# Get administrator privileges
+USER containeradministrator
+
+WORKDIR C:\\go\\src\\cmdline
+COPY main.go .
+
+RUN go get -d -v ./...
+RUN go build -mod=mod

--- a/test/cri-containerd/test-images/jobcontainer_cmdline/main.go
+++ b/test/cri-containerd/test-images/jobcontainer_cmdline/main.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+func main() {
+	fmt.Print(strings.Join(os.Args, " "))
+}


### PR DESCRIPTION
We already escape the arguments passed to us by Containerd to form a
Windows style commandline, however the commandline was being split back
into arguments and then passed to exec.Cmd from the go stdlib. exec.Cmd
internally also does escaping, which ended up applying some extra quotes
in some cases where the commandline had double/single quotes present. This change
just passes the commandline as is to the Cmdline field on the Windows
syscall.SysProcAttr. Go takes this field as is and doesn't do any further
processing on it which is the behavior we desire.

Signed-off-by: Daniel Canter <dcanter@microsoft.com>
(cherry picked from commit 7cb95b6)
Signed-off-by: Daniel Canter <dcanter@microsoft.com>