### PR TITLE
Add conpty (pseudo console) package

### DIFF
--- a/internal/conpty/conpty.go
+++ b/internal/conpty/conpty.go
@@ -1,0 +1,153 @@
+package conpty
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"sync"
+	"unsafe"
+
+	"github.com/Microsoft/hcsshim/internal/winapi"
+	"golang.org/x/sys/windows"
+)
+
+var (
+	errClosedConPty   = errors.New("pseudo console is closed")
+	errNotInitialized = errors.New("pseudo console hasn't been initialized")
+)
+
+// CPty is a wrapper around a Windows PseudoConsole handle. Create a new instance by calling `New()`.
+type CPty struct {
+	// handleLock guards hpc
+	handleLock sync.RWMutex
+	// hpc is the pseudo console handle
+	hpc windows.Handle
+	// inPipe and outPipe are our end of the pipes to read/write to the pseudo console.
+	inPipe  *os.File
+	outPipe *os.File
+}
+
+// New returns a new `CPty` object. This object is not ready for IO until `UpdateProcThreadAttribute` is called and a process has been started.
+func New(columns, rows int16, flags uint32) (*CPty, error) {
+	// First we need to make both ends of the conpty's pipes, two to get passed into a process to use as input/output, and two for us to keep to
+	// make use of this data.
+	ptyIn, inPipeOurs, err := os.Pipe()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create pipes for pseudo console: %w", err)
+	}
+
+	outPipeOurs, ptyOut, err := os.Pipe()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create pipes for pseudo console: %w", err)
+	}
+
+	var hpc windows.Handle
+	coord := windows.Coord{X: columns, Y: rows}
+	err = winapi.CreatePseudoConsole(coord, windows.Handle(ptyIn.Fd()), windows.Handle(ptyOut.Fd()), 0, &hpc)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create pseudo console: %w", err)
+	}
+
+	// The pty's end of its pipes can be closed here without worry. They're duped into the conhost
+	// that will be launched and will be released on a call to ClosePseudoConsole() (Close() on the CPty object).
+	if err := ptyOut.Close(); err != nil {
+		return nil, fmt.Errorf("failed to close pseudo console handle: %w", err)
+	}
+	if err := ptyIn.Close(); err != nil {
+		return nil, fmt.Errorf("failed to close pseudo console handle: %w", err)
+	}
+
+	return &CPty{
+		hpc:     hpc,
+		inPipe:  inPipeOurs,
+		outPipe: outPipeOurs,
+	}, nil
+}
+
+// UpdateProcThreadAttribute updates the passed in attribute list to contain the entry necessary for use with
+// CreateProcess.
+func (c *CPty) UpdateProcThreadAttribute(attributeList *winapi.ProcThreadAttributeList) error {
+	c.handleLock.RLock()
+	defer c.handleLock.RUnlock()
+
+	if c.hpc == 0 {
+		return errClosedConPty
+	}
+
+	err := winapi.UpdateProcThreadAttribute(
+		attributeList,
+		0,
+		winapi.PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE,
+		unsafe.Pointer(c.hpc),
+		unsafe.Sizeof(c.hpc),
+		nil,
+		nil,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to update proc thread attributes for pseudo console: %w", err)
+	}
+	return nil
+}
+
+// Resize resizes the internal buffers of the pseudo console to the passed in size
+func (c *CPty) Resize(columns, rows int16) error {
+	c.handleLock.RLock()
+	defer c.handleLock.RUnlock()
+
+	if c.hpc == 0 {
+		return errClosedConPty
+	}
+
+	coord := windows.Coord{X: columns, Y: rows}
+	if err := winapi.ResizePseudoConsole(c.hpc, coord); err != nil {
+		return fmt.Errorf("failed to resize pseudo console: %w", err)
+	}
+	return nil
+}
+
+// Close closes the pseudo-terminal and cleans up all attached resources
+func (c *CPty) Close() error {
+	c.handleLock.Lock()
+	defer c.handleLock.Unlock()
+
+	if c.hpc == 0 {
+		return errClosedConPty
+	}
+
+	// Close the pseudo console, set the handle to 0 to invalidate this object and then close the side of the pipes that we own.
+	winapi.ClosePseudoConsole(c.hpc)
+	c.hpc = 0
+	if err := c.inPipe.Close(); err != nil {
+		return fmt.Errorf("failed to close pseudo console input pipe: %w", err)
+	}
+	if err := c.outPipe.Close(); err != nil {
+		return fmt.Errorf("failed to close pseudo console output pipe: %w", err)
+	}
+	return nil
+}
+
+// OutPipe returns the output pipe of the pseudo console.
+func (c *CPty) OutPipe() *os.File {
+	return c.outPipe
+}
+
+// InPipe returns the input pipe of the pseudo console.
+func (c *CPty) InPipe() *os.File {
+	return c.inPipe
+}
+
+// Write writes the contents of `buf` to the pseudo console. Returns the number of bytes written and an error if there is one.
+func (c *CPty) Write(buf []byte) (int, error) {
+	if c.inPipe == nil {
+		return 0, errNotInitialized
+	}
+	return c.inPipe.Write(buf)
+}
+
+// Read reads from the pseudo console into `buf`. Returns the number of bytes read and an error if there is one.
+func (c *CPty) Read(buf []byte) (int, error) {
+	if c.outPipe == nil {
+		return 0, errNotInitialized
+	}
+	return c.outPipe.Read(buf)
+}

--- a/internal/conpty/conpty.go
+++ b/internal/conpty/conpty.go
@@ -28,7 +28,7 @@ type ConPTY struct {
 }
 
 // New returns a new `ConPTY` object. This object is not ready for IO until `UpdateProcThreadAttribute` is called and a process has been started.
-func New(columns, rows int16, flags uint32) (*ConPTY, error) {
+func New(width, height int16, flags uint32) (*ConPTY, error) {
 	// First we need to make both ends of the conpty's pipes, two to get passed into a process to use as input/output, and two for us to keep to
 	// make use of this data.
 	ptyIn, inPipeOurs, err := os.Pipe()
@@ -42,7 +42,7 @@ func New(columns, rows int16, flags uint32) (*ConPTY, error) {
 	}
 
 	var hpc windows.Handle
-	coord := windows.Coord{X: columns, Y: rows}
+	coord := windows.Coord{X: width, Y: height}
 	err = winapi.CreatePseudoConsole(coord, windows.Handle(ptyIn.Fd()), windows.Handle(ptyOut.Fd()), 0, &hpc)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create pseudo console: %w", err)
@@ -90,7 +90,7 @@ func (c *ConPTY) UpdateProcThreadAttribute(attributeList *winapi.ProcThreadAttri
 }
 
 // Resize resizes the internal buffers of the pseudo console to the passed in size
-func (c *ConPTY) Resize(columns, rows int16) error {
+func (c *ConPTY) Resize(width, height int16) error {
 	c.handleLock.RLock()
 	defer c.handleLock.RUnlock()
 
@@ -98,7 +98,7 @@ func (c *ConPTY) Resize(columns, rows int16) error {
 		return errClosedConPty
 	}
 
-	coord := windows.Coord{X: columns, Y: rows}
+	coord := windows.Coord{X: width, Y: height}
 	if err := winapi.ResizePseudoConsole(c.hpc, coord); err != nil {
 		return fmt.Errorf("failed to resize pseudo console: %w", err)
 	}

--- a/internal/winapi/console.go
+++ b/internal/winapi/console.go
@@ -1,0 +1,44 @@
+package winapi
+
+import (
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+const PSEUDOCONSOLE_INHERIT_CURSOR = 0x1
+
+// CreatePseudoConsole creates a windows pseudo console.
+func CreatePseudoConsole(size windows.Coord, hInput windows.Handle, hOutput windows.Handle, dwFlags uint32, hpcon *windows.Handle) error {
+	// We need this wrapper as the function takes a COORD struct and not a pointer to one, so we need to cast to something beforehand.
+	return createPseudoConsole(*((*uint32)(unsafe.Pointer(&size))), hInput, hOutput, 0, hpcon)
+}
+
+// ResizePseudoConsole resizes the internal buffers of the pseudo console to the width and height specified in `size`.
+func ResizePseudoConsole(hpcon windows.Handle, size windows.Coord) error {
+	// We need this wrapper as the function takes a COORD struct and not a pointer to one, so we need to cast to something beforehand.
+	return resizePseudoConsole(hpcon, *((*uint32)(unsafe.Pointer(&size))))
+}
+
+// HRESULT WINAPI CreatePseudoConsole(
+//     _In_ COORD size,
+//     _In_ HANDLE hInput,
+//     _In_ HANDLE hOutput,
+//     _In_ DWORD dwFlags,
+//     _Out_ HPCON* phPC
+// );
+//
+//sys createPseudoConsole(size uint32, hInput windows.Handle, hOutput windows.Handle, dwFlags uint32, hpcon *windows.Handle) (hr error) = kernel32.CreatePseudoConsole
+
+// void WINAPI ClosePseudoConsole(
+//     _In_ HPCON hPC
+// );
+//
+//sys ClosePseudoConsole(hpc windows.Handle) = kernel32.ClosePseudoConsole
+
+// HRESULT WINAPI ResizePseudoConsole(
+//     _In_ HPCON hPC ,
+//     _In_ COORD size
+// );
+//
+//sys resizePseudoConsole(hPc windows.Handle, size uint32) (hr error) = kernel32.ResizePseudoConsole

--- a/internal/winapi/process.go
+++ b/internal/winapi/process.go
@@ -26,6 +26,9 @@ type StartupInfoEx struct {
 	// This is a recreation of the same binding from the stdlib. The x/sys/windows variant for whatever reason
 	// doesn't work when updating the list for the pseudo console attribute. It has the process immediately exit
 	// with exit code 0xc0000142 shortly after start.
+	//
+	// TODO (dcantah): Swap to the x/sys/windows definitions after https://go-review.googlesource.com/c/sys/+/371276/1/windows/exec_windows.go#153
+	// gets in.
 	windows.StartupInfo
 	ProcThreadAttributeList *ProcThreadAttributeList
 }

--- a/internal/winapi/process.go
+++ b/internal/winapi/process.go
@@ -35,7 +35,7 @@ type StartupInfoEx struct {
 // DeleteProcThreadAttributeList.
 func NewProcThreadAttributeList(maxAttrCount uint32) (*ProcThreadAttributeList, error) {
 	var size uintptr
-	err := InitializeProcThreadAttributeList(nil, maxAttrCount, 0, &size)
+	err := initializeProcThreadAttributeList(nil, maxAttrCount, 0, &size)
 	if err != windows.ERROR_INSUFFICIENT_BUFFER {
 		if err == nil {
 			return nil, errors.New("unable to query buffer size from InitializeProcThreadAttributeList")
@@ -43,7 +43,7 @@ func NewProcThreadAttributeList(maxAttrCount uint32) (*ProcThreadAttributeList, 
 		return nil, err
 	}
 	al := (*ProcThreadAttributeList)(unsafe.Pointer(&make([]byte, size)[0]))
-	err = InitializeProcThreadAttributeList(al, maxAttrCount, 0, &size)
+	err = initializeProcThreadAttributeList(al, maxAttrCount, 0, &size)
 	if err != nil {
 		return nil, err
 	}
@@ -57,7 +57,7 @@ func NewProcThreadAttributeList(maxAttrCount uint32) (*ProcThreadAttributeList, 
 // 	[in, out]       PSIZE_T                      lpSize
 // );
 //
-//sys InitializeProcThreadAttributeList(lpAttributeList *ProcThreadAttributeList, dwAttributeCount uint32, dwFlags uint32, lpSize *uintptr) (err error) = kernel32.InitializeProcThreadAttributeList
+//sys initializeProcThreadAttributeList(lpAttributeList *ProcThreadAttributeList, dwAttributeCount uint32, dwFlags uint32, lpSize *uintptr) (err error) = kernel32.InitializeProcThreadAttributeList
 
 // void DeleteProcThreadAttributeList(
 // 	[in, out] LPPROC_THREAD_ATTRIBUTE_LIST lpAttributeList

--- a/internal/winapi/process.go
+++ b/internal/winapi/process.go
@@ -1,10 +1,80 @@
 package winapi
 
+import (
+	"errors"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
 const PROCESS_ALL_ACCESS uint32 = 2097151
 
-// DWORD GetProcessImageFileNameW(
-//	HANDLE hProcess,
-//	LPWSTR lpImageFileName,
-//	DWORD  nSize
+const (
+	PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE = 0x20016
+	PROC_THREAD_ATTRIBUTE_JOB_LIST      = 0x2000D
+)
+
+type ProcThreadAttributeList struct {
+	_ [1]byte
+}
+
+// typedef struct _STARTUPINFOEXW {
+// 	STARTUPINFOW                 StartupInfo;
+// 	LPPROC_THREAD_ATTRIBUTE_LIST lpAttributeList;
+// } STARTUPINFOEXW, *LPSTARTUPINFOEXW;
+type StartupInfoEx struct {
+	// This is a recreation of the same binding from the stdlib. The x/sys/windows variant for whatever reason
+	// doesn't work when updating the list for the pseudo console attribute. It has the process immediately exit
+	// with exit code 0xc0000142 shortly after start.
+	windows.StartupInfo
+	ProcThreadAttributeList *ProcThreadAttributeList
+}
+
+// NewProcThreadAttributeList allocates a new ProcThreadAttributeList, with
+// the requested maximum number of attributes. This must be cleaned up by calling
+// DeleteProcThreadAttributeList.
+func NewProcThreadAttributeList(maxAttrCount uint32) (*ProcThreadAttributeList, error) {
+	var size uintptr
+	err := InitializeProcThreadAttributeList(nil, maxAttrCount, 0, &size)
+	if err != windows.ERROR_INSUFFICIENT_BUFFER {
+		if err == nil {
+			return nil, errors.New("unable to query buffer size from InitializeProcThreadAttributeList")
+		}
+		return nil, err
+	}
+	al := (*ProcThreadAttributeList)(unsafe.Pointer(&make([]byte, size)[0]))
+	err = InitializeProcThreadAttributeList(al, maxAttrCount, 0, &size)
+	if err != nil {
+		return nil, err
+	}
+	return al, nil
+}
+
+// BOOL InitializeProcThreadAttributeList(
+// 	[out, optional] LPPROC_THREAD_ATTRIBUTE_LIST lpAttributeList,
+// 	[in]            DWORD                        dwAttributeCount,
+// 					DWORD                        dwFlags,
+// 	[in, out]       PSIZE_T                      lpSize
 // );
-//sys GetProcessImageFileName(hProcess windows.Handle, imageFileName *uint16, nSize uint32) (size uint32, err error) = kernel32.GetProcessImageFileNameW
+//
+//sys InitializeProcThreadAttributeList(lpAttributeList *ProcThreadAttributeList, dwAttributeCount uint32, dwFlags uint32, lpSize *uintptr) (err error) = kernel32.InitializeProcThreadAttributeList
+
+// void DeleteProcThreadAttributeList(
+// 	[in, out] LPPROC_THREAD_ATTRIBUTE_LIST lpAttributeList
+// );
+//
+//sys DeleteProcThreadAttributeList(lpAttributeList *ProcThreadAttributeList) = kernel32.DeleteProcThreadAttributeList
+
+// BOOL UpdateProcThreadAttribute(
+// 	[in, out]       LPPROC_THREAD_ATTRIBUTE_LIST lpAttributeList,
+// 	[in]            DWORD                        dwFlags,
+// 	[in]            DWORD_PTR                    Attribute,
+// 	[in]            PVOID                        lpValue,
+// 	[in]            SIZE_T                       cbSize,
+// 	[out, optional] PVOID                        lpPreviousValue,
+// 	[in, optional]  PSIZE_T                      lpReturnSize
+// );
+//
+//sys UpdateProcThreadAttribute(lpAttributeList *ProcThreadAttributeList, dwFlags uint32, attribute uintptr, lpValue unsafe.Pointer, cbSize uintptr, lpPreviousValue unsafe.Pointer, lpReturnSize *uintptr) (err error) = kernel32.UpdateProcThreadAttribute
+
+//sys CreateProcessAsUser(token windows.Token, appName *uint16, commandLine *uint16, procSecurity *windows.SecurityAttributes, threadSecurity *windows.SecurityAttributes, inheritHandles bool, creationFlags uint32, env *uint16, currentDir *uint16, startupInfo *windows.StartupInfo, outProcInfo *windows.ProcessInformation) (err error) = advapi32.CreateProcessAsUserW

--- a/internal/winapi/winapi.go
+++ b/internal/winapi/winapi.go
@@ -2,4 +2,4 @@
 // be thought of as an extension to golang.org/x/sys/windows.
 package winapi
 
-//go:generate go run ..\..\mksyscall_windows.go -output zsyscall_windows.go system.go net.go path.go thread.go iocp.go jobobject.go logon.go memory.go process.go processor.go devices.go filesystem.go errors.go
+//go:generate go run ..\..\mksyscall_windows.go -output zsyscall_windows.go console.go system.go net.go path.go thread.go iocp.go jobobject.go logon.go memory.go process.go processor.go devices.go filesystem.go errors.go

--- a/internal/winapi/zsyscall_windows.go
+++ b/internal/winapi/zsyscall_windows.go
@@ -260,7 +260,7 @@ func LocalFree(ptr uintptr) {
 	return
 }
 
-func InitializeProcThreadAttributeList(lpAttributeList *ProcThreadAttributeList, dwAttributeCount uint32, dwFlags uint32, lpSize *uintptr) (err error) {
+func initializeProcThreadAttributeList(lpAttributeList *ProcThreadAttributeList, dwAttributeCount uint32, dwFlags uint32, lpSize *uintptr) (err error) {
 	r1, _, e1 := syscall.Syscall6(procInitializeProcThreadAttributeList.Addr(), 4, uintptr(unsafe.Pointer(lpAttributeList)), uintptr(dwAttributeCount), uintptr(dwFlags), uintptr(unsafe.Pointer(lpSize)), 0, 0)
 	if r1 == 0 {
 		if e1 != 0 {

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/winapi/console.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/winapi/console.go
@@ -1,0 +1,44 @@
+package winapi
+
+import (
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+const PSEUDOCONSOLE_INHERIT_CURSOR = 0x1
+
+// CreatePseudoConsole creates a windows pseudo console.
+func CreatePseudoConsole(size windows.Coord, hInput windows.Handle, hOutput windows.Handle, dwFlags uint32, hpcon *windows.Handle) error {
+	// We need this wrapper as the function takes a COORD struct and not a pointer to one, so we need to cast to something beforehand.
+	return createPseudoConsole(*((*uint32)(unsafe.Pointer(&size))), hInput, hOutput, 0, hpcon)
+}
+
+// ResizePseudoConsole resizes the internal buffers of the pseudo console to the width and height specified in `size`.
+func ResizePseudoConsole(hpcon windows.Handle, size windows.Coord) error {
+	// We need this wrapper as the function takes a COORD struct and not a pointer to one, so we need to cast to something beforehand.
+	return resizePseudoConsole(hpcon, *((*uint32)(unsafe.Pointer(&size))))
+}
+
+// HRESULT WINAPI CreatePseudoConsole(
+//     _In_ COORD size,
+//     _In_ HANDLE hInput,
+//     _In_ HANDLE hOutput,
+//     _In_ DWORD dwFlags,
+//     _Out_ HPCON* phPC
+// );
+//
+//sys createPseudoConsole(size uint32, hInput windows.Handle, hOutput windows.Handle, dwFlags uint32, hpcon *windows.Handle) (hr error) = kernel32.CreatePseudoConsole
+
+// void WINAPI ClosePseudoConsole(
+//     _In_ HPCON hPC
+// );
+//
+//sys ClosePseudoConsole(hpc windows.Handle) = kernel32.ClosePseudoConsole
+
+// HRESULT WINAPI ResizePseudoConsole(
+//     _In_ HPCON hPC ,
+//     _In_ COORD size
+// );
+//
+//sys resizePseudoConsole(hPc windows.Handle, size uint32) (hr error) = kernel32.ResizePseudoConsole

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/winapi/process.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/winapi/process.go
@@ -35,7 +35,7 @@ type StartupInfoEx struct {
 // DeleteProcThreadAttributeList.
 func NewProcThreadAttributeList(maxAttrCount uint32) (*ProcThreadAttributeList, error) {
 	var size uintptr
-	err := InitializeProcThreadAttributeList(nil, maxAttrCount, 0, &size)
+	err := initializeProcThreadAttributeList(nil, maxAttrCount, 0, &size)
 	if err != windows.ERROR_INSUFFICIENT_BUFFER {
 		if err == nil {
 			return nil, errors.New("unable to query buffer size from InitializeProcThreadAttributeList")
@@ -43,7 +43,7 @@ func NewProcThreadAttributeList(maxAttrCount uint32) (*ProcThreadAttributeList, 
 		return nil, err
 	}
 	al := (*ProcThreadAttributeList)(unsafe.Pointer(&make([]byte, size)[0]))
-	err = InitializeProcThreadAttributeList(al, maxAttrCount, 0, &size)
+	err = initializeProcThreadAttributeList(al, maxAttrCount, 0, &size)
 	if err != nil {
 		return nil, err
 	}
@@ -57,7 +57,7 @@ func NewProcThreadAttributeList(maxAttrCount uint32) (*ProcThreadAttributeList, 
 // 	[in, out]       PSIZE_T                      lpSize
 // );
 //
-//sys InitializeProcThreadAttributeList(lpAttributeList *ProcThreadAttributeList, dwAttributeCount uint32, dwFlags uint32, lpSize *uintptr) (err error) = kernel32.InitializeProcThreadAttributeList
+//sys initializeProcThreadAttributeList(lpAttributeList *ProcThreadAttributeList, dwAttributeCount uint32, dwFlags uint32, lpSize *uintptr) (err error) = kernel32.InitializeProcThreadAttributeList
 
 // void DeleteProcThreadAttributeList(
 // 	[in, out] LPPROC_THREAD_ATTRIBUTE_LIST lpAttributeList

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/winapi/process.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/winapi/process.go
@@ -1,10 +1,80 @@
 package winapi
 
+import (
+	"errors"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
 const PROCESS_ALL_ACCESS uint32 = 2097151
 
-// DWORD GetProcessImageFileNameW(
-//	HANDLE hProcess,
-//	LPWSTR lpImageFileName,
-//	DWORD  nSize
+const (
+	PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE = 0x20016
+	PROC_THREAD_ATTRIBUTE_JOB_LIST      = 0x2000D
+)
+
+type ProcThreadAttributeList struct {
+	_ [1]byte
+}
+
+// typedef struct _STARTUPINFOEXW {
+// 	STARTUPINFOW                 StartupInfo;
+// 	LPPROC_THREAD_ATTRIBUTE_LIST lpAttributeList;
+// } STARTUPINFOEXW, *LPSTARTUPINFOEXW;
+type StartupInfoEx struct {
+	// This is a recreation of the same binding from the stdlib. The x/sys/windows variant for whatever reason
+	// doesn't work when updating the list for the pseudo console attribute. It has the process immediately exit
+	// with exit code 0xc0000142 shortly after start.
+	windows.StartupInfo
+	ProcThreadAttributeList *ProcThreadAttributeList
+}
+
+// NewProcThreadAttributeList allocates a new ProcThreadAttributeList, with
+// the requested maximum number of attributes. This must be cleaned up by calling
+// DeleteProcThreadAttributeList.
+func NewProcThreadAttributeList(maxAttrCount uint32) (*ProcThreadAttributeList, error) {
+	var size uintptr
+	err := InitializeProcThreadAttributeList(nil, maxAttrCount, 0, &size)
+	if err != windows.ERROR_INSUFFICIENT_BUFFER {
+		if err == nil {
+			return nil, errors.New("unable to query buffer size from InitializeProcThreadAttributeList")
+		}
+		return nil, err
+	}
+	al := (*ProcThreadAttributeList)(unsafe.Pointer(&make([]byte, size)[0]))
+	err = InitializeProcThreadAttributeList(al, maxAttrCount, 0, &size)
+	if err != nil {
+		return nil, err
+	}
+	return al, nil
+}
+
+// BOOL InitializeProcThreadAttributeList(
+// 	[out, optional] LPPROC_THREAD_ATTRIBUTE_LIST lpAttributeList,
+// 	[in]            DWORD                        dwAttributeCount,
+// 					DWORD                        dwFlags,
+// 	[in, out]       PSIZE_T                      lpSize
 // );
-//sys GetProcessImageFileName(hProcess windows.Handle, imageFileName *uint16, nSize uint32) (size uint32, err error) = kernel32.GetProcessImageFileNameW
+//
+//sys InitializeProcThreadAttributeList(lpAttributeList *ProcThreadAttributeList, dwAttributeCount uint32, dwFlags uint32, lpSize *uintptr) (err error) = kernel32.InitializeProcThreadAttributeList
+
+// void DeleteProcThreadAttributeList(
+// 	[in, out] LPPROC_THREAD_ATTRIBUTE_LIST lpAttributeList
+// );
+//
+//sys DeleteProcThreadAttributeList(lpAttributeList *ProcThreadAttributeList) = kernel32.DeleteProcThreadAttributeList
+
+// BOOL UpdateProcThreadAttribute(
+// 	[in, out]       LPPROC_THREAD_ATTRIBUTE_LIST lpAttributeList,
+// 	[in]            DWORD                        dwFlags,
+// 	[in]            DWORD_PTR                    Attribute,
+// 	[in]            PVOID                        lpValue,
+// 	[in]            SIZE_T                       cbSize,
+// 	[out, optional] PVOID                        lpPreviousValue,
+// 	[in, optional]  PSIZE_T                      lpReturnSize
+// );
+//
+//sys UpdateProcThreadAttribute(lpAttributeList *ProcThreadAttributeList, dwFlags uint32, attribute uintptr, lpValue unsafe.Pointer, cbSize uintptr, lpPreviousValue unsafe.Pointer, lpReturnSize *uintptr) (err error) = kernel32.UpdateProcThreadAttribute
+
+//sys CreateProcessAsUser(token windows.Token, appName *uint16, commandLine *uint16, procSecurity *windows.SecurityAttributes, threadSecurity *windows.SecurityAttributes, inheritHandles bool, creationFlags uint32, env *uint16, currentDir *uint16, startupInfo *windows.StartupInfo, outProcInfo *windows.ProcessInformation) (err error) = advapi32.CreateProcessAsUserW

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/winapi/winapi.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/winapi/winapi.go
@@ -2,4 +2,4 @@
 // be thought of as an extension to golang.org/x/sys/windows.
 package winapi
 
-//go:generate go run ..\..\mksyscall_windows.go -output zsyscall_windows.go system.go net.go path.go thread.go iocp.go jobobject.go logon.go memory.go process.go processor.go devices.go filesystem.go errors.go
+//go:generate go run ..\..\mksyscall_windows.go -output zsyscall_windows.go console.go system.go net.go path.go thread.go iocp.go jobobject.go logon.go memory.go process.go processor.go devices.go filesystem.go errors.go

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/winapi/zsyscall_windows.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/winapi/zsyscall_windows.go
@@ -260,7 +260,7 @@ func LocalFree(ptr uintptr) {
 	return
 }
 
-func InitializeProcThreadAttributeList(lpAttributeList *ProcThreadAttributeList, dwAttributeCount uint32, dwFlags uint32, lpSize *uintptr) (err error) {
+func initializeProcThreadAttributeList(lpAttributeList *ProcThreadAttributeList, dwAttributeCount uint32, dwFlags uint32, lpSize *uintptr) (err error) {
 	r1, _, e1 := syscall.Syscall6(procInitializeProcThreadAttributeList.Addr(), 4, uintptr(unsafe.Pointer(lpAttributeList)), uintptr(dwAttributeCount), uintptr(dwFlags), uintptr(unsafe.Pointer(lpSize)), 0, 0)
 	if r1 == 0 {
 		if e1 != 0 {


### PR DESCRIPTION
This change adds a conpty package (and necessary bindings) that houses go friendly wrappers around
the Pseudo Console API in Windows. This will be used to support tty scenarios for Host Process containers.

There's not many tests I can add here as you need to hook this up to a running
process, where that work is coming soon. I've included a video of this working below using the 
new process execution package I've been working on. 

https://user-images.githubusercontent.com/36526702/141923467-0dda59db-1480-4144-bf16-527f80c20838.mp4


Code for the demo for a sneak peak at the API:
```go
package main

import (
	"context"
	"fmt"
	"io"
	"log"
	"os"
	"syscall"

	"github.com/Microsoft/hcsshim/internal/conpty"
	"github.com/Microsoft/hcsshim/internal/exec"
	"github.com/Microsoft/hcsshim/internal/jobobject"
	"github.com/containerd/console"
)

type rawConReader struct {
	f *os.File
}

func (r rawConReader) Read(b []byte) (int, error) {
	n, err := syscall.Read(syscall.Handle(r.f.Fd()), b)
	if n == 0 && len(b) != 0 && err == nil {
		// A zero-byte read on a console indicates that the user wrote Ctrl-Z.
		b[0] = 26
		return 1, nil
	}
	return n, err
}

func main() {
	cpty, err := conpty.New(80, 20, 0)
	if err != nil {
		log.Fatal(err)
	}
	defer cpty.Close()

	job, err := jobobject.Create(context.Background(), &jobobject.Options{Name: "test"})
	if err != nil {
		log.Fatal(err)
	}
	defer job.Close()

	e, err := exec.New(
		`C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe`,
		"powershell",
		exec.WithJobObject(job),
		exec.WithConPty(cpty),
		exec.WithDir("C:\\"),
		exec.WithEnv(os.Environ()),
	)
	if err != nil {
		log.Fatal(err)
	}

	err = e.Start()
	if err != nil {
		log.Fatalf("failed to start process: %v", err)
	}

	var osStdin io.Reader = os.Stdin
	con, err := console.ConsoleFromFile(os.Stdin)
	if err == nil {
		err = con.SetRaw()
		if err != nil {
			log.Fatal(err)
		}
		defer func() {
			_ = con.Reset()
		}()
		// Console reads return EOF whenever the user presses Ctrl-Z.
		// Wrap the reads to translate these EOFs back.
		osStdin = rawConReader{os.Stdin}
	}

	go func() {
		_, _ = io.Copy(os.Stdout, cpty.OutPipe())
	}()

	go func() {
		_, _ = io.Copy(cpty.InPipe(), osStdin)
	}()

	err = e.Wait()
	if err != nil {
		log.Fatalf("error waiting for process: %v", err)
	}
	fmt.Printf("exit code was: %d\n", e.ExitCode())
}
```









