### PR TITLE
Fix ReadExt4SuperBlock function

### DIFF
--- a/ext4/tar2ext4/tar2ext4.go
+++ b/ext4/tar2ext4/tar2ext4.go
@@ -272,6 +272,10 @@ func ReadExt4SuperBlock(vhdPath string) (*format.SuperBlock, error) {
 	if err := binary.Read(vhd, binary.LittleEndian, &sb); err != nil {
 		return nil, err
 	}
+	// Make sure the magic bytes are correct.
+	if sb.Magic != format.SuperBlockMagic {
+		return nil, fmt.Errorf("not an ext4 file system")
+	}
 	return &sb, nil
 }
 

--- a/ext4/tar2ext4/tar2ext4.go
+++ b/ext4/tar2ext4/tar2ext4.go
@@ -274,7 +274,7 @@ func ReadExt4SuperBlock(vhdPath string) (*format.SuperBlock, error) {
 	}
 	// Make sure the magic bytes are correct.
 	if sb.Magic != format.SuperBlockMagic {
-		return nil, fmt.Errorf("not an ext4 file system")
+		return nil, errors.New("not an ext4 file system")
 	}
 	return &sb, nil
 }

--- a/test/vendor/github.com/Microsoft/hcsshim/ext4/tar2ext4/tar2ext4.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/ext4/tar2ext4/tar2ext4.go
@@ -272,6 +272,10 @@ func ReadExt4SuperBlock(vhdPath string) (*format.SuperBlock, error) {
 	if err := binary.Read(vhd, binary.LittleEndian, &sb); err != nil {
 		return nil, err
 	}
+	// Make sure the magic bytes are correct.
+	if sb.Magic != format.SuperBlockMagic {
+		return nil, fmt.Errorf("not an ext4 file system")
+	}
 	return &sb, nil
 }
 

--- a/test/vendor/github.com/Microsoft/hcsshim/ext4/tar2ext4/tar2ext4.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/ext4/tar2ext4/tar2ext4.go
@@ -274,7 +274,7 @@ func ReadExt4SuperBlock(vhdPath string) (*format.SuperBlock, error) {
 	}
 	// Make sure the magic bytes are correct.
 	if sb.Magic != format.SuperBlockMagic {
-		return nil, fmt.Errorf("not an ext4 file system")
+		return nil, errors.New("not an ext4 file system")
 	}
 	return &sb, nil
 }


### PR DESCRIPTION
Previously the function would read bytes from a given file
and convert them into internal ext4 super block object,
without checking that the read bytes are actually ext4
super block.
Fix the behavior by checking ext4 super block magic.

Signed-off-by: Maksim An <maksiman@microsoft.com>