### PR TITLE
Add function to write hash device

### DIFF
--- a/cmd/dmverity-vhd/main.go
+++ b/cmd/dmverity-vhd/main.go
@@ -118,7 +118,7 @@ var createVHDCommand = cli.Command{
 			Usage: "Optional: custom registry password",
 		},
 		cli.BoolFlag{
-			Name:  hashDeviceVhdFlag,
+			Name:  hashDeviceVhdFlag + ",hdv",
 			Usage: "Optional: save hash-device as a VHD",
 		},
 	},

--- a/ext4/tar2ext4/tar2ext4.go
+++ b/ext4/tar2ext4/tar2ext4.go
@@ -3,17 +3,14 @@ package tar2ext4
 import (
 	"archive/tar"
 	"bufio"
-	"bytes"
 	"encoding/binary"
 	"fmt"
+	"github.com/pkg/errors"
 	"io"
 	"io/ioutil"
 	"os"
 	"path"
 	"strings"
-	"unsafe"
-
-	"github.com/pkg/errors"
 
 	"github.com/Microsoft/hcsshim/ext4/dmverity"
 	"github.com/Microsoft/hcsshim/ext4/internal/compactext4"
@@ -194,50 +191,13 @@ func Convert(r io.Reader, w io.ReadWriteSeeker, options ...Option) error {
 	}
 
 	if p.appendDMVerity {
-		// Rewind the stream for dm-verity processing
-		if _, err := w.Seek(0, io.SeekStart); err != nil {
-			return err
-		}
-
-		merkleTree, err := dmverity.MerkleTree(bufio.NewReaderSize(w, dmverity.MerkleTreeBufioSize))
-		if err != nil {
-			return errors.Wrap(err, "failed to build merkle tree")
-		}
-
-		// Write dm-verity super-block and then the merkle tree after the end of the
-		// ext4 filesystem
-		ext4size, err := w.Seek(0, io.SeekEnd)
-		if err != nil {
-			return err
-		}
-
-		superBlock := dmverity.NewDMVeritySuperblock(uint64(ext4size))
-		if err = binary.Write(w, binary.LittleEndian, superBlock); err != nil {
-			return err
-		}
-
-		// pad the super-block
-		sbsize := int(unsafe.Sizeof(*superBlock))
-		padding := bytes.Repeat([]byte{0}, ext4BlockSize-(sbsize%ext4BlockSize))
-		if _, err = w.Write(padding); err != nil {
-			return err
-		}
-
-		// write the tree
-		if _, err = w.Write(merkleTree); err != nil {
+		if err := dmverity.ComputeAndWriteHashDevice(w, w); err != nil {
 			return err
 		}
 	}
 
 	if p.appendVhdFooter {
-		size, err := w.Seek(0, io.SeekEnd)
-		if err != nil {
-			return err
-		}
-		err = binary.Write(w, binary.BigEndian, makeFixedVHDFooter(size))
-		if err != nil {
-			return err
-		}
+		return ConvertToVhd(w)
 	}
 	return nil
 }
@@ -311,4 +271,16 @@ func ConvertAndComputeRootDigest(r io.Reader) (string, error) {
 
 	hash := dmverity.RootHash(tree)
 	return fmt.Sprintf("%x", hash), nil
+}
+
+// ConvertToVhd converts given io.ReadWriteSeeker to VHD, by appending the VHD footer with a fixed size.
+func ConvertToVhd(w io.ReadWriteSeeker) error {
+	size, err := w.Seek(0, io.SeekEnd)
+	if err != nil {
+		return err
+	}
+	if err = binary.Write(w, binary.BigEndian, makeFixedVHDFooter(size)); err != nil {
+		return nil
+	}
+	return nil
 }

--- a/ext4/tar2ext4/tar2ext4.go
+++ b/ext4/tar2ext4/tar2ext4.go
@@ -273,14 +273,11 @@ func ConvertAndComputeRootDigest(r io.Reader) (string, error) {
 	return fmt.Sprintf("%x", hash), nil
 }
 
-// ConvertToVhd converts given io.ReadWriteSeeker to VHD, by appending the VHD footer with a fixed size.
-func ConvertToVhd(w io.ReadWriteSeeker) error {
+// ConvertToVhd converts given io.WriteSeeker to VHD, by appending the VHD footer with a fixed size.
+func ConvertToVhd(w io.WriteSeeker) error {
 	size, err := w.Seek(0, io.SeekEnd)
 	if err != nil {
 		return err
 	}
-	if err = binary.Write(w, binary.BigEndian, makeFixedVHDFooter(size)); err != nil {
-		return nil
-	}
-	return nil
+	return binary.Write(w, binary.BigEndian, makeFixedVHDFooter(size))
 }

--- a/test/vendor/github.com/Microsoft/hcsshim/ext4/tar2ext4/tar2ext4.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/ext4/tar2ext4/tar2ext4.go
@@ -3,17 +3,14 @@ package tar2ext4
 import (
 	"archive/tar"
 	"bufio"
-	"bytes"
 	"encoding/binary"
 	"fmt"
+	"github.com/pkg/errors"
 	"io"
 	"io/ioutil"
 	"os"
 	"path"
 	"strings"
-	"unsafe"
-
-	"github.com/pkg/errors"
 
 	"github.com/Microsoft/hcsshim/ext4/dmverity"
 	"github.com/Microsoft/hcsshim/ext4/internal/compactext4"
@@ -194,50 +191,13 @@ func Convert(r io.Reader, w io.ReadWriteSeeker, options ...Option) error {
 	}
 
 	if p.appendDMVerity {
-		// Rewind the stream for dm-verity processing
-		if _, err := w.Seek(0, io.SeekStart); err != nil {
-			return err
-		}
-
-		merkleTree, err := dmverity.MerkleTree(bufio.NewReaderSize(w, dmverity.MerkleTreeBufioSize))
-		if err != nil {
-			return errors.Wrap(err, "failed to build merkle tree")
-		}
-
-		// Write dm-verity super-block and then the merkle tree after the end of the
-		// ext4 filesystem
-		ext4size, err := w.Seek(0, io.SeekEnd)
-		if err != nil {
-			return err
-		}
-
-		superBlock := dmverity.NewDMVeritySuperblock(uint64(ext4size))
-		if err = binary.Write(w, binary.LittleEndian, superBlock); err != nil {
-			return err
-		}
-
-		// pad the super-block
-		sbsize := int(unsafe.Sizeof(*superBlock))
-		padding := bytes.Repeat([]byte{0}, ext4BlockSize-(sbsize%ext4BlockSize))
-		if _, err = w.Write(padding); err != nil {
-			return err
-		}
-
-		// write the tree
-		if _, err = w.Write(merkleTree); err != nil {
+		if err := dmverity.ComputeAndWriteHashDevice(w, w); err != nil {
 			return err
 		}
 	}
 
 	if p.appendVhdFooter {
-		size, err := w.Seek(0, io.SeekEnd)
-		if err != nil {
-			return err
-		}
-		err = binary.Write(w, binary.BigEndian, makeFixedVHDFooter(size))
-		if err != nil {
-			return err
-		}
+		return ConvertToVhd(w)
 	}
 	return nil
 }
@@ -311,4 +271,16 @@ func ConvertAndComputeRootDigest(r io.Reader) (string, error) {
 
 	hash := dmverity.RootHash(tree)
 	return fmt.Sprintf("%x", hash), nil
+}
+
+// ConvertToVhd converts given io.ReadWriteSeeker to VHD, by appending the VHD footer with a fixed size.
+func ConvertToVhd(w io.ReadWriteSeeker) error {
+	size, err := w.Seek(0, io.SeekEnd)
+	if err != nil {
+		return err
+	}
+	if err = binary.Write(w, binary.BigEndian, makeFixedVHDFooter(size)); err != nil {
+		return nil
+	}
+	return nil
 }

--- a/test/vendor/github.com/Microsoft/hcsshim/ext4/tar2ext4/tar2ext4.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/ext4/tar2ext4/tar2ext4.go
@@ -273,14 +273,11 @@ func ConvertAndComputeRootDigest(r io.Reader) (string, error) {
 	return fmt.Sprintf("%x", hash), nil
 }
 
-// ConvertToVhd converts given io.ReadWriteSeeker to VHD, by appending the VHD footer with a fixed size.
-func ConvertToVhd(w io.ReadWriteSeeker) error {
+// ConvertToVhd converts given io.WriteSeeker to VHD, by appending the VHD footer with a fixed size.
+func ConvertToVhd(w io.WriteSeeker) error {
 	size, err := w.Seek(0, io.SeekEnd)
 	if err != nil {
 		return err
 	}
-	if err = binary.Write(w, binary.BigEndian, makeFixedVHDFooter(size)); err != nil {
-		return nil
-	}
-	return nil
+	return binary.Write(w, binary.BigEndian, makeFixedVHDFooter(size))
 }


### PR DESCRIPTION
Split hash-device computation and writing into a separate function.
This allows to store hash device in a separate file, which (e.g.) can
be converted to VHDs and exposed inside VMs as separate block devices.

Signed-off-by: Maksim An <maksiman@microsoft.com>