### PR TITLE
Revendor in /test and remove dead code

### DIFF
--- a/ext4/tar2ext4/tar2ext4.go
+++ b/ext4/tar2ext4/tar2ext4.go
@@ -64,7 +64,6 @@ func MaximumDiskSize(size int64) Option {
 const (
 	whiteoutPrefix = ".wh."
 	opaqueWhiteout = ".wh..wh..opq"
-	ext4BlockSize  = compactext4.BlockSize
 )
 
 // ConvertTarToExt4 writes a compact ext4 file system image that contains the files in the

--- a/test/vendor/github.com/Microsoft/hcsshim/ext4/tar2ext4/tar2ext4.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/ext4/tar2ext4/tar2ext4.go
@@ -64,7 +64,6 @@ func MaximumDiskSize(size int64) Option {
 const (
 	whiteoutPrefix = ".wh."
 	opaqueWhiteout = ".wh..wh..opq"
-	ext4BlockSize  = compactext4.BlockSize
 )
 
 // ConvertTarToExt4 writes a compact ext4 file system image that contains the files in the

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/winapi/process.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/winapi/process.go
@@ -26,6 +26,9 @@ type StartupInfoEx struct {
 	// This is a recreation of the same binding from the stdlib. The x/sys/windows variant for whatever reason
 	// doesn't work when updating the list for the pseudo console attribute. It has the process immediately exit
 	// with exit code 0xc0000142 shortly after start.
+	//
+	// TODO (dcantah): Swap to the x/sys/windows definitions after https://go-review.googlesource.com/c/sys/+/371276/1/windows/exec_windows.go#153
+	// gets in.
 	windows.StartupInfo
 	ProcThreadAttributeList *ProcThreadAttributeList
 }


### PR DESCRIPTION
Somehow after the last two check-in's the CI (specifically our linter)
started whining about ext4BlockSize being dead code. The last PR
to master our verify-test-vendor step also somehow didn't catch that
/internal/winapi/process.go was updated and needed to be pulled in, but it 
did after check-in This change fixes both of those issues.

Signed-off-by: Daniel Canter <dcanter@microsoft.com>