### PR TITLE
Swap to the internal/exec pkg for host process containers

### DIFF
--- a/internal/exec/exec.go
+++ b/internal/exec/exec.go
@@ -297,18 +297,27 @@ func (e *Exec) Kill() error {
 
 // Stdin returns the pipe standard input is hooked up to. This will be closed once Wait returns.
 func (e *Exec) Stdin() *os.File {
+	if e.cpty != nil {
+		return e.cpty.InPipe()
+	}
 	return e.stdioPipesOurSide[0]
 }
 
 // Stdout returns the pipe standard output is hooked up to. It's expected that the client will continuously drain the pipe if standard output is requested.
 // The pipe will be closed once Wait returns.
 func (e *Exec) Stdout() *os.File {
+	if e.cpty != nil {
+		return e.cpty.OutPipe()
+	}
 	return e.stdioPipesOurSide[1]
 }
 
 // Stderr returns the pipe standard error is hooked up to. It's expected that the client will continuously drain the pipe if standard output is requested.
 // This will be closed once Wait returns.
 func (e *Exec) Stderr() *os.File {
+	if e.cpty != nil {
+		return e.cpty.OutPipe()
+	}
 	return e.stdioPipesOurSide[2]
 }
 
@@ -318,7 +327,7 @@ func (e *Exec) setupStdio() error {
 	// If the client requested a pseudo console then there's nothing we need to do pipe wise, as the process inherits the other end of the pty's
 	// pipes.
 	if e.cpty != nil && stdioRequested {
-		return errors.New("can't setup both stdio pipes and a pseudo console")
+		return nil
 	}
 
 	// Go 1.16's pipe handles (from os.Pipe()) aren't inheritable, so mark them explicitly as such if any stdio handles are

--- a/internal/exec/exec.go
+++ b/internal/exec/exec.go
@@ -73,7 +73,6 @@ func New(path, cmdLine string, opts ...ExecOpts) (*Exec, error) {
 	if err := e.setupStdio(); err != nil {
 		return nil, err
 	}
-
 	return e, nil
 }
 

--- a/internal/jobcontainers/jobcontainer.go
+++ b/internal/jobcontainers/jobcontainer.go
@@ -4,17 +4,16 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
 	"sync"
-	"syscall"
 	"time"
 	"unsafe"
 
 	"github.com/Microsoft/go-winio/pkg/guid"
 	"github.com/Microsoft/hcsshim/internal/cow"
+	"github.com/Microsoft/hcsshim/internal/exec"
 	"github.com/Microsoft/hcsshim/internal/hcs"
 	"github.com/Microsoft/hcsshim/internal/hcs/schema1"
 	hcsschema "github.com/Microsoft/hcsshim/internal/hcs/schema2"
@@ -249,43 +248,32 @@ func (c *JobContainer) CreateProcess(ctx context.Context, config interface{}) (_
 		return nil, errors.Wrap(err, "failed to set PATHEXT")
 	}
 
-	cmd := &exec.Cmd{
-		Env:  env,
-		Dir:  workDir,
-		Path: absPath,
-		SysProcAttr: &syscall.SysProcAttr{
-			// CREATE_BREAKAWAY_FROM_JOB to make sure that we're not inheriting the job object (and by extension its limits)
-			// from whatever process is going to launch the container.
-			CreationFlags: windows.CREATE_NEW_PROCESS_GROUP | windows.CREATE_BREAKAWAY_FROM_JOB,
-			Token:         syscall.Token(token),
-			CmdLine:       commandLine,
-		},
+	cmd, err := exec.New(
+		absPath,
+		commandLine,
+		exec.WithDir(workDir),
+		exec.WithEnv(env),
+		exec.WithToken(token),
+		exec.WithJobObject(c.job),
+		exec.WithProcessFlags(windows.CREATE_BREAKAWAY_FROM_JOB),
+		exec.WithStdio(conf.CreateStdOutPipe, conf.CreateStdErrPipe, conf.CreateStdInPipe),
+	)
+	if err != nil {
+		return nil, err
 	}
 	process := newProcess(cmd)
 
 	// Create process pipes if asked for.
 	if conf.CreateStdInPipe {
-		stdin, err := process.cmd.StdinPipe()
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to create stdin pipe")
-		}
-		process.stdin = stdin
+		process.stdin = process.cmd.Stdin()
 	}
 
 	if conf.CreateStdOutPipe {
-		stdout, err := process.cmd.StdoutPipe()
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to create stdout pipe")
-		}
-		process.stdout = stdout
+		process.stdout = process.cmd.Stdout()
 	}
 
 	if conf.CreateStdErrPipe {
-		stderr, err := process.cmd.StderrPipe()
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to create stderr pipe")
-		}
-		process.stderr = stderr
+		process.stderr = process.cmd.Stderr()
 	}
 
 	defer func() {
@@ -296,10 +284,6 @@ func (c *JobContainer) CreateProcess(ctx context.Context, config interface{}) (_
 
 	if err = process.Start(); err != nil {
 		return nil, errors.Wrap(err, "failed to start host process")
-	}
-
-	if err = c.job.Assign(uint32(process.Pid())); err != nil {
-		return nil, errors.Wrap(err, "failed to assign process to job object")
 	}
 
 	// Assign the first process made as the init process of the container.


### PR DESCRIPTION
This change swaps to using the new internal/exec package for host process containers to make use of the pseudo console functionality and ability to launch a process in a job object at creation time instead of assigning shortly after. This PR additionally adds in the bits needed to get tty support for host process up and running.  See below for it in action:


https://user-images.githubusercontent.com/36526702/146683421-ae678d98-97d2-45ae-8450-ed4e076dfc03.mp4

