### PR TITLE
Wait for waitInitExit() to return

### DIFF
--- a/cmd/containerd-shim-runhcs-v1/pod.go
+++ b/cmd/containerd-shim-runhcs-v1/pod.go
@@ -380,8 +380,9 @@ func (p *pod) KillTask(ctx context.Context, tid, eid string, signal uint32, all 
 				return wt.KillExec(ctx, eid, signal, all)
 			})
 
-			// iterate all
-			return false
+			// Iterate all. Returning false stops the iteration. See:
+			// https://pkg.go.dev/sync#Map.Range
+			return true
 		})
 	}
 	eg.Go(func() error {

--- a/cmd/containerd-shim-runhcs-v1/task_hcs.go
+++ b/cmd/containerd-shim-runhcs-v1/task_hcs.go
@@ -536,8 +536,9 @@ func (ht *hcsTask) KillExec(ctx context.Context, eid string, signal uint32, all 
 				}).Warn("failed to kill exec in task")
 			}
 
-			// iterate all
-			return false
+			// Iterate all. Returning false stops the iteration. See:
+			// https://pkg.go.dev/sync#Map.Range
+			return true
 		})
 	}
 	if signal == 0x9 && eid == "" && ht.host != nil {
@@ -578,8 +579,9 @@ func (ht *hcsTask) DeleteExec(ctx context.Context, eid string) (int, uint32, tim
 				ex.ForceExit(ctx, 1)
 			}
 
-			// iterate next
-			return false
+			// Iterate all. Returning false stops the iteration. See:
+			// https://pkg.go.dev/sync#Map.Range
+			return true
 		})
 	}
 	switch state := e.State(); state {
@@ -617,8 +619,9 @@ func (ht *hcsTask) Pids(ctx context.Context) ([]runhcsopts.ProcessDetails, error
 		ex := value.(shimExec)
 		pidMap[ex.Pid()] = ex.ID()
 
-		// Iterate all
-		return false
+		// Iterate all. Returning false stops the iteration. See:
+		// https://pkg.go.dev/sync#Map.Range
+		return true
 	})
 	pidMap[ht.init.Pid()] = ht.init.ID()
 
@@ -699,8 +702,9 @@ func (ht *hcsTask) waitForHostExit() {
 		ex := value.(shimExec)
 		ex.ForceExit(ctx, 1)
 
-		// iterate all
-		return false
+		// Iterate all. Returning false stops the iteration. See:
+		// https://pkg.go.dev/sync#Map.Range
+		return true
 	})
 	ht.init.ForceExit(ctx, 1)
 	ht.closeHost(ctx)

--- a/cmd/containerd-shim-runhcs-v1/task_hcs_test.go
+++ b/cmd/containerd-shim-runhcs-v1/task_hcs_test.go
@@ -161,6 +161,8 @@ func Test_hcsTask_DeleteExec_InitExecID_CreatedState_Success(t *testing.T) {
 	// remove the 2nd exec so we just check without it.
 	lt.execs.Delete(second.id)
 
+	// Simulate waitInitExit() closing the host
+	close(lt.closed)
 	// try to delete the init exec
 	pid, status, at, err := lt.DeleteExec(context.TODO(), "")
 
@@ -178,6 +180,8 @@ func Test_hcsTask_DeleteExec_InitExecID_RunningState_Error(t *testing.T) {
 	// Start the init exec
 	_ = init.Start(context.TODO())
 
+	// Simulate waitInitExit() closing the host
+	close(lt.closed)
 	// try to delete the init exec
 	pid, status, at, err := lt.DeleteExec(context.TODO(), "")
 
@@ -192,6 +196,8 @@ func Test_hcsTask_DeleteExec_InitExecID_ExitedState_Success(t *testing.T) {
 
 	_ = init.Kill(context.TODO(), 0xf)
 
+	// Simulate waitInitExit() closing the host
+	close(lt.closed)
 	// try to delete the init exec
 	pid, status, at, err := lt.DeleteExec(context.TODO(), "")
 
@@ -207,6 +213,8 @@ func Test_hcsTask_DeleteExec_InitExecID_2ndExec_CreatedState_Error(t *testing.T)
 	// start the init exec (required to have 2nd exec)
 	_ = init.Start(context.TODO())
 
+	// Simulate waitInitExit() closing the host
+	close(lt.closed)
 	// try to delete the init exec
 	pid, status, at, err := lt.DeleteExec(context.TODO(), "")
 
@@ -226,6 +234,8 @@ func Test_hcsTask_DeleteExec_InitExecID_2ndExec_RunningState_Error(t *testing.T)
 	// put the 2nd exec into the running state
 	_ = second.Start(context.TODO())
 
+	// Simulate waitInitExit() closing the host
+	close(lt.closed)
 	// try to delete the init exec
 	pid, status, at, err := lt.DeleteExec(context.TODO(), "")
 
@@ -244,6 +254,8 @@ func Test_hcsTask_DeleteExec_InitExecID_2ndExec_ExitedState_Success(t *testing.T
 	// put the 2nd exec into the exited state
 	_ = second.Kill(context.TODO(), 0xf)
 
+	// Simulate waitInitExit() closing the host
+	close(lt.closed)
 	// try to delete the init exec
 	pid, status, at, err := lt.DeleteExec(context.TODO(), "")
 


### PR DESCRIPTION
This change gives waitInitExit() a chance to cleanup resource when DeleteExec() is called, before returning.

TL;DR

This should fix situations where the shim exits before releasing container resources.

TS;NM

I am not sure if this is a proper fix, or if it is just a band-aid over something that should be fixed elsewhere, but it did fix the ```TestRestartMonitor``` test in ```containerd```. This issue also seems to cause flakiness in the ```TestContainerdRestart```` test due to the fact that lingering sandboxes are picked up by the test and fails.

The restart monitor in ```containerd``` watches for situations where tasks end, and attempts to restart them. The ```TestRestartMonitor``` test will spawn a task, then send a ```Kill()``` signal to that task and wait for the restart monitor to respawn it.

The problem is that after the task is killed, it is properly marked as ```terminated```, but the shim exits before ```waitInitExit()``` returns, so it doesn't have a chance to cleanup container resources (unprepare layers, etc). The test issues a ```DeleteTask()```, which, due to the fact that the task has been marked as ```terminated``` does not fail any precondition and proceeds. Once the task is deleted, the shim exits (from my understanding), which if the ```waitInitExit()``` goroutine has not finished cleaning up container resources, will mean that lingering layers will remain mounted and in use:

![Screenshot from 2021-12-08 20-58-42](https://user-images.githubusercontent.com/903160/146798239-08eb9c8d-ffc9-487a-8cdd-e7bb248e78f3.png)

This gives the shim a chance to cleanup resources before deleting the task.

Signed-off-by: Gabriel Adrian Samfira <gsamfira@cloudbasesolutions.com>