### PR TITLE
HCS fixes for HclEnabled and guest state file type.

### DIFF
--- a/internal/hcs/schema2/isolation_settings.go
+++ b/internal/hcs/schema2/isolation_settings.go
@@ -17,4 +17,5 @@ type IsolationSettings struct {
 	DebugPort int64  `json:"DebugPort,omitempty"`
 	// Optional data passed by host on isolated virtual machine start
 	LaunchData string `json:"LaunchData,omitempty"`
+	HclEnabled bool   `json:"HclEnabled,omitempty"`
 }

--- a/internal/uvm/create_lcow.go
+++ b/internal/uvm/create_lcow.go
@@ -257,14 +257,14 @@ Example JSON document produced once the hcsschema.ComputeSytem returned by makeL
         },
         "GuestState": {
             "GuestStateFilePath": "d:\\ken\\aug27\\gcsinitnew.vmgs",
-            "GuestStateFileType": "FileMode",
+            "GuestStateFileType": "BlockStorage",
 			"ForceTransientState": true
         },
         "SecuritySettings": {
             "Isolation": {
                 "IsolationType": "SecureNestedPaging",
-
-                "LaunchData": "BukyDQANVcT5HviNDjU7z1icStE2SARnZHUwfvebd1s="
+                "LaunchData": "kBifgKNijdHjxdSUshmavrNofo2B01LiIi1cr8R4ytI=",
+                "HclEnabled": true
             }
         },
         "Version": {
@@ -381,7 +381,7 @@ func makeLCOWVMGSDoc(ctx context.Context, opts *OptionsLCOW, uvm *UtilityVM) (_ 
 
 	doc.VirtualMachine.GuestState = &hcsschema.GuestState{
 		GuestStateFilePath:  vmgsFullPath,
-		GuestStateFileType:  "FileMode",
+		GuestStateFileType:  "BlockStorage",
 		ForceTransientState: true, // tell HCS that this is just the source of the images, not ongoing state
 	}
 
@@ -426,6 +426,7 @@ func makeLCOWSecurityDoc(ctx context.Context, opts *OptionsLCOW, uvm *UtilityVM)
 		Isolation: &hcsschema.IsolationSettings{
 			IsolationType: "SecureNestedPaging",
 			LaunchData:    securityPolicyHash,
+			HclEnabled:    true,
 		},
 	}
 
@@ -716,7 +717,6 @@ func CreateLCOW(ctx context.Context, opts *OptionsLCOW) (_ *UtilityVM, err error
 	}
 
 	uvm := &UtilityVM{
-
 		id:                      opts.ID,
 		owner:                   opts.Owner,
 		operatingSystem:         "linux",

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/hcs/schema2/isolation_settings.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/hcs/schema2/isolation_settings.go
@@ -17,4 +17,5 @@ type IsolationSettings struct {
 	DebugPort int64  `json:"DebugPort,omitempty"`
 	// Optional data passed by host on isolated virtual machine start
 	LaunchData string `json:"LaunchData,omitempty"`
+	HclEnabled bool   `json:"HclEnabled,omitempty"`
 }

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/uvm/create_lcow.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/uvm/create_lcow.go
@@ -426,6 +426,7 @@ func makeLCOWSecurityDoc(ctx context.Context, opts *OptionsLCOW, uvm *UtilityVM)
 		Isolation: &hcsschema.IsolationSettings{
 			IsolationType: "SecureNestedPaging",
 			LaunchData:    securityPolicyHash,
+			HclEnabled:    true,
 		},
 	}
 

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/uvm/create_lcow.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/uvm/create_lcow.go
@@ -257,14 +257,14 @@ Example JSON document produced once the hcsschema.ComputeSytem returned by makeL
         },
         "GuestState": {
             "GuestStateFilePath": "d:\\ken\\aug27\\gcsinitnew.vmgs",
-            "GuestStateFileType": "FileMode",
+            "GuestStateFileType": "BlockStorage",
 			"ForceTransientState": true
         },
         "SecuritySettings": {
             "Isolation": {
                 "IsolationType": "SecureNestedPaging",
-
-                "LaunchData": "BukyDQANVcT5HviNDjU7z1icStE2SARnZHUwfvebd1s="
+                "LaunchData": "kBifgKNijdHjxdSUshmavrNofo2B01LiIi1cr8R4ytI=",
+                "HclEnabled": true
             }
         },
         "Version": {
@@ -381,7 +381,7 @@ func makeLCOWVMGSDoc(ctx context.Context, opts *OptionsLCOW, uvm *UtilityVM) (_ 
 
 	doc.VirtualMachine.GuestState = &hcsschema.GuestState{
 		GuestStateFilePath:  vmgsFullPath,
-		GuestStateFileType:  "FileMode",
+		GuestStateFileType:  "BlockStorage",
 		ForceTransientState: true, // tell HCS that this is just the source of the images, not ongoing state
 	}
 
@@ -717,7 +717,6 @@ func CreateLCOW(ctx context.Context, opts *OptionsLCOW) (_ *UtilityVM, err error
 	}
 
 	uvm := &UtilityVM{
-
 		id:                      opts.ID,
 		owner:                   opts.Owner,
 		operatingSystem:         "linux",


### PR DESCRIPTION
These are both required due to evolution of the hcs/vmms layers.
This PR replaces https://github.com/microsoft/hcsshim/pull/1232 (GuestStateFileType=BlockStorage) which had trouble with signing and so passing the CI. In addition it sets the HclEnabled flag which is required or the vmgs file is corrupted by the vmms leading to the UVM only starting exactly once.


Signed-off-by: Ken Gordon <Ken.Gordon@microsoft.com>