### PR TITLE
Rename conpty.New to conpty.Create

### DIFF
--- a/internal/conpty/conpty.go
+++ b/internal/conpty/conpty.go
@@ -16,7 +16,7 @@ var (
 	errNotInitialized = errors.New("pseudo console hasn't been initialized")
 )
 
-// ConPTY is a wrapper around a Windows PseudoConsole handle. Create a new instance by calling `New()`.
+// ConPTY is a wrapper around a Windows PseudoConsole handle. Create a new instance by calling `Create()`.
 type ConPTY struct {
 	// handleLock guards hpc
 	handleLock sync.RWMutex
@@ -27,8 +27,8 @@ type ConPTY struct {
 	outPipe *os.File
 }
 
-// New returns a new `ConPTY` object. This object is not ready for IO until `UpdateProcThreadAttribute` is called and a process has been started.
-func New(width, height int16, flags uint32) (*ConPTY, error) {
+// Create returns a new `ConPTY` object. This object is not ready for IO until `UpdateProcThreadAttribute` is called and a process has been started.
+func Create(width, height int16, flags uint32) (*ConPTY, error) {
 	// First we need to make both ends of the conpty's pipes, two to get passed into a process to use as input/output, and two for us to keep to
 	// make use of this data.
 	ptyIn, inPipeOurs, err := os.Pipe()

--- a/internal/exec/exec_test.go
+++ b/internal/exec/exec_test.go
@@ -166,7 +166,7 @@ func TestExecWithJob(t *testing.T) {
 }
 
 func TestPseudoConsolePowershell(t *testing.T) {
-	cpty, err := conpty.New(80, 20, 0)
+	cpty, err := conpty.Create(80, 20, 0)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/jobcontainers/jobcontainer.go
+++ b/internal/jobcontainers/jobcontainer.go
@@ -247,7 +247,7 @@ func (c *JobContainer) CreateProcess(ctx context.Context, config interface{}) (_
 
 	var cpty *conpty.ConPTY
 	if conf.EmulateConsole {
-		cpty, err = conpty.New(80, 20, 0)
+		cpty, err = conpty.Create(80, 20, 0)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This change renames conpty.New, the method used to create a new ConPTY object, to Create instead. Mostly preference and to stay in line with what we'd named the method for creating a job object. The windows API used to create the pty is 'CreatePseudoConsole' so to me it makes more sense and would be more familiar to folks if this was ever moved out of /internal for outside use. 