### PR TITLE
Rework TestPseudoConsolePowershell

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,6 @@
+run:
+  timeout: 8m
+
 linters:
   enable:
     - stylecheck

--- a/test/vendor/github.com/Microsoft/hcsshim/.golangci.yml
+++ b/test/vendor/github.com/Microsoft/hcsshim/.golangci.yml
@@ -1,3 +1,6 @@
+run:
+  timeout: 8m
+
 linters:
   enable:
     - stylecheck


### PR DESCRIPTION
Before, this test used to write something to the pty and then see if we
could read the same thing shortly afterwards. Really all we wanna test here
is just that we can write things in general, so the same thing that
TestExecStdinPowershell is currently doing should suffice.

If the process exits then the 'exit' write went through so that should be
plenty for this test. This change additionally adds a timeout for waiting
for the process to exit for TestPseudoConsolePowershell as well as
TestExecStdinPowershell so we have an indicator for if the 'exit' write
didn't work.