### PR TITLE
Add new gcs hooks, add expected mounts to security policy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ clean:
 test:
 	cd $(SRCROOT) && go test -v ./internal/guest/...
 
-out/delta.tar.gz: bin/init bin/vsockexec bin/cmd/gcs bin/cmd/gcstools Makefile
+out/delta.tar.gz: bin/init bin/vsockexec bin/cmd/gcs bin/cmd/gcstools bin/cmd/hooks/wait-paths Makefile
 	@mkdir -p out
 	rm -rf rootfs
 	mkdir -p rootfs/bin/
@@ -40,6 +40,7 @@ out/delta.tar.gz: bin/init bin/vsockexec bin/cmd/gcs bin/cmd/gcstools Makefile
 	cp bin/vsockexec rootfs/bin/
 	cp bin/cmd/gcs rootfs/bin/
 	cp bin/cmd/gcstools rootfs/bin/
+	cp bin/cmd/hooks/wait-paths rootfs/bin/
 	for tool in $(GCS_TOOLS); do ln -s gcstools rootfs/bin/$$tool; done
 	git -C $(SRCROOT) rev-parse HEAD > rootfs/gcs.commit && \
 	git -C $(SRCROOT) rev-parse --abbrev-ref HEAD > rootfs/gcs.branch
@@ -60,6 +61,7 @@ out/initrd.img: $(BASE) out/delta.tar.gz $(SRCROOT)/hack/catcpio.sh
 
 -include deps/cmd/gcs.gomake
 -include deps/cmd/gcstools.gomake
+-include deps/cmd/hooks/wait-paths.gomake
 
 # Implicit rule for includes that define Go targets.
 %.gomake: $(SRCROOT)/Makefile

--- a/cmd/gcs/main.go
+++ b/cmd/gcs/main.go
@@ -14,20 +14,22 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/Microsoft/hcsshim/internal/guest/bridge"
-	"github.com/Microsoft/hcsshim/internal/guest/kmsg"
-	"github.com/Microsoft/hcsshim/internal/guest/runtime/hcsv2"
-	"github.com/Microsoft/hcsshim/internal/guest/runtime/runc"
-	"github.com/Microsoft/hcsshim/internal/guest/transport"
-	"github.com/Microsoft/hcsshim/internal/log"
-	"github.com/Microsoft/hcsshim/internal/oc"
-	"github.com/cenkalti/backoff/v4"
 	"github.com/containerd/cgroups"
 	cgroupstats "github.com/containerd/cgroups/stats/v1"
 	oci "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"go.opencensus.io/trace"
+
+	"github.com/Microsoft/hcsshim/internal/guest/bridge"
+	"github.com/Microsoft/hcsshim/internal/guest/kmsg"
+	"github.com/Microsoft/hcsshim/internal/guest/runtime/hcsv2"
+	"github.com/Microsoft/hcsshim/internal/guest/runtime/runc"
+	"github.com/Microsoft/hcsshim/internal/guest/transport"
+	"github.com/Microsoft/hcsshim/internal/guestpath"
+	"github.com/Microsoft/hcsshim/internal/log"
+	"github.com/Microsoft/hcsshim/internal/oc"
+	"github.com/cenkalti/backoff/v4"
 )
 
 func memoryLogFormat(metrics *cgroupstats.Metrics) logrus.Fields {
@@ -229,7 +231,7 @@ func main() {
 
 	log.SetScrubbing(*scrubLogs)
 
-	baseLogPath := "/run/gcs/c"
+	baseLogPath := guestpath.LCOWRootPrefixInUVM
 
 	logrus.Info("GCS started")
 

--- a/cmd/hooks/wait-paths/main.go
+++ b/cmd/hooks/wait-paths/main.go
@@ -1,0 +1,72 @@
+// +build linux
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/urfave/cli"
+)
+
+const (
+	pathsFlag   = "paths"
+	timeoutFlag = "timeout"
+)
+
+// This is a hook that waits for a specific path to appear.
+// The hook has required list of comma-separated paths and a default timeout in seconds.
+
+func main() {
+	app := cli.NewApp()
+	app.Name = "wait-paths"
+	app.Usage = "Provide a list paths and an optional timeout"
+	app.Flags = []cli.Flag{
+		cli.StringFlag{
+			Name:     pathsFlag + ",p",
+			Usage:    "Comma-separated list of paths that should become available",
+			Required: true,
+		},
+		cli.IntFlag{
+			Name:  timeoutFlag + ",t",
+			Usage: "Timeout in seconds",
+			Value: 30,
+		},
+	}
+	app.Action = run
+	if err := app.Run(os.Args); err != nil {
+		logrus.Fatalf("%s\n", err)
+	}
+	os.Exit(0)
+}
+
+func run(cCtx *cli.Context) error {
+	timeout := cCtx.GlobalInt(timeoutFlag)
+	paths := strings.Split(cCtx.GlobalString(pathsFlag), ",")
+
+	waitCtx, cancel := context.WithTimeout(context.Background(), time.Duration(timeout)*time.Second)
+	defer cancel()
+
+	for _, path := range paths {
+		for {
+			if _, err := os.Stat(path); err != nil {
+				if !os.IsNotExist(err) {
+					return err
+				}
+				select {
+				case <-waitCtx.Done():
+					return fmt.Errorf("timeout while waiting for path %q to appear", path)
+				default:
+					time.Sleep(time.Millisecond * 10)
+					continue
+				}
+			}
+			break
+		}
+	}
+	return nil
+}

--- a/internal/devices/drivers.go
+++ b/internal/devices/drivers.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 
 	"github.com/Microsoft/hcsshim/internal/cmd"
+	"github.com/Microsoft/hcsshim/internal/guestpath"
 	"github.com/Microsoft/hcsshim/internal/log"
 	"github.com/Microsoft/hcsshim/internal/resources"
 	"github.com/Microsoft/hcsshim/internal/uvm"
@@ -45,7 +46,7 @@ func InstallKernelDriver(ctx context.Context, vm *uvm.UtilityVM, driver string) 
 		}
 		return closer, execPnPInstallDriver(ctx, vm, uvmPath)
 	}
-	uvmPathForShare := fmt.Sprintf(uvm.LCOWGlobalMountPrefix, vm.UVMMountCounter())
+	uvmPathForShare := fmt.Sprintf(guestpath.LCOWGlobalMountPrefixFmt, vm.UVMMountCounter())
 	scsiCloser, err := vm.AddSCSI(ctx, driver, uvmPathForShare, true, false, []string{}, uvm.VMAccessTypeIndividual)
 	if err != nil {
 		return closer, fmt.Errorf("failed to add SCSI disk to utility VM for path %+v: %s", driver, err)

--- a/internal/guest/runtime/hcsv2/sandbox_container.go
+++ b/internal/guest/runtime/hcsv2/sandbox_container.go
@@ -10,16 +10,18 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/Microsoft/hcsshim/internal/guest/network"
-	"github.com/Microsoft/hcsshim/internal/oc"
-	"github.com/Microsoft/hcsshim/pkg/annotations"
 	oci "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
 	"go.opencensus.io/trace"
+
+	"github.com/Microsoft/hcsshim/internal/guest/network"
+	"github.com/Microsoft/hcsshim/internal/guestpath"
+	"github.com/Microsoft/hcsshim/internal/oc"
+	"github.com/Microsoft/hcsshim/pkg/annotations"
 )
 
 func getSandboxRootDir(id string) string {
-	return filepath.Join("/run/gcs/c", id)
+	return filepath.Join(guestpath.LCOWRootPrefixInUVM, id)
 }
 
 func getSandboxHugePageMountsDir(id string) string {

--- a/internal/guest/runtime/hcsv2/spec.go
+++ b/internal/guest/runtime/hcsv2/spec.go
@@ -10,12 +10,14 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/Microsoft/hcsshim/internal/log"
-	"github.com/Microsoft/hcsshim/pkg/annotations"
 	"github.com/opencontainers/runc/libcontainer/devices"
 	"github.com/opencontainers/runc/libcontainer/user"
 	oci "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
+
+	"github.com/Microsoft/hcsshim/internal/hooks"
+	"github.com/Microsoft/hcsshim/internal/log"
+	"github.com/Microsoft/hcsshim/pkg/annotations"
 )
 
 // getNetworkNamespaceID returns the `ToLower` of
@@ -257,17 +259,7 @@ func applyAnnotationsToSpec(ctx context.Context, spec *oci.Spec) error {
 }
 
 // Helper function to create an oci prestart hook to run ldconfig
-func addLDConfigHook(ctx context.Context, spec *oci.Spec, args, env []string) error {
-	if spec.Hooks == nil {
-		spec.Hooks = &oci.Hooks{}
-	}
-
-	ldConfigHook := oci.Hook{
-		Path: "/sbin/ldconfig",
-		Args: args,
-		Env:  env,
-	}
-
-	spec.Hooks.Prestart = append(spec.Hooks.Prestart, ldConfigHook)
-	return nil
+func addLDConfigHook(_ context.Context, spec *oci.Spec, args, env []string) error {
+	ldConfigHook := hooks.NewOCIHook("/sbin/ldconfig", args, env)
+	return hooks.AddOCIHook(spec, hooks.Prestart, ldConfigHook)
 }

--- a/internal/guest/runtime/hcsv2/standalone_container.go
+++ b/internal/guest/runtime/hcsv2/standalone_container.go
@@ -10,15 +10,17 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/Microsoft/hcsshim/internal/guest/network"
-	"github.com/Microsoft/hcsshim/internal/oc"
 	oci "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
 	"go.opencensus.io/trace"
+
+	"github.com/Microsoft/hcsshim/internal/guest/network"
+	"github.com/Microsoft/hcsshim/internal/guestpath"
+	"github.com/Microsoft/hcsshim/internal/oc"
 )
 
 func getStandaloneRootDir(id string) string {
-	return filepath.Join("/run/gcs/c", id)
+	return filepath.Join(guestpath.LCOWRootPrefixInUVM, id)
 }
 
 func getStandaloneHostnamePath(id string) string {

--- a/internal/guest/runtime/hcsv2/uvm.go
+++ b/internal/guest/runtime/hcsv2/uvm.go
@@ -16,7 +16,7 @@ import (
 	"syscall"
 	"time"
 
-	shellwords "github.com/mattn/go-shellwords"
+	"github.com/mattn/go-shellwords"
 	"github.com/pkg/errors"
 
 	"github.com/Microsoft/hcsshim/internal/guest/gcserr"
@@ -225,10 +225,14 @@ func (h *Host) CreateContainer(ctx context.Context, id string, settings *prot.VM
 	// We append the variable after the security policy enforcing logic completes so as to bypass it; the
 	// security policy variable cannot be included in the security policy as its value is not available
 	// security policy construction time.
-
 	if policyEnforcer, ok := (h.securityPolicyEnforcer).(*securitypolicy.StandardSecurityPolicyEnforcer); ok {
 		secPolicyEnv := fmt.Sprintf("SECURITY_POLICY=%s", policyEnforcer.EncodedSecurityPolicy)
 		settings.OCISpecification.Process.Env = append(settings.OCISpecification.Process.Env, secPolicyEnv)
+	}
+
+	// Sandbox mount paths need to be resolved in the spec before expected mounts policy can be enforced.
+	if err = h.securityPolicyEnforcer.EnforceExpectedMountsPolicy(id, settings.OCISpecification); err != nil {
+		return nil, errors.Wrapf(err, "container creation denied due to policy")
 	}
 
 	// Create the BundlePath

--- a/internal/guest/storage/test/policy/mountmonitoringsecuritypolicyenforcer.go
+++ b/internal/guest/storage/test/policy/mountmonitoringsecuritypolicyenforcer.go
@@ -1,6 +1,8 @@
 package policy
 
 import (
+	oci "github.com/opencontainers/runtime-spec/specs-go"
+
 	"github.com/Microsoft/hcsshim/pkg/securitypolicy"
 )
 
@@ -30,5 +32,9 @@ func (p *MountMonitoringSecurityPolicyEnforcer) EnforceOverlayMountPolicy(contai
 }
 
 func (p *MountMonitoringSecurityPolicyEnforcer) EnforceCreateContainerPolicy(_ string, _ []string, _ []string, _ string) (err error) {
+	return nil
+}
+
+func (p *MountMonitoringSecurityPolicyEnforcer) EnforceExpectedMountsPolicy(_ string, _ *oci.Spec) error {
 	return nil
 }

--- a/internal/guestpath/paths.go
+++ b/internal/guestpath/paths.go
@@ -1,0 +1,24 @@
+package guestpath
+
+const (
+	// LCOWNvidiaMountPath is the path format in LCOW UVM where nvidia tools are mounted
+	// keep this value in sync with opengcs
+	LCOWNvidiaMountPath = "/run/nvidia"
+	// LCOWRootPrefixInUVM is the path inside UVM where LCOW container's root file system will be mounted
+	LCOWRootPrefixInUVM = "/run/gcs/c"
+	// WCOWRootPrefixInUVM is the path inside UVM where WCOW container's root file system will be mounted
+	WCOWRootPrefixInUVM = `C:\c`
+	// SandboxMountPrefix is mount prefix used in container spec to mark a sandbox-mount
+	SandboxMountPrefix = "sandbox://"
+	// HugePagesMountPrefix is mount prefix used in container spec to mark a huge-pages mount
+	HugePagesMountPrefix = "hugepages://"
+	// LCOWMountPathPrefixFmt is the path format in the LCOW UVM where non global mounts, such
+	// as Plan9 mounts are added
+	LCOWMountPathPrefixFmt = "/mounts/m%d"
+	// LCOWGlobalMountPrefixFmt is the path format in the LCOW UVM where global mounts are added
+	LCOWGlobalMountPrefixFmt = "/run/mounts/m%d"
+	// WCOWGlobalMountPrefixFmt is the path prefix format in the WCOW UVM where mounts are added
+	WCOWGlobalMountPrefixFmt = "C:\\mounts\\m%d"
+	// RootfsPath is part of the container's rootfs path
+	RootfsPath = "rootfs"
+)

--- a/internal/hcsoci/create.go
+++ b/internal/hcsoci/create.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Microsoft/go-winio/pkg/guid"
 	"github.com/Microsoft/hcsshim/internal/clone"
 	"github.com/Microsoft/hcsshim/internal/cow"
+	"github.com/Microsoft/hcsshim/internal/guestpath"
 	"github.com/Microsoft/hcsshim/internal/hcs"
 	hcsschema "github.com/Microsoft/hcsshim/internal/hcs/schema2"
 	"github.com/Microsoft/hcsshim/internal/log"
@@ -27,8 +28,8 @@ import (
 )
 
 var (
-	lcowRootInUVM = "/run/gcs/c/%s"
-	wcowRootInUVM = `C:\c\%s`
+	lcowRootInUVM = guestpath.LCOWRootPrefixInUVM + "/%s"
+	wcowRootInUVM = guestpath.WCOWRootPrefixInUVM + "/%s"
 )
 
 // CreateOptions are the set of fields used to call CreateContainer().

--- a/internal/hcsoci/devices.go
+++ b/internal/hcsoci/devices.go
@@ -9,7 +9,11 @@ import (
 	"path/filepath"
 	"strconv"
 
+	specs "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/pkg/errors"
+
 	"github.com/Microsoft/hcsshim/internal/devices"
+	"github.com/Microsoft/hcsshim/internal/guestpath"
 	hcsschema "github.com/Microsoft/hcsshim/internal/hcs/schema2"
 	"github.com/Microsoft/hcsshim/internal/log"
 	"github.com/Microsoft/hcsshim/internal/oci"
@@ -17,8 +21,6 @@ import (
 	"github.com/Microsoft/hcsshim/internal/uvm"
 	"github.com/Microsoft/hcsshim/osversion"
 	"github.com/Microsoft/hcsshim/pkg/annotations"
-	specs "github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/pkg/errors"
 )
 
 const deviceUtilExeName = "device-util.exe"
@@ -222,14 +224,14 @@ func handleAssignedDevicesLCOW(
 		scsiMount, err := vm.AddSCSI(
 			ctx,
 			gpuSupportVhdPath,
-			uvm.LCOWNvidiaMountPath,
+			guestpath.LCOWNvidiaMountPath,
 			true,
 			false,
 			options,
 			uvm.VMAccessTypeNoop,
 		)
 		if err != nil {
-			return resultDevs, closers, errors.Wrapf(err, "failed to add scsi device %s in the UVM %s at %s", gpuSupportVhdPath, vm.ID(), uvm.LCOWNvidiaMountPath)
+			return resultDevs, closers, errors.Wrapf(err, "failed to add scsi device %s in the UVM %s at %s", gpuSupportVhdPath, vm.ID(), guestpath.LCOWNvidiaMountPath)
 		}
 		closers = append(closers, scsiMount)
 	}

--- a/internal/hcsoci/hcsdoc_wcow.go
+++ b/internal/hcsoci/hcsdoc_wcow.go
@@ -11,6 +11,10 @@ import (
 	"regexp"
 	"strings"
 
+	specs "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/sirupsen/logrus"
+
+	"github.com/Microsoft/hcsshim/internal/guestpath"
 	"github.com/Microsoft/hcsshim/internal/hcs/schema1"
 	hcsschema "github.com/Microsoft/hcsshim/internal/hcs/schema2"
 	"github.com/Microsoft/hcsshim/internal/layers"
@@ -22,8 +26,6 @@ import (
 	"github.com/Microsoft/hcsshim/internal/wclayer"
 	"github.com/Microsoft/hcsshim/osversion"
 	"github.com/Microsoft/hcsshim/pkg/annotations"
-	specs "github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/sirupsen/logrus"
 )
 
 // A simple wrapper struct around the container mount configs that should be added to the
@@ -78,7 +80,7 @@ func createMountsConfig(ctx context.Context, coi *createOptionsInternal) (*mount
 					return nil, err
 				}
 				mdv2.HostPath = uvmPath
-			} else if strings.HasPrefix(mount.Source, "sandbox://") {
+			} else if strings.HasPrefix(mount.Source, guestpath.SandboxMountPrefix) {
 				// Convert to the path in the guest that was asked for.
 				mdv2.HostPath = convertToWCOWSandboxMountPath(mount.Source)
 			} else {

--- a/internal/hooks/spec.go
+++ b/internal/hooks/spec.go
@@ -1,0 +1,53 @@
+package hooks
+
+import (
+	"fmt"
+
+	oci "github.com/opencontainers/runtime-spec/specs-go"
+)
+
+// Note: The below type definition as well as constants have been copied from
+// https://github.com/opencontainers/runc/blob/master/libcontainer/configs/config.go.
+// This is done to not introduce a direct dependency on runc, which would complicate
+// integration with windows.
+type HookName string
+
+const (
+
+	// Prestart commands are executed after the container namespaces are created,
+	// but before the user supplied command is executed from init.
+	// Note: This hook is now deprecated
+	// Prestart commands are called in the Runtime namespace.
+	Prestart HookName = "prestart"
+
+	// CreateRuntime commands MUST be called as part of the create operation after
+	// the runtime environment has been created but before the pivot_root has been executed.
+	// CreateRuntime is called immediately after the deprecated Prestart hook.
+	// CreateRuntime commands are called in the Runtime Namespace.
+	CreateRuntime HookName = "createRuntime"
+)
+
+// NewOCIHook creates a new oci.Hook with given parameters
+func NewOCIHook(path string, args, env []string) oci.Hook {
+	return oci.Hook{
+		Path: path,
+		Args: args,
+		Env:  env,
+	}
+}
+
+// AddOCIHook adds oci.Hook of the given hook name to spec
+func AddOCIHook(spec *oci.Spec, hn HookName, hk oci.Hook) error {
+	if spec.Hooks == nil {
+		spec.Hooks = &oci.Hooks{}
+	}
+	switch hn {
+	case Prestart:
+		spec.Hooks.Prestart = append(spec.Hooks.Prestart, hk)
+	case CreateRuntime:
+		spec.Hooks.CreateRuntime = append(spec.Hooks.CreateRuntime, hk)
+	default:
+		return fmt.Errorf("hook %q is not supported", hn)
+	}
+	return nil
+}

--- a/internal/layers/layers.go
+++ b/internal/layers/layers.go
@@ -11,15 +11,17 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/sys/windows"
+
+	"github.com/Microsoft/hcsshim/internal/guestpath"
 	hcsschema "github.com/Microsoft/hcsshim/internal/hcs/schema2"
 	"github.com/Microsoft/hcsshim/internal/hcserror"
 	"github.com/Microsoft/hcsshim/internal/log"
 	"github.com/Microsoft/hcsshim/internal/ospath"
 	"github.com/Microsoft/hcsshim/internal/uvm"
 	"github.com/Microsoft/hcsshim/internal/wclayer"
-	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
-	"golang.org/x/sys/windows"
 )
 
 // ImageLayers contains all the layers for an image.
@@ -261,7 +263,7 @@ func MountContainerLayers(ctx context.Context, containerID string, layerFolders 
 		err = vm.CombineLayersWCOW(ctx, layers, containerScratchPathInUVM)
 		rootfs = containerScratchPathInUVM
 	} else {
-		rootfs = ospath.Join(vm.OS(), guestRoot, uvm.RootfsPath)
+		rootfs = ospath.Join(vm.OS(), guestRoot, guestpath.RootfsPath)
 		err = vm.CombineLayersLCOW(ctx, containerID, lcowUvmLayerPaths, containerScratchPathInUVM, rootfs)
 	}
 	if err != nil {
@@ -289,7 +291,7 @@ func addLCOWLayer(ctx context.Context, vm *uvm.UtilityVM, layerPath string) (uvm
 	}
 
 	options := []string{"ro"}
-	uvmPath = fmt.Sprintf(uvm.LCOWGlobalMountPrefix, vm.UVMMountCounter())
+	uvmPath = fmt.Sprintf(guestpath.LCOWGlobalMountPrefixFmt, vm.UVMMountCounter())
 	sm, err := vm.AddSCSI(ctx, layerPath, uvmPath, true, false, options, uvm.VMAccessTypeNoop)
 	if err != nil {
 		return "", fmt.Errorf("failed to add SCSI layer: %s", err)
@@ -460,7 +462,7 @@ func containerRootfsPath(vm *uvm.UtilityVM, rootPath string) string {
 	if vm.OS() == "windows" {
 		return ospath.Join(vm.OS(), rootPath)
 	}
-	return ospath.Join(vm.OS(), rootPath, uvm.RootfsPath)
+	return ospath.Join(vm.OS(), rootPath, guestpath.RootfsPath)
 }
 
 func getScratchVHDPath(layerFolders []string) (string, error) {

--- a/internal/tools/securitypolicy/README.md
+++ b/internal/tools/securitypolicy/README.md
@@ -21,6 +21,7 @@ be downloaded, turned into an ext4, and finally a dm-verity root hash calculated
 image_name = "rust:1.52.1"
 command = ["rustc", "--help"]
 working_dir = "/home/user"
+expected_mounts = ["/path/to/container/mount-1", "/path/to/container/mount-2"]
 
 [[container.env_rule]]
 strategy = "re2"
@@ -86,7 +87,14 @@ represented in JSON.
             "5": "1b80f120dbd88e4355d6241b519c3e25290215c469516b49dece9cf07175a766"
           }
         },
-        "working_dir": "/home/user"
+        "working_dir": "/home/user",
+        "expected_mounts": {
+          "length": 2,
+          "elements": {
+            "0": "/path/to/container/mount-1",
+            "1": "/path/to/container/mount-2"
+          }
+        }
       },
       "1": {
         "command": {
@@ -114,7 +122,11 @@ represented in JSON.
             "0": "16b514057a06ad665f92c02863aca074fd5976c755d26bff16365299169e8415"
           }
         },
-        "working_dir": "/"
+        "working_dir": "/",
+        "expected_mounts": {
+          "length": 0,
+          "elements": {}
+        }
       }
     }
   }
@@ -135,11 +147,11 @@ output raw JSON in addition to the Base64 encoded version
 
 Some images will be pulled from registries that require authorization. To add
 authorization information for a given image, you would add an `[auth]` object
-to the TOML definiton for that image. For example:
+to the TOML definition for that image. For example:
 
 ```toml
-[[image]]
-image_name = "rust:1.52.1"
+[[container]]
+name = "rust:1.52.1"
 command = ["rustc", "--help"]
 
 [auth]
@@ -147,8 +159,8 @@ username = "my username"
 password = "my password"
 ```
 
-Authorization information needs added on a per-image basis as it can vary from
-image to image and their respective registries.
+Authorization information needs to be added on a per-image basis as it can vary
+from image to image and their respective registries.
 
 To pull an image using anonymous access, no `[auth]` object is required.
 

--- a/internal/tools/securitypolicy/helpers/helpers.go
+++ b/internal/tools/securitypolicy/helpers/helpers.go
@@ -137,7 +137,13 @@ func PolicyContainersFromConfigs(containerConfigs []securitypolicy.ContainerConf
 			workingDir = containerConfig.WorkingDir
 		}
 
-		container, err := securitypolicy.NewContainer(containerConfig.Command, layerHashes, envRules, workingDir)
+		container, err := securitypolicy.NewContainer(
+			containerConfig.Command,
+			layerHashes,
+			envRules,
+			workingDir,
+			containerConfig.ExpectedMounts,
+		)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/tools/securitypolicy/helpers/helpers.go
+++ b/internal/tools/securitypolicy/helpers/helpers.go
@@ -74,6 +74,7 @@ func DefaultContainerConfigs() []securitypolicy.ContainerConfig {
 		[]securitypolicy.EnvRuleConfig{},
 		securitypolicy.AuthConfig{},
 		"",
+		[]string{},
 	)
 	return []securitypolicy.ContainerConfig{pause}
 }

--- a/internal/tools/securitypolicy/main.go
+++ b/internal/tools/securitypolicy/main.go
@@ -75,7 +75,6 @@ func createPolicyFromConfig(config *securitypolicy.PolicyConfig) (*securitypolic
 	// and any environment variable rules we might need
 	defaultContainers := helpers.DefaultContainerConfigs()
 	config.Containers = append(config.Containers, defaultContainers...)
-
 	policyContainers, err := helpers.PolicyContainersFromConfigs(config.Containers)
 	if err != nil {
 		return nil, err

--- a/internal/uvm/constants.go
+++ b/internal/uvm/constants.go
@@ -16,19 +16,6 @@ const (
 	// DefaultVPMemSizeBytes is the default size of a VPMem device if the create request
 	// doesn't specify.
 	DefaultVPMemSizeBytes = 4 * 1024 * 1024 * 1024 // 4GB
-
-	// LCOWMountPathPrefix is the path format in the LCOW UVM where non global mounts, such
-	// as Plan9 mounts are added
-	LCOWMountPathPrefix = "/mounts/m%d"
-	// LCOWGlobalMountPrefix is the path format in the LCOW UVM where global mounts are added
-	LCOWGlobalMountPrefix = "/run/mounts/m%d"
-	// LCOWNvidiaMountPath is the path format in LCOW UVM where nvidia tools are mounted
-	// keep this value in sync with opengcs
-	LCOWNvidiaMountPath = "/run/nvidia"
-	// WCOWGlobalMountPrefix is the path prefix format in the WCOW UVM where mounts are added
-	WCOWGlobalMountPrefix = "C:\\mounts\\m%d"
-	// RootfsPath is part of the container's rootfs path
-	RootfsPath = "rootfs"
 )
 
 var (

--- a/pkg/annotations/annotations.go
+++ b/pkg/annotations/annotations.go
@@ -261,7 +261,7 @@ const (
 	// GuestStateFile specifies the path of the vmgs file to use if required. Only applies in SNP mode.
 	GuestStateFile = "io.microsoft.virtualmachine.lcow.gueststatefile"
 
-	// AnnotationDisableLCOWTimeSyncService is used to disable the chronyd time
+	// DisableLCOWTimeSyncService is used to disable the chronyd time
 	// synchronization service inside the LCOW UVM.
 	DisableLCOWTimeSyncService = "io.microsoft.virtualmachine.lcow.timesync.disable"
 

--- a/pkg/securitypolicy/securitypolicy.go
+++ b/pkg/securitypolicy/securitypolicy.go
@@ -211,15 +211,16 @@ type ExpectedMounts struct {
 
 // NewContainer creates a new Container instance from the provided values
 // or an error if envRules validation fails.
-func NewContainer(command, layers []string, envRules []EnvRuleConfig, workingDir string) (*Container, error) {
+func NewContainer(command, layers []string, envRules []EnvRuleConfig, workingDir string, eMounts []string) (*Container, error) {
 	if err := validateEnvRules(envRules); err != nil {
 		return nil, err
 	}
 	return &Container{
-		Command:    newCommandArgs(command),
-		Layers:     newLayers(layers),
-		EnvRules:   newEnvRules(envRules),
-		WorkingDir: workingDir,
+		Command:        newCommandArgs(command),
+		Layers:         newLayers(layers),
+		EnvRules:       newEnvRules(envRules),
+		WorkingDir:     workingDir,
+		ExpectedMounts: newExpectedMounts(eMounts),
 	}, nil
 }
 
@@ -276,6 +277,16 @@ func newLayers(ls []string) Layers {
 	}
 	return Layers{
 		Elements: layers,
+	}
+}
+
+func newExpectedMounts(em []string) ExpectedMounts {
+	mounts := map[string]string{}
+	for i, m := range em {
+		mounts[strconv.Itoa(i)] = m
+	}
+	return ExpectedMounts{
+		Elements: mounts,
 	}
 }
 

--- a/test/cri-containerd/container_test.go
+++ b/test/cri-containerd/container_test.go
@@ -6,6 +6,7 @@ package cri_containerd
 import (
 	"bufio"
 	"context"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -14,9 +15,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Microsoft/hcsshim/pkg/annotations"
 	"github.com/sirupsen/logrus"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+
+	"github.com/Microsoft/hcsshim/internal/guestpath"
+	"github.com/Microsoft/hcsshim/pkg/annotations"
 )
 
 func runLogRotationContainer(t *testing.T, sandboxRequest *runtime.RunPodSandboxRequest, request *runtime.CreateContainerRequest, log string, logArchive string) {
@@ -725,7 +728,7 @@ func Test_CreateContainer_HugePageMount_LCOW(t *testing.T) {
 			},
 			Mounts: []*runtime.Mount{
 				{
-					HostPath:      "hugepages://2M/hugepage2M",
+					HostPath:      fmt.Sprintf("%s2M/hugepage2M", guestpath.HugePagesMountPrefix),
 					ContainerPath: "/mnt/hugepage2M",
 					Readonly:      false,
 					Propagation:   runtime.MountPropagation_PROPAGATION_BIDIRECTIONAL,

--- a/test/cri-containerd/policy_test.go
+++ b/test/cri-containerd/policy_test.go
@@ -47,6 +47,7 @@ func alpineSecurityPolicy(t *testing.T) string {
 		[]securitypolicy.EnvRuleConfig{},
 		securitypolicy.AuthConfig{},
 		"",
+		[]string{},
 	)
 
 	containers := append(defaultContainers, alpineContainer)

--- a/test/vendor/github.com/Microsoft/hcsshim/Makefile
+++ b/test/vendor/github.com/Microsoft/hcsshim/Makefile
@@ -32,7 +32,7 @@ clean:
 test:
 	cd $(SRCROOT) && go test -v ./internal/guest/...
 
-out/delta.tar.gz: bin/init bin/vsockexec bin/cmd/gcs bin/cmd/gcstools Makefile
+out/delta.tar.gz: bin/init bin/vsockexec bin/cmd/gcs bin/cmd/gcstools bin/cmd/hooks/wait-paths Makefile
 	@mkdir -p out
 	rm -rf rootfs
 	mkdir -p rootfs/bin/
@@ -40,6 +40,7 @@ out/delta.tar.gz: bin/init bin/vsockexec bin/cmd/gcs bin/cmd/gcstools Makefile
 	cp bin/vsockexec rootfs/bin/
 	cp bin/cmd/gcs rootfs/bin/
 	cp bin/cmd/gcstools rootfs/bin/
+	cp bin/cmd/hooks/wait-paths rootfs/bin/
 	for tool in $(GCS_TOOLS); do ln -s gcstools rootfs/bin/$$tool; done
 	git -C $(SRCROOT) rev-parse HEAD > rootfs/gcs.commit && \
 	git -C $(SRCROOT) rev-parse --abbrev-ref HEAD > rootfs/gcs.branch
@@ -60,6 +61,7 @@ out/initrd.img: $(BASE) out/delta.tar.gz $(SRCROOT)/hack/catcpio.sh
 
 -include deps/cmd/gcs.gomake
 -include deps/cmd/gcstools.gomake
+-include deps/cmd/hooks/wait-paths.gomake
 
 # Implicit rule for includes that define Go targets.
 %.gomake: $(SRCROOT)/Makefile

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/devices/drivers.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/devices/drivers.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 
 	"github.com/Microsoft/hcsshim/internal/cmd"
+	"github.com/Microsoft/hcsshim/internal/guestpath"
 	"github.com/Microsoft/hcsshim/internal/log"
 	"github.com/Microsoft/hcsshim/internal/resources"
 	"github.com/Microsoft/hcsshim/internal/uvm"
@@ -45,7 +46,7 @@ func InstallKernelDriver(ctx context.Context, vm *uvm.UtilityVM, driver string) 
 		}
 		return closer, execPnPInstallDriver(ctx, vm, uvmPath)
 	}
-	uvmPathForShare := fmt.Sprintf(uvm.LCOWGlobalMountPrefix, vm.UVMMountCounter())
+	uvmPathForShare := fmt.Sprintf(guestpath.LCOWGlobalMountPrefixFmt, vm.UVMMountCounter())
 	scsiCloser, err := vm.AddSCSI(ctx, driver, uvmPathForShare, true, false, []string{}, uvm.VMAccessTypeIndividual)
 	if err != nil {
 		return closer, fmt.Errorf("failed to add SCSI disk to utility VM for path %+v: %s", driver, err)

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/guestpath/paths.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/guestpath/paths.go
@@ -1,0 +1,24 @@
+package guestpath
+
+const (
+	// LCOWNvidiaMountPath is the path format in LCOW UVM where nvidia tools are mounted
+	// keep this value in sync with opengcs
+	LCOWNvidiaMountPath = "/run/nvidia"
+	// LCOWRootPrefixInUVM is the path inside UVM where LCOW container's root file system will be mounted
+	LCOWRootPrefixInUVM = "/run/gcs/c"
+	// WCOWRootPrefixInUVM is the path inside UVM where WCOW container's root file system will be mounted
+	WCOWRootPrefixInUVM = `C:\c`
+	// SandboxMountPrefix is mount prefix used in container spec to mark a sandbox-mount
+	SandboxMountPrefix = "sandbox://"
+	// HugePagesMountPrefix is mount prefix used in container spec to mark a huge-pages mount
+	HugePagesMountPrefix = "hugepages://"
+	// LCOWMountPathPrefixFmt is the path format in the LCOW UVM where non global mounts, such
+	// as Plan9 mounts are added
+	LCOWMountPathPrefixFmt = "/mounts/m%d"
+	// LCOWGlobalMountPrefixFmt is the path format in the LCOW UVM where global mounts are added
+	LCOWGlobalMountPrefixFmt = "/run/mounts/m%d"
+	// WCOWGlobalMountPrefixFmt is the path prefix format in the WCOW UVM where mounts are added
+	WCOWGlobalMountPrefixFmt = "C:\\mounts\\m%d"
+	// RootfsPath is part of the container's rootfs path
+	RootfsPath = "rootfs"
+)

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/hcsoci/create.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/hcsoci/create.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Microsoft/go-winio/pkg/guid"
 	"github.com/Microsoft/hcsshim/internal/clone"
 	"github.com/Microsoft/hcsshim/internal/cow"
+	"github.com/Microsoft/hcsshim/internal/guestpath"
 	"github.com/Microsoft/hcsshim/internal/hcs"
 	hcsschema "github.com/Microsoft/hcsshim/internal/hcs/schema2"
 	"github.com/Microsoft/hcsshim/internal/log"
@@ -27,8 +28,8 @@ import (
 )
 
 var (
-	lcowRootInUVM = "/run/gcs/c/%s"
-	wcowRootInUVM = `C:\c\%s`
+	lcowRootInUVM = guestpath.LCOWRootPrefixInUVM + "/%s"
+	wcowRootInUVM = guestpath.WCOWRootPrefixInUVM + "/%s"
 )
 
 // CreateOptions are the set of fields used to call CreateContainer().

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/hcsoci/devices.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/hcsoci/devices.go
@@ -9,7 +9,11 @@ import (
 	"path/filepath"
 	"strconv"
 
+	specs "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/pkg/errors"
+
 	"github.com/Microsoft/hcsshim/internal/devices"
+	"github.com/Microsoft/hcsshim/internal/guestpath"
 	hcsschema "github.com/Microsoft/hcsshim/internal/hcs/schema2"
 	"github.com/Microsoft/hcsshim/internal/log"
 	"github.com/Microsoft/hcsshim/internal/oci"
@@ -17,8 +21,6 @@ import (
 	"github.com/Microsoft/hcsshim/internal/uvm"
 	"github.com/Microsoft/hcsshim/osversion"
 	"github.com/Microsoft/hcsshim/pkg/annotations"
-	specs "github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/pkg/errors"
 )
 
 const deviceUtilExeName = "device-util.exe"
@@ -222,14 +224,14 @@ func handleAssignedDevicesLCOW(
 		scsiMount, err := vm.AddSCSI(
 			ctx,
 			gpuSupportVhdPath,
-			uvm.LCOWNvidiaMountPath,
+			guestpath.LCOWNvidiaMountPath,
 			true,
 			false,
 			options,
 			uvm.VMAccessTypeNoop,
 		)
 		if err != nil {
-			return resultDevs, closers, errors.Wrapf(err, "failed to add scsi device %s in the UVM %s at %s", gpuSupportVhdPath, vm.ID(), uvm.LCOWNvidiaMountPath)
+			return resultDevs, closers, errors.Wrapf(err, "failed to add scsi device %s in the UVM %s at %s", gpuSupportVhdPath, vm.ID(), guestpath.LCOWNvidiaMountPath)
 		}
 		closers = append(closers, scsiMount)
 	}

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/hcsoci/hcsdoc_wcow.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/hcsoci/hcsdoc_wcow.go
@@ -11,6 +11,10 @@ import (
 	"regexp"
 	"strings"
 
+	specs "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/sirupsen/logrus"
+
+	"github.com/Microsoft/hcsshim/internal/guestpath"
 	"github.com/Microsoft/hcsshim/internal/hcs/schema1"
 	hcsschema "github.com/Microsoft/hcsshim/internal/hcs/schema2"
 	"github.com/Microsoft/hcsshim/internal/layers"
@@ -22,8 +26,6 @@ import (
 	"github.com/Microsoft/hcsshim/internal/wclayer"
 	"github.com/Microsoft/hcsshim/osversion"
 	"github.com/Microsoft/hcsshim/pkg/annotations"
-	specs "github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/sirupsen/logrus"
 )
 
 // A simple wrapper struct around the container mount configs that should be added to the
@@ -78,7 +80,7 @@ func createMountsConfig(ctx context.Context, coi *createOptionsInternal) (*mount
 					return nil, err
 				}
 				mdv2.HostPath = uvmPath
-			} else if strings.HasPrefix(mount.Source, "sandbox://") {
+			} else if strings.HasPrefix(mount.Source, guestpath.SandboxMountPrefix) {
 				// Convert to the path in the guest that was asked for.
 				mdv2.HostPath = convertToWCOWSandboxMountPath(mount.Source)
 			} else {

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/hooks/spec.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/hooks/spec.go
@@ -1,0 +1,53 @@
+package hooks
+
+import (
+	"fmt"
+
+	oci "github.com/opencontainers/runtime-spec/specs-go"
+)
+
+// Note: The below type definition as well as constants have been copied from
+// https://github.com/opencontainers/runc/blob/master/libcontainer/configs/config.go.
+// This is done to not introduce a direct dependency on runc, which would complicate
+// integration with windows.
+type HookName string
+
+const (
+
+	// Prestart commands are executed after the container namespaces are created,
+	// but before the user supplied command is executed from init.
+	// Note: This hook is now deprecated
+	// Prestart commands are called in the Runtime namespace.
+	Prestart HookName = "prestart"
+
+	// CreateRuntime commands MUST be called as part of the create operation after
+	// the runtime environment has been created but before the pivot_root has been executed.
+	// CreateRuntime is called immediately after the deprecated Prestart hook.
+	// CreateRuntime commands are called in the Runtime Namespace.
+	CreateRuntime HookName = "createRuntime"
+)
+
+// NewOCIHook creates a new oci.Hook with given parameters
+func NewOCIHook(path string, args, env []string) oci.Hook {
+	return oci.Hook{
+		Path: path,
+		Args: args,
+		Env:  env,
+	}
+}
+
+// AddOCIHook adds oci.Hook of the given hook name to spec
+func AddOCIHook(spec *oci.Spec, hn HookName, hk oci.Hook) error {
+	if spec.Hooks == nil {
+		spec.Hooks = &oci.Hooks{}
+	}
+	switch hn {
+	case Prestart:
+		spec.Hooks.Prestart = append(spec.Hooks.Prestart, hk)
+	case CreateRuntime:
+		spec.Hooks.CreateRuntime = append(spec.Hooks.CreateRuntime, hk)
+	default:
+		return fmt.Errorf("hook %q is not supported", hn)
+	}
+	return nil
+}

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/layers/layers.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/layers/layers.go
@@ -11,15 +11,17 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/sys/windows"
+
+	"github.com/Microsoft/hcsshim/internal/guestpath"
 	hcsschema "github.com/Microsoft/hcsshim/internal/hcs/schema2"
 	"github.com/Microsoft/hcsshim/internal/hcserror"
 	"github.com/Microsoft/hcsshim/internal/log"
 	"github.com/Microsoft/hcsshim/internal/ospath"
 	"github.com/Microsoft/hcsshim/internal/uvm"
 	"github.com/Microsoft/hcsshim/internal/wclayer"
-	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
-	"golang.org/x/sys/windows"
 )
 
 // ImageLayers contains all the layers for an image.
@@ -261,7 +263,7 @@ func MountContainerLayers(ctx context.Context, containerID string, layerFolders 
 		err = vm.CombineLayersWCOW(ctx, layers, containerScratchPathInUVM)
 		rootfs = containerScratchPathInUVM
 	} else {
-		rootfs = ospath.Join(vm.OS(), guestRoot, uvm.RootfsPath)
+		rootfs = ospath.Join(vm.OS(), guestRoot, guestpath.RootfsPath)
 		err = vm.CombineLayersLCOW(ctx, containerID, lcowUvmLayerPaths, containerScratchPathInUVM, rootfs)
 	}
 	if err != nil {
@@ -289,7 +291,7 @@ func addLCOWLayer(ctx context.Context, vm *uvm.UtilityVM, layerPath string) (uvm
 	}
 
 	options := []string{"ro"}
-	uvmPath = fmt.Sprintf(uvm.LCOWGlobalMountPrefix, vm.UVMMountCounter())
+	uvmPath = fmt.Sprintf(guestpath.LCOWGlobalMountPrefixFmt, vm.UVMMountCounter())
 	sm, err := vm.AddSCSI(ctx, layerPath, uvmPath, true, false, options, uvm.VMAccessTypeNoop)
 	if err != nil {
 		return "", fmt.Errorf("failed to add SCSI layer: %s", err)
@@ -460,7 +462,7 @@ func containerRootfsPath(vm *uvm.UtilityVM, rootPath string) string {
 	if vm.OS() == "windows" {
 		return ospath.Join(vm.OS(), rootPath)
 	}
-	return ospath.Join(vm.OS(), rootPath, uvm.RootfsPath)
+	return ospath.Join(vm.OS(), rootPath, guestpath.RootfsPath)
 }
 
 func getScratchVHDPath(layerFolders []string) (string, error) {

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/tools/securitypolicy/helpers/helpers.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/tools/securitypolicy/helpers/helpers.go
@@ -137,7 +137,13 @@ func PolicyContainersFromConfigs(containerConfigs []securitypolicy.ContainerConf
 			workingDir = containerConfig.WorkingDir
 		}
 
-		container, err := securitypolicy.NewContainer(containerConfig.Command, layerHashes, envRules, workingDir)
+		container, err := securitypolicy.NewContainer(
+			containerConfig.Command,
+			layerHashes,
+			envRules,
+			workingDir,
+			containerConfig.ExpectedMounts,
+		)
 		if err != nil {
 			return nil, err
 		}

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/tools/securitypolicy/helpers/helpers.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/tools/securitypolicy/helpers/helpers.go
@@ -74,6 +74,7 @@ func DefaultContainerConfigs() []securitypolicy.ContainerConfig {
 		[]securitypolicy.EnvRuleConfig{},
 		securitypolicy.AuthConfig{},
 		"",
+		[]string{},
 	)
 	return []securitypolicy.ContainerConfig{pause}
 }

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/uvm/constants.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/uvm/constants.go
@@ -16,19 +16,6 @@ const (
 	// DefaultVPMemSizeBytes is the default size of a VPMem device if the create request
 	// doesn't specify.
 	DefaultVPMemSizeBytes = 4 * 1024 * 1024 * 1024 // 4GB
-
-	// LCOWMountPathPrefix is the path format in the LCOW UVM where non global mounts, such
-	// as Plan9 mounts are added
-	LCOWMountPathPrefix = "/mounts/m%d"
-	// LCOWGlobalMountPrefix is the path format in the LCOW UVM where global mounts are added
-	LCOWGlobalMountPrefix = "/run/mounts/m%d"
-	// LCOWNvidiaMountPath is the path format in LCOW UVM where nvidia tools are mounted
-	// keep this value in sync with opengcs
-	LCOWNvidiaMountPath = "/run/nvidia"
-	// WCOWGlobalMountPrefix is the path prefix format in the WCOW UVM where mounts are added
-	WCOWGlobalMountPrefix = "C:\\mounts\\m%d"
-	// RootfsPath is part of the container's rootfs path
-	RootfsPath = "rootfs"
 )
 
 var (

--- a/test/vendor/github.com/Microsoft/hcsshim/pkg/annotations/annotations.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/pkg/annotations/annotations.go
@@ -261,7 +261,7 @@ const (
 	// GuestStateFile specifies the path of the vmgs file to use if required. Only applies in SNP mode.
 	GuestStateFile = "io.microsoft.virtualmachine.lcow.gueststatefile"
 
-	// AnnotationDisableLCOWTimeSyncService is used to disable the chronyd time
+	// DisableLCOWTimeSyncService is used to disable the chronyd time
 	// synchronization service inside the LCOW UVM.
 	DisableLCOWTimeSyncService = "io.microsoft.virtualmachine.lcow.timesync.disable"
 

--- a/test/vendor/github.com/Microsoft/hcsshim/pkg/securitypolicy/securitypolicy.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/pkg/securitypolicy/securitypolicy.go
@@ -211,15 +211,16 @@ type ExpectedMounts struct {
 
 // NewContainer creates a new Container instance from the provided values
 // or an error if envRules validation fails.
-func NewContainer(command, layers []string, envRules []EnvRuleConfig, workingDir string) (*Container, error) {
+func NewContainer(command, layers []string, envRules []EnvRuleConfig, workingDir string, eMounts []string) (*Container, error) {
 	if err := validateEnvRules(envRules); err != nil {
 		return nil, err
 	}
 	return &Container{
-		Command:    newCommandArgs(command),
-		Layers:     newLayers(layers),
-		EnvRules:   newEnvRules(envRules),
-		WorkingDir: workingDir,
+		Command:        newCommandArgs(command),
+		Layers:         newLayers(layers),
+		EnvRules:       newEnvRules(envRules),
+		WorkingDir:     workingDir,
+		ExpectedMounts: newExpectedMounts(eMounts),
 	}, nil
 }
 
@@ -276,6 +277,16 @@ func newLayers(ls []string) Layers {
 	}
 	return Layers{
 		Elements: layers,
+	}
+}
+
+func newExpectedMounts(em []string) ExpectedMounts {
+	mounts := map[string]string{}
+	for i, m := range em {
+		mounts[strconv.Itoa(i)] = m
+	}
+	return ExpectedMounts{
+		Elements: mounts,
 	}
 }
 

--- a/test/vendor/modules.txt
+++ b/test/vendor/modules.txt
@@ -28,6 +28,7 @@ github.com/Microsoft/hcsshim/internal/credentials
 github.com/Microsoft/hcsshim/internal/devices
 github.com/Microsoft/hcsshim/internal/extendedtask
 github.com/Microsoft/hcsshim/internal/gcs
+github.com/Microsoft/hcsshim/internal/guestpath
 github.com/Microsoft/hcsshim/internal/hcs
 github.com/Microsoft/hcsshim/internal/hcs/resourcepaths
 github.com/Microsoft/hcsshim/internal/hcs/schema1
@@ -35,6 +36,7 @@ github.com/Microsoft/hcsshim/internal/hcs/schema2
 github.com/Microsoft/hcsshim/internal/hcserror
 github.com/Microsoft/hcsshim/internal/hcsoci
 github.com/Microsoft/hcsshim/internal/hns
+github.com/Microsoft/hcsshim/internal/hooks
 github.com/Microsoft/hcsshim/internal/interop
 github.com/Microsoft/hcsshim/internal/layers
 github.com/Microsoft/hcsshim/internal/lcow


### PR DESCRIPTION
Introduce a new `wait-paths` binary, which polls file system
until requested paths are available or a timeout is reached.

Security policy has been updated to have ExpectedMounts entries,
which will be used in conjunction with "wait-paths" hook for
synchronization purposes.

Refactor oci-hook logic into its own internal package and update
existing code to use that package. Copy runc HookName and constants
definitions to break dependency on runc

Introduce ExpectedMounts as part of security policy language and
the logic to enforce the policy, which resolves the expected mounts
in the UVM and adds a wait-paths hook to the spec.

Signed-off-by: Maksim An <maksiman@microsoft.com>