### PR TITLE
Change redundant conpty.ConPTY struct name

### DIFF
--- a/internal/exec/options.go
+++ b/internal/exec/options.go
@@ -14,7 +14,7 @@ type execConfig struct {
 	stdout, stderr, stdin bool
 
 	job          *jobobject.JobObject
-	cpty         *conpty.ConPTY
+	cpty         *conpty.Pty
 	token        windows.Token
 	processFlags uint32
 }
@@ -55,7 +55,7 @@ func WithJobObject(job *jobobject.JobObject) ExecOpts {
 }
 
 // WithConPty will launch the created process with a pseudo console attached to the process.
-func WithConPty(cpty *conpty.ConPTY) ExecOpts {
+func WithConPty(cpty *conpty.Pty) ExecOpts {
 	return func(e *execConfig) error {
 		e.cpty = cpty
 		return nil

--- a/internal/jobcontainers/jobcontainer.go
+++ b/internal/jobcontainers/jobcontainer.go
@@ -245,7 +245,7 @@ func (c *JobContainer) CreateProcess(ctx context.Context, config interface{}) (_
 		return nil, errors.Wrap(err, "failed to set PATHEXT")
 	}
 
-	var cpty *conpty.ConPTY
+	var cpty *conpty.Pty
 	if conf.EmulateConsole {
 		cpty, err = conpty.Create(80, 20, 0)
 		if err != nil {

--- a/internal/jobcontainers/process.go
+++ b/internal/jobcontainers/process.go
@@ -20,7 +20,7 @@ import (
 // JobProcess represents a process run in a job object.
 type JobProcess struct {
 	cmd            *exec.Exec
-	cpty           *conpty.ConPTY
+	cpty           *conpty.Pty
 	procLock       sync.Mutex
 	stdioLock      sync.Mutex
 	stdin          io.WriteCloser
@@ -41,7 +41,7 @@ var sigMap = map[string]int{
 
 var _ cow.Process = &JobProcess{}
 
-func newProcess(cmd *exec.Exec, cpty *conpty.ConPTY) *JobProcess {
+func newProcess(cmd *exec.Exec, cpty *conpty.Pty) *JobProcess {
 	return &JobProcess{
 		cmd:       cmd,
 		cpty:      cpty,


### PR DESCRIPTION
This change renames the ConPTY struct in the conpty package to just Pty 