### PR TITLE
[release/0.9] Add ws2022 image/build to cri-containerd tests (#1160)

### DIFF
--- a/osversion/windowsbuilds.go
+++ b/osversion/windowsbuilds.go
@@ -38,4 +38,13 @@ const (
 
 	// V21H1 corresponds to Windows Server 21H1 (semi-annual channel).
 	V21H1 = 19043
+
+	// V21H2Win10 corresponds to Windows 10 (November 2021 Update).
+	V21H2Win10 = 19044
+
+	// V21H2Server corresponds to Windows Server 2022 (ltsc2022).
+	V21H2Server = 20348
+
+	// V21H2Win11 corresponds to Windows 11 (original release).
+	V21H2Win11 = 22000
 )

--- a/test/cri-containerd/main.go
+++ b/test/cri-containerd/main.go
@@ -166,7 +166,16 @@ func getWindowsNanoserverImage(build uint16) string {
 		return "mcr.microsoft.com/windows/nanoserver:2004"
 	case osversion.V20H2:
 		return "mcr.microsoft.com/windows/nanoserver:2009"
+	case osversion.V21H2Server:
+		return "mcr.microsoft.com/windows/nanoserver:ltsc2022"
 	default:
+		// Due to some efforts in improving down-level compatibility for Windows containers (see
+		// https://techcommunity.microsoft.com/t5/containers/windows-server-2022-and-beyond-for-containers/ba-p/2712487)
+		// the ltsc2022 image should continue to work on builds ws2022 and onwards. With this in mind,
+		// if there's no mapping for the host build, just use the Windows Server 2022 image.
+		if build > osversion.V21H2Server {
+			return "mcr.microsoft.com/windows/nanoserver:ltsc2022"
+		}
 		panic("unsupported build")
 	}
 }
@@ -183,7 +192,16 @@ func getWindowsServerCoreImage(build uint16) string {
 		return "mcr.microsoft.com/windows/servercore:2004"
 	case osversion.V20H2:
 		return "mcr.microsoft.com/windows/servercore:2009"
+	case osversion.V21H2Server:
+		return "mcr.microsoft.com/windows/servercore:ltsc2022"
 	default:
+		// Due to some efforts in improving down-level compatibility for Windows containers (see
+		// https://techcommunity.microsoft.com/t5/containers/windows-server-2022-and-beyond-for-containers/ba-p/2712487)
+		// the ltsc2022 image should continue to work on builds ws2022 and onwards. With this in mind,
+		// if there's no mapping for the host build, just use the Windows Server 2022 image.
+		if build > osversion.V21H2Server {
+			return "mcr.microsoft.com/windows/servercore:ltsc2022"
+		}
 		panic("unsupported build")
 	}
 }

--- a/test/vendor/github.com/Microsoft/hcsshim/osversion/windowsbuilds.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/osversion/windowsbuilds.go
@@ -38,4 +38,13 @@ const (
 
 	// V21H1 corresponds to Windows Server 21H1 (semi-annual channel).
 	V21H1 = 19043
+
+	// V21H2Win10 corresponds to Windows 10 (November 2021 Update).
+	V21H2Win10 = 19044
+
+	// V21H2Server corresponds to Windows Server 2022 (ltsc2022).
+	V21H2Server = 20348
+
+	// V21H2Win11 corresponds to Windows 11 (original release).
+	V21H2Win11 = 22000
 )


### PR DESCRIPTION
This change backports the following changes to get ws2022 support for the cri-containerd suite. 

1. osversion package definitions for 21h2: https://github.com/microsoft/hcsshim/pull/1205
2. Add ws2022 image/build to cri-containerd tests: https://github.com/microsoft/hcsshim/pull/1160
