### PR TITLE
Add logging to layer retry code path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         uses: golangci/golangci-lint-action@v2
         with:
           version: v1.42.1 # Has fixes for stylecheck configuration https://github.com/golangci/golangci-lint/pull/2017/files
-          args: --timeout=5m -v
+          args: -v
           only-new-issues: true
 
   verify-main-vendor:

--- a/internal/layers/layers.go
+++ b/internal/layers/layers.go
@@ -116,6 +116,8 @@ func MountContainerLayers(ctx context.Context, containerID string, layerFolders 
 				// for ERROR_NOT_READY as well.
 				if hcserr, ok := lErr.(*hcserror.HcsError); ok {
 					if hcserr.Err == windows.ERROR_NOT_READY || hcserr.Err == windows.ERROR_DEVICE_NOT_CONNECTED {
+						log.G(ctx).WithField("path", path).WithError(hcserr.Err).Warning("retrying layer operations after failure")
+
 						// Sleep for a little before a re-attempt. A probable cause for these issues in the first place is events not getting
 						// reported in time so might be good to give some time for things to "cool down" or get back to a known state.
 						time.Sleep(time.Millisecond * 100)

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/layers/layers.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/layers/layers.go
@@ -116,6 +116,8 @@ func MountContainerLayers(ctx context.Context, containerID string, layerFolders 
 				// for ERROR_NOT_READY as well.
 				if hcserr, ok := lErr.(*hcserror.HcsError); ok {
 					if hcserr.Err == windows.ERROR_NOT_READY || hcserr.Err == windows.ERROR_DEVICE_NOT_CONNECTED {
+						log.G(ctx).WithField("path", path).WithError(hcserr.Err).Warning("retrying layer operations after failure")
+
 						// Sleep for a little before a re-attempt. A probable cause for these issues in the first place is events not getting
 						// reported in time so might be good to give some time for things to "cool down" or get back to a known state.
 						time.Sleep(time.Millisecond * 100)


### PR DESCRIPTION
This change adds a small log to the code path that handles retrying layer setup if we encountered a set of known error codes that we'd observed on ws2019. This is mostly just so we can tell how often we're actually hitting this and see which error is most prevalent.

This additionally contains a commit to remove the --timeout flag passed for our golangci runs. The command line flags have higher priority than the config file so our timeout defined there wasn't being honored.