### PR TITLE
Fix Test_ExtendedTask_ProcessorInfo CRI test

### DIFF
--- a/test/cri-containerd/extended_task_test.go
+++ b/test/cri-containerd/extended_task_test.go
@@ -81,14 +81,20 @@ func Test_ExtendedTask_ProcessorInfo(t *testing.T) {
 			defer stopPodSandbox(t, client, ctx, podID)
 
 			resp, err := getPodProcessorInfo(ctx, podID)
-			if err == nil && test.expectedError {
-				t.Fatalf("expected to get an error, instead got %v response", resp)
-			}
-			if err != nil && !test.expectedError {
-				t.Fatalf("failed to get pod processor info with %v", err)
-			}
-			if resp.Count != 2 {
-				t.Fatalf("expected to see 2 cpus on the pod, instead got %v", resp.Count)
+			if test.expectedError {
+				if err == nil {
+					t.Fatalf("expected to get an error, instead got %v response", resp)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("failed to get pod processor info with %v", err)
+				}
+				if resp == nil {
+					t.Fatalf("expected non-nil processor info response")
+				}
+				if resp.Count != 2 {
+					t.Fatalf("expected to see 2 cpus on the pod, instead got %v", resp.Count)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
Test_ExtendedTask_ProcessorInfo had a minor bug, when the
processor info request would return an error and the error was
expected. The test would still proceed to check the processor
count from the response in whicn case the response is nil and
the check results in nil point dereference.

Signed-off-by: Maksim An <maksiman@microsoft.com>