### PR TITLE
Fix checkptr error with > 1 process in job object

### DIFF
--- a/internal/jobobject/jobobject.go
+++ b/internal/jobobject/jobobject.go
@@ -364,9 +364,8 @@ func (job *JobObject) Pids() ([]uint32, error) {
 	}
 
 	bufInfo := (*winapi.JOBOBJECT_BASIC_PROCESS_ID_LIST)(unsafe.Pointer(&buf[0]))
-	bufPids := bufInfo.AllPids()
 	pids := make([]uint32, bufInfo.NumberOfProcessIdsInList)
-	for i, bufPid := range bufPids {
+	for i, bufPid := range bufInfo.AllPids() {
 		pids[i] = uint32(bufPid)
 	}
 	return pids, nil

--- a/internal/jobobject/jobobject_test.go
+++ b/internal/jobobject/jobobject_test.go
@@ -261,3 +261,35 @@ func TestNoMoreProcessesMessageTerminate(t *testing.T) {
 		t.Fatal("didn't receive no more processes message within timeout")
 	}
 }
+
+func TestVerifyPidCount(t *testing.T) {
+	// This test verifies that job.Pids() returns the right info and works with > 1 process.
+	options := &Options{
+		Name:          "test",
+		Notifications: true,
+	}
+	job, err := Create(context.Background(), options)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer job.Close()
+
+	numProcs := 2
+	_, err = createProcsAndAssign(numProcs, job)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pids, err := job.Pids()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(pids) != numProcs {
+		t.Fatalf("expected %d processes in the job, got: %d", numProcs, len(pids))
+	}
+
+	if err := job.Terminate(1); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/winapi/jobobject.go
+++ b/internal/winapi/jobobject.go
@@ -93,7 +93,7 @@ type JOBOBJECT_BASIC_PROCESS_ID_LIST struct {
 
 // AllPids returns all the process Ids in the job object.
 func (p *JOBOBJECT_BASIC_PROCESS_ID_LIST) AllPids() []uintptr {
-	return (*[(1 << 27) - 1]uintptr)(unsafe.Pointer(&p.ProcessIdList[0]))[:p.NumberOfProcessIdsInList]
+	return (*[(1 << 27) - 1]uintptr)(unsafe.Pointer(&p.ProcessIdList[0]))[:p.NumberOfProcessIdsInList:p.NumberOfProcessIdsInList]
 }
 
 // https://docs.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-jobobject_basic_accounting_information

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/winapi/jobobject.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/winapi/jobobject.go
@@ -93,7 +93,7 @@ type JOBOBJECT_BASIC_PROCESS_ID_LIST struct {
 
 // AllPids returns all the process Ids in the job object.
 func (p *JOBOBJECT_BASIC_PROCESS_ID_LIST) AllPids() []uintptr {
-	return (*[(1 << 27) - 1]uintptr)(unsafe.Pointer(&p.ProcessIdList[0]))[:p.NumberOfProcessIdsInList]
+	return (*[(1 << 27) - 1]uintptr)(unsafe.Pointer(&p.ProcessIdList[0]))[:p.NumberOfProcessIdsInList:p.NumberOfProcessIdsInList]
 }
 
 // https://docs.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-jobobject_basic_accounting_information


### PR DESCRIPTION
The `AllPids` method on JOBOBJECT_BASIC_PROCESS_ID_LIST would allocate a very large array to store any pids in the job object, cast the memory to this array, and then slice down to what elements it actually took up in the array based off the value of what was in the NumberOfProcessIdsInList field. The checkptr compile option doesn't like when slices don't have an explicit length and capacity so this change updates the slicing to use a three-index slice to set the capacity to the same as the length.

Before for fmt.Println(len(arr), cap(arr)) -> 2, 134217727
After: -> 2, 2

This change additionally adds a test in internal/jobobject and modifies the TestExecWithJob test in internal/exec to verify that checkptr doesn't get angry when we hit a code path that performs the cast (calling jobobject.Pids() if there's greater than 1 element)