### PR TITLE
Skip flaky TestPseudoConsolePowershell 

### DIFF
--- a/internal/exec/exec_test.go
+++ b/internal/exec/exec_test.go
@@ -176,6 +176,11 @@ func TestExecWithJob(t *testing.T) {
 }
 
 func TestPseudoConsolePowershell(t *testing.T) {
+	// This test is fairly flaky on the Github CI but seems to run fine locally. Skip this for now to let contributions continue without a hitch
+	// and until we can replace this with a better suited test shortly.
+	//
+	// TODO(dcantah): Fix/find a better test here
+	t.Skip("Skipping flaky test")
 	cpty, err := conpty.Create(80, 20, 0)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
This test is fairly flaky on the Github CI but seems to run fine locally (maybe pure
luck). Skip this for now to let contributions continue without a hitch and until we
can replace this with a better suited test shortly.