### PR TITLE
shim: Don't shadow err return in createPod

### DIFF
--- a/cmd/containerd-shim-runhcs-v1/pod.go
+++ b/cmd/containerd-shim-runhcs-v1/pod.go
@@ -53,7 +53,7 @@ type shimPod interface {
 	KillTask(ctx context.Context, tid, eid string, signal uint32, all bool) error
 }
 
-func createPod(ctx context.Context, events publisher, req *task.CreateTaskRequest, s *specs.Spec) (shimPod, error) {
+func createPod(ctx context.Context, events publisher, req *task.CreateTaskRequest, s *specs.Spec) (_ shimPod, err error) {
 	log.G(ctx).WithField("tid", req.ID).Debug("createPod")
 
 	if osversion.Build() < osversion.RS5 {


### PR DESCRIPTION
Correctly uses a named return value on createPod. Previously if err was
redeclared in a nested scope and then returned, defers would not see the
returned error value. In particular this prevented the UVM cleanup defer
from working properly.

Signed-off-by: Kevin Parsons <kevpar@microsoft.com>