### PR TITLE
Shutdown hcsshim properly

### DIFF
--- a/cmd/containerd-shim-runhcs-v1/main.go
+++ b/cmd/containerd-shim-runhcs-v1/main.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/Microsoft/go-winio/pkg/etw"
 	"github.com/Microsoft/go-winio/pkg/etwlogrus"
@@ -41,6 +42,9 @@ var (
 	containerdBinaryFlag string
 
 	idFlag string
+
+	// gracefulShutdownTimeout is how long to wait for clean-up before just exiting
+	gracefulShutdownTimeout = 3 * time.Second
 )
 
 func etwCallback(sourceID guid.GUID, state etw.ProviderState, level etw.Level, matchAnyKeyword uint64, matchAllKeyword uint64, filterData uintptr) {

--- a/cmd/containerd-shim-runhcs-v1/serve.go
+++ b/cmd/containerd-shim-runhcs-v1/serve.go
@@ -221,8 +221,7 @@ var serveCommand = cli.Command{
 		case err := <-serrs:
 			return err
 		case <-time.After(2 * time.Millisecond):
-			// TODO: JTERRY75 this is terrible code. Contribute a change to
-			// ttrpc that you can:
+			// TODO: Contribute a change to ttrpc so that you can:
 			//
 			// go func () { errs <- s.Serve() }
 			// select {
@@ -246,8 +245,10 @@ var serveCommand = cli.Command{
 				// Shouldn't need to os.Exit without clean up (ie, deferred `.Close()`s)
 				return nil
 			}
-			// Drain any remaining active ttrpc requests; times out after 200 ms
-			err = s.Shutdown(context.Background())
+			// currently the ttrpc shutdown is the only clean up to wait on
+			sctx, cancel := context.WithTimeout(context.Background(), gracefulShutdownTimeout)
+			defer cancel()
+			err = s.Shutdown(sctx)
 		}
 
 		return err

--- a/cmd/containerd-shim-runhcs-v1/serve.go
+++ b/cmd/containerd-shim-runhcs-v1/serve.go
@@ -183,7 +183,7 @@ var serveCommand = cli.Command{
 			WithTID(idFlag),
 			WithIsSandbox(ctx.Bool("is-sandbox")))
 		if err != nil {
-			return fmt.Errorf("starting service: %w", err)
+			return fmt.Errorf("failed to create new service: %w", err)
 		}
 
 		s, err := ttrpc.NewServer(ttrpc.WithUnaryServerInterceptor(octtrpc.ServerInterceptor()))
@@ -240,7 +240,7 @@ var serveCommand = cli.Command{
 		case err = <-serrs:
 			// the ttrpc server shutdown without processing a shutdown request
 		case <-svc.Done():
-			if !svc.GracefulShutdown {
+			if !svc.gracefulShutdown {
 				// Return immediately, but still close ttrpc server, pipes, and spans
 				// Shouldn't need to os.Exit without clean up (ie, deferred `.Close()`s)
 				return nil

--- a/cmd/containerd-shim-runhcs-v1/service.go
+++ b/cmd/containerd-shim-runhcs-v1/service.go
@@ -18,7 +18,29 @@ import (
 	"go.opencensus.io/trace"
 )
 
-var _ = (task.TaskService)(&service{})
+type ServiceOptions struct {
+	Events    publisher
+	TID       string
+	IsSandbox bool
+}
+
+type ServiceOption func(*ServiceOptions)
+
+func WithEventPublisher(e publisher) ServiceOption {
+	return func(o *ServiceOptions) {
+		o.Events = e
+	}
+}
+func WithTID(tid string) ServiceOption {
+	return func(o *ServiceOptions) {
+		o.TID = tid
+	}
+}
+func WithIsSandbox(s bool) ServiceOption {
+	return func(o *ServiceOptions) {
+		o.IsSandbox = s
+	}
+}
 
 type service struct {
 	events publisher
@@ -42,10 +64,35 @@ type service struct {
 	taskOrPod atomic.Value
 
 	// cl is the create lock. Since each shim MUST only track a single task or
-	// POD. `cl` is used to create the task or POD sandbox. It SHOULD not be
+	// POD. `cl` is used to create the task or POD sandbox. It SHOULD NOT be
 	// taken when creating tasks in a POD sandbox as they can happen
 	// concurrently.
 	cl sync.Mutex
+
+	// shut is closed to signal a shut request is received
+	shut chan struct{}
+	// shutOnce is responsible for closign `shut` and any other necessary cleanup
+	shutOnce sync.Once
+	// GracefulShutdown dictates whether to shutdown gracefully and clean up resources
+	// or exit immediately
+	GracefulShutdown bool
+}
+
+var _ = (task.TaskService)(&service{})
+
+func NewService(o ...ServiceOption) (svc *service, err error) {
+	var opts ServiceOptions
+	for _, op := range o {
+		op(&opts)
+	}
+
+	svc = &service{
+		events:    opts.Events,
+		tid:       opts.TID,
+		isSandbox: opts.IsSandbox,
+		shut:      make(chan struct{}),
+	}
+	return svc, nil
 }
 
 func (s *service) State(ctx context.Context, req *task.StateRequest) (resp *task.StateResponse, err error) {
@@ -474,4 +521,17 @@ func (s *service) ComputeProcessorInfo(ctx context.Context, req *extendedtask.Co
 
 	r, e := s.computeProcessorInfoInternal(ctx, req)
 	return r, errdefs.ToGRPC(e)
+}
+
+func (s *service) Done() <-chan struct{} {
+	return s.shut
+}
+
+func (s *service) IsShutdown() bool {
+	select {
+	case <-s.shut:
+		return true
+	default:
+		return false
+	}
 }

--- a/cmd/containerd-shim-runhcs-v1/service.go
+++ b/cmd/containerd-shim-runhcs-v1/service.go
@@ -69,13 +69,13 @@ type service struct {
 	// concurrently.
 	cl sync.Mutex
 
-	// shut is closed to signal a shut request is received
-	shut chan struct{}
-	// shutOnce is responsible for closign `shut` and any other necessary cleanup
-	shutOnce sync.Once
-	// GracefulShutdown dictates whether to shutdown gracefully and clean up resources
+	// shutdown is closed to signal a shutdown request is received
+	shutdown chan struct{}
+	// shutdownOnce is responsible for closing `shutdown` and any other necessary cleanup
+	shutdownOnce sync.Once
+	// gracefulShutdown dictates whether to shutdown gracefully and clean up resources
 	// or exit immediately
-	GracefulShutdown bool
+	gracefulShutdown bool
 }
 
 var _ = (task.TaskService)(&service{})
@@ -90,7 +90,7 @@ func NewService(o ...ServiceOption) (svc *service, err error) {
 		events:    opts.Events,
 		tid:       opts.TID,
 		isSandbox: opts.IsSandbox,
-		shut:      make(chan struct{}),
+		shutdown:  make(chan struct{}),
 	}
 	return svc, nil
 }
@@ -524,12 +524,12 @@ func (s *service) ComputeProcessorInfo(ctx context.Context, req *extendedtask.Co
 }
 
 func (s *service) Done() <-chan struct{} {
-	return s.shut
+	return s.shutdown
 }
 
 func (s *service) IsShutdown() bool {
 	select {
-	case <-s.shut:
+	case <-s.shutdown:
 		return true
 	default:
 		return false

--- a/cmd/containerd-shim-runhcs-v1/service_internal.go
+++ b/cmd/containerd-shim-runhcs-v1/service_internal.go
@@ -447,12 +447,13 @@ func (s *service) shutdownInternal(ctx context.Context, req *task.ShutdownReques
 		return empty, nil
 	}
 
-	if req.Now {
-		os.Exit(0)
-	}
-	// TODO: JTERRY75 if we dont use `now` issue a Shutdown to the ttrpc
-	// connection to drain any active requests.
-	os.Exit(0)
+	s.shutOnce.Do(func() {
+		// TODO: should taskOrPod be deleted/set to nil?
+		// TODO: is there any extra leftovers of the shimTask/Pod to clean? ie: verify all handles are closed?
+		s.GracefulShutdown = !req.Now
+		close(s.shut)
+	})
+
 	return empty, nil
 }
 

--- a/cmd/containerd-shim-runhcs-v1/service_internal.go
+++ b/cmd/containerd-shim-runhcs-v1/service_internal.go
@@ -447,11 +447,11 @@ func (s *service) shutdownInternal(ctx context.Context, req *task.ShutdownReques
 		return empty, nil
 	}
 
-	s.shutOnce.Do(func() {
+	s.shutdownOnce.Do(func() {
 		// TODO: should taskOrPod be deleted/set to nil?
 		// TODO: is there any extra leftovers of the shimTask/Pod to clean? ie: verify all handles are closed?
-		s.GracefulShutdown = !req.Now
-		close(s.shut)
+		s.gracefulShutdown = !req.Now
+		close(s.shutdown)
 	})
 
 	return empty, nil

--- a/cmd/containerd-shim-runhcs-v1/service_internal_podshim_test.go
+++ b/cmd/containerd-shim-runhcs-v1/service_internal_podshim_test.go
@@ -2,9 +2,11 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"math/rand"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/Microsoft/hcsshim/cmd/containerd-shim-runhcs-v1/options"
 	"github.com/Microsoft/hcsshim/cmd/containerd-shim-runhcs-v1/stats"
@@ -16,10 +18,19 @@ import (
 
 func setupPodServiceWithFakes(t *testing.T) (*service, *testShimTask, *testShimTask, *testShimExec) {
 	tid := strconv.Itoa(rand.Int())
-	s := service{
-		tid:       tid,
-		isSandbox: true,
+
+	s, err := NewService(WithTID(tid), WithIsSandbox(true))
+	if err != nil {
+		t.Fatalf("could not create service: %v", err)
 	}
+
+	// clean up the service
+	t.Cleanup(func() {
+		s.shutdownInternal(context.Background(), &task.ShutdownRequest{
+			ID:  s.tid,
+			Now: true,
+		})
+	})
 
 	pod := &testShimPod{id: tid}
 
@@ -45,7 +56,7 @@ func setupPodServiceWithFakes(t *testing.T) (*service, *testShimTask, *testShimT
 	pod.tasks.Store(task.id, task)
 	pod.tasks.Store(task2.id, task2)
 	s.taskOrPod.Store(pod)
-	return &s, task, task2, task2exec2
+	return s, task, task2, task2exec2
 }
 
 func Test_PodShim_getPod_NotCreated_Error(t *testing.T) {
@@ -720,6 +731,38 @@ func Test_PodShim_statsInternal_2ndTaskID_Success(t *testing.T) {
 			}
 			stats := statsI.(*stats.Statistics)
 			verifyExpectedStats(t, t2.isWCOW, false, stats)
+		})
+	}
+}
+
+func Test_PodShim_shutdownInternal(t *testing.T) {
+	for _, now := range []bool{true, false} {
+		t.Run(fmt.Sprintf("%s_Now_%t", t.Name(), now), func(t *testing.T) {
+			s, _, _, _ := setupPodServiceWithFakes(t)
+
+			if s.IsShutdown() {
+				t.Fatal("service prematurely shutdown")
+			}
+
+			_, err := s.shutdownInternal(context.Background(), &task.ShutdownRequest{
+				ID:  s.tid,
+				Now: now,
+			})
+			if err != nil {
+				t.Fatalf("could not shut down service: %v", err)
+			}
+
+			tm := time.NewTimer(5 * time.Millisecond)
+			select {
+			case <-tm.C:
+				t.Fatalf("shutdown channel did not close")
+			case <-s.Done():
+				tm.Stop()
+			}
+
+			if !s.IsShutdown() {
+				t.Fatal("service did not shutdown")
+			}
 		})
 	}
 }

--- a/cmd/containerd-shim-runhcs-v1/service_internal_podshim_test.go
+++ b/cmd/containerd-shim-runhcs-v1/service_internal_podshim_test.go
@@ -26,10 +26,12 @@ func setupPodServiceWithFakes(t *testing.T) (*service, *testShimTask, *testShimT
 
 	// clean up the service
 	t.Cleanup(func() {
-		s.shutdownInternal(context.Background(), &task.ShutdownRequest{
+		if _, err := s.shutdownInternal(context.Background(), &task.ShutdownRequest{
 			ID:  s.tid,
 			Now: true,
-		})
+		}); err != nil {
+			t.Fatalf("could not shutdown service: %v", err)
+		}
 	})
 
 	pod := &testShimPod{id: tid}

--- a/cmd/containerd-shim-runhcs-v1/service_internal_taskshim_test.go
+++ b/cmd/containerd-shim-runhcs-v1/service_internal_taskshim_test.go
@@ -26,10 +26,12 @@ func setupTaskServiceWithFakes(t *testing.T) (*service, *testShimTask, *testShim
 
 	// clean up the service
 	t.Cleanup(func() {
-		s.shutdownInternal(context.Background(), &task.ShutdownRequest{
+		if _, err := s.shutdownInternal(context.Background(), &task.ShutdownRequest{
 			ID:  s.tid,
 			Now: true,
-		})
+		}); err != nil {
+			t.Fatalf("could not shutdown service: %v", err)
+		}
 	})
 
 	task := &testShimTask{

--- a/cmd/containerd-shim-runhcs-v1/service_internal_taskshim_test.go
+++ b/cmd/containerd-shim-runhcs-v1/service_internal_taskshim_test.go
@@ -2,9 +2,11 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"math/rand"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/Microsoft/hcsshim/cmd/containerd-shim-runhcs-v1/options"
 	"github.com/Microsoft/hcsshim/cmd/containerd-shim-runhcs-v1/stats"
@@ -16,10 +18,20 @@ import (
 
 func setupTaskServiceWithFakes(t *testing.T) (*service, *testShimTask, *testShimExec) {
 	tid := strconv.Itoa(rand.Int())
-	s := service{
-		tid:       tid,
-		isSandbox: false,
+
+	s, err := NewService(WithTID(tid), WithIsSandbox(false))
+	if err != nil {
+		t.Fatalf("could not create service: %v", err)
 	}
+
+	// clean up the service
+	t.Cleanup(func() {
+		s.shutdownInternal(context.Background(), &task.ShutdownRequest{
+			ID:  s.tid,
+			Now: true,
+		})
+	})
+
 	task := &testShimTask{
 		id:    tid,
 		exec:  newTestShimExec(tid, tid, 10),
@@ -29,7 +41,7 @@ func setupTaskServiceWithFakes(t *testing.T) (*service, *testShimTask, *testShim
 	secondExec := newTestShimExec(tid, secondExecID, 101)
 	task.execs[secondExecID] = secondExec
 	s.taskOrPod.Store(task)
-	return &s, task, secondExec
+	return s, task, secondExec
 }
 
 func Test_TaskShim_getTask_NotCreated_Error(t *testing.T) {
@@ -616,6 +628,38 @@ func Test_TaskShim_statsInternal_InitTaskID_Sucess(t *testing.T) {
 			}
 			stats := statsI.(*stats.Statistics)
 			verifyExpectedStats(t, t1.isWCOW, true, stats)
+		})
+	}
+}
+
+func Test_TaskShim_shutdownInternal(t *testing.T) {
+	for _, now := range []bool{true, false} {
+		t.Run(fmt.Sprintf("%s_Now_%t", t.Name(), now), func(t *testing.T) {
+			s, _, _ := setupTaskServiceWithFakes(t)
+
+			if s.IsShutdown() {
+				t.Fatal("service prematurely shutdown")
+			}
+
+			_, err := s.shutdownInternal(context.Background(), &task.ShutdownRequest{
+				ID:  s.tid,
+				Now: now,
+			})
+			if err != nil {
+				t.Fatalf("could not shut down service: %v", err)
+			}
+
+			tm := time.NewTimer(5 * time.Millisecond)
+			select {
+			case <-tm.C:
+				t.Fatalf("shutdown channel did not close")
+			case <-s.Done():
+				tm.Stop()
+			}
+
+			if !s.IsShutdown() {
+				t.Fatal("service did not shutdown")
+			}
 		})
 	}
 }


### PR DESCRIPTION
Currently, when a `Shutdown` request is received, `service` calls `os.Exit` to forcefully exits the binary without cleaning up resources and IO channels, ending spans, or flushing logs. Primarily this prevents logging of shim-wide or long running spans but can also leak un-closed system resources.

For reference, the runc shim within containerd [does not respect](https://github.com/containerd/containerd/blob/77d53d2d230c3bcd3f02e6f493019a72905c875b/runtime/v2/runc/task/service.go#L470) the `ShutdownRequest.Now` parameter, and calls several cleanup callbacks instead of exiting immediately via `os.Exit`

Added `.Done()` and `.IsShutdown()` methods to `service` to signal that a service shutdown request from containerd for the init task was received, and updated the `serve` action to wait on a shutdown request to close the ttrpc servers and pipes.

Added `NewService` method and creation options to properly initialize the `service` struct, namely to create the internal channel to signal shutdown.

Added tests for `shutdownInternal`.

Signed-off-by: Hamza El-Saawy <hamzaelsaawy@microsoft.com>