### PR TITLE
Replace string error check for net.ErrClosed

### DIFF
--- a/cmd/containerd-shim-runhcs-v1/serve.go
+++ b/cmd/containerd-shim-runhcs-v1/serve.go
@@ -242,7 +242,7 @@ var serveCommand = cli.Command{
 }
 
 func trapClosedConnErr(err error) error {
-	if err == nil || strings.Contains(err.Error(), "use of closed network connection") {
+	if err == nil || errors.Is(err, net.ErrClosed) {
 		return nil
 	}
 	return err

--- a/cmd/ncproxy/server.go
+++ b/cmd/ncproxy/server.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"net"
-	"strings"
 	"sync"
 
 	"github.com/Microsoft/go-winio"
@@ -103,7 +102,7 @@ func (s *server) cleanupResources(ctx context.Context) {
 }
 
 func trapClosedConnErr(err error) error {
-	if err == nil || strings.Contains(err.Error(), "use of closed network connection") {
+	if err == nil || errors.Is(err, net.ErrClosed) {
 		return nil
 	}
 	return err

--- a/internal/uvm/computeagent.go
+++ b/internal/uvm/computeagent.go
@@ -2,7 +2,7 @@ package uvm
 
 import (
 	"context"
-	"strings"
+	"net"
 
 	"github.com/Microsoft/go-winio"
 	"github.com/Microsoft/hcsshim/hcn"
@@ -250,7 +250,7 @@ func setupAndServe(ctx context.Context, caAddr string, vm *UtilityVM) error {
 }
 
 func trapClosedConnErr(err error) error {
-	if err == nil || strings.Contains(err.Error(), "use of closed network connection") {
+	if err == nil || errors.Is(err, net.ErrClosed) {
 		return nil
 	}
 	return err

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/uvm/computeagent.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/uvm/computeagent.go
@@ -2,7 +2,7 @@ package uvm
 
 import (
 	"context"
-	"strings"
+	"net"
 
 	"github.com/Microsoft/go-winio"
 	"github.com/Microsoft/hcsshim/hcn"
@@ -250,7 +250,7 @@ func setupAndServe(ctx context.Context, caAddr string, vm *UtilityVM) error {
 }
 
 func trapClosedConnErr(err error) error {
-	if err == nil || strings.Contains(err.Error(), "use of closed network connection") {
+	if err == nil || errors.Is(err, net.ErrClosed) {
 		return nil
 	}
 	return err


### PR DESCRIPTION
In go 1.16 they exported net.ErrClosed so the hacky check of the string "use of closed network connection" is no longer needed (hurray). We have 1.17 listed in our go.mod file so there shouldn't be any build concerns here with using a 1.16 addition.