### PR TITLE
Cleanup 'getUserTokenInheritAnnotation'

### DIFF
--- a/internal/jobcontainers/jobcontainer.go
+++ b/internal/jobcontainers/jobcontainer.go
@@ -206,7 +206,7 @@ func (c *JobContainer) CreateProcess(ctx context.Context, config interface{}) (_
 	}
 
 	var token windows.Token
-	if getUserTokenInheritAnnotation(c.spec.Annotations) {
+	if inheritUserTokenIsSet(c.spec.Annotations) {
 		token, err = openCurrentProcessToken()
 		if err != nil {
 			return nil, err

--- a/internal/jobcontainers/oci.go
+++ b/internal/jobcontainers/oci.go
@@ -12,13 +12,14 @@ import (
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 )
 
-const processorWeightMax = 10000
-
 // This file contains helpers for converting parts of the oci spec to useful
 // structures/limits to be applied to a job object.
-func getUserTokenInheritAnnotation(annots map[string]string) bool {
-	val, ok := annots[annotations.HostProcessInheritUser]
-	return ok && val == "true"
+
+const processorWeightMax = 10000
+
+// inheritUserTokenIsSet checks if the annotation that specifies whether we should inherit the token of the current process is set.
+func inheritUserTokenIsSet(annots map[string]string) bool {
+	return annots[annotations.HostProcessInheritUser] == "true"
 }
 
 // Oci spec to job object limit information. Will do any conversions to job object specific values from


### PR DESCRIPTION
This function used to just return a bool of whether the annotation was "true"
or not which is a bit diffferent than what the name implied. Change to inheritUserTokenIsSet
to be more clear. It also used to check if the annotation was set internally which
shouldn't be needed as we only cared about whether it was "true" or not. If the
value isn't in the map we should just get back the default value of a string which
is fine for what it was being used for.

Additionally moves a comment that was mistakingly directly above the function body
to the top of the file.