### PR TITLE
Fix bugs in network setup introduced by a refactor PR

### DIFF
--- a/internal/uvm/network.go
+++ b/internal/uvm/network.go
@@ -345,7 +345,7 @@ func (uvm *UtilityVM) AddNetNS(ctx context.Context, hcnNamespace *hcn.HostComput
 			guestNamespace := hcsschema.ModifySettingRequest{
 				GuestRequest: guestrequest.ModificationRequest{
 					ResourceType: guestresource.ResourceTypeNetworkNamespace,
-					RequestType:  guestrequest.RequestTypeRemove,
+					RequestType:  guestrequest.RequestTypeAdd,
 					Settings:     hcnNamespace,
 				},
 			}
@@ -686,7 +686,7 @@ func (uvm *UtilityVM) AddNICInGuest(ctx context.Context, cfg *guestresource.LCOW
 	request := hcsschema.ModifySettingRequest{}
 	request.GuestRequest = guestrequest.ModificationRequest{
 		ResourceType: guestresource.ResourceTypeNetwork,
-		RequestType:  guestrequest.RequestTypePreAdd,
+		RequestType:  guestrequest.RequestTypeAdd,
 		Settings:     cfg,
 	}
 

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/uvm/network.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/uvm/network.go
@@ -345,7 +345,7 @@ func (uvm *UtilityVM) AddNetNS(ctx context.Context, hcnNamespace *hcn.HostComput
 			guestNamespace := hcsschema.ModifySettingRequest{
 				GuestRequest: guestrequest.ModificationRequest{
 					ResourceType: guestresource.ResourceTypeNetworkNamespace,
-					RequestType:  guestrequest.RequestTypeRemove,
+					RequestType:  guestrequest.RequestTypeAdd,
 					Settings:     hcnNamespace,
 				},
 			}
@@ -686,7 +686,7 @@ func (uvm *UtilityVM) AddNICInGuest(ctx context.Context, cfg *guestresource.LCOW
 	request := hcsschema.ModifySettingRequest{}
 	request.GuestRequest = guestrequest.ModificationRequest{
 		ResourceType: guestresource.ResourceTypeNetwork,
-		RequestType:  guestrequest.RequestTypePreAdd,
+		RequestType:  guestrequest.RequestTypeAdd,
 		Settings:     cfg,
 	}
 


### PR DESCRIPTION
When consolidating guest protocol into its own package
in https://github.com/microsoft/hcsshim/pull/1240 wrong constant
definition was used for adding a network namespace. Fix this by
using the correct constants.

Signed-off-by: Maksim An <maksiman@microsoft.com>