### PR TITLE
Revert "Enable gofmt in linter"

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,7 +3,6 @@ run:
 
 linters:
   enable:
-    - gofmt
     - stylecheck
 
 linters-settings:

--- a/test/vendor/github.com/Microsoft/hcsshim/.golangci.yml
+++ b/test/vendor/github.com/Microsoft/hcsshim/.golangci.yml
@@ -3,7 +3,6 @@ run:
 
 linters:
   enable:
-    - gofmt
     - stylecheck
 
 linters-settings:


### PR DESCRIPTION
Reverts commit f9c0efaab4ed4a9435579be25d8467f56ab05407 that enabled the
gofmt option for our golangci-lint step. For some reason after this change
the linter is complaining about a set of issues in internal\guest\transport\vsock.go
on lines 36 and 37, but the issue only arises on the push trigger and not the
pull_request trigger. This change is mainly to see if somehow this fixes
the issues so we can investigate further.