### PR TITLE
Put Linux build tag on /internal/guest/transport/vsock.go

### DIFF
--- a/internal/guest/transport/vsock.go
+++ b/internal/guest/transport/vsock.go
@@ -1,3 +1,6 @@
+//go:build linux
+// +build linux
+
 package transport
 
 import (


### PR DESCRIPTION
Most of the code in /internal/guest has build tags as it's all Linux specific
so apply one for vsock.go as well as vsock.Dial is unimplemented on Windows.

This also fixes a linter issue we've been seeing on the push trigger for
golangci-lint. It complains that the error check we're performing can
never be true (err == nil) because on linting this file with GOOS=windows
it will check the Windows implementation for vsock.Dial which is hard coded
to return an unimplemented error.