### PR TITLE
Working directory enforcement

### DIFF
--- a/internal/guest/runtime/hcsv2/uvm.go
+++ b/internal/guest/runtime/hcsv2/uvm.go
@@ -154,7 +154,12 @@ func (h *Host) CreateContainer(ctx context.Context, id string, settings *prot.VM
 		return nil, gcserr.NewHresultError(gcserr.HrVmcomputeSystemAlreadyExists)
 	}
 
-	err = h.securityPolicyEnforcer.EnforceCreateContainerPolicy(id, settings.OCISpecification.Process.Args, settings.OCISpecification.Process.Env)
+	err = h.securityPolicyEnforcer.EnforceCreateContainerPolicy(
+		id,
+		settings.OCISpecification.Process.Args,
+		settings.OCISpecification.Process.Env,
+		settings.OCISpecification.Process.Cwd,
+	)
 
 	if err != nil {
 		return nil, errors.Wrapf(err, "container creation denied due to policy")

--- a/internal/guest/storage/test/policy/mountmonitoringsecuritypolicyenforcer.go
+++ b/internal/guest/storage/test/policy/mountmonitoringsecuritypolicyenforcer.go
@@ -29,6 +29,6 @@ func (p *MountMonitoringSecurityPolicyEnforcer) EnforceOverlayMountPolicy(contai
 	return nil
 }
 
-func (p *MountMonitoringSecurityPolicyEnforcer) EnforceCreateContainerPolicy(containerID string, argList []string, envList []string) (err error) {
+func (p *MountMonitoringSecurityPolicyEnforcer) EnforceCreateContainerPolicy(_ string, _ []string, _ []string, _ string) (err error) {
 	return nil
 }

--- a/internal/jobcontainers/logon.go
+++ b/internal/jobcontainers/logon.go
@@ -31,7 +31,9 @@ func groupExists(groupName string) bool {
 	); err != nil {
 		return false
 	}
-	defer windows.NetApiBufferFree(p)
+	defer func() {
+		_ = windows.NetApiBufferFree(p)
+	}()
 	return true
 }
 

--- a/internal/tools/securitypolicy/main.go
+++ b/internal/tools/securitypolicy/main.go
@@ -80,6 +80,7 @@ func createPolicyFromConfig(config *securitypolicy.PolicyConfig) (*securitypolic
 		[]string{"/pause"},
 		[]securitypolicy.EnvRule{},
 		securitypolicy.AuthConfig{},
+		"",
 	)
 	config.Containers = append(config.Containers, pause)
 
@@ -147,7 +148,11 @@ func createPolicyFromConfig(config *securitypolicy.PolicyConfig) (*securitypolic
 		}
 		envRules = append(envRules, rule)
 
-		container, err := securitypolicy.NewContainer(containerConfig.Command, layerHashes, envRules)
+		workingDir := containerConfig.WorkingDir
+		if workingDir == "" {
+			workingDir = imgConfig.Config.WorkingDir
+		}
+		container, err := securitypolicy.NewContainer(containerConfig.Command, layerHashes, envRules, workingDir)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/tools/securitypolicy/main.go
+++ b/internal/tools/securitypolicy/main.go
@@ -148,9 +148,12 @@ func createPolicyFromConfig(config *securitypolicy.PolicyConfig) (*securitypolic
 		}
 		envRules = append(envRules, rule)
 
-		workingDir := containerConfig.WorkingDir
-		if workingDir == "" {
+		workingDir := "/"
+		if imgConfig.Config.WorkingDir != "" {
 			workingDir = imgConfig.Config.WorkingDir
+		}
+		if containerConfig.WorkingDir != "" {
+			workingDir = containerConfig.WorkingDir
 		}
 		container, err := securitypolicy.NewContainer(containerConfig.Command, layerHashes, envRules, workingDir)
 		if err != nil {

--- a/pkg/securitypolicy/securitypolicy.go
+++ b/pkg/securitypolicy/securitypolicy.go
@@ -38,19 +38,27 @@ type EnvRuleConfig struct {
 // ContainerConfig contains toml or JSON config for container described
 // in security policy.
 type ContainerConfig struct {
-	ImageName string     `json:"image_name" toml:"image_name"`
-	Command   []string   `json:"command" toml:"command"`
-	Auth      AuthConfig `json:"auth" toml:"auth"`
-	EnvRules  []EnvRule  `json:"env_rules" toml:"env_rule"`
+	ImageName  string     `json:"image_name" toml:"image_name"`
+	Command    []string   `json:"command" toml:"command"`
+	Auth       AuthConfig `json:"auth" toml:"auth"`
+	EnvRules   []EnvRule  `json:"env_rules" toml:"env_rule"`
+	WorkingDir string     `json:"working_dir" toml:"working_dir"`
 }
 
 // NewContainerConfig creates a new ContainerConfig from the given values.
-func NewContainerConfig(imageName string, command []string, envRules []EnvRule, auth AuthConfig) ContainerConfig {
+func NewContainerConfig(
+	imageName string,
+	command []string,
+	envRules []EnvRule,
+	auth AuthConfig,
+	workingDir string,
+) ContainerConfig {
 	return ContainerConfig{
-		ImageName: imageName,
-		Command:   command,
-		EnvRules:  envRules,
-		Auth:      auth,
+		ImageName:  imageName,
+		Command:    command,
+		EnvRules:   envRules,
+		Auth:       auth,
+		WorkingDir: workingDir,
 	}
 }
 
@@ -72,6 +80,9 @@ type securityPolicyContainer struct {
 	// order that the layers are overlayed is important and needs to be enforced
 	// as part of policy.
 	Layers []string `json:"layers"`
+	// WorkingDir is a path to container's working directory, which all the processes
+	// will default to.
+	WorkingDir string `json:"working_dir"`
 }
 
 // SecurityPolicyState is a structure that holds user supplied policy to enforce
@@ -141,9 +152,10 @@ type Containers struct {
 }
 
 type Container struct {
-	Command  CommandArgs `json:"command"`
-	EnvRules EnvRules    `json:"env_rules"`
-	Layers   Layers      `json:"layers"`
+	Command    CommandArgs `json:"command"`
+	EnvRules   EnvRules    `json:"env_rules"`
+	Layers     Layers      `json:"layers"`
+	WorkingDir string      `json:"working_dir"`
 }
 
 type Layers struct {
@@ -170,14 +182,15 @@ type EnvRule struct {
 
 // NewContainer creates a new Container instance from the provided values
 // or an error if envRules validation fails.
-func NewContainer(command, layers []string, envRules []EnvRule) (*Container, error) {
+func NewContainer(command, layers []string, envRules []EnvRule, workingDir string) (*Container, error) {
 	if err := validateEnvRules(envRules); err != nil {
 		return nil, err
 	}
 	return &Container{
-		Command:  newCommandArgs(command),
-		Layers:   newLayers(layers),
-		EnvRules: newEnvRules(envRules),
+		Command:    newCommandArgs(command),
+		Layers:     newLayers(layers),
+		EnvRules:   newEnvRules(envRules),
+		WorkingDir: workingDir,
 	}, nil
 }
 

--- a/pkg/securitypolicy/securitypolicy_test.go
+++ b/pkg/securitypolicy/securitypolicy_test.go
@@ -799,7 +799,7 @@ func (*generatedContainers) Generate(r *rand.Rand, size int) reflect.Value {
 }
 
 func generateContainers(r *rand.Rand, upTo int32) *generatedContainers {
-	containers := []securityPolicyContainer{}
+	var containers []securityPolicyContainer
 
 	numContainers := (int)(atLeastOneAtMost(r, upTo))
 	for i := 0; i < numContainers; i++ {

--- a/pkg/securitypolicy/securitypolicy_test.go
+++ b/pkg/securitypolicy/securitypolicy_test.go
@@ -3,6 +3,7 @@ package securitypolicy
 import (
 	"fmt"
 	"math/rand"
+	"os"
 	"reflect"
 	"strconv"
 	"strings"
@@ -34,7 +35,9 @@ const (
 var testRand *rand.Rand
 
 func init() {
-	testRand = rand.New(rand.NewSource(time.Now().Unix()))
+	seed := rand.NewSource(time.Now().Unix())
+	testRand = rand.New(seed)
+	fmt.Fprintf(os.Stdout, "securitypolicy_test seed: %d\n", seed.Int63())
 }
 
 // Validate that our conversion from the external SecurityPolicy representation

--- a/pkg/securitypolicy/securitypolicy_test.go
+++ b/pkg/securitypolicy/securitypolicy_test.go
@@ -707,8 +707,7 @@ func Test_WorkingDirectoryPolicy_Matches(t *testing.T) {
 			return false
 		}
 
-		err = tc.policy.enforceWorkingDirPolicy(tc.containerID, tc.container.WorkingDir)
-		return err == nil
+		return tc.policy.enforceWorkingDirPolicy(tc.containerID, tc.container.WorkingDir) == nil
 	}
 
 	if err := quick.Check(testFunc, &quick.Config{MaxCount: 1000}); err != nil {
@@ -729,8 +728,7 @@ func Test_WorkingDirectoryPolicy_NoMatches(t *testing.T) {
 			return false
 		}
 
-		err = tc.policy.enforceWorkingDirPolicy(tc.containerID, randString(testRand, 20))
-		return err != nil
+		return tc.policy.enforceWorkingDirPolicy(tc.containerID, randString(testRand, 20)) != nil
 	}
 
 	if err := quick.Check(testFunc, &quick.Config{MaxCount: 1000}); err != nil {

--- a/pkg/securitypolicy/securitypolicyenforcer.go
+++ b/pkg/securitypolicy/securitypolicyenforcer.go
@@ -334,10 +334,10 @@ func (pe *StandardSecurityPolicyEnforcer) EnforceCreateContainerPolicy(
 }
 
 func (pe *StandardSecurityPolicyEnforcer) enforceCommandPolicy(containerID string, argList []string) (err error) {
-	// Get a list of all the indexes into our security policy's list of
+	// Get a list of all the indices into our security policy's list of
 	// containers that are possible matches for this containerID based
 	// on the image overlay layout
-	possibleIndexes := possibleIndexesForID(containerID, pe.ContainerIndexToContainerIds)
+	possibleIndices := possibleIndicesForID(containerID, pe.ContainerIndexToContainerIds)
 
 	// Loop through every possible match and do two things:
 	// 1- see if any command matches. we need at least one match or
@@ -345,7 +345,7 @@ func (pe *StandardSecurityPolicyEnforcer) enforceCommandPolicy(containerID strin
 	// 2- remove this containerID as a possible match for any container from the
 	//    security policy whose command line isn't a match.
 	matchingCommandFound := false
-	for _, possibleIndex := range possibleIndexes {
+	for _, possibleIndex := range possibleIndices {
 		cmd := pe.Containers[possibleIndex].Command
 		if cmp.Equal(cmd, argList) {
 			matchingCommandFound = true
@@ -368,11 +368,11 @@ func (pe *StandardSecurityPolicyEnforcer) enforceEnvironmentVariablePolicy(conta
 	// Get a list of all the indexes into our security policy's list of
 	// containers that are possible matches for this containerID based
 	// on the image overlay layout and command line
-	possibleIndexes := possibleIndexesForID(containerID, pe.ContainerIndexToContainerIds)
+	possibleIndices := possibleIndicesForID(containerID, pe.ContainerIndexToContainerIds)
 
 	for _, envVariable := range envList {
 		matchingRuleFoundForSomeContainer := false
-		for _, possibleIndex := range possibleIndexes {
+		for _, possibleIndex := range possibleIndices {
 			envRules := pe.Containers[possibleIndex].EnvRules
 			ok := envIsMatchedByRule(envVariable, envRules)
 			if ok {
@@ -393,7 +393,7 @@ func (pe *StandardSecurityPolicyEnforcer) enforceEnvironmentVariablePolicy(conta
 }
 
 func (pe *StandardSecurityPolicyEnforcer) enforceWorkingDirPolicy(containerID string, workingDir string) error {
-	possibleIndices := possibleIndexesForID(containerID, pe.ContainerIndexToContainerIds)
+	possibleIndices := possibleIndicesForID(containerID, pe.ContainerIndexToContainerIds)
 
 	matched := false
 	for _, pIndex := range possibleIndices {
@@ -459,7 +459,7 @@ func equalForOverlay(a1 []string, a2 []string) bool {
 	return true
 }
 
-func possibleIndexesForID(containerID string, mapping map[int]map[string]struct{}) []int {
+func possibleIndicesForID(containerID string, mapping map[int]map[string]struct{}) []int {
 	possibles := []int{}
 	for index, ids := range mapping {
 		for id := range ids {

--- a/pkg/securitypolicy/securitypolicyenforcer.go
+++ b/pkg/securitypolicy/securitypolicyenforcer.go
@@ -400,9 +400,9 @@ func (pe *StandardSecurityPolicyEnforcer) enforceWorkingDirPolicy(containerID st
 		pWorkingDir := pe.Containers[pIndex].WorkingDir
 		if pWorkingDir == workingDir {
 			matched = true
-			continue
+		} else {
+			pe.narrowMatchesForContainerIndex(pIndex, containerID)
 		}
-		pe.narrowMatchesForContainerIndex(pIndex, containerID)
 	}
 	if !matched {
 		return fmt.Errorf("working_dir %s unmached by policy rule", workingDir)

--- a/pkg/securitypolicy/securitypolicyenforcer.go
+++ b/pkg/securitypolicy/securitypolicyenforcer.go
@@ -14,7 +14,7 @@ type SecurityPolicyEnforcer interface {
 	EnforceDeviceMountPolicy(target string, deviceHash string) (err error)
 	EnforceDeviceUnmountPolicy(unmountTarget string) (err error)
 	EnforceOverlayMountPolicy(containerID string, layerPaths []string) (err error)
-	EnforceCreateContainerPolicy(containerID string, argList []string, envList []string) (err error)
+	EnforceCreateContainerPolicy(containerID string, argList []string, envList []string, workingDir string) (err error)
 }
 
 func NewSecurityPolicyEnforcer(state SecurityPolicyState) (SecurityPolicyEnforcer, error) {
@@ -298,7 +298,12 @@ func (pe *StandardSecurityPolicyEnforcer) EnforceOverlayMountPolicy(containerID 
 	return nil
 }
 
-func (pe *StandardSecurityPolicyEnforcer) EnforceCreateContainerPolicy(containerID string, argList []string, envList []string) (err error) {
+func (pe *StandardSecurityPolicyEnforcer) EnforceCreateContainerPolicy(
+	containerID string,
+	argList []string,
+	envList []string,
+	workingDir string,
+) (err error) {
 	pe.mutex.Lock()
 	defer pe.mutex.Unlock()
 
@@ -310,13 +315,15 @@ func (pe *StandardSecurityPolicyEnforcer) EnforceCreateContainerPolicy(container
 		return errors.New("container has already been started")
 	}
 
-	err = pe.enforceCommandPolicy(containerID, argList)
-	if err != nil {
+	if err = pe.enforceCommandPolicy(containerID, argList); err != nil {
 		return err
 	}
 
-	err = pe.enforceEnvironmentVariablePolicy(containerID, envList)
-	if err != nil {
+	if err = pe.enforceEnvironmentVariablePolicy(containerID, envList); err != nil {
+		return err
+	}
+
+	if err = pe.enforceWorkingDirPolicy(containerID, workingDir); err != nil {
 		return err
 	}
 
@@ -382,6 +389,24 @@ func (pe *StandardSecurityPolicyEnforcer) enforceEnvironmentVariablePolicy(conta
 		}
 	}
 
+	return nil
+}
+
+func (pe *StandardSecurityPolicyEnforcer) enforceWorkingDirPolicy(containerID string, workingDir string) error {
+	possibleIndices := possibleIndexesForID(containerID, pe.ContainerIndexToContainerIds)
+
+	matched := false
+	for _, pIndex := range possibleIndices {
+		pWorkingDir := pe.Containers[pIndex].WorkingDir
+		if pWorkingDir == workingDir {
+			matched = true
+			continue
+		}
+		pe.narrowMatchesForContainerIndex(pIndex, containerID)
+	}
+	if !matched {
+		return fmt.Errorf("working_dir %s unmached by policy rule", workingDir)
+	}
 	return nil
 }
 
@@ -463,7 +488,7 @@ func (p *OpenDoorSecurityPolicyEnforcer) EnforceOverlayMountPolicy(containerID s
 	return nil
 }
 
-func (p *OpenDoorSecurityPolicyEnforcer) EnforceCreateContainerPolicy(containerID string, argList []string, envList []string) (err error) {
+func (p *OpenDoorSecurityPolicyEnforcer) EnforceCreateContainerPolicy(_ string, _ []string, _ []string, _ string) (err error) {
 	return nil
 }
 
@@ -483,6 +508,6 @@ func (p *ClosedDoorSecurityPolicyEnforcer) EnforceOverlayMountPolicy(containerID
 	return errors.New("creating an overlay fs is denied by policy")
 }
 
-func (p *ClosedDoorSecurityPolicyEnforcer) EnforceCreateContainerPolicy(containerID string, argList []string, envList []string) (err error) {
+func (p *ClosedDoorSecurityPolicyEnforcer) EnforceCreateContainerPolicy(_ string, _ []string, _ []string, _ string) (err error) {
 	return errors.New("running commands is denied by policy")
 }

--- a/test/vendor/github.com/Microsoft/hcsshim/pkg/securitypolicy/securitypolicy.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/pkg/securitypolicy/securitypolicy.go
@@ -38,19 +38,27 @@ type EnvRuleConfig struct {
 // ContainerConfig contains toml or JSON config for container described
 // in security policy.
 type ContainerConfig struct {
-	ImageName string     `json:"image_name" toml:"image_name"`
-	Command   []string   `json:"command" toml:"command"`
-	Auth      AuthConfig `json:"auth" toml:"auth"`
-	EnvRules  []EnvRule  `json:"env_rules" toml:"env_rule"`
+	ImageName  string     `json:"image_name" toml:"image_name"`
+	Command    []string   `json:"command" toml:"command"`
+	Auth       AuthConfig `json:"auth" toml:"auth"`
+	EnvRules   []EnvRule  `json:"env_rules" toml:"env_rule"`
+	WorkingDir string     `json:"working_dir" toml:"working_dir"`
 }
 
 // NewContainerConfig creates a new ContainerConfig from the given values.
-func NewContainerConfig(imageName string, command []string, envRules []EnvRule, auth AuthConfig) ContainerConfig {
+func NewContainerConfig(
+	imageName string,
+	command []string,
+	envRules []EnvRule,
+	auth AuthConfig,
+	workingDir string,
+) ContainerConfig {
 	return ContainerConfig{
-		ImageName: imageName,
-		Command:   command,
-		EnvRules:  envRules,
-		Auth:      auth,
+		ImageName:  imageName,
+		Command:    command,
+		EnvRules:   envRules,
+		Auth:       auth,
+		WorkingDir: workingDir,
 	}
 }
 
@@ -72,6 +80,9 @@ type securityPolicyContainer struct {
 	// order that the layers are overlayed is important and needs to be enforced
 	// as part of policy.
 	Layers []string `json:"layers"`
+	// WorkingDir is a path to container's working directory, which all the processes
+	// will default to.
+	WorkingDir string `json:"working_dir"`
 }
 
 // SecurityPolicyState is a structure that holds user supplied policy to enforce
@@ -141,9 +152,10 @@ type Containers struct {
 }
 
 type Container struct {
-	Command  CommandArgs `json:"command"`
-	EnvRules EnvRules    `json:"env_rules"`
-	Layers   Layers      `json:"layers"`
+	Command    CommandArgs `json:"command"`
+	EnvRules   EnvRules    `json:"env_rules"`
+	Layers     Layers      `json:"layers"`
+	WorkingDir string      `json:"working_dir"`
 }
 
 type Layers struct {
@@ -170,14 +182,15 @@ type EnvRule struct {
 
 // NewContainer creates a new Container instance from the provided values
 // or an error if envRules validation fails.
-func NewContainer(command, layers []string, envRules []EnvRule) (*Container, error) {
+func NewContainer(command, layers []string, envRules []EnvRule, workingDir string) (*Container, error) {
 	if err := validateEnvRules(envRules); err != nil {
 		return nil, err
 	}
 	return &Container{
-		Command:  newCommandArgs(command),
-		Layers:   newLayers(layers),
-		EnvRules: newEnvRules(envRules),
+		Command:    newCommandArgs(command),
+		Layers:     newLayers(layers),
+		EnvRules:   newEnvRules(envRules),
+		WorkingDir: workingDir,
 	}, nil
 }
 

--- a/test/vendor/github.com/Microsoft/hcsshim/pkg/securitypolicy/securitypolicyenforcer.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/pkg/securitypolicy/securitypolicyenforcer.go
@@ -334,10 +334,10 @@ func (pe *StandardSecurityPolicyEnforcer) EnforceCreateContainerPolicy(
 }
 
 func (pe *StandardSecurityPolicyEnforcer) enforceCommandPolicy(containerID string, argList []string) (err error) {
-	// Get a list of all the indexes into our security policy's list of
+	// Get a list of all the indices into our security policy's list of
 	// containers that are possible matches for this containerID based
 	// on the image overlay layout
-	possibleIndexes := possibleIndexesForID(containerID, pe.ContainerIndexToContainerIds)
+	possibleIndices := possibleIndicesForID(containerID, pe.ContainerIndexToContainerIds)
 
 	// Loop through every possible match and do two things:
 	// 1- see if any command matches. we need at least one match or
@@ -345,7 +345,7 @@ func (pe *StandardSecurityPolicyEnforcer) enforceCommandPolicy(containerID strin
 	// 2- remove this containerID as a possible match for any container from the
 	//    security policy whose command line isn't a match.
 	matchingCommandFound := false
-	for _, possibleIndex := range possibleIndexes {
+	for _, possibleIndex := range possibleIndices {
 		cmd := pe.Containers[possibleIndex].Command
 		if cmp.Equal(cmd, argList) {
 			matchingCommandFound = true
@@ -368,11 +368,11 @@ func (pe *StandardSecurityPolicyEnforcer) enforceEnvironmentVariablePolicy(conta
 	// Get a list of all the indexes into our security policy's list of
 	// containers that are possible matches for this containerID based
 	// on the image overlay layout and command line
-	possibleIndexes := possibleIndexesForID(containerID, pe.ContainerIndexToContainerIds)
+	possibleIndices := possibleIndicesForID(containerID, pe.ContainerIndexToContainerIds)
 
 	for _, envVariable := range envList {
 		matchingRuleFoundForSomeContainer := false
-		for _, possibleIndex := range possibleIndexes {
+		for _, possibleIndex := range possibleIndices {
 			envRules := pe.Containers[possibleIndex].EnvRules
 			ok := envIsMatchedByRule(envVariable, envRules)
 			if ok {
@@ -393,7 +393,7 @@ func (pe *StandardSecurityPolicyEnforcer) enforceEnvironmentVariablePolicy(conta
 }
 
 func (pe *StandardSecurityPolicyEnforcer) enforceWorkingDirPolicy(containerID string, workingDir string) error {
-	possibleIndices := possibleIndexesForID(containerID, pe.ContainerIndexToContainerIds)
+	possibleIndices := possibleIndicesForID(containerID, pe.ContainerIndexToContainerIds)
 
 	matched := false
 	for _, pIndex := range possibleIndices {
@@ -459,7 +459,7 @@ func equalForOverlay(a1 []string, a2 []string) bool {
 	return true
 }
 
-func possibleIndexesForID(containerID string, mapping map[int]map[string]struct{}) []int {
+func possibleIndicesForID(containerID string, mapping map[int]map[string]struct{}) []int {
 	possibles := []int{}
 	for index, ids := range mapping {
 		for id := range ids {

--- a/test/vendor/github.com/Microsoft/hcsshim/pkg/securitypolicy/securitypolicyenforcer.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/pkg/securitypolicy/securitypolicyenforcer.go
@@ -400,9 +400,9 @@ func (pe *StandardSecurityPolicyEnforcer) enforceWorkingDirPolicy(containerID st
 		pWorkingDir := pe.Containers[pIndex].WorkingDir
 		if pWorkingDir == workingDir {
 			matched = true
-			continue
+		} else {
+			pe.narrowMatchesForContainerIndex(pIndex, containerID)
 		}
-		pe.narrowMatchesForContainerIndex(pIndex, containerID)
 	}
 	if !matched {
 		return fmt.Errorf("working_dir %s unmached by policy rule", workingDir)

--- a/test/vendor/github.com/Microsoft/hcsshim/pkg/securitypolicy/securitypolicyenforcer.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/pkg/securitypolicy/securitypolicyenforcer.go
@@ -14,7 +14,7 @@ type SecurityPolicyEnforcer interface {
 	EnforceDeviceMountPolicy(target string, deviceHash string) (err error)
 	EnforceDeviceUnmountPolicy(unmountTarget string) (err error)
 	EnforceOverlayMountPolicy(containerID string, layerPaths []string) (err error)
-	EnforceCreateContainerPolicy(containerID string, argList []string, envList []string) (err error)
+	EnforceCreateContainerPolicy(containerID string, argList []string, envList []string, workingDir string) (err error)
 }
 
 func NewSecurityPolicyEnforcer(state SecurityPolicyState) (SecurityPolicyEnforcer, error) {
@@ -298,7 +298,12 @@ func (pe *StandardSecurityPolicyEnforcer) EnforceOverlayMountPolicy(containerID 
 	return nil
 }
 
-func (pe *StandardSecurityPolicyEnforcer) EnforceCreateContainerPolicy(containerID string, argList []string, envList []string) (err error) {
+func (pe *StandardSecurityPolicyEnforcer) EnforceCreateContainerPolicy(
+	containerID string,
+	argList []string,
+	envList []string,
+	workingDir string,
+) (err error) {
 	pe.mutex.Lock()
 	defer pe.mutex.Unlock()
 
@@ -310,13 +315,15 @@ func (pe *StandardSecurityPolicyEnforcer) EnforceCreateContainerPolicy(container
 		return errors.New("container has already been started")
 	}
 
-	err = pe.enforceCommandPolicy(containerID, argList)
-	if err != nil {
+	if err = pe.enforceCommandPolicy(containerID, argList); err != nil {
 		return err
 	}
 
-	err = pe.enforceEnvironmentVariablePolicy(containerID, envList)
-	if err != nil {
+	if err = pe.enforceEnvironmentVariablePolicy(containerID, envList); err != nil {
+		return err
+	}
+
+	if err = pe.enforceWorkingDirPolicy(containerID, workingDir); err != nil {
 		return err
 	}
 
@@ -382,6 +389,24 @@ func (pe *StandardSecurityPolicyEnforcer) enforceEnvironmentVariablePolicy(conta
 		}
 	}
 
+	return nil
+}
+
+func (pe *StandardSecurityPolicyEnforcer) enforceWorkingDirPolicy(containerID string, workingDir string) error {
+	possibleIndices := possibleIndexesForID(containerID, pe.ContainerIndexToContainerIds)
+
+	matched := false
+	for _, pIndex := range possibleIndices {
+		pWorkingDir := pe.Containers[pIndex].WorkingDir
+		if pWorkingDir == workingDir {
+			matched = true
+			continue
+		}
+		pe.narrowMatchesForContainerIndex(pIndex, containerID)
+	}
+	if !matched {
+		return fmt.Errorf("working_dir %s unmached by policy rule", workingDir)
+	}
 	return nil
 }
 
@@ -463,7 +488,7 @@ func (p *OpenDoorSecurityPolicyEnforcer) EnforceOverlayMountPolicy(containerID s
 	return nil
 }
 
-func (p *OpenDoorSecurityPolicyEnforcer) EnforceCreateContainerPolicy(containerID string, argList []string, envList []string) (err error) {
+func (p *OpenDoorSecurityPolicyEnforcer) EnforceCreateContainerPolicy(_ string, _ []string, _ []string, _ string) (err error) {
 	return nil
 }
 
@@ -483,6 +508,6 @@ func (p *ClosedDoorSecurityPolicyEnforcer) EnforceOverlayMountPolicy(containerID
 	return errors.New("creating an overlay fs is denied by policy")
 }
 
-func (p *ClosedDoorSecurityPolicyEnforcer) EnforceCreateContainerPolicy(containerID string, argList []string, envList []string) (err error) {
+func (p *ClosedDoorSecurityPolicyEnforcer) EnforceCreateContainerPolicy(_ string, _ []string, _ []string, _ string) (err error) {
 	return errors.New("running commands is denied by policy")
 }


### PR DESCRIPTION
The working directory can be set as part of container image
by WORKINGDIR Dockerfile directive or could be explicitly
set inside CRI container config. Changing the CWD of container
can change the expected behavior of a container.

If the working_dir config is not present or empty inside the
policy config, this information will be gathered from container
image spec.

Add logic to enforce CWD enforcement inside GCS and extend
policy dev tool and policy structure to support this scenario.
The enforcement is an exact string match between what's in the
policy and what's in the generated container spec. If the paths
don't match, the container will fail to start.

Add a utility funcion that picks a random container from an array
and generates a valid/invalid overlay for that container. Refactor
tests to use the new utility function
