### PR TITLE
test: use `T.TempDir` to create temporary test directory

### DIFF
--- a/cmd/ncproxy/server_test.go
+++ b/cmd/ncproxy/server_test.go
@@ -2,9 +2,7 @@ package main
 
 import (
 	"context"
-	"io/ioutil"
 	"net"
-	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -24,11 +22,7 @@ func TestRegisterComputeAgent(t *testing.T) {
 	ctx := context.Background()
 
 	// setup test database
-	tempDir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 
 	db, err := bolt.Open(filepath.Join(tempDir, "networkproxy.db.test"), 0600, nil)
 	if err != nil {
@@ -73,11 +67,7 @@ func TestConfigureNetworking(t *testing.T) {
 	ctx := context.Background()
 
 	// setup test database
-	tempDir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 
 	db, err := bolt.Open(filepath.Join(tempDir, "networkproxy.db.test"), 0600, nil)
 	if err != nil {
@@ -155,11 +145,7 @@ func TestReconnectComputeAgents_Success(t *testing.T) {
 	ctx := context.Background()
 
 	// setup test database
-	tempDir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 
 	db, err := bolt.Open(filepath.Join(tempDir, "networkproxy.db.test"), 0600, nil)
 	if err != nil {
@@ -204,11 +190,7 @@ func TestReconnectComputeAgents_Failure(t *testing.T) {
 	ctx := context.Background()
 
 	// setup test database
-	tempDir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 
 	db, err := bolt.Open(filepath.Join(tempDir, "networkproxy.db.test"), 0600, nil)
 	if err != nil {

--- a/internal/exec/exec_test.go
+++ b/internal/exec/exec_test.go
@@ -3,7 +3,6 @@ package exec
 import (
 	"context"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -39,11 +38,7 @@ func TestExec(t *testing.T) {
 
 func TestExecWithDir(t *testing.T) {
 	// Test that the working directory is successfully set to whatever was passed in.
-	dir, err := ioutil.TempDir("", "exec-test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	e, err := New(
 		`C:\Windows\System32\cmd.exe`,

--- a/internal/guest/storage/utilities_test.go
+++ b/internal/guest/storage/utilities_test.go
@@ -5,7 +5,6 @@ package storage
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -15,14 +14,10 @@ import (
 func Test_WaitForFileMatchingPattern_Success(t *testing.T) {
 	ctx, _ := context.WithTimeout(context.Background(), 2*time.Second)
 
-	testDir, err := ioutil.TempDir("", "vmbus_test")
-	if err != nil {
-		t.Fatalf("unexpected error creating temp dir %v", err)
-	}
-	defer os.RemoveAll(testDir)
+	testDir := t.TempDir()
 
 	actualPath := filepath.Join(testDir, "path1")
-	err = os.Mkdir(actualPath, 0777)
+	err := os.Mkdir(actualPath, 0777)
 	if err != nil {
 		t.Fatalf("unexpected error creating test path: %v", err)
 	}
@@ -43,11 +38,7 @@ func Test_WaitForFileMatchingPattern_Success(t *testing.T) {
 func Test_WaitForFileMatchingPattern_Multiple_Matches(t *testing.T) {
 	ctx, _ := context.WithTimeout(context.Background(), 2*time.Second)
 
-	testDir, err := ioutil.TempDir("", "vmbus_test")
-	if err != nil {
-		t.Fatalf("unexpected error creating temp dir %v", err)
-	}
-	defer os.RemoveAll(testDir)
+	testDir := t.TempDir()
 
 	actualPaths := []string{"path1", "path2"}
 	for _, p := range actualPaths {
@@ -59,7 +50,7 @@ func Test_WaitForFileMatchingPattern_Multiple_Matches(t *testing.T) {
 	}
 
 	pathPattern := filepath.Join(testDir, "path*")
-	_, err = WaitForFileMatchingPattern(ctx, pathPattern)
+	_, err := WaitForFileMatchingPattern(ctx, pathPattern)
 	if err == nil {
 		t.Fatalf("expected to fail due to multiple matching files")
 	}
@@ -68,14 +59,10 @@ func Test_WaitForFileMatchingPattern_Multiple_Matches(t *testing.T) {
 func Test_WaitForFileMatchingPattern_No_Matches(t *testing.T) {
 	ctx, _ := context.WithTimeout(context.Background(), 2*time.Second)
 
-	testDir, err := ioutil.TempDir("", "vmbus_test")
-	if err != nil {
-		t.Fatalf("unexpected error creating temp dir %v", err)
-	}
-	defer os.RemoveAll(testDir)
+	testDir := t.TempDir()
 
 	actualPath := filepath.Join(testDir, "path1")
-	err = os.Mkdir(actualPath, 0777)
+	err := os.Mkdir(actualPath, 0777)
 	if err != nil {
 		t.Fatalf("unexpected error creating test path: %v", err)
 	}

--- a/internal/jobcontainers/path_test.go
+++ b/internal/jobcontainers/path_test.go
@@ -1,7 +1,6 @@
 package jobcontainers
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -128,30 +127,29 @@ func TestGetApplicationNamePing(t *testing.T) {
 }
 
 func TestGetApplicationNameRandomBinary(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 
 	// Create fake executables in a temporary directory to use for the below tests.
 	testExe := filepath.Join(tempDir, "test.exe")
-	_, err = os.Create(testExe)
+	f1, err := os.Create(testExe)
 	if err != nil {
 		t.Fatal(err)
 	}
+	t.Cleanup(func() { _ = f1.Close() })
 
 	test2Exe := filepath.Join(tempDir, "test 2.exe")
-	_, err = os.Create(test2Exe)
+	f2, err := os.Create(test2Exe)
 	if err != nil {
 		t.Fatal(err)
 	}
+	t.Cleanup(func() { _ = f2.Close() })
 
 	exeWithSpace := filepath.Join(tempDir, "exe with space.exe")
-	_, err = os.Create(exeWithSpace)
+	f3, err := os.Create(exeWithSpace)
 	if err != nil {
 		t.Fatal(err)
 	}
+	t.Cleanup(func() { _ = f3.Close() })
 
 	tests := []*config{
 		// See if we can successfully find "exe with space.exe" with no quoting, it should first try "exe.exe", then "exe with.exe" and then finally

--- a/internal/ncproxy/store/store_test.go
+++ b/internal/ncproxy/store/store_test.go
@@ -2,8 +2,6 @@ package store
 
 import (
 	"context"
-	"io/ioutil"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -13,11 +11,7 @@ import (
 
 func TestComputeAgentStore(t *testing.T) {
 	ctx := context.Background()
-	tempDir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 
 	db, err := bolt.Open(filepath.Join(tempDir, "networkproxy.db.test"), 0600, nil)
 	if err != nil {
@@ -54,11 +48,7 @@ func TestComputeAgentStore(t *testing.T) {
 
 func TestComputeAgentStore_GetComputeAgents(t *testing.T) {
 	ctx := context.Background()
-	tempDir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 
 	db, err := bolt.Open(filepath.Join(tempDir, "networkproxy.db.test"), 0600, nil)
 	if err != nil {
@@ -93,11 +83,7 @@ func TestComputeAgentStore_GetComputeAgents(t *testing.T) {
 
 func TestEndpointStore(t *testing.T) {
 	ctx := context.Background()
-	tempDir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 
 	db, err := bolt.Open(filepath.Join(tempDir, "networkproxy.db.test"), 0600, nil)
 	if err != nil {
@@ -143,11 +129,7 @@ func TestEndpointStore(t *testing.T) {
 
 func TestEndpointStore_GetAll(t *testing.T) {
 	ctx := context.Background()
-	tempDir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 
 	db, err := bolt.Open(filepath.Join(tempDir, "networkproxy.db.test"), 0600, nil)
 	if err != nil {
@@ -192,11 +174,7 @@ func TestEndpointStore_GetAll(t *testing.T) {
 
 func TestNetworkStore(t *testing.T) {
 	ctx := context.Background()
-	tempDir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 
 	db, err := bolt.Open(filepath.Join(tempDir, "networkproxy.db.test"), 0600, nil)
 	if err != nil {
@@ -236,11 +214,7 @@ func TestNetworkStore(t *testing.T) {
 
 func TestNetworkStore_GetAll(t *testing.T) {
 	ctx := context.Background()
-	tempDir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 
 	db, err := bolt.Open(filepath.Join(tempDir, "networkproxy.db.test"), 0600, nil)
 	if err != nil {

--- a/internal/safefile/safeopen_admin_test.go
+++ b/internal/safefile/safeopen_admin_test.go
@@ -13,18 +13,16 @@ import (
 )
 
 func TestOpenRelative(t *testing.T) {
-	badroot, err := tempRoot()
+	badroot, err := tempRoot(t)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.RemoveAll(badroot.Name())
 	defer badroot.Close()
 
-	root, err := tempRoot()
+	root, err := tempRoot(t)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.RemoveAll(root.Name())
 	defer root.Close()
 
 	// Create a file

--- a/internal/safefile/safeopen_admin_test.go
+++ b/internal/safefile/safeopen_admin_test.go
@@ -17,13 +17,11 @@ func TestOpenRelative(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer badroot.Close()
 
 	root, err := tempRoot(t)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer root.Close()
 
 	// Create a file
 	f, err := OpenRelative("foo", root, 0, syscall.FILE_SHARE_READ, winapi.FILE_CREATE, 0)

--- a/internal/safefile/safeopen_test.go
+++ b/internal/safefile/safeopen_test.go
@@ -1,7 +1,6 @@
 package safefile
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"syscall"
@@ -10,25 +9,25 @@ import (
 	winio "github.com/Microsoft/go-winio"
 )
 
-func tempRoot() (*os.File, error) {
-	name, err := ioutil.TempDir("", "hcsshim-test")
-	if err != nil {
-		return nil, err
-	}
+func tempRoot(t *testing.T) (*os.File, error) {
+	name := t.TempDir()
 	f, err := OpenRoot(name)
 	if err != nil {
-		os.Remove(name)
 		return nil, err
 	}
-	return f, nil
+
+	t.Cleanup(func() {
+		_ = f.Close()
+	})
+
+	return f, err
 }
 
 func TestRemoveRelativeReadOnly(t *testing.T) {
-	root, err := tempRoot()
+	root, err := tempRoot(t)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.RemoveAll(root.Name())
 	defer root.Close()
 
 	p := filepath.Join(root.Name(), "foo")

--- a/internal/safefile/safeopen_test.go
+++ b/internal/safefile/safeopen_test.go
@@ -28,7 +28,6 @@ func TestRemoveRelativeReadOnly(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer root.Close()
 
 	p := filepath.Join(root.Name(), "foo")
 	f, err := os.Create(p)

--- a/test/containerd-shim-runhcs-v1/delete_test.go
+++ b/test/containerd-shim-runhcs-v1/delete_test.go
@@ -1,9 +1,9 @@
+//go:build functional
 // +build functional
 
 package main
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 	"time"
@@ -71,13 +71,7 @@ func Test_Delete_No_Bundle_Path(t *testing.T) {
 }
 
 func Test_Delete_HcsSystem_NotFound(t *testing.T) {
-	dir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatal("failed to create tmpdir")
-	}
-	defer func() {
-		os.RemoveAll(dir)
-	}()
+	dir := t.TempDir()
 
 	before := time.Now()
 	stdout, stderr, err := runGlobalCommand(

--- a/test/containerd-shim-runhcs-v1/start_test.go
+++ b/test/containerd-shim-runhcs-v1/start_test.go
@@ -1,3 +1,4 @@
+//go:build functional
 // +build functional
 
 package main
@@ -7,7 +8,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -27,10 +27,7 @@ func createStartCommand(t *testing.T) (*exec.Cmd, *bytes.Buffer, *bytes.Buffer) 
 }
 
 func createStartCommandWithID(t *testing.T, id string) (*exec.Cmd, *bytes.Buffer, *bytes.Buffer) {
-	bundleDir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatalf("failed to create bundle with: %v", err)
-	}
+	bundleDir := t.TempDir()
 	wd, err := os.Getwd()
 	if err != nil {
 		t.Fatalf("failed os.Getwd() with: %v", err)

--- a/test/cri-containerd/container_network_test.go
+++ b/test/cri-containerd/container_network_test.go
@@ -6,7 +6,6 @@ package cri_containerd
 import (
 	"bufio"
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -22,15 +21,7 @@ func Test_Container_Network_LCOW(t *testing.T) {
 	pullRequiredLCOWImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
 
 	// create a directory and log file
-	dir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatalf("failed creating temp dir: %v", err)
-	}
-	defer func() {
-		if err := os.RemoveAll(dir); err != nil {
-			t.Fatalf("failed deleting temp dir: %v", err)
-		}
-	}()
+	dir := t.TempDir()
 	log := filepath.Join(dir, "ping.txt")
 
 	sandboxRequest := getRunPodSandboxRequest(t, lcowRuntimeHandler)

--- a/test/cri-containerd/container_test.go
+++ b/test/cri-containerd/container_test.go
@@ -7,7 +7,6 @@ import (
 	"bufio"
 	"context"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -67,15 +66,7 @@ func Test_RotateLogs_LCOW(t *testing.T) {
 	requireFeatures(t, featureLCOW)
 
 	image := "alpine:latest"
-	dir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatalf("failed creating temp dir: %v", err)
-	}
-	defer func() {
-		if err := os.RemoveAll(dir); err != nil {
-			t.Fatalf("failed deleting temp dir: %v", err)
-		}
-	}()
+	dir := t.TempDir()
 	log := filepath.Join(dir, "log.txt")
 	logArchive := filepath.Join(dir, "log-archive.txt")
 

--- a/test/cri-containerd/createcontainer_test.go
+++ b/test/cri-containerd/createcontainer_test.go
@@ -938,11 +938,7 @@ func Test_CreateContainer_Mount_Dir_LCOW(t *testing.T) {
 
 	pullRequiredLCOWImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
 
-	tempDir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatalf("Failed to create temp dir: %s", err)
-	}
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 
 	containerFilePath := "/foo"
 
@@ -974,11 +970,7 @@ func Test_CreateContainer_Mount_ReadOnlyDir_LCOW(t *testing.T) {
 
 	pullRequiredLCOWImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
 
-	tempDir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatalf("Failed to create temp dir: %s", err)
-	}
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 
 	containerFilePath := "/foo"
 
@@ -1101,11 +1093,7 @@ func Test_CreateContainer_Mount_Dir_WCOW(t *testing.T) {
 
 	pullRequiredImages(t, []string{imageWindowsNanoserver})
 
-	tempDir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatalf("Failed to create temp dir: %s", err)
-	}
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 
 	containerFilePath := "C:\\foo"
 
@@ -1138,11 +1126,7 @@ func Test_CreateContainer_Mount_ReadOnlyDir_WCOW(t *testing.T) {
 
 	pullRequiredImages(t, []string{imageWindowsNanoserver})
 
-	tempDir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatalf("Failed to create temp dir: %s", err)
-	}
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 
 	containerFilePath := "C:\\foo"
 
@@ -1176,11 +1160,7 @@ func Test_CreateContainer_Mount_EmptyDir_WCOW(t *testing.T) {
 
 	pullRequiredImages(t, []string{imageWindowsNanoserver})
 
-	tempDir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatalf("Failed to create temp dir: %s", err)
-	}
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 	path := filepath.Join(tempDir, "kubernetes.io~empty-dir", "volume1")
 	if err := os.MkdirAll(path, 0); err != nil {
 		t.Fatalf("Failed to create kubernetes.io~empty-dir volume path: %s", err)
@@ -1223,11 +1203,7 @@ func Test_Mount_ReadOnlyDirReuse_WCOW(t *testing.T) {
 
 	containerPath := `C:\foo`
 
-	tempDir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatalf("Failed to create temp dir: %s", err)
-	}
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 
 	sandboxRequest := getRunPodSandboxRequest(t, wcowHypervisorRuntimeHandler)
 

--- a/test/cri-containerd/jobcontainer_test.go
+++ b/test/cri-containerd/jobcontainer_test.go
@@ -283,11 +283,7 @@ func Test_RunContainer_VHD_JobContainer_WCOW(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 	defer cancel()
 
-	dir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	vhdPath := filepath.Join(dir, "test.vhdx")
 	containerRequest.Config.Command = []string{
@@ -337,11 +333,7 @@ func Test_RunContainer_ETW_JobContainer_WCOW(t *testing.T) {
 	// For this test we'll launch an image that has a wprp file inside that we'll use to take an etw trace.
 	// After the etl file is generated we'll use tracerpt to create a report/dump file of the trace. This is
 	// just to verify that a common use case of grabbing host traces/diagnostics can be achieved.
-	dir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	// Need for network name is solely because the only provider defined in the image is for HNS, so
 	// we do a simple HNS operation to get some output.
 	var (
@@ -416,11 +408,7 @@ func Test_RunContainer_HostVolumes_JobContainer_WCOW(t *testing.T) {
 func Test_RunContainer_JobContainer_VolumeMount(t *testing.T) {
 	client := newTestRuntimeClient(t)
 
-	dir, err := ioutil.TempDir("", "example")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	tmpfn := filepath.Join(dir, "tmpfile")
 	if err := ioutil.WriteFile(tmpfn, []byte("test"), 0777); err != nil {

--- a/test/cri-containerd/runpodsandbox_test.go
+++ b/test/cri-containerd/runpodsandbox_test.go
@@ -9,8 +9,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
-	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -1086,11 +1084,7 @@ func Test_RunPodSandbox_MultipleContainersSameVhd_LCOW(t *testing.T) {
 	}
 
 	// Create a temporary ext4 VHD to mount into the container.
-	vhdHostDir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatalf("failed to create temp directory: %s", err)
-	}
-	defer os.RemoveAll(vhdHostDir)
+	vhdHostDir := t.TempDir()
 	vhdHostPath := filepath.Join(vhdHostDir, "temp.vhdx")
 	createExt4VHD(ctx, t, vhdHostPath)
 
@@ -1175,11 +1169,7 @@ func Test_RunPodSandbox_MultipleContainersSameVhd_RShared_LCOW(t *testing.T) {
 	defer stopPodSandbox(t, client, ctx, podID)
 
 	// Create a temporary ext4 VHD to mount into the container.
-	vhdHostDir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatalf("failed to create temp directory: %s", err)
-	}
-	defer os.RemoveAll(vhdHostDir)
+	vhdHostDir := t.TempDir()
 	vhdHostPath := filepath.Join(vhdHostDir, "temp.vhdx")
 	createExt4VHD(ctx, t, vhdHostPath)
 
@@ -1298,15 +1288,10 @@ func Test_RunPodSandbox_MultipleContainersSameVhd_WCOW(t *testing.T) {
 		annotations.AllowOvercommit: "true",
 	}
 
-	vhdHostDir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatalf("failed to create temporary directory: %s", err)
-	}
-	defer os.RemoveAll(vhdHostDir)
-
+	vhdHostDir := t.TempDir()
 	vhdHostPath := filepath.Join(vhdHostDir, "temp.vhdx")
 
-	if err = hcs.CreateNTFSVHD(ctx, vhdHostPath, 10); err != nil {
+	if err := hcs.CreateNTFSVHD(ctx, vhdHostPath, 10); err != nil {
 		t.Fatalf("failed to create NTFS VHD: %s", err)
 	}
 

--- a/test/functional/uvm_scsi_test.go
+++ b/test/functional/uvm_scsi_test.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -220,18 +219,10 @@ func TestParallelScsiOps(t *testing.T) {
 	defer u.Close()
 
 	// Create a sandbox to use
-	tempDir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatalf("failed to create tmpdir for test: %v", err)
-	}
+	tempDir := t.TempDir()
 	if err := lcow.CreateScratch(context.Background(), u, filepath.Join(tempDir, "sandbox.vhdx"), lcow.DefaultScratchSizeGB, ""); err != nil {
 		t.Fatalf("failed to create EXT4 scratch for LCOW test cases: %s", err)
 	}
-	defer func() {
-		if err := os.RemoveAll(tempDir); err != nil {
-			t.Errorf("failed to remove sandbox tmpdir: %v", err)
-		}
-	}()
 	copySandbox := func(dir string, workerId, iteration int) (string, error) {
 		orig, err := os.Open(filepath.Join(dir, "sandbox.vhdx"))
 		if err != nil {

--- a/test/runhcs/create-scratch_test.go
+++ b/test/runhcs/create-scratch_test.go
@@ -1,10 +1,10 @@
+//go:build functional
 // +build functional
 
 package runhcs
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -29,14 +29,8 @@ func Test_CreateScratch_DirDestpath_Failure(t *testing.T) {
 		Debug: true,
 	}
 
-	td, err := ioutil.TempDir("", "CreateScratch")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Remove(td)
-
 	ctx := context.TODO()
-	err = rhcs.CreateScratch(ctx, td)
+	err := rhcs.CreateScratch(ctx, t.TempDir())
 	if err == nil {
 		t.Fatal("Should have failed 'CreateScratch' command with dir destpath")
 	}
@@ -47,16 +41,10 @@ func Test_CreateScratch_ValidDestpath_Success(t *testing.T) {
 		Debug: true,
 	}
 
-	td, err := ioutil.TempDir("", "CreateScratch")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(td)
-
-	scratchPath := filepath.Join(td, "scratch.vhdx")
+	scratchPath := filepath.Join(t.TempDir(), "scratch.vhdx")
 
 	ctx := context.TODO()
-	err = rhcs.CreateScratch(ctx, scratchPath)
+	err := rhcs.CreateScratch(ctx, scratchPath)
 	if err != nil {
 		t.Fatalf("Failed 'CreateScratch' command with: %v", err)
 	}
@@ -71,19 +59,13 @@ func Test_CreateScratchWithOpts_SizeGB_Success(t *testing.T) {
 		Debug: true,
 	}
 
-	td, err := ioutil.TempDir("", "CreateScratchWithSize")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(td)
-
-	scratchPath := filepath.Join(td, "scratch.vhdx")
+	scratchPath := filepath.Join(t.TempDir(), "scratch.vhdx")
 
 	ctx := context.TODO()
 	opts := &runhcs.CreateScratchOpts{
 		SizeGB: 30,
 	}
-	err = rhcs.CreateScratchWithOpts(ctx, scratchPath, opts)
+	err := rhcs.CreateScratchWithOpts(ctx, scratchPath, opts)
 	if err != nil {
 		t.Fatalf("Failed 'CreateScratch' command with: %v", err)
 	}


### PR DESCRIPTION
A small testing enhancement.

We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete.

Reference: https://pkg.go.dev/testing#T.TempDir