### PR TITLE
Fix error seen while stopping container under normal code flow

### DIFF
--- a/cmd/containerd-shim-runhcs-v1/exec_hcs.go
+++ b/cmd/containerd-shim-runhcs-v1/exec_hcs.go
@@ -300,7 +300,11 @@ func (he *hcsExec) Kill(ctx context.Context, signal uint32) error {
 		}
 		return nil
 	case shimExecStateExited:
-		return errors.Wrapf(errdefs.ErrNotFound, "exec: '%s' in task: '%s' not found", he.id, he.tid)
+		log.G(ctx).WithFields(logrus.Fields{
+			"eid": he.id,
+			"tid": he.tid,
+		}).Debug("shimExecStateExited")
+		return nil
 	default:
 		return newExecInvalidStateError(he.tid, he.id, he.state, "kill")
 	}


### PR DESCRIPTION
**Root Cause:** 
When a container is stopped, hcsshim throws "rpc error: code = NotFound desc = exec: <eid> in task: <tid> not found" error while killing the associated task. 
The call to  func (p *pod) KillTask(ctx context.Context, tid, eid string, signal uint32, **all** bool) happens twice in the callstack - once with the argument **all = false** and the second time with **all = true**. The taskId associated with the container is killed during the first call and is already in the shimExecStateExited state when kill() gets called for the second time, resulting in the task not found error.
**Fix:** 
Since the task we are looking for has already exited, it is safe to have the code behave as a no-op here and return successfully. The fix also adds an info log for the same.
**Testing**
Tested the fix manually and also ran tests under hcsshim/test locally.