### PR TITLE
Set up dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: "gomod"
+    directory: "/test"
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Dependabot automatically creates PRs for updated dependencies and tracks security vulnerabilities.

----

While dependabot updates *some* of dependencies in hcsshim (see https://github.com/microsoft/hcsshim/pull/1313 for example), it:

1. Doesn't track updates to GitHub Actions workflow files
2. Ignores many updates to `go.mod` for unknown reason. I tried committing this config to my fork and got more than five updates (five open PRs is default dependabot limit, there are definitely more updates). There are also two security issues (one in github.com/docker/distribution and one in github.com/docker/docker).