### PR TITLE
Default to deny all security policy.

### DIFF
--- a/internal/guest/runtime/hcsv2/uvm.go
+++ b/internal/guest/runtime/hcsv2/uvm.go
@@ -16,7 +16,7 @@ import (
 	"syscall"
 	"time"
 
-	shellwords "github.com/mattn/go-shellwords"
+	"github.com/mattn/go-shellwords"
 	"github.com/pkg/errors"
 
 	"github.com/Microsoft/hcsshim/internal/guest/gcserr"
@@ -66,7 +66,7 @@ func NewHost(rtime runtime.Runtime, vsock transport.Transport) *Host {
 		rtime:                     rtime,
 		vsock:                     vsock,
 		securityPolicyEnforcerSet: false,
-		securityPolicyEnforcer:    &securitypolicy.OpenDoorSecurityPolicyEnforcer{},
+		securityPolicyEnforcer:    &securitypolicy.ClosedDoorSecurityPolicyEnforcer{},
 	}
 }
 

--- a/internal/tools/securitypolicy/README.md
+++ b/internal/tools/securitypolicy/README.md
@@ -159,4 +159,3 @@ isn't in the TOML configuration.
 If the version of the pause container changes from 3.1, you will need to update
 the hardcoded root hash by running the `dmverity-vhd` to compute the root hash
 for the new container and update this tool accordingly.
-

--- a/internal/uvm/security_policy.go
+++ b/internal/uvm/security_policy.go
@@ -20,7 +20,12 @@ func (uvm *UtilityVM) SetSecurityPolicy(ctx context.Context, policy string) erro
 	}
 
 	if policy == "" {
-		return nil
+		openDoorPolicy := securitypolicy.NewOpenDoorPolicy()
+		policyString, err := openDoorPolicy.EncodeToString()
+		if err != nil {
+			return err
+		}
+		policy = policyString
 	}
 
 	uvm.m.Lock()

--- a/pkg/securitypolicy/securitypolicy.go
+++ b/pkg/securitypolicy/securitypolicy.go
@@ -160,12 +160,13 @@ type SecurityPolicy struct {
 	Containers Containers `json:"containers"`
 }
 
+// EncodeToString returns base64 encoded string representation of SecurityPolicy.
 func (sp *SecurityPolicy) EncodeToString() (string, error) {
-	j, err := json.Marshal(sp)
+	jsn, err := json.Marshal(sp)
 	if err != nil {
 		return "", err
 	}
-	return base64.StdEncoding.EncodeToString(j), nil
+	return base64.StdEncoding.EncodeToString(jsn), nil
 }
 
 type Containers struct {

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/uvm/security_policy.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/uvm/security_policy.go
@@ -20,7 +20,12 @@ func (uvm *UtilityVM) SetSecurityPolicy(ctx context.Context, policy string) erro
 	}
 
 	if policy == "" {
-		return nil
+		openDoorPolicy := securitypolicy.NewOpenDoorPolicy()
+		policyString, err := openDoorPolicy.EncodeToString()
+		if err != nil {
+			return err
+		}
+		policy = policyString
 	}
 
 	uvm.m.Lock()

--- a/test/vendor/github.com/Microsoft/hcsshim/pkg/securitypolicy/securitypolicy.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/pkg/securitypolicy/securitypolicy.go
@@ -160,12 +160,13 @@ type SecurityPolicy struct {
 	Containers Containers `json:"containers"`
 }
 
+// EncodeToString returns base64 encoded string representation of SecurityPolicy.
 func (sp *SecurityPolicy) EncodeToString() (string, error) {
-	j, err := json.Marshal(sp)
+	jsn, err := json.Marshal(sp)
 	if err != nil {
 		return "", err
 	}
-	return base64.StdEncoding.EncodeToString(j), nil
+	return base64.StdEncoding.EncodeToString(jsn), nil
 }
 
 type Containers struct {


### PR DESCRIPTION
When bringing up the UVM default to closed door security policy
to reject any modification requests prior to security policy is set
inside GCS.
When security policy is empty, default to open door policy.

Signed-off-by: Maksim An <maksiman@microsoft.com>