### PR TITLE
Add Go bindflt/silo definitions

### DIFF
--- a/internal/exec/exec_test.go
+++ b/internal/exec/exec_test.go
@@ -176,7 +176,7 @@ func TestExecsWithJob(t *testing.T) {
 	}
 
 	if len(pids) != 2 {
-		t.Fatalf("should be two pids in job object, got: %d", len(pids))
+		t.Fatalf("should be two pids in job object, got: %d. Pids: %+v", len(pids), pids)
 	}
 
 	for _, pid := range pids {

--- a/internal/jobobject/jobobject.go
+++ b/internal/jobobject/jobobject.go
@@ -3,7 +3,10 @@ package jobobject
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
 	"sync"
+	"sync/atomic"
 	"unsafe"
 
 	"github.com/Microsoft/hcsshim/internal/queue"
@@ -24,7 +27,10 @@ import (
 // the job, a queue to receive iocp notifications about the lifecycle
 // of the job and a mutex for synchronized handle access.
 type JobObject struct {
-	handle     windows.Handle
+	handle windows.Handle
+	// All accesses to this MUST be done atomically. 1 signifies that this
+	// job is currently a silo.
+	isAppSilo  uint32
 	mq         *queue.MessageQueue
 	handleLock sync.RWMutex
 }
@@ -56,6 +62,7 @@ const (
 var (
 	ErrAlreadyClosed = errors.New("the handle has already been closed")
 	ErrNotRegistered = errors.New("job is not registered to receive notifications")
+	ErrNotSilo       = errors.New("job is not a silo")
 )
 
 // Options represents the set of configurable options when making or opening a job object.
@@ -68,6 +75,9 @@ type Options struct {
 	// `UseNTVariant` specifies if we should use the `Nt` variant of Open/CreateJobObject.
 	// Defaults to false.
 	UseNTVariant bool
+	// `Silo` specifies to promote the job to a silo. This additionally sets the flag
+	// JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE as it is required for the upgrade to complete.
+	Silo bool
 }
 
 // Create creates a job object.
@@ -132,6 +142,16 @@ func Create(ctx context.Context, options *Options) (_ *JobObject, err error) {
 			return nil, err
 		}
 		job.mq = mq
+	}
+
+	if options.Silo {
+		// This is a required setting for upgrading to a silo.
+		if err := job.SetTerminateOnLastHandleClose(); err != nil {
+			return nil, err
+		}
+		if err := job.PromoteToSilo(); err != nil {
+			return nil, err
+		}
 	}
 
 	return job, nil
@@ -435,4 +455,97 @@ func (job *JobObject) QueryStorageStats() (*winapi.JOBOBJECT_BASIC_AND_IO_ACCOUN
 		return nil, errors.Wrap(err, "failed to query for job object storage stats")
 	}
 	return &info, nil
+}
+
+// ApplyFileBinding makes a file binding using the Bind Filter from target to root. If the job has
+// not been upgraded to a silo this call will fail. The binding is only applied and visible for processes
+// running in the job, any processes on the host or in another job will not be able to see the binding.
+func (job *JobObject) ApplyFileBinding(root, target string, merged bool) error {
+	job.handleLock.RLock()
+	defer job.handleLock.RUnlock()
+
+	if job.handle == 0 {
+		return ErrAlreadyClosed
+	}
+
+	if !job.isSilo() {
+		return ErrNotSilo
+	}
+
+	// The parent directory needs to exist for the bind to work.
+	if _, err := os.Stat(filepath.Dir(root)); os.IsNotExist(err) {
+		if err := os.MkdirAll(filepath.Dir(root), 0); err != nil {
+			return err
+		}
+	}
+
+	rootPtr, err := windows.UTF16PtrFromString(root)
+	if err != nil {
+		return err
+	}
+
+	targetPtr, err := windows.UTF16PtrFromString(target)
+	if err != nil {
+		return err
+	}
+
+	flags := winapi.BINDFLT_FLAG_USE_CURRENT_SILO_MAPPING
+	if merged {
+		flags |= winapi.BINDFLT_FLAG_MERGED_BIND_MAPPING
+	}
+
+	if err := winapi.BfSetupFilterEx(
+		flags,
+		job.handle,
+		nil,
+		rootPtr,
+		targetPtr,
+		nil,
+		0,
+	); err != nil {
+		return fmt.Errorf("failed to bind target %q to root %q for job object: %w", target, root, err)
+	}
+	return nil
+}
+
+// PromoteToSilo promotes a job object to a silo. There must be no running processess
+// in the job for this to succeed. If the job is already a silo this is a no-op.
+func (job *JobObject) PromoteToSilo() error {
+	job.handleLock.RLock()
+	defer job.handleLock.RUnlock()
+
+	if job.handle == 0 {
+		return ErrAlreadyClosed
+	}
+
+	if job.isSilo() {
+		return nil
+	}
+
+	pids, err := job.Pids()
+	if err != nil {
+		return err
+	}
+
+	if len(pids) != 0 {
+		return fmt.Errorf("job cannot have running processes to be promoted to a silo, found %d running processes", len(pids))
+	}
+
+	_, err = windows.SetInformationJobObject(
+		job.handle,
+		winapi.JobObjectCreateSilo,
+		0,
+		0,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to promote job to silo: %w", err)
+	}
+
+	atomic.StoreUint32(&job.isAppSilo, 1)
+	return nil
+}
+
+// isSilo returns if the job object is a silo.
+func (job *JobObject) isSilo() bool {
+	return atomic.LoadUint32(&job.isAppSilo) == 1
 }

--- a/internal/jobobject/jobobject.go
+++ b/internal/jobobject/jobobject.go
@@ -473,7 +473,10 @@ func (job *JobObject) ApplyFileBinding(root, target string, merged bool) error {
 	}
 
 	// The parent directory needs to exist for the bind to work.
-	if _, err := os.Stat(filepath.Dir(root)); os.IsNotExist(err) {
+	if _, err := os.Stat(filepath.Dir(root)); err != nil {
+		if !os.IsNotExist(err) {
+			return err
+		}
 		if err := os.MkdirAll(filepath.Dir(root), 0); err != nil {
 			return err
 		}

--- a/internal/winapi/bindflt.go
+++ b/internal/winapi/bindflt.go
@@ -1,0 +1,20 @@
+package winapi
+
+const (
+	BINDFLT_FLAG_READ_ONLY_MAPPING        uint32 = 0x00000001
+	BINDFLT_FLAG_MERGED_BIND_MAPPING      uint32 = 0x00000002
+	BINDFLT_FLAG_USE_CURRENT_SILO_MAPPING uint32 = 0x00000004
+)
+
+// HRESULT
+// BfSetupFilterEx(
+//     _In_ ULONG Flags,
+//     _In_opt_ HANDLE JobHandle,
+//     _In_opt_ PSID Sid,
+//     _In_ LPCWSTR VirtualizationRootPath,
+//     _In_ LPCWSTR VirtualizationTargetPath,
+//     _In_reads_opt_( VirtualizationExceptionPathCount ) LPCWSTR* VirtualizationExceptionPaths,
+//     _In_opt_ ULONG VirtualizationExceptionPathCount
+// );
+//
+//sys BfSetupFilterEx(flags uint32, jobHandle windows.Handle, sid *windows.SID, virtRootPath *uint16, virtTargetPath *uint16, virtExceptions **uint16, virtExceptionPathCount uint32) (hr error) = bindfltapi.BfSetupFilterEx?

--- a/internal/winapi/jobobject.go
+++ b/internal/winapi/jobobject.go
@@ -52,6 +52,7 @@ const (
 	JobObjectLimitViolationInformation       uint32 = 13
 	JobObjectMemoryUsageInformation          uint32 = 28
 	JobObjectNotificationLimitInformation2   uint32 = 33
+	JobObjectCreateSilo                      uint32 = 35
 	JobObjectIoAttribution                   uint32 = 42
 )
 

--- a/internal/winapi/winapi.go
+++ b/internal/winapi/winapi.go
@@ -2,4 +2,4 @@
 // be thought of as an extension to golang.org/x/sys/windows.
 package winapi
 
-//go:generate go run ..\..\mksyscall_windows.go -output zsyscall_windows.go user.go console.go system.go net.go path.go thread.go jobobject.go logon.go memory.go process.go processor.go devices.go filesystem.go errors.go
+//go:generate go run ..\..\mksyscall_windows.go -output zsyscall_windows.go bindflt.go user.go console.go system.go net.go path.go thread.go jobobject.go logon.go memory.go process.go processor.go devices.go filesystem.go errors.go

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/winapi/bindflt.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/winapi/bindflt.go
@@ -1,0 +1,20 @@
+package winapi
+
+const (
+	BINDFLT_FLAG_READ_ONLY_MAPPING        uint32 = 0x00000001
+	BINDFLT_FLAG_MERGED_BIND_MAPPING      uint32 = 0x00000002
+	BINDFLT_FLAG_USE_CURRENT_SILO_MAPPING uint32 = 0x00000004
+)
+
+// HRESULT
+// BfSetupFilterEx(
+//     _In_ ULONG Flags,
+//     _In_opt_ HANDLE JobHandle,
+//     _In_opt_ PSID Sid,
+//     _In_ LPCWSTR VirtualizationRootPath,
+//     _In_ LPCWSTR VirtualizationTargetPath,
+//     _In_reads_opt_( VirtualizationExceptionPathCount ) LPCWSTR* VirtualizationExceptionPaths,
+//     _In_opt_ ULONG VirtualizationExceptionPathCount
+// );
+//
+//sys BfSetupFilterEx(flags uint32, jobHandle windows.Handle, sid *windows.SID, virtRootPath *uint16, virtTargetPath *uint16, virtExceptions **uint16, virtExceptionPathCount uint32) (hr error) = bindfltapi.BfSetupFilterEx?

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/winapi/jobobject.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/winapi/jobobject.go
@@ -52,6 +52,7 @@ const (
 	JobObjectLimitViolationInformation       uint32 = 13
 	JobObjectMemoryUsageInformation          uint32 = 28
 	JobObjectNotificationLimitInformation2   uint32 = 33
+	JobObjectCreateSilo                      uint32 = 35
 	JobObjectIoAttribution                   uint32 = 42
 )
 

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/winapi/winapi.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/winapi/winapi.go
@@ -2,4 +2,4 @@
 // be thought of as an extension to golang.org/x/sys/windows.
 package winapi
 
-//go:generate go run ..\..\mksyscall_windows.go -output zsyscall_windows.go user.go console.go system.go net.go path.go thread.go jobobject.go logon.go memory.go process.go processor.go devices.go filesystem.go errors.go
+//go:generate go run ..\..\mksyscall_windows.go -output zsyscall_windows.go bindflt.go user.go console.go system.go net.go path.go thread.go jobobject.go logon.go memory.go process.go processor.go devices.go filesystem.go errors.go


### PR DESCRIPTION
This change adds a couple Go bindings for calls and constants from bindfltapi.dll as well as some silo flags for job objects. Together these allow file bindings (think bind mounts on Linux) to be performed for a specific job object. The bindings
are only viewable from processes within that specific job.

This change additionally adds a couple unit tests for this behavior.