### PR TITLE
Scrubbing bugfix: incorrect return variable

### DIFF
--- a/internal/log/scrub.go
+++ b/internal/log/scrub.go
@@ -60,7 +60,7 @@ func ScrubProcessParameters(s string) (string, error) {
 	if err := encode(buf, pp); err != nil {
 		return "", err
 	}
-	return strings.TrimSpace(s), nil
+	return strings.TrimSpace(buf.String()), nil
 }
 
 // ScrubBridgeCreate scrubs requests sent over the bridge of type

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/log/scrub.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/log/scrub.go
@@ -60,7 +60,7 @@ func ScrubProcessParameters(s string) (string, error) {
 	if err := encode(buf, pp); err != nil {
 		return "", err
 	}
-	return strings.TrimSpace(s), nil
+	return strings.TrimSpace(buf.String()), nil
 }
 
 // ScrubBridgeCreate scrubs requests sent over the bridge of type


### PR DESCRIPTION
Bug where un-scrubbed parameter was returned instead of scrubbed result

Signed-off-by: Hamza El-Saawy <hamzaelsaawy@microsoft.com>