### PR TITLE
Fix up job object options for unit tests

### DIFF
--- a/internal/exec/exec_test.go
+++ b/internal/exec/exec_test.go
@@ -3,7 +3,6 @@ package exec
 import (
 	"context"
 	"io"
-	"log"
 	"os"
 	"path/filepath"
 	"testing"
@@ -127,9 +126,9 @@ func TestExecStdinPowershell(t *testing.T) {
 
 func TestExecsWithJob(t *testing.T) {
 	// Test that we can assign processes to a job object at creation time.
-	job, err := jobobject.Create(context.Background(), &jobobject.Options{Name: "test"})
+	job, err := jobobject.Create(context.Background(), nil)
 	if err != nil {
-		log.Fatal(err)
+		t.Fatal(err)
 	}
 	defer job.Close()
 


### PR DESCRIPTION
Most of the `jobobject` package tests we have ask for options that aren't actually needed/used. This change makes it so that any test that doesn't need a named job object doesn't ask for one and any test that doesn't plan on using the iocp messages doesn't flip the notifications field either. This wasn't causing any issues, but it's probably best to filter down what's being tested to only what's needed.