### PR TITLE
Fix dm-verity target naming format in linux guest

### DIFF
--- a/internal/guest/storage/scsi/scsi.go
+++ b/internal/guest/storage/scsi/scsi.go
@@ -45,7 +45,7 @@ var (
 const (
 	scsiDevicesPath  = "/sys/bus/scsi/devices"
 	vmbusDevicesPath = "/sys/bus/vmbus/devices"
-	verityDeviceFmt  = "verity-scsi-contr%d-lun%d-%s"
+	verityDeviceFmt  = "dm-verity-scsi-contr%d-lun%d-%s"
 )
 
 // fetchActualControllerNumber retrieves the actual controller number assigned to a SCSI controller


### PR DESCRIPTION
When adding layer integrity checking feature for SCSI devices,
the dm-verity device format naming was inconsistent with the
already existing pmem based verity target.
Make the naming consistent by changing `verity-scsi-...` to
`dm-verity-scsi-...`.

Signed-off-by: Maksim An <maksiman@microsoft.com>