### PR TITLE
Removed shim publisher dependence on global flag/setting 

### DIFF
--- a/cmd/containerd-shim-runhcs-v1/events.go
+++ b/cmd/containerd-shim-runhcs-v1/events.go
@@ -15,17 +15,19 @@ type publisher interface {
 }
 
 type eventPublisher struct {
+	namespace       string
 	remotePublisher *shim.RemoteEventsPublisher
 }
 
-var _ = (publisher)(&eventPublisher{})
+var _ publisher = &eventPublisher{}
 
-func newEventPublisher(address string) (*eventPublisher, error) {
+func newEventPublisher(address, namespace string) (*eventPublisher, error) {
 	p, err := shim.NewPublisher(address)
 	if err != nil {
 		return nil, err
 	}
 	return &eventPublisher{
+		namespace:       namespace,
 		remotePublisher: p,
 	}, nil
 }
@@ -46,5 +48,5 @@ func (e *eventPublisher) publishEvent(ctx context.Context, topic string, event i
 		return nil
 	}
 
-	return e.remotePublisher.Publish(namespaces.WithNamespace(ctx, namespaceFlag), topic, event)
+	return e.remotePublisher.Publish(namespaces.WithNamespace(ctx, e.namespace), topic, event)
 }

--- a/cmd/containerd-shim-runhcs-v1/events_test.go
+++ b/cmd/containerd-shim-runhcs-v1/events_test.go
@@ -6,7 +6,7 @@ type fakePublisher struct {
 	events []interface{}
 }
 
-var _ = (publisher)(&fakePublisher{})
+var _ publisher = &fakePublisher{}
 
 func newFakePublisher() *fakePublisher {
 	return &fakePublisher{}

--- a/cmd/containerd-shim-runhcs-v1/serve.go
+++ b/cmd/containerd-shim-runhcs-v1/serve.go
@@ -1,3 +1,5 @@
+//go:build windows
+
 package main
 
 import (
@@ -175,7 +177,7 @@ var serveCommand = cli.Command{
 		}
 
 		ttrpcAddress := os.Getenv(ttrpcAddressEnv)
-		ttrpcEventPublisher, err := newEventPublisher(ttrpcAddress)
+		ttrpcEventPublisher, err := newEventPublisher(ttrpcAddress, namespaceFlag)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Shim `eventPublisher` now uses an internal setting for the namespace instead of relying on a global flag.

Signed-off-by: Hamza El-Saawy <hamzaelsaawy@microsoft.com>