### PR TITLE
Implement file binding support for host process containers

### DIFF
--- a/internal/jobcontainers/jobcontainer.go
+++ b/internal/jobcontainers/jobcontainer.go
@@ -280,8 +280,8 @@ func (c *JobContainer) CreateProcess(ctx context.Context, config interface{}) (_
 			// would be to treat all paths as relative to the volume.
 			//
 			// For example:
-			// A working directory of C:\ would become C:\C\12345678\
-			// A working directory of C:\work\dir would become C:\C\12345678\work\dir
+			// A working directory of C:\ would become C:\hpc\12345678\
+			// A working directory of C:\work\dir would become C:\hpc\12345678\work\dir
 			//
 			// The below calls replaceWithMountPoint to replace any occurrences of the environment variable that points to where the container image
 			// volume is mounted.

--- a/internal/jobcontainers/jobcontainer.go
+++ b/internal/jobcontainers/jobcontainer.go
@@ -787,7 +787,7 @@ func (c *JobContainer) bindSetup(ctx context.Context, s *specs.Spec) (err error)
 		return err
 	}
 	c.rootfsLocation = rootfsLocation
-	return c.setupMounts(s)
+	return c.setupMounts(ctx, s)
 }
 
 // This handles the fallback case where bind mounting isn't available on the machine. This mounts the

--- a/internal/jobcontainers/jobcontainer.go
+++ b/internal/jobcontainers/jobcontainer.go
@@ -258,8 +258,9 @@ func (c *JobContainer) CreateProcess(ctx context.Context, config interface{}) (_
 			}
 		}
 	} else {
-		// Bind support is available, set the default working directory to C:\payload if
-		// nothing is set.
+		// Just use the exact working directory the user asked for if we have file binding support.
+		// Still support replacing %CONTAINER_SANDBOX_MOUNT_POINT% in the string for backwards compat
+		// however.
 		if conf.WorkingDirectory != "" {
 			workDir, _ = c.replaceWithMountPoint(conf.WorkingDirectory)
 		}
@@ -312,7 +313,7 @@ func (c *JobContainer) CreateProcess(ctx context.Context, config interface{}) (_
 	// Add the rootfs location to PATH so you can run things from the root of the image.
 	for idx, envVar := range env {
 		ev := strings.TrimSpace(envVar)
-		if len(ev) >= 5 && strings.ToLower(ev[:5]) == "path=" {
+		if strings.HasPrefix(strings.ToLower(ev), "path=") {
 			rootfsLoc := c.rootfsLocation
 			if rune(ev[len(ev)-1]) != ';' {
 				rootfsLoc = ";" + rootfsLoc

--- a/internal/jobcontainers/jobcontainer.go
+++ b/internal/jobcontainers/jobcontainer.go
@@ -31,6 +31,15 @@ import (
 	"golang.org/x/sys/windows"
 )
 
+var fileBindingSupport bool
+
+func init() {
+	bindDLL := `C:\windows\system32\bindfltapi.dll`
+	if _, err := os.Stat(bindDLL); err == nil {
+		fileBindingSupport = true
+	}
+}
+
 // Split arguments but ignore spaces in quotes.
 //
 // For example instead of:
@@ -42,6 +51,7 @@ func splitArgs(cmdLine string) []string {
 }
 
 const (
+	// jobContainerNameFmt is the naming format that job objects for job containers will follow.
 	jobContainerNameFmt = "JobContainer_%s"
 	// Environment variable set in every process in the job detailing where the containers volume
 	// is mounted on the host.
@@ -56,10 +66,16 @@ type initProc struct {
 
 // JobContainer represents a lightweight container composed from a job object.
 type JobContainer struct {
-	id               string
-	spec             *specs.Spec          // OCI spec used to create the container
-	job              *jobobject.JobObject // Object representing the job object the container owns
-	sandboxMount     string               // Path to where the sandbox is mounted on the host
+	id string
+	// OCI spec used to create the container.
+	spec *specs.Spec
+	// The job object the container owns.
+	job *jobobject.JobObject
+	// Path to where the rootfs is located on the host
+	// if no file binding support is available, or in the
+	// silo if it is.
+	rootfsLocation string
+
 	closedWaitOnce   sync.Once
 	init             initProc
 	token            windows.Token
@@ -70,8 +86,11 @@ type JobContainer struct {
 	waitError        error
 }
 
-var _ cow.ProcessHost = &JobContainer{}
-var _ cow.Container = &JobContainer{}
+// Compile time checks for interface adherance.
+var (
+	_ cow.ProcessHost = &JobContainer{}
+	_ cow.Container   = &JobContainer{}
+)
 
 func newJobContainer(id string, s *specs.Spec) *JobContainer {
 	return &JobContainer{
@@ -83,7 +102,7 @@ func newJobContainer(id string, s *specs.Spec) *JobContainer {
 	}
 }
 
-// Create creates a new JobContainer from `s`.
+// Create creates a new JobContainer from the OCI runtime spec `s`.
 func Create(ctx context.Context, id string, s *specs.Spec) (_ cow.Container, _ *resources.Resources, err error) {
 	log.G(ctx).WithField("id", id).Debug("Creating job container")
 
@@ -106,17 +125,16 @@ func Create(ctx context.Context, id string, s *specs.Spec) (_ cow.Container, _ *
 		Name:          fmt.Sprintf(jobContainerNameFmt, id),
 		Notifications: true,
 	}
-	job, err := jobobject.Create(ctx, options)
+	container.job, err = jobobject.Create(ctx, options)
 	if err != nil {
-		return nil, nil, errors.Wrap(err, "failed to create job object")
+		return nil, nil, fmt.Errorf("failed to create job object: %w", err)
 	}
 
 	// Parity with how we handle process isolated containers. We set the same flag which
-	// behaves the same way for a silo.
-	if err := job.SetTerminateOnLastHandleClose(); err != nil {
-		return nil, nil, errors.Wrap(err, "failed to set terminate on last handle close on job container")
+	// behaves the same way for a server silo.
+	if err := container.job.SetTerminateOnLastHandleClose(); err != nil {
+		return nil, nil, fmt.Errorf("failed to set terminate on last handle close on job container: %w", err)
 	}
-	container.job = job
 
 	r := resources.NewContainerResources(id)
 	defer func() {
@@ -126,18 +144,30 @@ func Create(ctx context.Context, id string, s *specs.Spec) (_ cow.Container, _ *
 		}
 	}()
 
-	sandboxPath := fmt.Sprintf(sandboxMountFormat, id)
-	if err := mountLayers(ctx, id, s, sandboxPath); err != nil {
-		return nil, nil, errors.Wrap(err, "failed to mount container layers")
+	// If bind mount support is available on the host, there's a lot of new functionality we
+	// can make use of that improves the UX for volume mounts and where the containers rootfs
+	// shows up on the host. You can do per silo bindings so every container can have a static
+	// path for its rootfs location and avoid having to make liberal use of the
+	// CONTAINER_SANDBOX_MOUNT_POINT environment variable.
+	if fileBindingSupport {
+		if err := container.bindSetup(ctx, s); err != nil {
+			return nil, nil, err
+		}
+	} else {
+		if err := container.fallbackSetup(ctx, s); err != nil {
+			return nil, nil, err
+		}
 	}
-	container.sandboxMount = sandboxPath
 
-	layers := layers.NewImageLayers(nil, "", s.Windows.LayerFolders, sandboxPath, false)
+	// We actually don't need to pass in anything for volumeMountPath below if we have file binding support,
+	// the filter allows us to pass in a raw volume path and it can use that to bind a volume to a friendly path
+	// instead so we can skip calling SetVolumeMountPoint.
+	var rootfsMountPoint string
+	if !fileBindingSupport {
+		rootfsMountPoint = container.rootfsLocation
+	}
+	layers := layers.NewImageLayers(nil, "", s.Windows.LayerFolders, rootfsMountPoint, false)
 	r.SetLayers(layers)
-
-	if err := setupMounts(s, container.sandboxMount); err != nil {
-		return nil, nil, err
-	}
 
 	volumeGUIDRegex := `^\\\\\?\\(Volume)\{{0,1}[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}(\}){0,1}\}(|\\)$`
 	if matched, err := regexp.MatchString(volumeGUIDRegex, s.Root.Path); !matched || err != nil {
@@ -146,12 +176,12 @@ func Create(ctx context.Context, id string, s *specs.Spec) (_ cow.Container, _ *
 
 	limits, err := specToLimits(ctx, id, s)
 	if err != nil {
-		return nil, nil, errors.Wrap(err, "failed to convert OCI spec to job object limits")
+		return nil, nil, fmt.Errorf("failed to convert OCI spec to job object limits: %w", err)
 	}
 
 	// Set resource limits on the job object based off of oci spec.
-	if err := job.SetResourceLimits(limits); err != nil {
-		return nil, nil, errors.Wrap(err, "failed to set resource limits")
+	if err := container.job.SetResourceLimits(limits); err != nil {
+		return nil, nil, fmt.Errorf("failed to set resource limits: %w", err)
 	}
 
 	go container.waitBackground(ctx)
@@ -166,9 +196,28 @@ func (c *JobContainer) CreateProcess(ctx context.Context, config interface{}) (_
 		return nil, errors.New("unsupported process config passed in")
 	}
 
-	// Replace any occurrences of the sandbox mount point env variable in the commandline.
-	// %CONTAINER_SANDBOX_MOUNTPOINT%\mybinary.exe -> C:\C\123456789\mybinary.exe
+	// Replace any occurences of the sandbox mount env variable in the commandline.
+	// For example: %CONTAINER_SANDBOX_MOUNTPOINT%\mybinary.exe -> C:\<rootfslocation>\mybinary.exe.
 	commandLine, _ := c.replaceWithMountPoint(conf.CommandLine)
+
+	// This is to workaround a rather unfortunate outcome with launching a process in a silo that
+	// has bound files.
+	// If a user requested to launch a program at C:\<rootfslocation>\mybinary.exe because they
+	// expect C:\<rootfslocation>\mybinary.exe to exist once the file bindings are done, it actually
+	// won't work. This is because the process is launched on the host first and the
+	// bindings are only visible to processes in that silo specifically. The shim is not
+	// one of these processes, and this is where we're invoking CreateProcess. So CreateProcess
+	// and our commandline resolution logic won't be able to find the process being asked for.
+	// Deep down in the depths of CreateProcess the culprit is a NtQueryAttributesFile call that
+	// fails as it doesn't have any context surrounding paths available to our silo.
+	//
+	// A way to get around this is to launch a process that will always exist (cmd) and is in our
+	// path, and then just invoke the program with the cmdline supplied. We could also add a new
+	// mode/flag for the shim where it's just a dummy process launcher, so we can invoke the shim
+	// instead of cmd and have more control over things.
+	if fileBindingSupport {
+		commandLine = "cmd /c " + commandLine
+	}
 
 	removeDriveLetter := func(name string) string {
 		// If just the letter and colon (C:) then replace with a single backslash. Else just trim the drive letter and leave the rest of the
@@ -181,24 +230,40 @@ func (c *JobContainer) CreateProcess(ctx context.Context, config interface{}) (_
 		return name
 	}
 
-	workDir := c.sandboxMount
-	if conf.WorkingDirectory != "" {
-		var changed bool
-		// For now, we join the working directory requested with where the sandbox volume is located. It's expected that the default behavior
-		// would be to treat all paths as relative to the volume.
-		//
-		// For example:
-		// A working directory of C:\ would become C:\C\12345678\
-		// A working directory of C:\work\dir would become C:\C\12345678\work\dir
-		//
-		// The below calls replaceWithMountPoint to replace any occurrences of the environment variable that points to where the container image
-		// volume is mounted.
-		workDir, changed = c.replaceWithMountPoint(conf.WorkingDirectory)
-		// If the working directory was changed, that means the user supplied %CONTAINER_SANDBOX_MOUNT_POINT%\\my\dir or something similar.
-		// In that case there's nothing left to do, as we don't want to join it with the mount point again.. If it *wasn't* changed, then we
-		// need to join it with the mount point, as it's some normal path.
-		if !changed {
-			workDir = filepath.Join(c.sandboxMount, removeDriveLetter(workDir))
+	workDir := c.rootfsLocation
+	// Only need to adjust the working directory in the case where bind support isn't available.
+	if !fileBindingSupport {
+		if conf.WorkingDirectory != "" {
+			var changed bool
+			// For now, we join the working directory requested with where the sandbox volume is located. It's expected that the default behavior
+			// would be to treat all paths as relative to the volume.
+			//
+			// For example:
+			// A working directory of C:\ would become C:\C\12345678\
+			// A working directory of C:\work\dir would become C:\C\12345678\work\dir
+			//
+			// The below calls replaceWithMountPoint to replace any occurrences of the environment variable that points to where the container image
+			// volume is mounted.
+			workDir, changed = c.replaceWithMountPoint(conf.WorkingDirectory)
+			// If the working directory was changed, that means the user supplied %CONTAINER_SANDBOX_MOUNT_POINT%\\my\dir or something similar.
+			// In that case there's nothing left to do, as we don't want to join it with the mount point again.. If it *wasn't* changed, then we
+			// need to join it with the mount point, as it's some normal path.
+			if !changed {
+				workDir = filepath.Join(c.rootfsLocation, removeDriveLetter(workDir))
+			}
+		}
+	} else {
+		// Bind support is available, set the default working directory to C:\payload if
+		// nothing is set.
+		if conf.WorkingDirectory != "" {
+			workDir, _ = c.replaceWithMountPoint(conf.WorkingDirectory)
+		}
+	}
+
+	// Make sure the working directory exists.
+	if _, err := os.Stat(workDir); os.IsNotExist(err) {
+		if err := os.MkdirAll(workDir, 0700); err != nil {
+			return nil, err
 		}
 	}
 
@@ -237,8 +302,19 @@ func (c *JobContainer) CreateProcess(ctx context.Context, config interface{}) (_
 		envs = append(envs, k+"="+expanded)
 	}
 	env = append(env, envs...)
+	env = append(env, sandboxMountPointEnvVar+"="+c.rootfsLocation)
 
-	env = append(env, sandboxMountPointEnvVar+"="+c.sandboxMount)
+	// Add the rootfs location to PATH so you can run things from the root of the image.
+	for idx, envVar := range env {
+		ev := strings.TrimSpace(strings.ToLower(envVar))
+		if len(ev) >= 4 && strings.ToLower(ev[:4]) == "path" {
+			rootfsLoc := c.rootfsLocation
+			if ev[len(ev):] != ";" {
+				rootfsLoc = ";" + rootfsLoc
+			}
+			env[idx] = ev + rootfsLoc
+		}
+	}
 
 	// exec.Cmd internally does its own path resolution and as part of this checks some well known file extensions on the file given (e.g. if
 	// the user just provided /path/to/mybinary). CreateProcess is perfectly capable of launching an executable that doesn't have the .exe extension
@@ -645,7 +721,36 @@ func systemProcessInformation() ([]*winapi.SYSTEM_PROCESS_INFORMATION, error) {
 // Takes a string and replaces any occurrences of CONTAINER_SANDBOX_MOUNT_POINT with where the containers' volume is mounted, as well as returning
 // if the string actually contained the environment variable.
 func (c *JobContainer) replaceWithMountPoint(str string) (string, bool) {
-	newStr := strings.ReplaceAll(str, "%"+sandboxMountPointEnvVar+"%", c.sandboxMount[:len(c.sandboxMount)-1])
-	newStr = strings.ReplaceAll(newStr, "$env:"+sandboxMountPointEnvVar, c.sandboxMount[:len(c.sandboxMount)-1])
+	mountPoint := c.rootfsLocation
+	newStr := strings.ReplaceAll(str, "%"+sandboxMountPointEnvVar+"%", mountPoint[:len(mountPoint)-1])
+	newStr = strings.ReplaceAll(newStr, "$env:"+sandboxMountPointEnvVar, mountPoint[:len(mountPoint)-1])
 	return newStr, str != newStr
+}
+
+func (c *JobContainer) bindSetup(ctx context.Context, s *specs.Spec) (err error) {
+	// Must be upgraded to a silo so we can get per silo bindings for the container.
+	if err := c.job.PromoteToSilo(); err != nil {
+		return err
+	}
+	// Union the container layers. Luckily bindflt works fine with \\?\volume paths, so we don't need to
+	// mount the volume anywhere friendly (for example, somewhere under C:\) first.
+	if err := c.mountLayers(ctx, c.id, s, ""); err != nil {
+		return fmt.Errorf("failed to mount container layers: %w", err)
+	}
+	if err := c.setupRootfsBinding(defaultSiloRootfsLocation, s.Root.Path+"\\"); err != nil {
+		return err
+	}
+	c.rootfsLocation = defaultSiloRootfsLocation
+	return c.setupMounts(s)
+}
+
+// This handles the fallback case where bind mounting isn't available on the machine. This mounts the
+// container layers on the host and sets up any mounts present in the OCI runtime spec.
+func (c *JobContainer) fallbackSetup(ctx context.Context, s *specs.Spec) (err error) {
+	sandboxPath := fmt.Sprintf(fallbackRootfsFormat, c.id)
+	if err := c.mountLayers(ctx, c.id, s, sandboxPath); err != nil {
+		return fmt.Errorf("failed to mount container layers: %w", err)
+	}
+	c.rootfsLocation = sandboxPath
+	return fallbackMountSetup(s, c.rootfsLocation)
 }

--- a/internal/jobcontainers/mounts.go
+++ b/internal/jobcontainers/mounts.go
@@ -89,15 +89,6 @@ func (c *JobContainer) setupMounts(ctx context.Context, spec *specs.Spec) error 
 		if err := c.job.ApplyFileBinding(mount.Destination, mount.Source, false); err != nil {
 			return err
 		}
-
-		// For backwards compat with the way directory/file mounts are done on machines without the bind filter dll,
-		// also bind the mount under a relative path in the rootfs location. This ensures any apps that used to make
-		// use of the CONTAINER_SANDBOX_MOUNT_POINT env var can continue doing so, or they can just access the mount
-		// at mount.Destination, either or.
-		fullCtrPath := filepath.Join(c.rootfsLocation, stripDriveLetter(mount.Destination))
-		if err := c.job.ApplyFileBinding(fullCtrPath, mount.Source, false); err != nil {
-			return err
-		}
 	}
 	return nil
 }

--- a/internal/jobcontainers/mounts.go
+++ b/internal/jobcontainers/mounts.go
@@ -28,11 +28,12 @@ func stripDriveLetter(name string) string {
 	return name
 }
 
-// setupMounts adds the custom mounts requested in the OCI runtime spec. Mounts are a bit funny as you already have
-// access to everything on the host, so just symlink in whatever was requested to the path where the container volume
-// is mounted. At least then the mount can be accessed from a path relative to the default working directory/where the volume
-// is.
-func setupMounts(spec *specs.Spec, sandboxVolumePath string) error {
+// fallbackMountSetup adds the mounts requested in the OCI runtime spec. This is
+// the fallback behavior if the Bind Filter dll is not available on the host, so
+// typical bind mount like functionality can't be used. Instead, symlink the
+// path requested to a relative path under where the container image volume is
+// located.
+func fallbackMountSetup(spec *specs.Spec, sandboxVolumePath string) error {
 	for _, mount := range spec.Mounts {
 		if mount.Destination == "" || mount.Source == "" {
 			return fmt.Errorf("invalid OCI spec - a mount must have both source and a destination: %+v", mount)
@@ -54,5 +55,34 @@ func setupMounts(spec *specs.Spec, sandboxVolumePath string) error {
 		}
 	}
 
+	return nil
+}
+
+// setupMounts sets up all requested mounts present in the OCI runtime spec. They will be mounted from
+// mount.Source to mount.Destination as well as mounted from mount.Source to under the rootfs location
+// for backwards compat with systems that don't have the Bind Filter functionality available.
+func (c *JobContainer) setupMounts(spec *specs.Spec) error {
+	for _, mount := range spec.Mounts {
+		if mount.Destination == "" || mount.Source == "" {
+			return fmt.Errorf("invalid OCI spec - a mount must have both source and a destination: %+v", mount)
+		}
+
+		if isnamedPipePath(mount.Source) {
+			return errors.New("named pipe mounts not supported for job containers - interact with the pipe directly")
+		}
+
+		if err := c.job.ApplyFileBinding(mount.Destination, mount.Source, false); err != nil {
+			return err
+		}
+
+		// For backwards compat with the way directory/file mounts are done on machines without the bind filter dll,
+		// also bind the mount under a relative path in the rootfs location. This ensures any apps that used to make
+		// use of the CONTAINER_SANDBOX_MOUNT_POINT env var can continue doing so, or they can just access the mount
+		// at mount.Destination, either or.
+		fullCtrPath := filepath.Join(c.rootfsLocation, stripDriveLetter(mount.Destination))
+		if err := c.job.ApplyFileBinding(fullCtrPath, mount.Source, false); err != nil {
+			return err
+		}
+	}
 	return nil
 }

--- a/internal/jobcontainers/mounts.go
+++ b/internal/jobcontainers/mounts.go
@@ -3,13 +3,17 @@
 package jobcontainers
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 
+	"github.com/Microsoft/hcsshim/internal/log"
+	"github.com/Microsoft/hcsshim/internal/logfields"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 )
 
 // namedPipePath returns true if the given path is to a named pipe.
@@ -61,7 +65,7 @@ func fallbackMountSetup(spec *specs.Spec, sandboxVolumePath string) error {
 // setupMounts sets up all requested mounts present in the OCI runtime spec. They will be mounted from
 // mount.Source to mount.Destination as well as mounted from mount.Source to under the rootfs location
 // for backwards compat with systems that don't have the Bind Filter functionality available.
-func (c *JobContainer) setupMounts(spec *specs.Spec) error {
+func (c *JobContainer) setupMounts(ctx context.Context, spec *specs.Spec) error {
 	for _, mount := range spec.Mounts {
 		if mount.Destination == "" || mount.Source == "" {
 			return fmt.Errorf("invalid OCI spec - a mount must have both source and a destination: %+v", mount)
@@ -69,6 +73,17 @@ func (c *JobContainer) setupMounts(spec *specs.Spec) error {
 
 		if isnamedPipePath(mount.Source) {
 			return errors.New("named pipe mounts not supported for job containers - interact with the pipe directly")
+		}
+
+		// If the destination exists, log a warning. The default behavior for bindflt is to shadow the directory,
+		// but on the host this may lead to more wonky situations than in a normal container. Mounts should not
+		// be relied on too heavily so this shouldn't be an error case.
+		if _, err := os.Stat(mount.Destination); err == nil {
+			log.G(ctx).WithFields(logrus.Fields{
+				logfields.ContainerID: c.id,
+				"mountSource":         mount.Source,
+				"mountDestination":    mount.Destination,
+			}).Warn("job container mount destination exists and will be shadowed")
 		}
 
 		if err := c.job.ApplyFileBinding(mount.Destination, mount.Source, false); err != nil {

--- a/internal/jobcontainers/mounts_test.go
+++ b/internal/jobcontainers/mounts_test.go
@@ -17,7 +17,7 @@ func TestNamePipeDeny(t *testing.T) {
 			},
 		},
 	}
-	if err := setupMounts(s, "/test"); err == nil {
+	if err := fallbackMountSetup(s, "/test"); err == nil {
 		t.Fatal("expected named pipe mount validation to fail for job container")
 	}
 }

--- a/internal/jobcontainers/oci.go
+++ b/internal/jobcontainers/oci.go
@@ -20,6 +20,11 @@ import (
 
 const processorWeightMax = 10000
 
+// customRootfsLocation grabs the value of the annotation exposed that sets a custom rootfs location for the job container.
+func customRootfsLocation(annots map[string]string) string {
+	return annots[annotations.HostProcessRootfsLocation]
+}
+
 // inheritUserTokenIsSet checks if the annotation that specifies whether we should inherit the token of the current process is set.
 func inheritUserTokenIsSet(annots map[string]string) bool {
 	return annots[annotations.HostProcessInheritUser] == "true"

--- a/internal/jobcontainers/storage.go
+++ b/internal/jobcontainers/storage.go
@@ -18,12 +18,12 @@ import (
 // fallbackRootfsFormat is the fallback location for the rootfs if file binding support isn't available.
 // %s will be expanded with the container ID. Trailing backslash required for SetVolumeMountPoint and
 // DeleteVolumeMountPoint
-const fallbackRootfsFormat = `C:\C\%s\`
+const fallbackRootfsFormat = `C:\hpc\%s\`
 
 // defaultSiloRootfsLocation is the default location the rootfs for the container will show up
 // inside of a given silo. If bind filter support isn't available the rootfs will be
 // C:\C\<containerID>
-const defaultSiloRootfsLocation = `C:\payload\`
+const defaultSiloRootfsLocation = `C:\hpc\`
 
 func (c *JobContainer) mountLayers(ctx context.Context, containerID string, s *specs.Spec, volumeMountPath string) (err error) {
 	if s == nil || s.Windows == nil || s.Windows.LayerFolders == nil {

--- a/internal/jobcontainers/storage.go
+++ b/internal/jobcontainers/storage.go
@@ -22,7 +22,7 @@ const fallbackRootfsFormat = `C:\hpc\%s\`
 
 // defaultSiloRootfsLocation is the default location the rootfs for the container will show up
 // inside of a given silo. If bind filter support isn't available the rootfs will be
-// C:\C\<containerID>
+// C:\hpc\<containerID>
 const defaultSiloRootfsLocation = `C:\hpc\`
 
 func (c *JobContainer) mountLayers(ctx context.Context, containerID string, s *specs.Spec, volumeMountPath string) (err error) {

--- a/internal/jobobject/jobobject.go
+++ b/internal/jobobject/jobobject.go
@@ -468,14 +468,11 @@ func (job *JobObject) ApplyFileBinding(root, target string, merged bool) error {
 		return ErrNotSilo
 	}
 
-	// The parent directory needs to exist for the bind to work.
-	if _, err := os.Stat(filepath.Dir(root)); err != nil {
-		if !os.IsNotExist(err) {
-			return err
-		}
-		if err := os.MkdirAll(filepath.Dir(root), 0); err != nil {
-			return err
-		}
+	// The parent directory needs to exist for the bind to work. MkdirAll stats and
+	// returns nil if the directory exists internally so we should be fine to mkdirall
+	// every time.
+	if err := os.MkdirAll(filepath.Dir(root), 0); err != nil {
+		return err
 	}
 
 	rootPtr, err := windows.UTF16PtrFromString(root)

--- a/internal/layers/layers.go
+++ b/internal/layers/layers.go
@@ -10,10 +10,6 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
-	"golang.org/x/sys/windows"
-
 	"github.com/Microsoft/hcsshim/internal/guestpath"
 	hcsschema "github.com/Microsoft/hcsshim/internal/hcs/schema2"
 	"github.com/Microsoft/hcsshim/internal/hcserror"
@@ -21,6 +17,9 @@ import (
 	"github.com/Microsoft/hcsshim/internal/ospath"
 	"github.com/Microsoft/hcsshim/internal/uvm"
 	"github.com/Microsoft/hcsshim/internal/wclayer"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/sys/windows"
 )
 
 // ImageLayers contains all the layers for an image.
@@ -402,7 +401,8 @@ func UnmountContainerLayers(ctx context.Context, layerFolders []string, containe
 			return errors.New("need at least one layer for Unmount")
 		}
 
-		// Remove the mount point if there is one. This is the case for job containers.
+		// Remove the mount point if there is one. This is the fallback case for job containers
+		// if no bind mount support is available.
 		if volumeMountPath != "" {
 			if err := removeSandboxMountPoint(ctx, volumeMountPath); err != nil {
 				return err

--- a/internal/layers/layers.go
+++ b/internal/layers/layers.go
@@ -10,6 +10,10 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/sys/windows"
+
 	"github.com/Microsoft/hcsshim/internal/guestpath"
 	hcsschema "github.com/Microsoft/hcsshim/internal/hcs/schema2"
 	"github.com/Microsoft/hcsshim/internal/hcserror"
@@ -17,9 +21,6 @@ import (
 	"github.com/Microsoft/hcsshim/internal/ospath"
 	"github.com/Microsoft/hcsshim/internal/uvm"
 	"github.com/Microsoft/hcsshim/internal/wclayer"
-	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
-	"golang.org/x/sys/windows"
 )
 
 // ImageLayers contains all the layers for an image.

--- a/pkg/annotations/annotations.go
+++ b/pkg/annotations/annotations.go
@@ -94,6 +94,12 @@ const (
 	// HostProcessContainer indicates to launch a host process container (job container in this repository).
 	HostProcessContainer = "microsoft.com/hostprocess-container"
 
+	// HostProcessRootfsLocation indicates where the rootfs for a host process container should be located. If file binding support is
+	// available (Windows versions 20H1 and up) this will be the absolute path where the rootfs for a container will be located on the host
+	// and will be unique per container. On < 20H1 hosts, the location will be C:\<path-supplied>\<containerID>. So for example, if the value
+	// supplied was C:\rootfs and the container's ID is 12345678 the rootfs will be located at C:\rootfs\12345678.
+	HostProcessRootfsLocation = "microsoft.com/hostprocess-rootfs-location"
+
 	// AllowOvercommit indicates if we should allow over commit memory for UVM.
 	// Defaults to true. For physical backed memory, set to false.
 	AllowOvercommit = "io.microsoft.virtualmachine.computetopology.memory.allowovercommit"

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/jobobject/jobobject.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/jobobject/jobobject.go
@@ -468,14 +468,11 @@ func (job *JobObject) ApplyFileBinding(root, target string, merged bool) error {
 		return ErrNotSilo
 	}
 
-	// The parent directory needs to exist for the bind to work.
-	if _, err := os.Stat(filepath.Dir(root)); err != nil {
-		if !os.IsNotExist(err) {
-			return err
-		}
-		if err := os.MkdirAll(filepath.Dir(root), 0); err != nil {
-			return err
-		}
+	// The parent directory needs to exist for the bind to work. MkdirAll stats and
+	// returns nil if the directory exists internally so we should be fine to mkdirall
+	// every time.
+	if err := os.MkdirAll(filepath.Dir(root), 0); err != nil {
+		return err
 	}
 
 	rootPtr, err := windows.UTF16PtrFromString(root)

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/layers/layers.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/layers/layers.go
@@ -10,10 +10,6 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
-	"golang.org/x/sys/windows"
-
 	"github.com/Microsoft/hcsshim/internal/guestpath"
 	hcsschema "github.com/Microsoft/hcsshim/internal/hcs/schema2"
 	"github.com/Microsoft/hcsshim/internal/hcserror"
@@ -21,6 +17,9 @@ import (
 	"github.com/Microsoft/hcsshim/internal/ospath"
 	"github.com/Microsoft/hcsshim/internal/uvm"
 	"github.com/Microsoft/hcsshim/internal/wclayer"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/sys/windows"
 )
 
 // ImageLayers contains all the layers for an image.
@@ -402,7 +401,8 @@ func UnmountContainerLayers(ctx context.Context, layerFolders []string, containe
 			return errors.New("need at least one layer for Unmount")
 		}
 
-		// Remove the mount point if there is one. This is the case for job containers.
+		// Remove the mount point if there is one. This is the fallback case for job containers
+		// if no bind mount support is available.
 		if volumeMountPath != "" {
 			if err := removeSandboxMountPoint(ctx, volumeMountPath); err != nil {
 				return err

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/layers/layers.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/layers/layers.go
@@ -10,6 +10,10 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/sys/windows"
+
 	"github.com/Microsoft/hcsshim/internal/guestpath"
 	hcsschema "github.com/Microsoft/hcsshim/internal/hcs/schema2"
 	"github.com/Microsoft/hcsshim/internal/hcserror"
@@ -17,9 +21,6 @@ import (
 	"github.com/Microsoft/hcsshim/internal/ospath"
 	"github.com/Microsoft/hcsshim/internal/uvm"
 	"github.com/Microsoft/hcsshim/internal/wclayer"
-	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
-	"golang.org/x/sys/windows"
 )
 
 // ImageLayers contains all the layers for an image.

--- a/test/vendor/github.com/Microsoft/hcsshim/pkg/annotations/annotations.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/pkg/annotations/annotations.go
@@ -94,6 +94,12 @@ const (
 	// HostProcessContainer indicates to launch a host process container (job container in this repository).
 	HostProcessContainer = "microsoft.com/hostprocess-container"
 
+	// HostProcessRootfsLocation indicates where the rootfs for a host process container should be located. If file binding support is
+	// available (Windows versions 20H1 and up) this will be the absolute path where the rootfs for a container will be located on the host
+	// and will be unique per container. On < 20H1 hosts, the location will be C:\<path-supplied>\<containerID>. So for example, if the value
+	// supplied was C:\rootfs and the container's ID is 12345678 the rootfs will be located at C:\rootfs\12345678.
+	HostProcessRootfsLocation = "microsoft.com/hostprocess-rootfs-location"
+
 	// AllowOvercommit indicates if we should allow over commit memory for UVM.
 	// Defaults to true. For physical backed memory, set to false.
 	AllowOvercommit = "io.microsoft.virtualmachine.computetopology.memory.allowovercommit"


### PR DESCRIPTION
This change adds in file binding support for host process containers if the host has the functionality available (bindfltapi.dll exists). This makes it so mounts in the runtime spec actually show up in the container at `mount.Destination` instead of simply being symlinks to a relative path, as well as are completely unique per container. This is achieved by upgrading the job object to a silo and making use of silo local file bindings that the Bind Filter supports.

This additionally opens up the opportunity for the rootfs for the container to be container local and unique. So instead of the rootfs showing up to any process on the host and being located at C:\C\\{containerid}, it now (by default at least) will be present at C:\hpc and be unique in each container as well. In a similar fashion to the mount changes, this only takes affect if the host has file binding support available.