### PR TITLE
Pin go version for linter to 1.17.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,13 +59,14 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '^1.17.0'
+          go-version: '1.17.8'
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
           version: v1.42.1 # Has fixes for stylecheck configuration https://github.com/golangci/golangci-lint/pull/2017/files
           args: -v
+          skip-go-installation: true
           only-new-issues: true
 
   verify-main-vendor:


### PR DESCRIPTION
Some of the tooling golangci-lint uses doesn't fully support 1.18 yet resulting in a bunch of hard to decode errors. We were using ^1.17.0 as our version listed so we ended up resolving to 1.18 a couple of days ago and finally ran into this. v1.45.0 of golangci-lint has a workaround for this which is disabling some of the problematic linters, but these are some of our most used. This seems like a sane fix for now until the kinks are ironed out and things are working on 1.18.