### PR TITLE
Reorganizing makefile and adding info to rootfs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,8 @@ endif
 GO_BUILD:=CGO_ENABLED=$(CGO_ENABLED) $(GO) build $(GO_FLAGS) $(GO_FLAGS_EXTRA)
 
 SRCROOT=$(dir $(abspath $(firstword $(MAKEFILE_LIST))))
+# additional directories to search for rule prerequisites and targets
+VPATH=$(SRCROOT)
 
 DELTA_TARGET=out/delta.tar.gz
 
@@ -47,30 +49,6 @@ out/rootfs.vhd: out/rootfs.tar.gz bin/cmd/tar2ext4
 	gzip -f -d ./out/rootfs.tar.gz
 	bin/cmd/tar2ext4 -vhd -i ./out/rootfs.tar -o $@
 
-out/delta.tar.gz: bin/init bin/vsockexec bin/cmd/gcs bin/cmd/gcstools bin/cmd/hooks/wait-paths Makefile
-	@mkdir -p out
-	rm -rf rootfs
-	mkdir -p rootfs/bin/
-	cp bin/init rootfs/
-	cp bin/vsockexec rootfs/bin/
-	cp bin/cmd/gcs rootfs/bin/
-	cp bin/cmd/gcstools rootfs/bin/
-	cp bin/cmd/hooks/wait-paths rootfs/bin/
-	for tool in $(GCS_TOOLS); do ln -s gcstools rootfs/bin/$$tool; done
-	git -C $(SRCROOT) rev-parse HEAD > rootfs/gcs.commit && \
-	git -C $(SRCROOT) rev-parse --abbrev-ref HEAD > rootfs/gcs.branch
-	tar -zcf $@ -C rootfs .
-	rm -rf rootfs
-
-# This target includes utilities which may be useful for testing purposes.
-out/delta-dev.tar.gz: out/delta.tar.gz bin/internal/tools/snp-report
-	rm -rf rootfs-dev
-	mkdir rootfs-dev
-	tar -xzf out/delta.tar.gz -C rootfs-dev
-	cp bin/internal/tools/snp-report rootfs-dev/bin/
-	tar -zcf $@ -C rootfs-dev .
-	rm -rf rootfs-dev
-
 out/rootfs.tar.gz: out/initrd.img
 	rm -rf rootfs-conv
 	mkdir rootfs-conv
@@ -82,6 +60,35 @@ out/initrd.img: $(BASE) $(DELTA_TARGET) $(SRCROOT)/hack/catcpio.sh
 	$(SRCROOT)/hack/catcpio.sh "$(BASE)" $(DELTA_TARGET) > out/initrd.img.uncompressed
 	gzip -c out/initrd.img.uncompressed > $@
 	rm out/initrd.img.uncompressed
+
+# This target includes utilities which may be useful for testing purposes.
+out/delta-dev.tar.gz: out/delta.tar.gz bin/internal/tools/snp-report
+	rm -rf rootfs-dev
+	mkdir rootfs-dev
+	tar -xzf out/delta.tar.gz -C rootfs-dev
+	cp bin/internal/tools/snp-report rootfs-dev/bin/
+	tar -zcf $@ -C rootfs-dev .
+	rm -rf rootfs-dev
+
+out/delta.tar.gz: bin/init bin/vsockexec bin/cmd/gcs bin/cmd/gcstools bin/cmd/hooks/wait-paths Makefile
+	@mkdir -p out
+	rm -rf rootfs
+	mkdir -p rootfs/bin/
+	mkdir -p rootfs/info/
+	cp bin/init rootfs/
+	cp bin/vsockexec rootfs/bin/
+	cp bin/cmd/gcs rootfs/bin/
+	cp bin/cmd/gcstools rootfs/bin/
+	cp bin/cmd/hooks/wait-paths rootfs/bin/
+	for tool in $(GCS_TOOLS); do ln -s gcstools rootfs/bin/$$tool; done
+	git -C $(SRCROOT) rev-parse HEAD > rootfs/info/gcs.commit && \
+	git -C $(SRCROOT) rev-parse --abbrev-ref HEAD > rootfs/info/gcs.branch && \
+	date --iso-8601=minute --utc > rootfs/info/tar.date
+	$(if $(realpath $(subst .tar,.testdata.json,$(BASE))), \
+		jq -r '.IMAGE_NAME' $(subst .tar,.testdata.json,$(BASE)) 2>/dev/null > rootfs/info/image.name && \
+		jq -r '.DATETIME' $(subst .tar,.testdata.json,$(BASE)) 2>/dev/null > rootfs/info/build.date )
+	tar -zcf $@ -C rootfs .
+	rm -rf rootfs
 
 -include deps/cmd/gcs.gomake
 -include deps/cmd/gcstools.gomake
@@ -100,8 +107,6 @@ out/initrd.img: $(BASE) $(DELTA_TARGET) $(SRCROOT)/hack/catcpio.sh
 	@/bin/echo -e '\tmv $$@.new $$@' >> $@.new
 	@/bin/echo -e '-include $(@:%.gomake=%.godeps)' >> $@.new
 	mv $@.new $@
-
-VPATH=$(SRCROOT)
 
 bin/vsockexec: vsockexec/vsockexec.o vsockexec/vsock.o
 	@mkdir -p bin

--- a/Makefile
+++ b/Makefile
@@ -84,9 +84,9 @@ out/delta.tar.gz: bin/init bin/vsockexec bin/cmd/gcs bin/cmd/gcstools bin/cmd/ho
 	git -C $(SRCROOT) rev-parse HEAD > rootfs/info/gcs.commit && \
 	git -C $(SRCROOT) rev-parse --abbrev-ref HEAD > rootfs/info/gcs.branch && \
 	date --iso-8601=minute --utc > rootfs/info/tar.date
-	$(if $(realpath $(subst .tar,.testdata.json,$(BASE))), \
+	$(if $(and $(realpath $(subst .tar,.testdata.json,$(BASE))), $(shell which jq)), \
 		jq -r '.IMAGE_NAME' $(subst .tar,.testdata.json,$(BASE)) 2>/dev/null > rootfs/info/image.name && \
-		jq -r '.DATETIME' $(subst .tar,.testdata.json,$(BASE)) 2>/dev/null > rootfs/info/build.date )
+		jq -r '.DATETIME' $(subst .tar,.testdata.json,$(BASE)) 2>/dev/null > rootfs/info/build.date)
 	tar -zcf $@ -C rootfs .
 	rm -rf rootfs
 

--- a/test/vendor/github.com/Microsoft/hcsshim/Makefile
+++ b/test/vendor/github.com/Microsoft/hcsshim/Makefile
@@ -16,6 +16,8 @@ endif
 GO_BUILD:=CGO_ENABLED=$(CGO_ENABLED) $(GO) build $(GO_FLAGS) $(GO_FLAGS_EXTRA)
 
 SRCROOT=$(dir $(abspath $(firstword $(MAKEFILE_LIST))))
+# additional directories to search for rule prerequisites and targets
+VPATH=$(SRCROOT)
 
 DELTA_TARGET=out/delta.tar.gz
 
@@ -47,30 +49,6 @@ out/rootfs.vhd: out/rootfs.tar.gz bin/cmd/tar2ext4
 	gzip -f -d ./out/rootfs.tar.gz
 	bin/cmd/tar2ext4 -vhd -i ./out/rootfs.tar -o $@
 
-out/delta.tar.gz: bin/init bin/vsockexec bin/cmd/gcs bin/cmd/gcstools bin/cmd/hooks/wait-paths Makefile
-	@mkdir -p out
-	rm -rf rootfs
-	mkdir -p rootfs/bin/
-	cp bin/init rootfs/
-	cp bin/vsockexec rootfs/bin/
-	cp bin/cmd/gcs rootfs/bin/
-	cp bin/cmd/gcstools rootfs/bin/
-	cp bin/cmd/hooks/wait-paths rootfs/bin/
-	for tool in $(GCS_TOOLS); do ln -s gcstools rootfs/bin/$$tool; done
-	git -C $(SRCROOT) rev-parse HEAD > rootfs/gcs.commit && \
-	git -C $(SRCROOT) rev-parse --abbrev-ref HEAD > rootfs/gcs.branch
-	tar -zcf $@ -C rootfs .
-	rm -rf rootfs
-
-# This target includes utilities which may be useful for testing purposes.
-out/delta-dev.tar.gz: out/delta.tar.gz bin/internal/tools/snp-report
-	rm -rf rootfs-dev
-	mkdir rootfs-dev
-	tar -xzf out/delta.tar.gz -C rootfs-dev
-	cp bin/internal/tools/snp-report rootfs-dev/bin/
-	tar -zcf $@ -C rootfs-dev .
-	rm -rf rootfs-dev
-
 out/rootfs.tar.gz: out/initrd.img
 	rm -rf rootfs-conv
 	mkdir rootfs-conv
@@ -82,6 +60,35 @@ out/initrd.img: $(BASE) $(DELTA_TARGET) $(SRCROOT)/hack/catcpio.sh
 	$(SRCROOT)/hack/catcpio.sh "$(BASE)" $(DELTA_TARGET) > out/initrd.img.uncompressed
 	gzip -c out/initrd.img.uncompressed > $@
 	rm out/initrd.img.uncompressed
+
+# This target includes utilities which may be useful for testing purposes.
+out/delta-dev.tar.gz: out/delta.tar.gz bin/internal/tools/snp-report
+	rm -rf rootfs-dev
+	mkdir rootfs-dev
+	tar -xzf out/delta.tar.gz -C rootfs-dev
+	cp bin/internal/tools/snp-report rootfs-dev/bin/
+	tar -zcf $@ -C rootfs-dev .
+	rm -rf rootfs-dev
+
+out/delta.tar.gz: bin/init bin/vsockexec bin/cmd/gcs bin/cmd/gcstools bin/cmd/hooks/wait-paths Makefile
+	@mkdir -p out
+	rm -rf rootfs
+	mkdir -p rootfs/bin/
+	mkdir -p rootfs/info/
+	cp bin/init rootfs/
+	cp bin/vsockexec rootfs/bin/
+	cp bin/cmd/gcs rootfs/bin/
+	cp bin/cmd/gcstools rootfs/bin/
+	cp bin/cmd/hooks/wait-paths rootfs/bin/
+	for tool in $(GCS_TOOLS); do ln -s gcstools rootfs/bin/$$tool; done
+	git -C $(SRCROOT) rev-parse HEAD > rootfs/info/gcs.commit && \
+	git -C $(SRCROOT) rev-parse --abbrev-ref HEAD > rootfs/info/gcs.branch && \
+	date --iso-8601=minute --utc > rootfs/info/tar.date
+	$(if $(realpath $(subst .tar,.testdata.json,$(BASE))), \
+		jq -r '.IMAGE_NAME' $(subst .tar,.testdata.json,$(BASE)) 2>/dev/null > rootfs/info/image.name && \
+		jq -r '.DATETIME' $(subst .tar,.testdata.json,$(BASE)) 2>/dev/null > rootfs/info/build.date )
+	tar -zcf $@ -C rootfs .
+	rm -rf rootfs
 
 -include deps/cmd/gcs.gomake
 -include deps/cmd/gcstools.gomake
@@ -100,8 +107,6 @@ out/initrd.img: $(BASE) $(DELTA_TARGET) $(SRCROOT)/hack/catcpio.sh
 	@/bin/echo -e '\tmv $$@.new $$@' >> $@.new
 	@/bin/echo -e '-include $(@:%.gomake=%.godeps)' >> $@.new
 	mv $@.new $@
-
-VPATH=$(SRCROOT)
 
 bin/vsockexec: vsockexec/vsockexec.o vsockexec/vsock.o
 	@mkdir -p bin

--- a/test/vendor/github.com/Microsoft/hcsshim/Makefile
+++ b/test/vendor/github.com/Microsoft/hcsshim/Makefile
@@ -84,9 +84,9 @@ out/delta.tar.gz: bin/init bin/vsockexec bin/cmd/gcs bin/cmd/gcstools bin/cmd/ho
 	git -C $(SRCROOT) rev-parse HEAD > rootfs/info/gcs.commit && \
 	git -C $(SRCROOT) rev-parse --abbrev-ref HEAD > rootfs/info/gcs.branch && \
 	date --iso-8601=minute --utc > rootfs/info/tar.date
-	$(if $(realpath $(subst .tar,.testdata.json,$(BASE))), \
+	$(if $(and $(realpath $(subst .tar,.testdata.json,$(BASE))), $(shell which jq)), \
 		jq -r '.IMAGE_NAME' $(subst .tar,.testdata.json,$(BASE)) 2>/dev/null > rootfs/info/image.name && \
-		jq -r '.DATETIME' $(subst .tar,.testdata.json,$(BASE)) 2>/dev/null > rootfs/info/build.date )
+		jq -r '.DATETIME' $(subst .tar,.testdata.json,$(BASE)) 2>/dev/null > rootfs/info/build.date)
 	tar -zcf $@ -C rootfs .
 	rm -rf rootfs
 


### PR DESCRIPTION
Reorganized makefile to read from top to bottom, and added additional
files to LCOW rootfs that include the time stamp of of the vhd creation,
the image build date, and its full name (pulled from a *.testdata.json
file in the yocto release).

Signed-off-by: Hamza El-Saawy <hamzaelsaawy@microsoft.com>