### PR TITLE
Swap to fmt.Errorf in jobobject package

### DIFF
--- a/internal/jobobject/jobobject.go
+++ b/internal/jobobject/jobobject.go
@@ -235,7 +235,7 @@ func setupNotifications(ctx context.Context, job *JobObject) (*queue.MessageQueu
 	jobMap.Store(uintptr(job.handle), mq)
 	if err := attachIOCP(job.handle, ioCompletionPort); err != nil {
 		jobMap.Delete(uintptr(job.handle))
-		return nil, errors.Wrap(err, "failed to attach job to IO completion port")
+		return nil, fmt.Errorf("failed to attach job to IO completion port: %w", err)
 	}
 	return mq, nil
 }
@@ -362,7 +362,7 @@ func (job *JobObject) Pids() ([]uint32, error) {
 	}
 
 	if err != winapi.ERROR_MORE_DATA {
-		return nil, errors.Wrap(err, "failed initial query for PIDs in job object")
+		return nil, fmt.Errorf("failed initial query for PIDs in job object: %w", err)
 	}
 
 	jobBasicProcessIDListSize := unsafe.Sizeof(info) + (unsafe.Sizeof(info.ProcessIdList[0]) * uintptr(info.NumberOfAssignedProcesses-1))
@@ -374,7 +374,7 @@ func (job *JobObject) Pids() ([]uint32, error) {
 		uint32(len(buf)),
 		nil,
 	); err != nil {
-		return nil, errors.Wrap(err, "failed to query for PIDs in job object")
+		return nil, fmt.Errorf("failed to query for PIDs in job object: %w", err)
 	}
 
 	bufInfo := (*winapi.JOBOBJECT_BASIC_PROCESS_ID_LIST)(unsafe.Pointer(&buf[0]))
@@ -402,7 +402,7 @@ func (job *JobObject) QueryMemoryStats() (*winapi.JOBOBJECT_MEMORY_USAGE_INFORMA
 		uint32(unsafe.Sizeof(info)),
 		nil,
 	); err != nil {
-		return nil, errors.Wrap(err, "failed to query for job object memory stats")
+		return nil, fmt.Errorf("failed to query for job object memory stats: %w", err)
 	}
 	return &info, nil
 }
@@ -424,7 +424,7 @@ func (job *JobObject) QueryProcessorStats() (*winapi.JOBOBJECT_BASIC_ACCOUNTING_
 		uint32(unsafe.Sizeof(info)),
 		nil,
 	); err != nil {
-		return nil, errors.Wrap(err, "failed to query for job object process stats")
+		return nil, fmt.Errorf("failed to query for job object process stats: %w", err)
 	}
 	return &info, nil
 }
@@ -446,7 +446,7 @@ func (job *JobObject) QueryStorageStats() (*winapi.JOBOBJECT_BASIC_AND_IO_ACCOUN
 		uint32(unsafe.Sizeof(info)),
 		nil,
 	); err != nil {
-		return nil, errors.Wrap(err, "failed to query for job object storage stats")
+		return nil, fmt.Errorf("failed to query for job object storage stats: %w", err)
 	}
 	return &info, nil
 }

--- a/internal/jobobject/jobobject.go
+++ b/internal/jobobject/jobobject.go
@@ -4,6 +4,7 @@ package jobobject
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -13,7 +14,6 @@ import (
 
 	"github.com/Microsoft/hcsshim/internal/queue"
 	"github.com/Microsoft/hcsshim/internal/winapi"
-	"github.com/pkg/errors"
 	"golang.org/x/sys/windows"
 )
 

--- a/internal/jobobject/jobobject_test.go
+++ b/internal/jobobject/jobobject_test.go
@@ -4,6 +4,7 @@ package jobobject
 
 import (
 	"context"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -11,7 +12,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pkg/errors"
 	"golang.org/x/sys/windows"
 )
 

--- a/internal/jobobject/limits.go
+++ b/internal/jobobject/limits.go
@@ -24,23 +24,23 @@ func (job *JobObject) SetResourceLimits(limits *JobLimits) error {
 	// Go through and check what limits were specified and apply them to the job.
 	if limits.MemoryLimitInBytes != 0 {
 		if err := job.SetMemoryLimit(limits.MemoryLimitInBytes); err != nil {
-			return errors.Wrap(err, "failed to set job object memory limit")
+			return fmt.Errorf("failed to set job object memory limit: %w", err)
 		}
 	}
 
 	if limits.CPULimit != 0 {
 		if err := job.SetCPULimit(RateBased, limits.CPULimit); err != nil {
-			return errors.Wrap(err, "failed to set job object cpu limit")
+			return fmt.Errorf("failed to set job object cpu limit: %w", err)
 		}
 	} else if limits.CPUWeight != 0 {
 		if err := job.SetCPULimit(WeightBased, limits.CPUWeight); err != nil {
-			return errors.Wrap(err, "failed to set job object cpu limit")
+			return fmt.Errorf("failed to set job object cpu limit: %w", err)
 		}
 	}
 
 	if limits.MaxBandwidth != 0 || limits.MaxIOPS != 0 {
 		if err := job.SetIOLimit(limits.MaxBandwidth, limits.MaxIOPS); err != nil {
-			return errors.Wrap(err, "failed to set io limit on job object")
+			return fmt.Errorf("failed to set io limit on job object: %w", err)
 		}
 	}
 	return nil
@@ -208,7 +208,7 @@ func (job *JobObject) getExtendedInformation() (*windows.JOBOBJECT_EXTENDED_LIMI
 		uint32(unsafe.Sizeof(info)),
 		nil,
 	); err != nil {
-		return nil, errors.Wrapf(err, "query %v returned error", info)
+		return nil, fmt.Errorf("query %v returned error: %w", info, err)
 	}
 	return &info, nil
 }
@@ -230,7 +230,7 @@ func (job *JobObject) getCPURateControlInformation() (*winapi.JOBOBJECT_CPU_RATE
 		uint32(unsafe.Sizeof(info)),
 		nil,
 	); err != nil {
-		return nil, errors.Wrapf(err, "query %v returned error", info)
+		return nil, fmt.Errorf("query %v returned error: %w", info, err)
 	}
 	return &info, nil
 }
@@ -250,7 +250,7 @@ func (job *JobObject) setExtendedInformation(info *windows.JOBOBJECT_EXTENDED_LI
 		uintptr(unsafe.Pointer(info)),
 		uint32(unsafe.Sizeof(*info)),
 	); err != nil {
-		return errors.Wrapf(err, "failed to set Extended info %v on job object", info)
+		return fmt.Errorf("failed to set Extended info %v on job object: %w", info, err)
 	}
 	return nil
 }
@@ -273,7 +273,7 @@ func (job *JobObject) getIOLimit() (*winapi.JOBOBJECT_IO_RATE_CONTROL_INFORMATIO
 		&ioInfo,
 		&blockCount,
 	); err != nil {
-		return nil, errors.Wrapf(err, "query %v returned error", ioInfo)
+		return nil, fmt.Errorf("query %v returned error: %w", ioInfo, err)
 	}
 
 	if !isFlagSet(winapi.JOB_OBJECT_IO_RATE_CONTROL_ENABLE, ioInfo.ControlFlags) {
@@ -292,7 +292,7 @@ func (job *JobObject) setIORateControlInfo(ioInfo *winapi.JOBOBJECT_IO_RATE_CONT
 	}
 
 	if _, err := winapi.SetIoRateControlInformationJobObject(job.handle, ioInfo); err != nil {
-		return errors.Wrapf(err, "failed to set IO limit info %v on job object", ioInfo)
+		return fmt.Errorf("failed to set IO limit info %v on job object: %w", ioInfo, err)
 	}
 	return nil
 }
@@ -311,7 +311,7 @@ func (job *JobObject) setCPURateControlInfo(cpuInfo *winapi.JOBOBJECT_CPU_RATE_C
 		uintptr(unsafe.Pointer(cpuInfo)),
 		uint32(unsafe.Sizeof(cpuInfo)),
 	); err != nil {
-		return errors.Wrapf(err, "failed to set cpu limit info %v on job object", cpuInfo)
+		return fmt.Errorf("failed to set cpu limit info %v on job object: %w", cpuInfo, err)
 	}
 	return nil
 }

--- a/internal/jobobject/limits.go
+++ b/internal/jobobject/limits.go
@@ -3,11 +3,11 @@
 package jobobject
 
 import (
+	"errors"
 	"fmt"
 	"unsafe"
 
 	"github.com/Microsoft/hcsshim/internal/winapi"
-	"github.com/pkg/errors"
 	"golang.org/x/sys/windows"
 )
 


### PR DESCRIPTION
This change swaps to fmt.Errorf for wrapped errors in the jobobject package from errors.Wrap. We'd had talks of moving this code to winio where we've removed our pkg/errors dependency so this would make the port easier.

We should probably do this for most things to see if we can get rid of our pkg/errors use, the only thing I'm not sure on is we use the stack embedding errors.Wrap provides for the gcs https://github.com/microsoft/hcsshim/blob/master/internal/guest/gcserr/errors.go#L57-L88 