### PR TITLE
Use /internal/memory constants

### DIFF
--- a/cmd/containerd-shim-runhcs-v1/delete.go
+++ b/cmd/containerd-shim-runhcs-v1/delete.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/Microsoft/hcsshim/internal/hcs"
+	"github.com/Microsoft/hcsshim/internal/memory"
 	"github.com/Microsoft/hcsshim/internal/oc"
 	"github.com/Microsoft/hcsshim/internal/winapi"
 	"github.com/containerd/containerd/runtime/v2/task"
@@ -69,7 +70,7 @@ The delete command will be executed in the container's bundle as its cwd.
 		// This should be done as the first thing so that we don't miss any panic logs even if
 		// something goes wrong during delete op.
 		// The file can be very large so read only first 1MB of data.
-		readLimit := int64(1024 * 1024) // 1MB
+		readLimit := int64(memory.MegaByte) // 1MB
 		logBytes, err := limitedRead(filepath.Join(bundleFlag, "panic.log"), readLimit)
 		if err == nil && len(logBytes) > 0 {
 			if int64(len(logBytes)) == readLimit {

--- a/cmd/containerd-shim-runhcs-v1/delete.go
+++ b/cmd/containerd-shim-runhcs-v1/delete.go
@@ -70,7 +70,7 @@ The delete command will be executed in the container's bundle as its cwd.
 		// This should be done as the first thing so that we don't miss any panic logs even if
 		// something goes wrong during delete op.
 		// The file can be very large so read only first 1MB of data.
-		readLimit := int64(memory.MegaByte) // 1MB
+		readLimit := int64(memory.MiB) // 1MB
 		logBytes, err := limitedRead(filepath.Join(bundleFlag, "panic.log"), readLimit)
 		if err == nil && len(logBytes) > 0 {
 			if int64(len(logBytes)) == readLimit {

--- a/cmd/containerd-shim-runhcs-v1/task_hcs.go
+++ b/cmd/containerd-shim-runhcs-v1/task_hcs.go
@@ -1007,7 +1007,7 @@ func (ht *hcsTask) updateWCOWResources(ctx context.Context, data interface{}, an
 		return errors.New("must have resources be type *WindowsResources when updating a wcow container")
 	}
 	if resources.Memory != nil && resources.Memory.Limit != nil {
-		newMemorySizeInMB := *resources.Memory.Limit / memory.MegaByte
+		newMemorySizeInMB := *resources.Memory.Limit / memory.MiB
 		memoryLimit := hcsoci.NormalizeMemorySize(ctx, ht.id, newMemorySizeInMB)
 		if err := ht.requestUpdateContainer(ctx, resourcepaths.SiloMemoryResourcePath, memoryLimit); err != nil {
 			return err

--- a/cmd/containerd-shim-runhcs-v1/task_hcs.go
+++ b/cmd/containerd-shim-runhcs-v1/task_hcs.go
@@ -31,6 +31,7 @@ import (
 	"github.com/Microsoft/hcsshim/internal/hcsoci"
 	"github.com/Microsoft/hcsshim/internal/jobcontainers"
 	"github.com/Microsoft/hcsshim/internal/log"
+	"github.com/Microsoft/hcsshim/internal/memory"
 	"github.com/Microsoft/hcsshim/internal/oci"
 	"github.com/Microsoft/hcsshim/internal/processorinfo"
 	"github.com/Microsoft/hcsshim/internal/protocol/guestrequest"
@@ -41,8 +42,6 @@ import (
 	"github.com/Microsoft/hcsshim/osversion"
 	"github.com/Microsoft/hcsshim/pkg/annotations"
 )
-
-const bytesPerMB = 1024 * 1024
 
 func newHcsStandaloneTask(ctx context.Context, events publisher, req *task.CreateTaskRequest, s *specs.Spec) (shimTask, error) {
 	log.G(ctx).WithField("tid", req.ID).Debug("newHcsStandaloneTask")
@@ -1008,7 +1007,7 @@ func (ht *hcsTask) updateWCOWResources(ctx context.Context, data interface{}, an
 		return errors.New("must have resources be type *WindowsResources when updating a wcow container")
 	}
 	if resources.Memory != nil && resources.Memory.Limit != nil {
-		newMemorySizeInMB := *resources.Memory.Limit / bytesPerMB
+		newMemorySizeInMB := *resources.Memory.Limit / memory.MegaByte
 		memoryLimit := hcsoci.NormalizeMemorySize(ctx, ht.id, newMemorySizeInMB)
 		if err := ht.requestUpdateContainer(ctx, resourcepaths.SiloMemoryResourcePath, memoryLimit); err != nil {
 			return err

--- a/computestorage/helpers.go
+++ b/computestorage/helpers.go
@@ -62,8 +62,8 @@ func SetupContainerBaseLayer(ctx context.Context, layerPath, baseVhdPath, diffVh
 	createParams := &vhd.CreateVirtualDiskParameters{
 		Version: 2,
 		Version2: vhd.CreateVersion2{
-			MaximumSize:      sizeInGB * memory.GigaByte,
-			BlockSizeInBytes: defaultVHDXBlockSizeInMB * uint32(memory.MegaByte),
+			MaximumSize:      sizeInGB * memory.GiB,
+			BlockSizeInBytes: defaultVHDXBlockSizeInMB * memory.MiB,
 		},
 	}
 	handle, err := vhd.CreateVirtualDisk(baseVhdPath, vhd.VirtualDiskAccessNone, vhd.CreateVirtualDiskFlagNone, createParams)
@@ -138,8 +138,8 @@ func SetupUtilityVMBaseLayer(ctx context.Context, uvmPath, baseVhdPath, diffVhdP
 	createParams := &vhd.CreateVirtualDiskParameters{
 		Version: 2,
 		Version2: vhd.CreateVersion2{
-			MaximumSize:      sizeInGB * memory.GigaByte,
-			BlockSizeInBytes: defaultVHDXBlockSizeInMB * uint32(memory.MegaByte),
+			MaximumSize:      sizeInGB * memory.GiB,
+			BlockSizeInBytes: defaultVHDXBlockSizeInMB * memory.MiB,
 		},
 	}
 	handle, err := vhd.CreateVirtualDisk(baseVhdPath, vhd.VirtualDiskAccessNone, vhd.CreateVirtualDiskFlagNone, createParams)

--- a/computestorage/helpers.go
+++ b/computestorage/helpers.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/Microsoft/go-winio/pkg/security"
 	"github.com/Microsoft/go-winio/vhd"
+	"github.com/Microsoft/hcsshim/internal/memory"
 	"github.com/pkg/errors"
 	"golang.org/x/sys/windows"
 )
@@ -61,8 +62,8 @@ func SetupContainerBaseLayer(ctx context.Context, layerPath, baseVhdPath, diffVh
 	createParams := &vhd.CreateVirtualDiskParameters{
 		Version: 2,
 		Version2: vhd.CreateVersion2{
-			MaximumSize:      sizeInGB * 1024 * 1024 * 1024,
-			BlockSizeInBytes: defaultVHDXBlockSizeInMB * 1024 * 1024,
+			MaximumSize:      sizeInGB * memory.GigaByte,
+			BlockSizeInBytes: defaultVHDXBlockSizeInMB * uint32(memory.MegaByte),
 		},
 	}
 	handle, err := vhd.CreateVirtualDisk(baseVhdPath, vhd.VirtualDiskAccessNone, vhd.CreateVirtualDiskFlagNone, createParams)
@@ -137,8 +138,8 @@ func SetupUtilityVMBaseLayer(ctx context.Context, uvmPath, baseVhdPath, diffVhdP
 	createParams := &vhd.CreateVirtualDiskParameters{
 		Version: 2,
 		Version2: vhd.CreateVersion2{
-			MaximumSize:      sizeInGB * 1024 * 1024 * 1024,
-			BlockSizeInBytes: defaultVHDXBlockSizeInMB * 1024 * 1024,
+			MaximumSize:      sizeInGB * memory.GigaByte,
+			BlockSizeInBytes: defaultVHDXBlockSizeInMB * uint32(memory.MegaByte),
 		},
 	}
 	handle, err := vhd.CreateVirtualDisk(baseVhdPath, vhd.VirtualDiskAccessNone, vhd.CreateVirtualDiskFlagNone, createParams)

--- a/ext4/dmverity/dmverity.go
+++ b/ext4/dmverity/dmverity.go
@@ -14,14 +14,15 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/Microsoft/hcsshim/ext4/internal/compactext4"
+	"github.com/Microsoft/hcsshim/internal/memory"
 )
 
 const (
 	blockSize = compactext4.BlockSize
 	// MerkleTreeBufioSize is a default buffer size to use with bufio.Reader
-	MerkleTreeBufioSize = 1024 * 1024 // 1MB
+	MerkleTreeBufioSize = int(memory.MegaByte) // 1MB
 	// RecommendedVHDSizeGB is the recommended size in GB for VHDs, which is not a hard limit.
-	RecommendedVHDSizeGB = 128 * 1024 * 1024 * 1024
+	RecommendedVHDSizeGB = 128 * int64(memory.GigaByte)
 	// VeritySignature is a value written to dm-verity super-block.
 	VeritySignature = "verity"
 )

--- a/ext4/dmverity/dmverity.go
+++ b/ext4/dmverity/dmverity.go
@@ -20,9 +20,9 @@ import (
 const (
 	blockSize = compactext4.BlockSize
 	// MerkleTreeBufioSize is a default buffer size to use with bufio.Reader
-	MerkleTreeBufioSize = int(memory.MegaByte) // 1MB
+	MerkleTreeBufioSize = memory.MiB // 1MB
 	// RecommendedVHDSizeGB is the recommended size in GB for VHDs, which is not a hard limit.
-	RecommendedVHDSizeGB = 128 * int64(memory.GigaByte)
+	RecommendedVHDSizeGB = 128 * memory.GiB
 	// VeritySignature is a value written to dm-verity super-block.
 	VeritySignature = "verity"
 )

--- a/ext4/internal/compactext4/compact.go
+++ b/ext4/internal/compactext4/compact.go
@@ -102,15 +102,15 @@ const (
 	maxInodesPerGroup       = BlockSize * 8 // Limited by the inode bitmap
 	inodesPerGroupIncrement = BlockSize / inodeSize
 
-	defaultMaxDiskSize = 16 * int64(memory.GigaByte)    // 16GB
+	defaultMaxDiskSize = 16 * memory.GiB                // 16GB
 	maxMaxDiskSize     = 16 * 1024 * 1024 * 1024 * 1024 // 16TB
 
 	groupDescriptorSize      = 32 // Use the small group descriptor
 	groupsPerDescriptorBlock = BlockSize / groupDescriptorSize
 
-	maxFileSize             = 128 * int64(memory.GigaByte) // 128GB file size maximum for now
-	smallSymlinkSize        = 59                           // max symlink size that goes directly in the inode
-	maxBlocksPerExtent      = 0x8000                       // maximum number of blocks in an extent
+	maxFileSize             = 128 * memory.GiB // 128GB file size maximum for now
+	smallSymlinkSize        = 59               // max symlink size that goes directly in the inode
+	maxBlocksPerExtent      = 0x8000           // maximum number of blocks in an extent
 	inodeDataSize           = 60
 	inodeUsedSize           = 152 // fields through CrtimeExtra
 	inodeExtraSize          = inodeSize - inodeUsedSize

--- a/ext4/internal/compactext4/compact.go
+++ b/ext4/internal/compactext4/compact.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/Microsoft/hcsshim/ext4/internal/format"
+	"github.com/Microsoft/hcsshim/internal/memory"
 )
 
 // Writer writes a compact ext4 file system.
@@ -101,15 +102,15 @@ const (
 	maxInodesPerGroup       = BlockSize * 8 // Limited by the inode bitmap
 	inodesPerGroupIncrement = BlockSize / inodeSize
 
-	defaultMaxDiskSize = 16 * 1024 * 1024 * 1024        // 16GB
+	defaultMaxDiskSize = 16 * int64(memory.GigaByte)    // 16GB
 	maxMaxDiskSize     = 16 * 1024 * 1024 * 1024 * 1024 // 16TB
 
 	groupDescriptorSize      = 32 // Use the small group descriptor
 	groupsPerDescriptorBlock = BlockSize / groupDescriptorSize
 
-	maxFileSize             = 128 * 1024 * 1024 * 1024 // 128GB file size maximum for now
-	smallSymlinkSize        = 59                       // max symlink size that goes directly in the inode
-	maxBlocksPerExtent      = 0x8000                   // maximum number of blocks in an extent
+	maxFileSize             = 128 * int64(memory.GigaByte) // 128GB file size maximum for now
+	smallSymlinkSize        = 59                           // max symlink size that goes directly in the inode
+	maxBlocksPerExtent      = 0x8000                       // maximum number of blocks in an extent
 	inodeDataSize           = 60
 	inodeUsedSize           = 152 // fields through CrtimeExtra
 	inodeExtraSize          = inodeSize - inodeUsedSize

--- a/ext4/internal/compactext4/compact_test.go
+++ b/ext4/internal/compactext4/compact_test.go
@@ -319,9 +319,9 @@ func TestTime(t *testing.T) {
 
 func TestLargeFile(t *testing.T) {
 	testFiles := []testFile{
-		{Path: "small", File: &File{}, DataSize: int64(memory.MegaByte)},        // can't change type
-		{Path: "medium", File: &File{}, DataSize: 200 * int64(memory.MegaByte)}, // can't change type
-		{Path: "large", File: &File{}, DataSize: 600 * int64(memory.MegaByte)},  // can't change type
+		{Path: "small", File: &File{}, DataSize: memory.MiB},        // can't change type
+		{Path: "medium", File: &File{}, DataSize: 200 * memory.MiB}, // can't change type
+		{Path: "large", File: &File{}, DataSize: 600 * memory.MiB},  // can't change type
 	}
 	runTestsOnFiles(t, testFiles)
 }

--- a/ext4/internal/compactext4/compact_test.go
+++ b/ext4/internal/compactext4/compact_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/Microsoft/hcsshim/ext4/internal/format"
+	"github.com/Microsoft/hcsshim/internal/memory"
 )
 
 type testFile struct {
@@ -318,9 +319,9 @@ func TestTime(t *testing.T) {
 
 func TestLargeFile(t *testing.T) {
 	testFiles := []testFile{
-		{Path: "small", File: &File{}, DataSize: 1024 * 1024},        // can't change type
-		{Path: "medium", File: &File{}, DataSize: 200 * 1024 * 1024}, // can't change type
-		{Path: "large", File: &File{}, DataSize: 600 * 1024 * 1024},  // can't change type
+		{Path: "small", File: &File{}, DataSize: int64(memory.MegaByte)},        // can't change type
+		{Path: "medium", File: &File{}, DataSize: 200 * int64(memory.MegaByte)}, // can't change type
+		{Path: "large", File: &File{}, DataSize: 600 * int64(memory.MegaByte)},  // can't change type
 	}
 	runTestsOnFiles(t, testFiles)
 }

--- a/internal/guest/storage/crypt/crypt_test.go
+++ b/internal/guest/storage/crypt/crypt_test.go
@@ -195,7 +195,7 @@ func Test_Encrypt_Create_Sparse_File_Error(t *testing.T) {
 	// Test what happens when it isn't possible to create a sparse file, and
 	// make sure that _createSparseEmptyFile receives the right arguments.
 
-	blockDeviceSize := int64(memory.GigaByte)
+	blockDeviceSize := int64(memory.GiB)
 
 	_generateKeyFile = func(path string, size int64) error {
 		return nil
@@ -247,7 +247,7 @@ func Test_Encrypt_Mkfs_Error(t *testing.T) {
 	// Test what happens when mkfs fails to format the unencrypted device.
 	// Verify that the arguments passed to it are the right ones.
 
-	blockDeviceSize := int64(memory.GigaByte)
+	blockDeviceSize := int64(memory.GiB)
 
 	_generateKeyFile = func(path string, size int64) error {
 		return nil
@@ -297,7 +297,7 @@ func Test_Encrypt_Sparse_Copy_Error(t *testing.T) {
 	// Test what happens when the sparse copy fails. Verify that the arguments
 	// passed to it are the right ones.
 
-	blockDeviceSize := int64(memory.GigaByte)
+	blockDeviceSize := int64(memory.GiB)
 
 	_generateKeyFile = func(path string, size int64) error {
 		return nil
@@ -355,7 +355,7 @@ func Test_Encrypt_Success(t *testing.T) {
 
 	// Test what happens when everything goes right.
 
-	blockDeviceSize := int64(memory.GigaByte)
+	blockDeviceSize := int64(memory.GiB)
 
 	_generateKeyFile = func(path string, size int64) error {
 		return nil

--- a/internal/guest/storage/crypt/crypt_test.go
+++ b/internal/guest/storage/crypt/crypt_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/Microsoft/hcsshim/internal/memory"
 	"github.com/pkg/errors"
 )
 
@@ -194,7 +195,7 @@ func Test_Encrypt_Create_Sparse_File_Error(t *testing.T) {
 	// Test what happens when it isn't possible to create a sparse file, and
 	// make sure that _createSparseEmptyFile receives the right arguments.
 
-	blockDeviceSize := int64(1024 * 1024 * 1024)
+	blockDeviceSize := int64(memory.GigaByte)
 
 	_generateKeyFile = func(path string, size int64) error {
 		return nil
@@ -246,7 +247,7 @@ func Test_Encrypt_Mkfs_Error(t *testing.T) {
 	// Test what happens when mkfs fails to format the unencrypted device.
 	// Verify that the arguments passed to it are the right ones.
 
-	blockDeviceSize := int64(1024 * 1024 * 1024)
+	blockDeviceSize := int64(memory.GigaByte)
 
 	_generateKeyFile = func(path string, size int64) error {
 		return nil
@@ -296,7 +297,7 @@ func Test_Encrypt_Sparse_Copy_Error(t *testing.T) {
 	// Test what happens when the sparse copy fails. Verify that the arguments
 	// passed to it are the right ones.
 
-	blockDeviceSize := int64(1024 * 1024 * 1024)
+	blockDeviceSize := int64(memory.GigaByte)
 
 	_generateKeyFile = func(path string, size int64) error {
 		return nil
@@ -354,7 +355,7 @@ func Test_Encrypt_Success(t *testing.T) {
 
 	// Test what happens when everything goes right.
 
-	blockDeviceSize := int64(1024 * 1024 * 1024)
+	blockDeviceSize := int64(memory.GigaByte)
 
 	_generateKeyFile = func(path string, size int64) error {
 		return nil

--- a/internal/guest/storage/overlay/overlay.go
+++ b/internal/guest/storage/overlay/overlay.go
@@ -44,7 +44,7 @@ func processErrNoSpace(ctx context.Context, path string, err error) {
 	used := all - free
 
 	toGigabyteStr := func(val uint64) string {
-		return fmt.Sprintf("%.1f", float64(val)/float64(memory.GigaByte))
+		return fmt.Sprintf("%.1f", float64(val)/float64(memory.GiB))
 	}
 
 	log.G(ctx).WithFields(logrus.Fields{

--- a/internal/jobcontainers/oci.go
+++ b/internal/jobcontainers/oci.go
@@ -58,7 +58,7 @@ func specToLimits(ctx context.Context, cid string, s *specs.Spec) (*jobobject.Jo
 		CPUWeight:          realCPUWeight,
 		MaxIOPS:            maxIops,
 		MaxBandwidth:       maxBandwidth,
-		MemoryLimitInBytes: memLimitMB * memory.MegaByte,
+		MemoryLimitInBytes: memLimitMB * memory.MiB,
 	}, nil
 }
 

--- a/internal/jobcontainers/oci.go
+++ b/internal/jobcontainers/oci.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/Microsoft/hcsshim/internal/hcsoci"
 	"github.com/Microsoft/hcsshim/internal/jobobject"
+	"github.com/Microsoft/hcsshim/internal/memory"
 	"github.com/Microsoft/hcsshim/internal/processorinfo"
 	"github.com/Microsoft/hcsshim/pkg/annotations"
 
@@ -57,7 +58,7 @@ func specToLimits(ctx context.Context, cid string, s *specs.Spec) (*jobobject.Jo
 		CPUWeight:          realCPUWeight,
 		MaxIOPS:            maxIops,
 		MaxBandwidth:       maxBandwidth,
-		MemoryLimitInBytes: memLimitMB * 1024 * 1024,
+		MemoryLimitInBytes: memLimitMB * memory.MegaByte,
 	}, nil
 }
 

--- a/internal/memory/pool.go
+++ b/internal/memory/pool.go
@@ -5,8 +5,8 @@ import (
 )
 
 const (
-	minimumClassSize  = MegaByte
-	maximumClassSize  = 4 * GigaByte
+	minimumClassSize  = MiB
+	maximumClassSize  = 4 * GiB
 	memoryClassNumber = 7
 )
 
@@ -179,7 +179,7 @@ func (pa *PoolAllocator) findNextOffset(memCls classType) (classType, uint64, er
 			continue
 		}
 
-		target := maximumClassSize
+		target := uint64(maximumClassSize)
 		for offset := range pi.free {
 			if offset < target {
 				target = offset

--- a/internal/memory/pool_test.go
+++ b/internal/memory/pool_test.go
@@ -38,13 +38,13 @@ func Test_MemAlloc_allocate_without_expand(t *testing.T) {
 		offset: 0,
 	}
 
-	testAllocate(t, ma, MegaByte)
+	testAllocate(t, ma, MiB)
 }
 
 func Test_MemAlloc_allocate_not_enough_space(t *testing.T) {
 	ma := &PoolAllocator{}
 
-	_, err := ma.Allocate(MegaByte)
+	_, err := ma.Allocate(MiB)
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -72,7 +72,7 @@ func Test_MemAlloc_expand(t *testing.T) {
 
 	poolCls0 := pa.pools[0]
 	for i := 0; i < 4; i++ {
-		offset := uint64(i) * MegaByte
+		offset := uint64(i) * MiB
 		_, ok := poolCls0.free[offset]
 		if !ok {
 			t.Fatalf("did not find region with offset=%d", offset)
@@ -88,12 +88,12 @@ func Test_MemAlloc_expand(t *testing.T) {
 func Test_MemAlloc_allocate_automatically_expands(t *testing.T) {
 	pa := &PoolAllocator{}
 	pa.pools[2] = newEmptyMemoryPool()
-	pa.pools[2].free[MegaByte] = &region{
+	pa.pools[2].free[MiB] = &region{
 		class:  2,
-		offset: MegaByte,
+		offset: MiB,
 	}
 
-	testAllocate(t, pa, MegaByte)
+	testAllocate(t, pa, MiB)
 
 	if pa.pools[1] == nil {
 		t.Fatalf("memory not extended for class type 1")
@@ -112,7 +112,7 @@ func Test_MemAlloc_alloc_and_release(t *testing.T) {
 	}
 	pa.pools[0].free[0] = r
 
-	testAllocate(t, pa, MegaByte)
+	testAllocate(t, pa, MiB)
 
 	err := pa.Release(r)
 	if err != nil {
@@ -147,10 +147,10 @@ func Test_MemAlloc_release_invalid_offset(t *testing.T) {
 	}
 	pa.pools[0].free[0] = r
 
-	testAllocate(t, pa, MegaByte)
+	testAllocate(t, pa, MiB)
 
 	// change the actual offset
-	r.offset = MegaByte
+	r.offset = MiB
 	err := pa.Release(r)
 	if err == nil {
 		t.Fatal("no error returned")
@@ -163,7 +163,7 @@ func Test_MemAlloc_release_invalid_offset(t *testing.T) {
 func Test_MemAlloc_Max_Out(t *testing.T) {
 	ma := NewPoolMemoryAllocator()
 	for i := 0; i < 4096; i++ {
-		_, err := ma.Allocate(MegaByte)
+		_, err := ma.Allocate(MiB)
 		if err != nil {
 			t.Fatalf("unexpected error during memory allocation: %s", err)
 		}
@@ -172,7 +172,7 @@ func Test_MemAlloc_Max_Out(t *testing.T) {
 		t.Fatalf("expected 4096 busy blocks of class 0, got %d instead", len(ma.pools[0].busy))
 	}
 	for i := 0; i < 4096; i++ {
-		offset := uint64(i) * MegaByte
+		offset := uint64(i) * MiB
 		if _, ok := ma.pools[0].busy[offset]; !ok {
 			t.Fatalf("expected to find offset %d", offset)
 		}
@@ -189,17 +189,17 @@ func Test_GetMemoryClass(t *testing.T) {
 	testCases := []config{
 		{
 			name:     "Size_1MB_Class_0",
-			size:     MegaByte,
+			size:     MiB,
 			expected: 0,
 		},
 		{
 			name:     "Size_6MB_Class_2",
-			size:     6 * MegaByte,
+			size:     6 * MiB,
 			expected: 2,
 		},
 		{
 			name:     "Size_2GB_Class_6",
-			size:     2 * GigaByte,
+			size:     2 * GiB,
 			expected: 6,
 		},
 	}

--- a/internal/memory/types.go
+++ b/internal/memory/types.go
@@ -5,8 +5,8 @@ import "github.com/pkg/errors"
 type classType uint32
 
 const (
-	MegaByte = uint64(1024 * 1024)
-	GigaByte = 1024 * MegaByte
+	MegaByte uint64 = 1024 * 1024
+	GigaByte uint64 = 1024 * MegaByte
 )
 
 var (

--- a/internal/memory/types.go
+++ b/internal/memory/types.go
@@ -5,8 +5,8 @@ import "github.com/pkg/errors"
 type classType uint32
 
 const (
-	MegaByte uint64 = 1024 * 1024
-	GigaByte uint64 = 1024 * MegaByte
+	MiB = 1024 * 1024
+	GiB = 1024 * MiB
 )
 
 var (

--- a/internal/tools/uvmboot/lcow.go
+++ b/internal/tools/uvmboot/lcow.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/Microsoft/hcsshim/internal/cmd"
+	"github.com/Microsoft/hcsshim/internal/memory"
 	"github.com/Microsoft/hcsshim/internal/uvm"
 	"github.com/containerd/console"
 	"github.com/sirupsen/logrus"
@@ -111,7 +112,7 @@ var lcowCommand = cli.Command{
 				options.VPMemDeviceCount = uint32(c.Uint(vpMemMaxCountArgName))
 			}
 			if c.IsSet(vpMemMaxSizeArgName) {
-				options.VPMemSizeBytes = c.Uint64(vpMemMaxSizeArgName) * 1024 * 1024 // convert from MB to bytes
+				options.VPMemSizeBytes = c.Uint64(vpMemMaxSizeArgName) * memory.MegaByte // convert from MB to bytes
 			}
 			if !useGcs {
 				if c.IsSet(execCommandLineArgName) {

--- a/internal/tools/uvmboot/lcow.go
+++ b/internal/tools/uvmboot/lcow.go
@@ -112,7 +112,7 @@ var lcowCommand = cli.Command{
 				options.VPMemDeviceCount = uint32(c.Uint(vpMemMaxCountArgName))
 			}
 			if c.IsSet(vpMemMaxSizeArgName) {
-				options.VPMemSizeBytes = c.Uint64(vpMemMaxSizeArgName) * memory.MegaByte // convert from MB to bytes
+				options.VPMemSizeBytes = c.Uint64(vpMemMaxSizeArgName) * memory.MiB // convert from MB to bytes
 			}
 			if !useGcs {
 				if c.IsSet(execCommandLineArgName) {

--- a/internal/uvm/constants.go
+++ b/internal/uvm/constants.go
@@ -3,6 +3,7 @@ package uvm
 import (
 	"errors"
 
+	"github.com/Microsoft/hcsshim/internal/memory"
 	"github.com/Microsoft/hcsshim/internal/protocol/guestrequest"
 )
 
@@ -17,7 +18,7 @@ const (
 
 	// DefaultVPMemSizeBytes is the default size of a VPMem device if the create request
 	// doesn't specify.
-	DefaultVPMemSizeBytes = 4 * 1024 * 1024 * 1024 // 4GB
+	DefaultVPMemSizeBytes = 4 * memory.GigaByte // 4GB
 )
 
 var (

--- a/internal/uvm/constants.go
+++ b/internal/uvm/constants.go
@@ -18,7 +18,7 @@ const (
 
 	// DefaultVPMemSizeBytes is the default size of a VPMem device if the create request
 	// doesn't specify.
-	DefaultVPMemSizeBytes = 4 * memory.GigaByte // 4GB
+	DefaultVPMemSizeBytes = 4 * memory.GiB // 4GB
 )
 
 var (

--- a/internal/uvm/memory_update.go
+++ b/internal/uvm/memory_update.go
@@ -8,18 +8,16 @@ import (
 
 	"github.com/Microsoft/hcsshim/internal/hcs/resourcepaths"
 	hcsschema "github.com/Microsoft/hcsshim/internal/hcs/schema2"
+	"github.com/Microsoft/hcsshim/internal/memory"
 )
 
-const (
-	bytesPerPage = 4096
-	bytesPerMB   = 1024 * 1024
-)
+const bytesPerPage = 4096
 
 // UpdateMemory makes a call to the VM's orchestrator to update the VM's size in MB
 // Internally, HCS will get the number of pages this corresponds to and attempt to assign
 // pages to numa nodes evenly
 func (uvm *UtilityVM) UpdateMemory(ctx context.Context, sizeInBytes uint64) error {
-	requestedSizeInMB := sizeInBytes / bytesPerMB
+	requestedSizeInMB := sizeInBytes / memory.MegaByte
 	actual := uvm.normalizeMemorySize(ctx, requestedSizeInMB)
 	req := &hcsschema.ModifySettingRequest{
 		ResourcePath: resourcepaths.MemoryResourcePath,

--- a/internal/uvm/memory_update.go
+++ b/internal/uvm/memory_update.go
@@ -17,7 +17,7 @@ const bytesPerPage = 4096
 // Internally, HCS will get the number of pages this corresponds to and attempt to assign
 // pages to numa nodes evenly
 func (uvm *UtilityVM) UpdateMemory(ctx context.Context, sizeInBytes uint64) error {
-	requestedSizeInMB := sizeInBytes / memory.MegaByte
+	requestedSizeInMB := sizeInBytes / memory.MiB
 	actual := uvm.normalizeMemorySize(ctx, requestedSizeInMB)
 	req := &hcsschema.ModifySettingRequest{
 		ResourcePath: resourcepaths.MemoryResourcePath,

--- a/internal/uvm/vpmem_mapped_test.go
+++ b/internal/uvm/vpmem_mapped_test.go
@@ -41,11 +41,11 @@ func setupNewVPMemScenario(ctx context.Context, t *testing.T, size uint64, hostP
 
 func Test_VPMem_MapDevice_New(t *testing.T) {
 	// basic scenario already validated in the helper function
-	setupNewVPMemScenario(context.TODO(), t, memory.MegaByte, "foo", "bar")
+	setupNewVPMemScenario(context.TODO(), t, memory.MiB, "foo", "bar")
 }
 
 func Test_VPMem_UnmapDevice_With_Removal(t *testing.T) {
-	pmem, _ := setupNewVPMemScenario(context.TODO(), t, memory.MegaByte, "foo", "bar")
+	pmem, _ := setupNewVPMemScenario(context.TODO(), t, memory.MiB, "foo", "bar")
 
 	err := pmem.unmapVHDLayer(context.TODO(), "foo")
 	if err != nil {
@@ -57,7 +57,7 @@ func Test_VPMem_UnmapDevice_With_Removal(t *testing.T) {
 }
 
 func Test_VPMem_UnmapDevice_Without_Removal(t *testing.T) {
-	pmem, mappedDevice := setupNewVPMemScenario(context.TODO(), t, memory.MegaByte, "foo", "bar")
+	pmem, mappedDevice := setupNewVPMemScenario(context.TODO(), t, memory.MiB, "foo", "bar")
 	err := pmem.mapVHDLayer(context.TODO(), mappedDevice)
 	if err != nil {
 		t.Fatalf("unexpected error when mapping device: %s", err)

--- a/test/cri-containerd/container_update_test.go
+++ b/test/cri-containerd/container_update_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/Microsoft/hcsshim/internal/memory"
 	"github.com/Microsoft/hcsshim/osversion"
 	"github.com/Microsoft/hcsshim/pkg/annotations"
 	testutilities "github.com/Microsoft/hcsshim/test/functional/utilities"
@@ -302,7 +303,7 @@ func Test_Container_UpdateResources_Memory(t *testing.T) {
 			defer removePodSandbox(t, client, ctx, podID)
 			defer stopPodSandbox(t, client, ctx, podID)
 
-			var startingMemorySize int64 = 768 * 1024 * 1024
+			var startingMemorySize int64 = 768 * int64(memory.MegaByte)
 			containerRequest := &runtime.CreateContainerRequest{
 				Config: &runtime.ContainerConfig{
 					Metadata: &runtime.ContainerMetadata{

--- a/test/cri-containerd/container_update_test.go
+++ b/test/cri-containerd/container_update_test.go
@@ -303,7 +303,7 @@ func Test_Container_UpdateResources_Memory(t *testing.T) {
 			defer removePodSandbox(t, client, ctx, podID)
 			defer stopPodSandbox(t, client, ctx, podID)
 
-			var startingMemorySize int64 = 768 * int64(memory.MegaByte)
+			var startingMemorySize int64 = 768 * memory.MiB
 			containerRequest := &runtime.CreateContainerRequest{
 				Config: &runtime.ContainerConfig{
 					Metadata: &runtime.ContainerMetadata{

--- a/test/cri-containerd/createcontainer_test.go
+++ b/test/cri-containerd/createcontainer_test.go
@@ -277,7 +277,7 @@ func Test_CreateContainer_MemorySize_Config_WCOW_Process(t *testing.T) {
 			},
 			Windows: &runtime.WindowsContainerConfig{
 				Resources: &runtime.WindowsContainerResources{
-					MemoryLimitInBytes: 768 * int64(memory.MegaByte), // 768MB
+					MemoryLimitInBytes: 768 * memory.MiB, // 768MB
 				},
 			},
 		},
@@ -337,7 +337,7 @@ func Test_CreateContainer_MemorySize_Config_WCOW_Hypervisor(t *testing.T) {
 			},
 			Windows: &runtime.WindowsContainerConfig{
 				Resources: &runtime.WindowsContainerResources{
-					MemoryLimitInBytes: 768 * int64(memory.MegaByte), // 768MB
+					MemoryLimitInBytes: 768 * memory.MiB, // 768MB
 				},
 			},
 		},
@@ -393,7 +393,7 @@ func Test_CreateContainer_MemorySize_LCOW(t *testing.T) {
 			},
 			Linux: &runtime.LinuxContainerConfig{
 				Resources: &runtime.LinuxContainerResources{
-					MemoryLimitInBytes: 768 * int64(memory.MegaByte), // 768MB
+					MemoryLimitInBytes: 768 * memory.MiB, // 768MB
 				},
 			},
 		},

--- a/test/cri-containerd/createcontainer_test.go
+++ b/test/cri-containerd/createcontainer_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/Microsoft/go-winio"
+	"github.com/Microsoft/hcsshim/internal/memory"
 	"github.com/Microsoft/hcsshim/osversion"
 	"github.com/Microsoft/hcsshim/pkg/annotations"
 	testutilities "github.com/Microsoft/hcsshim/test/functional/utilities"
@@ -276,7 +277,7 @@ func Test_CreateContainer_MemorySize_Config_WCOW_Process(t *testing.T) {
 			},
 			Windows: &runtime.WindowsContainerConfig{
 				Resources: &runtime.WindowsContainerResources{
-					MemoryLimitInBytes: 768 * 1024 * 1024, // 768MB
+					MemoryLimitInBytes: 768 * int64(memory.MegaByte), // 768MB
 				},
 			},
 		},
@@ -336,7 +337,7 @@ func Test_CreateContainer_MemorySize_Config_WCOW_Hypervisor(t *testing.T) {
 			},
 			Windows: &runtime.WindowsContainerConfig{
 				Resources: &runtime.WindowsContainerResources{
-					MemoryLimitInBytes: 768 * 1024 * 1024, // 768MB
+					MemoryLimitInBytes: 768 * int64(memory.MegaByte), // 768MB
 				},
 			},
 		},
@@ -392,7 +393,7 @@ func Test_CreateContainer_MemorySize_LCOW(t *testing.T) {
 			},
 			Linux: &runtime.LinuxContainerConfig{
 				Resources: &runtime.LinuxContainerResources{
-					MemoryLimitInBytes: 768 * 1024 * 1024, // 768MB
+					MemoryLimitInBytes: 768 * int64(memory.MegaByte), // 768MB
 				},
 			},
 		},

--- a/test/cri-containerd/pod_update_test.go
+++ b/test/cri-containerd/pod_update_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/Microsoft/hcsshim/internal/cpugroup"
+	"github.com/Microsoft/hcsshim/internal/memory"
 	"github.com/Microsoft/hcsshim/internal/processorinfo"
 	"github.com/Microsoft/hcsshim/pkg/annotations"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
@@ -45,7 +46,7 @@ func Test_Pod_UpdateResources_Memory(t *testing.T) {
 			} else {
 				pullRequiredImages(t, []string{test.sandboxImage})
 			}
-			var startingMemorySize int64 = 768 * 1024 * 1024
+			var startingMemorySize int64 = 768 * int64(memory.MegaByte)
 			podRequest := getRunPodSandboxRequest(
 				t,
 				test.runtimeHandler,
@@ -116,7 +117,7 @@ func Test_Pod_UpdateResources_Memory_PA(t *testing.T) {
 			} else {
 				pullRequiredImages(t, []string{test.sandboxImage})
 			}
-			var startingMemorySize int64 = 200 * 1024 * 1024
+			var startingMemorySize int64 = 200 * int64(memory.MegaByte)
 			podRequest := getRunPodSandboxRequest(
 				t,
 				test.runtimeHandler,

--- a/test/cri-containerd/pod_update_test.go
+++ b/test/cri-containerd/pod_update_test.go
@@ -46,7 +46,7 @@ func Test_Pod_UpdateResources_Memory(t *testing.T) {
 			} else {
 				pullRequiredImages(t, []string{test.sandboxImage})
 			}
-			var startingMemorySize int64 = 768 * int64(memory.MegaByte)
+			var startingMemorySize int64 = 768 * memory.MiB
 			podRequest := getRunPodSandboxRequest(
 				t,
 				test.runtimeHandler,
@@ -117,7 +117,7 @@ func Test_Pod_UpdateResources_Memory_PA(t *testing.T) {
 			} else {
 				pullRequiredImages(t, []string{test.sandboxImage})
 			}
-			var startingMemorySize int64 = 200 * int64(memory.MegaByte)
+			var startingMemorySize int64 = 200 * memory.MiB
 			podRequest := getRunPodSandboxRequest(
 				t,
 				test.runtimeHandler,

--- a/test/cri-containerd/stats_test.go
+++ b/test/cri-containerd/stats_test.go
@@ -5,9 +5,11 @@ package cri_containerd
 
 import (
 	"context"
-	"github.com/Microsoft/hcsshim/pkg/annotations"
 	"strconv"
 	"testing"
+
+	"github.com/Microsoft/hcsshim/internal/memory"
+	"github.com/Microsoft/hcsshim/pkg/annotations"
 
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 )
@@ -79,7 +81,7 @@ func verifyPhysicallyBackedWorkingSet(t *testing.T, num uint64, stat *runtime.Co
 	if stat == nil {
 		t.Fatal("expected stat to be non nil")
 	}
-	numInBytes := num * 1024 * 1024
+	numInBytes := num * memory.MegaByte
 	if stat.Memory.WorkingSetBytes.Value != numInBytes {
 		t.Fatalf("expected working set size to be %d bytes but got: %d", numInBytes, stat.Memory.WorkingSetBytes.Value)
 	}

--- a/test/cri-containerd/stats_test.go
+++ b/test/cri-containerd/stats_test.go
@@ -81,7 +81,7 @@ func verifyPhysicallyBackedWorkingSet(t *testing.T, num uint64, stat *runtime.Co
 	if stat == nil {
 		t.Fatal("expected stat to be non nil")
 	}
-	numInBytes := num * memory.MegaByte
+	numInBytes := num * memory.MiB
 	if stat.Memory.WorkingSetBytes.Value != numInBytes {
 		t.Fatalf("expected working set size to be %d bytes but got: %d", numInBytes, stat.Memory.WorkingSetBytes.Value)
 	}

--- a/test/functional/test.go
+++ b/test/functional/test.go
@@ -13,10 +13,6 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-const (
-	bytesPerMB = 1024 * 1024
-)
-
 var pauseDurationOnCreateContainerFailure time.Duration
 
 func init() {

--- a/test/functional/uvm_memory_test.go
+++ b/test/functional/uvm_memory_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Microsoft/hcsshim/internal/memory"
 	"github.com/Microsoft/hcsshim/internal/uvm"
 	"github.com/Microsoft/hcsshim/osversion"
 	testutilities "github.com/Microsoft/hcsshim/test/functional/utilities"
@@ -22,7 +23,7 @@ func TestUVMMemoryUpdateLCOW(t *testing.T) {
 	u := testutilities.CreateLCOWUVMFromOpts(ctx, t, opts)
 	defer u.Close()
 
-	newMemorySize := uint64(opts.MemorySizeInMB/2) * bytesPerMB
+	newMemorySize := uint64(opts.MemorySizeInMB/2) * memory.MegaByte
 
 	if err := u.UpdateMemory(ctx, newMemorySize); err != nil {
 		t.Fatalf("failed to make call to modify UVM memory size in MB with: %v", err)
@@ -49,7 +50,7 @@ func TestUVMMemoryUpdateWCOW(t *testing.T) {
 	defer os.RemoveAll(uvmScratchDir)
 	defer u.Close()
 
-	newMemoryInBytes := uint64(opts.MemorySizeInMB/2) * bytesPerMB
+	newMemoryInBytes := uint64(opts.MemorySizeInMB/2) * memory.MegaByte
 	if err := u.UpdateMemory(ctx, newMemoryInBytes); err != nil {
 		t.Fatalf("failed to make call to modify UVM memory size in MB with: %v", err)
 	}

--- a/test/functional/uvm_memory_test.go
+++ b/test/functional/uvm_memory_test.go
@@ -23,7 +23,7 @@ func TestUVMMemoryUpdateLCOW(t *testing.T) {
 	u := testutilities.CreateLCOWUVMFromOpts(ctx, t, opts)
 	defer u.Close()
 
-	newMemorySize := uint64(opts.MemorySizeInMB/2) * memory.MegaByte
+	newMemorySize := uint64(opts.MemorySizeInMB/2) * memory.MiB
 
 	if err := u.UpdateMemory(ctx, newMemorySize); err != nil {
 		t.Fatalf("failed to make call to modify UVM memory size in MB with: %v", err)
@@ -50,7 +50,7 @@ func TestUVMMemoryUpdateWCOW(t *testing.T) {
 	defer os.RemoveAll(uvmScratchDir)
 	defer u.Close()
 
-	newMemoryInBytes := uint64(opts.MemorySizeInMB/2) * memory.MegaByte
+	newMemoryInBytes := uint64(opts.MemorySizeInMB/2) * memory.MiB
 	if err := u.UpdateMemory(ctx, newMemoryInBytes); err != nil {
 		t.Fatalf("failed to make call to modify UVM memory size in MB with: %v", err)
 	}

--- a/test/vendor/github.com/Microsoft/hcsshim/computestorage/helpers.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/computestorage/helpers.go
@@ -62,8 +62,8 @@ func SetupContainerBaseLayer(ctx context.Context, layerPath, baseVhdPath, diffVh
 	createParams := &vhd.CreateVirtualDiskParameters{
 		Version: 2,
 		Version2: vhd.CreateVersion2{
-			MaximumSize:      sizeInGB * memory.GigaByte,
-			BlockSizeInBytes: defaultVHDXBlockSizeInMB * uint32(memory.MegaByte),
+			MaximumSize:      sizeInGB * memory.GiB,
+			BlockSizeInBytes: defaultVHDXBlockSizeInMB * memory.MiB,
 		},
 	}
 	handle, err := vhd.CreateVirtualDisk(baseVhdPath, vhd.VirtualDiskAccessNone, vhd.CreateVirtualDiskFlagNone, createParams)
@@ -138,8 +138,8 @@ func SetupUtilityVMBaseLayer(ctx context.Context, uvmPath, baseVhdPath, diffVhdP
 	createParams := &vhd.CreateVirtualDiskParameters{
 		Version: 2,
 		Version2: vhd.CreateVersion2{
-			MaximumSize:      sizeInGB * memory.GigaByte,
-			BlockSizeInBytes: defaultVHDXBlockSizeInMB * uint32(memory.MegaByte),
+			MaximumSize:      sizeInGB * memory.GiB,
+			BlockSizeInBytes: defaultVHDXBlockSizeInMB * memory.MiB,
 		},
 	}
 	handle, err := vhd.CreateVirtualDisk(baseVhdPath, vhd.VirtualDiskAccessNone, vhd.CreateVirtualDiskFlagNone, createParams)

--- a/test/vendor/github.com/Microsoft/hcsshim/computestorage/helpers.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/computestorage/helpers.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/Microsoft/go-winio/pkg/security"
 	"github.com/Microsoft/go-winio/vhd"
+	"github.com/Microsoft/hcsshim/internal/memory"
 	"github.com/pkg/errors"
 	"golang.org/x/sys/windows"
 )
@@ -61,8 +62,8 @@ func SetupContainerBaseLayer(ctx context.Context, layerPath, baseVhdPath, diffVh
 	createParams := &vhd.CreateVirtualDiskParameters{
 		Version: 2,
 		Version2: vhd.CreateVersion2{
-			MaximumSize:      sizeInGB * 1024 * 1024 * 1024,
-			BlockSizeInBytes: defaultVHDXBlockSizeInMB * 1024 * 1024,
+			MaximumSize:      sizeInGB * memory.GigaByte,
+			BlockSizeInBytes: defaultVHDXBlockSizeInMB * uint32(memory.MegaByte),
 		},
 	}
 	handle, err := vhd.CreateVirtualDisk(baseVhdPath, vhd.VirtualDiskAccessNone, vhd.CreateVirtualDiskFlagNone, createParams)
@@ -137,8 +138,8 @@ func SetupUtilityVMBaseLayer(ctx context.Context, uvmPath, baseVhdPath, diffVhdP
 	createParams := &vhd.CreateVirtualDiskParameters{
 		Version: 2,
 		Version2: vhd.CreateVersion2{
-			MaximumSize:      sizeInGB * 1024 * 1024 * 1024,
-			BlockSizeInBytes: defaultVHDXBlockSizeInMB * 1024 * 1024,
+			MaximumSize:      sizeInGB * memory.GigaByte,
+			BlockSizeInBytes: defaultVHDXBlockSizeInMB * uint32(memory.MegaByte),
 		},
 	}
 	handle, err := vhd.CreateVirtualDisk(baseVhdPath, vhd.VirtualDiskAccessNone, vhd.CreateVirtualDiskFlagNone, createParams)

--- a/test/vendor/github.com/Microsoft/hcsshim/ext4/dmverity/dmverity.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/ext4/dmverity/dmverity.go
@@ -14,14 +14,15 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/Microsoft/hcsshim/ext4/internal/compactext4"
+	"github.com/Microsoft/hcsshim/internal/memory"
 )
 
 const (
 	blockSize = compactext4.BlockSize
 	// MerkleTreeBufioSize is a default buffer size to use with bufio.Reader
-	MerkleTreeBufioSize = 1024 * 1024 // 1MB
+	MerkleTreeBufioSize = int(memory.MegaByte) // 1MB
 	// RecommendedVHDSizeGB is the recommended size in GB for VHDs, which is not a hard limit.
-	RecommendedVHDSizeGB = 128 * 1024 * 1024 * 1024
+	RecommendedVHDSizeGB = 128 * int64(memory.GigaByte)
 	// VeritySignature is a value written to dm-verity super-block.
 	VeritySignature = "verity"
 )

--- a/test/vendor/github.com/Microsoft/hcsshim/ext4/dmverity/dmverity.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/ext4/dmverity/dmverity.go
@@ -20,9 +20,9 @@ import (
 const (
 	blockSize = compactext4.BlockSize
 	// MerkleTreeBufioSize is a default buffer size to use with bufio.Reader
-	MerkleTreeBufioSize = int(memory.MegaByte) // 1MB
+	MerkleTreeBufioSize = memory.MiB // 1MB
 	// RecommendedVHDSizeGB is the recommended size in GB for VHDs, which is not a hard limit.
-	RecommendedVHDSizeGB = 128 * int64(memory.GigaByte)
+	RecommendedVHDSizeGB = 128 * memory.GiB
 	// VeritySignature is a value written to dm-verity super-block.
 	VeritySignature = "verity"
 )

--- a/test/vendor/github.com/Microsoft/hcsshim/ext4/internal/compactext4/compact.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/ext4/internal/compactext4/compact.go
@@ -102,15 +102,15 @@ const (
 	maxInodesPerGroup       = BlockSize * 8 // Limited by the inode bitmap
 	inodesPerGroupIncrement = BlockSize / inodeSize
 
-	defaultMaxDiskSize = 16 * int64(memory.GigaByte)    // 16GB
+	defaultMaxDiskSize = 16 * memory.GiB                // 16GB
 	maxMaxDiskSize     = 16 * 1024 * 1024 * 1024 * 1024 // 16TB
 
 	groupDescriptorSize      = 32 // Use the small group descriptor
 	groupsPerDescriptorBlock = BlockSize / groupDescriptorSize
 
-	maxFileSize             = 128 * int64(memory.GigaByte) // 128GB file size maximum for now
-	smallSymlinkSize        = 59                           // max symlink size that goes directly in the inode
-	maxBlocksPerExtent      = 0x8000                       // maximum number of blocks in an extent
+	maxFileSize             = 128 * memory.GiB // 128GB file size maximum for now
+	smallSymlinkSize        = 59               // max symlink size that goes directly in the inode
+	maxBlocksPerExtent      = 0x8000           // maximum number of blocks in an extent
 	inodeDataSize           = 60
 	inodeUsedSize           = 152 // fields through CrtimeExtra
 	inodeExtraSize          = inodeSize - inodeUsedSize

--- a/test/vendor/github.com/Microsoft/hcsshim/ext4/internal/compactext4/compact.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/ext4/internal/compactext4/compact.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/Microsoft/hcsshim/ext4/internal/format"
+	"github.com/Microsoft/hcsshim/internal/memory"
 )
 
 // Writer writes a compact ext4 file system.
@@ -101,15 +102,15 @@ const (
 	maxInodesPerGroup       = BlockSize * 8 // Limited by the inode bitmap
 	inodesPerGroupIncrement = BlockSize / inodeSize
 
-	defaultMaxDiskSize = 16 * 1024 * 1024 * 1024        // 16GB
+	defaultMaxDiskSize = 16 * int64(memory.GigaByte)    // 16GB
 	maxMaxDiskSize     = 16 * 1024 * 1024 * 1024 * 1024 // 16TB
 
 	groupDescriptorSize      = 32 // Use the small group descriptor
 	groupsPerDescriptorBlock = BlockSize / groupDescriptorSize
 
-	maxFileSize             = 128 * 1024 * 1024 * 1024 // 128GB file size maximum for now
-	smallSymlinkSize        = 59                       // max symlink size that goes directly in the inode
-	maxBlocksPerExtent      = 0x8000                   // maximum number of blocks in an extent
+	maxFileSize             = 128 * int64(memory.GigaByte) // 128GB file size maximum for now
+	smallSymlinkSize        = 59                           // max symlink size that goes directly in the inode
+	maxBlocksPerExtent      = 0x8000                       // maximum number of blocks in an extent
 	inodeDataSize           = 60
 	inodeUsedSize           = 152 // fields through CrtimeExtra
 	inodeExtraSize          = inodeSize - inodeUsedSize

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/memory/pool.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/memory/pool.go
@@ -5,8 +5,8 @@ import (
 )
 
 const (
-	minimumClassSize  = MegaByte
-	maximumClassSize  = 4 * GigaByte
+	minimumClassSize  = MiB
+	maximumClassSize  = 4 * GiB
 	memoryClassNumber = 7
 )
 
@@ -179,7 +179,7 @@ func (pa *PoolAllocator) findNextOffset(memCls classType) (classType, uint64, er
 			continue
 		}
 
-		target := maximumClassSize
+		target := uint64(maximumClassSize)
 		for offset := range pi.free {
 			if offset < target {
 				target = offset

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/memory/types.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/memory/types.go
@@ -5,8 +5,8 @@ import "github.com/pkg/errors"
 type classType uint32
 
 const (
-	MegaByte = uint64(1024 * 1024)
-	GigaByte = 1024 * MegaByte
+	MegaByte uint64 = 1024 * 1024
+	GigaByte uint64 = 1024 * MegaByte
 )
 
 var (

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/memory/types.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/memory/types.go
@@ -5,8 +5,8 @@ import "github.com/pkg/errors"
 type classType uint32
 
 const (
-	MegaByte uint64 = 1024 * 1024
-	GigaByte uint64 = 1024 * MegaByte
+	MiB = 1024 * 1024
+	GiB = 1024 * MiB
 )
 
 var (

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/uvm/constants.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/uvm/constants.go
@@ -3,6 +3,7 @@ package uvm
 import (
 	"errors"
 
+	"github.com/Microsoft/hcsshim/internal/memory"
 	"github.com/Microsoft/hcsshim/internal/protocol/guestrequest"
 )
 
@@ -17,7 +18,7 @@ const (
 
 	// DefaultVPMemSizeBytes is the default size of a VPMem device if the create request
 	// doesn't specify.
-	DefaultVPMemSizeBytes = 4 * 1024 * 1024 * 1024 // 4GB
+	DefaultVPMemSizeBytes = 4 * memory.GigaByte // 4GB
 )
 
 var (

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/uvm/constants.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/uvm/constants.go
@@ -18,7 +18,7 @@ const (
 
 	// DefaultVPMemSizeBytes is the default size of a VPMem device if the create request
 	// doesn't specify.
-	DefaultVPMemSizeBytes = 4 * memory.GigaByte // 4GB
+	DefaultVPMemSizeBytes = 4 * memory.GiB // 4GB
 )
 
 var (

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/uvm/memory_update.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/uvm/memory_update.go
@@ -8,18 +8,16 @@ import (
 
 	"github.com/Microsoft/hcsshim/internal/hcs/resourcepaths"
 	hcsschema "github.com/Microsoft/hcsshim/internal/hcs/schema2"
+	"github.com/Microsoft/hcsshim/internal/memory"
 )
 
-const (
-	bytesPerPage = 4096
-	bytesPerMB   = 1024 * 1024
-)
+const bytesPerPage = 4096
 
 // UpdateMemory makes a call to the VM's orchestrator to update the VM's size in MB
 // Internally, HCS will get the number of pages this corresponds to and attempt to assign
 // pages to numa nodes evenly
 func (uvm *UtilityVM) UpdateMemory(ctx context.Context, sizeInBytes uint64) error {
-	requestedSizeInMB := sizeInBytes / bytesPerMB
+	requestedSizeInMB := sizeInBytes / memory.MegaByte
 	actual := uvm.normalizeMemorySize(ctx, requestedSizeInMB)
 	req := &hcsschema.ModifySettingRequest{
 		ResourcePath: resourcepaths.MemoryResourcePath,

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/uvm/memory_update.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/uvm/memory_update.go
@@ -17,7 +17,7 @@ const bytesPerPage = 4096
 // Internally, HCS will get the number of pages this corresponds to and attempt to assign
 // pages to numa nodes evenly
 func (uvm *UtilityVM) UpdateMemory(ctx context.Context, sizeInBytes uint64) error {
-	requestedSizeInMB := sizeInBytes / memory.MegaByte
+	requestedSizeInMB := sizeInBytes / memory.MiB
 	actual := uvm.normalizeMemorySize(ctx, requestedSizeInMB)
 	req := &hcsschema.ModifySettingRequest{
 		ResourcePath: resourcepaths.MemoryResourcePath,


### PR DESCRIPTION
We have a bunch of 1024 * 1024 or 1024 * 1024 * 1024 numerical constants (or just other named megabyte constants) lying around. This changes to using the constants we have defined in the /internal/memory package instead.

This change additionally renames the memory.MegaByte and memory.GigaByte constants to Mib and GiB respectively, and leaves them as untyped consts.