### PR TITLE
Allow multiple CreateContainer operations at the same time.

### DIFF
--- a/internal/guest/bridge/bridge_v2.go
+++ b/internal/guest/bridge/bridge_v2.go
@@ -199,7 +199,7 @@ func (b *Bridge) execProcessV2(r *Request) (_ RequestResponse, err error) {
 	var c *hcsv2.Container
 	if params.IsExternal || request.ContainerID == hcsv2.UVMContainerID {
 		pid, err = b.hostState.RunExternalProcess(ctx, params, conSettings)
-	} else if c, err = b.hostState.GetRunningContainer(request.ContainerID); err == nil {
+	} else if c, err = b.hostState.GetCreatedContainer(request.ContainerID); err == nil {
 		// We found a V2 container. Treat this as a V2 process.
 		if params.OCIProcess == nil {
 			pid, err = c.Start(ctx, conSettings)
@@ -267,7 +267,7 @@ func (b *Bridge) signalContainerV2(ctx context.Context, span *trace.Span, r *Req
 		b.quitChan <- true
 		b.hostState.Shutdown()
 	} else {
-		c, err := b.hostState.GetRunningContainer(request.ContainerID)
+		c, err := b.hostState.GetCreatedContainer(request.ContainerID)
 		if err != nil {
 			return nil, err
 		}
@@ -296,7 +296,7 @@ func (b *Bridge) signalProcessV2(r *Request) (_ RequestResponse, err error) {
 		trace.Int64Attribute("pid", int64(request.ProcessID)),
 		trace.Int64Attribute("signal", int64(request.Options.Signal)))
 
-	c, err := b.hostState.GetRunningContainer(request.ContainerID)
+	c, err := b.hostState.GetCreatedContainer(request.ContainerID)
 	if err != nil {
 		return nil, err
 	}
@@ -344,7 +344,7 @@ func (b *Bridge) getPropertiesV2(r *Request) (_ RequestResponse, err error) {
 		return nil, errors.New("getPropertiesV2 is not supported against the UVM")
 	}
 
-	c, err := b.hostState.GetRunningContainer(request.ContainerID)
+	c, err := b.hostState.GetCreatedContainer(request.ContainerID)
 	if err != nil {
 		return nil, err
 	}
@@ -407,7 +407,7 @@ func (b *Bridge) waitOnProcessV2(r *Request) (_ RequestResponse, err error) {
 		}
 		exitCodeChan, doneChan = p.Wait()
 	} else {
-		c, err := b.hostState.GetRunningContainer(request.ContainerID)
+		c, err := b.hostState.GetCreatedContainer(request.ContainerID)
 		if err != nil {
 			return nil, err
 		}
@@ -453,7 +453,7 @@ func (b *Bridge) resizeConsoleV2(r *Request) (_ RequestResponse, err error) {
 		trace.Int64Attribute("height", int64(request.Height)),
 		trace.Int64Attribute("width", int64(request.Width)))
 
-	c, err := b.hostState.GetRunningContainer(request.ContainerID)
+	c, err := b.hostState.GetCreatedContainer(request.ContainerID)
 	if err != nil {
 		return nil, err
 	}
@@ -514,7 +514,7 @@ func (b *Bridge) deleteContainerStateV2(r *Request) (_ RequestResponse, err erro
 		return nil, errors.Wrapf(err, "failed to unmarshal JSON in message \"%s\"", r.Message)
 	}
 
-	c, err := b.hostState.GetRunningContainer(request.ContainerID)
+	c, err := b.hostState.GetCreatedContainer(request.ContainerID)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/guest/bridge/bridge_v2.go
+++ b/internal/guest/bridge/bridge_v2.go
@@ -199,7 +199,7 @@ func (b *Bridge) execProcessV2(r *Request) (_ RequestResponse, err error) {
 	var c *hcsv2.Container
 	if params.IsExternal || request.ContainerID == hcsv2.UVMContainerID {
 		pid, err = b.hostState.RunExternalProcess(ctx, params, conSettings)
-	} else if c, err = b.hostState.GetContainer(request.ContainerID); err == nil {
+	} else if c, err = b.hostState.GetRunningContainer(request.ContainerID); err == nil {
 		// We found a V2 container. Treat this as a V2 process.
 		if params.OCIProcess == nil {
 			pid, err = c.Start(ctx, conSettings)
@@ -267,7 +267,7 @@ func (b *Bridge) signalContainerV2(ctx context.Context, span *trace.Span, r *Req
 		b.quitChan <- true
 		b.hostState.Shutdown()
 	} else {
-		c, err := b.hostState.GetContainer(request.ContainerID)
+		c, err := b.hostState.GetRunningContainer(request.ContainerID)
 		if err != nil {
 			return nil, err
 		}
@@ -296,7 +296,7 @@ func (b *Bridge) signalProcessV2(r *Request) (_ RequestResponse, err error) {
 		trace.Int64Attribute("pid", int64(request.ProcessID)),
 		trace.Int64Attribute("signal", int64(request.Options.Signal)))
 
-	c, err := b.hostState.GetContainer(request.ContainerID)
+	c, err := b.hostState.GetRunningContainer(request.ContainerID)
 	if err != nil {
 		return nil, err
 	}
@@ -344,7 +344,7 @@ func (b *Bridge) getPropertiesV2(r *Request) (_ RequestResponse, err error) {
 		return nil, errors.New("getPropertiesV2 is not supported against the UVM")
 	}
 
-	c, err := b.hostState.GetContainer(request.ContainerID)
+	c, err := b.hostState.GetRunningContainer(request.ContainerID)
 	if err != nil {
 		return nil, err
 	}
@@ -407,7 +407,7 @@ func (b *Bridge) waitOnProcessV2(r *Request) (_ RequestResponse, err error) {
 		}
 		exitCodeChan, doneChan = p.Wait()
 	} else {
-		c, err := b.hostState.GetContainer(request.ContainerID)
+		c, err := b.hostState.GetRunningContainer(request.ContainerID)
 		if err != nil {
 			return nil, err
 		}
@@ -453,7 +453,7 @@ func (b *Bridge) resizeConsoleV2(r *Request) (_ RequestResponse, err error) {
 		trace.Int64Attribute("height", int64(request.Height)),
 		trace.Int64Attribute("width", int64(request.Width)))
 
-	c, err := b.hostState.GetContainer(request.ContainerID)
+	c, err := b.hostState.GetRunningContainer(request.ContainerID)
 	if err != nil {
 		return nil, err
 	}
@@ -514,7 +514,7 @@ func (b *Bridge) deleteContainerStateV2(r *Request) (_ RequestResponse, err erro
 		return nil, errors.Wrapf(err, "failed to unmarshal JSON in message \"%s\"", r.Message)
 	}
 
-	c, err := b.hostState.GetContainer(request.ContainerID)
+	c, err := b.hostState.GetRunningContainer(request.ContainerID)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/guest/gcserr/errors.go
+++ b/internal/guest/gcserr/errors.go
@@ -87,14 +87,14 @@ func BaseStackTrace(e error) errors.StackTrace {
 	return tracer.StackTrace()
 }
 
-type baseHresultError struct {
+type BaseHresultError struct {
 	hresult Hresult
 }
 
-func (e *baseHresultError) Error() string {
+func (e *BaseHresultError) Error() string {
 	return fmt.Sprintf("HRESULT: 0x%x", uint32(e.Hresult()))
 }
-func (e *baseHresultError) Hresult() Hresult {
+func (e *BaseHresultError) Hresult() Hresult {
 	return e.hresult
 }
 
@@ -139,7 +139,7 @@ func (e *wrappingHresultError) StackTrace() errors.StackTrace {
 
 // NewHresultError produces a new error with the given HRESULT.
 func NewHresultError(hresult Hresult) error {
-	return &baseHresultError{hresult: hresult}
+	return &BaseHresultError{hresult: hresult}
 }
 
 // WrapHresult produces a new error with the given HRESULT and wrapping the

--- a/internal/guest/gcserr/errors.go
+++ b/internal/guest/gcserr/errors.go
@@ -87,14 +87,14 @@ func BaseStackTrace(e error) errors.StackTrace {
 	return tracer.StackTrace()
 }
 
-type BaseHresultError struct {
+type baseHresultError struct {
 	hresult Hresult
 }
 
-func (e *BaseHresultError) Error() string {
+func (e *baseHresultError) Error() string {
 	return fmt.Sprintf("HRESULT: 0x%x", uint32(e.Hresult()))
 }
-func (e *BaseHresultError) Hresult() Hresult {
+func (e *baseHresultError) Hresult() Hresult {
 	return e.hresult
 }
 
@@ -139,7 +139,7 @@ func (e *wrappingHresultError) StackTrace() errors.StackTrace {
 
 // NewHresultError produces a new error with the given HRESULT.
 func NewHresultError(hresult Hresult) error {
-	return &BaseHresultError{hresult: hresult}
+	return &baseHresultError{hresult: hresult}
 }
 
 // WrapHresult produces a new error with the given HRESULT and wrapping the

--- a/internal/guest/runtime/hcsv2/container.go
+++ b/internal/guest/runtime/hcsv2/container.go
@@ -5,7 +5,6 @@ package hcsv2
 
 import (
 	"context"
-	"fmt"
 	"sync"
 	"sync/atomic"
 	"syscall"
@@ -58,6 +57,7 @@ type Container struct {
 	processesMutex sync.Mutex
 	processes      map[uint32]*containerProcess
 
+	// Only access atomically through getStatus/setStatus.
 	status containerStatus
 }
 
@@ -242,13 +242,6 @@ func (c *Container) getStatus() containerStatus {
 	return containerStatus(val)
 }
 
-func (c *Container) setStatus(st containerStatus) error {
-	switch st {
-	case containerCreating, containerCreated:
-		break
-	default:
-		return fmt.Errorf("unknown status: %d", st)
-	}
+func (c *Container) setStatus(st containerStatus) {
 	atomic.StoreUint32((*uint32)(&c.status), uint32(st))
-	return nil
 }

--- a/internal/guest/runtime/hcsv2/container.go
+++ b/internal/guest/runtime/hcsv2/container.go
@@ -28,11 +28,16 @@ import (
 	"github.com/Microsoft/hcsshim/internal/protocol/guestresource"
 )
 
+// containerStatus has been introduced to enable parallel container creation
 type containerStatus uint8
 
 const (
+	// containerCreating is the default status set on a Container object, when
+	// no underlying runtime container or init process has been assigned
 	containerCreating containerStatus = iota
-	containerRunning
+	// containerCreated is the status when a runtime container and init process
+	// have been assigned, but runtime start command has not been issued yet
+	containerCreated
 )
 
 type Container struct {

--- a/internal/guest/runtime/hcsv2/container.go
+++ b/internal/guest/runtime/hcsv2/container.go
@@ -28,6 +28,13 @@ import (
 	"github.com/Microsoft/hcsshim/internal/protocol/guestresource"
 )
 
+type containerStatus int
+
+const (
+	containerCreating containerStatus = iota
+	containerRunning
+)
+
 type Container struct {
 	id    string
 	vsock transport.Transport
@@ -43,6 +50,8 @@ type Container struct {
 
 	processesMutex sync.Mutex
 	processes      map[uint32]*containerProcess
+
+	Status containerStatus
 }
 
 func (c *Container) Start(ctx context.Context, conSettings stdio.ConnectionSettings) (int, error) {

--- a/internal/guest/runtime/hcsv2/container.go
+++ b/internal/guest/runtime/hcsv2/container.go
@@ -28,13 +28,10 @@ import (
 	"github.com/Microsoft/hcsshim/internal/protocol/guestresource"
 )
 
-// containerStatus has been introduced to enable parallel container creation
-type containerStatus uint8
-
 const (
 	// containerCreating is the default status set on a Container object, when
 	// no underlying runtime container or init process has been assigned
-	containerCreating containerStatus = iota
+	containerCreating uint32 = iota
 	// containerCreated is the status when a runtime container and init process
 	// have been assigned, but runtime start command has not been issued yet
 	containerCreated
@@ -56,7 +53,7 @@ type Container struct {
 	processesMutex sync.Mutex
 	processes      map[uint32]*containerProcess
 
-	status containerStatus
+	status uint32
 }
 
 func (c *Container) Start(ctx context.Context, conSettings stdio.ConnectionSettings) (int, error) {

--- a/internal/guest/runtime/hcsv2/container.go
+++ b/internal/guest/runtime/hcsv2/container.go
@@ -28,7 +28,7 @@ import (
 	"github.com/Microsoft/hcsshim/internal/protocol/guestresource"
 )
 
-type containerStatus int
+type containerStatus uint8
 
 const (
 	containerCreating containerStatus = iota
@@ -51,7 +51,7 @@ type Container struct {
 	processesMutex sync.Mutex
 	processes      map[uint32]*containerProcess
 
-	Status containerStatus
+	status containerStatus
 }
 
 func (c *Container) Start(ctx context.Context, conSettings stdio.ConnectionSettings) (int, error) {

--- a/internal/guest/runtime/hcsv2/uvm.go
+++ b/internal/guest/runtime/hcsv2/uvm.go
@@ -13,6 +13,7 @@ import (
 	"path"
 	"path/filepath"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -331,7 +332,7 @@ func (h *Host) CreateContainer(ctx context.Context, id string, settings *prot.VM
 		}
 	}
 
-	c.status = containerCreated
+	atomic.StoreUint32(&c.status, containerCreated)
 	return c, nil
 }
 

--- a/internal/guest/runtime/hcsv2/uvm.go
+++ b/internal/guest/runtime/hcsv2/uvm.go
@@ -130,8 +130,9 @@ func (h *Host) GetRunningContainer(id string) (*Container, error) {
 	if c, ok := h.containers[id]; !ok {
 		return nil, gcserr.NewHresultError(gcserr.HrVmcomputeSystemNotFound)
 	} else {
-		if c.Status != containerRunning {
-			return nil, gcserr.NewHresultError(gcserr.HrVmcomputeInvalidState)
+		if c.status != containerRunning {
+			return nil, fmt.Errorf("container is not in state running: %w",
+				gcserr.NewHresultError(gcserr.HrVmcomputeInvalidState))
 		}
 		return c, nil
 	}
@@ -180,7 +181,7 @@ func (h *Host) CreateContainer(ctx context.Context, id string, settings *prot.VM
 		isSandbox: criType == "sandbox",
 		exitType:  prot.NtUnexpectedExit,
 		processes: make(map[uint32]*containerProcess),
-		Status:    containerCreating,
+		status:    containerCreating,
 	}
 
 	if err := h.AddContainer(id, c); err != nil {
@@ -331,7 +332,7 @@ func (h *Host) CreateContainer(ctx context.Context, id string, settings *prot.VM
 		}
 	}
 
-	c.Status = containerRunning
+	c.status = containerRunning
 	return c, nil
 }
 

--- a/internal/guest/runtime/hcsv2/uvm.go
+++ b/internal/guest/runtime/hcsv2/uvm.go
@@ -13,7 +13,6 @@ import (
 	"path"
 	"path/filepath"
 	"sync"
-	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -130,7 +129,7 @@ func (h *Host) GetCreatedContainer(id string) (*Container, error) {
 	if c, ok := h.containers[id]; !ok {
 		return nil, gcserr.NewHresultError(gcserr.HrVmcomputeSystemNotFound)
 	} else {
-		if c.status != containerCreated {
+		if c.getStatus() != containerCreated {
 			return nil, fmt.Errorf("container is not in state \"created\": %w",
 				gcserr.NewHresultError(gcserr.HrVmcomputeInvalidState))
 		}
@@ -332,7 +331,9 @@ func (h *Host) CreateContainer(ctx context.Context, id string, settings *prot.VM
 		}
 	}
 
-	atomic.StoreUint32(&c.status, containerCreated)
+	if err := c.setStatus(containerCreated); err != nil {
+		return nil, err
+	}
 	return c, nil
 }
 

--- a/internal/guest/runtime/hcsv2/uvm.go
+++ b/internal/guest/runtime/hcsv2/uvm.go
@@ -331,9 +331,7 @@ func (h *Host) CreateContainer(ctx context.Context, id string, settings *prot.VM
 		}
 	}
 
-	if err := c.setStatus(containerCreated); err != nil {
-		return nil, err
-	}
+	c.setStatus(containerCreated)
 	return c, nil
 }
 

--- a/test/cri-containerd/policy_test.go
+++ b/test/cri-containerd/policy_test.go
@@ -232,13 +232,13 @@ func Test_RunContainers_WithSyncHooks_ValidWaitPath(t *testing.T) {
 	cidWriter := createContainer(t, client, ctx, writerReq)
 	cidWaiter := createContainer(t, client, ctx, waiterReq)
 
-	startContainer(t, client, ctx, cidWriter)
-	defer removeContainer(t, client, ctx, cidWriter)
-	defer stopContainer(t, client, ctx, cidWriter)
-
 	startContainer(t, client, ctx, cidWaiter)
 	defer removeContainer(t, client, ctx, cidWaiter)
 	defer stopContainer(t, client, ctx, cidWaiter)
+
+	startContainer(t, client, ctx, cidWriter)
+	defer removeContainer(t, client, ctx, cidWriter)
+	defer stopContainer(t, client, ctx, cidWriter)
 }
 
 func Test_RunContainers_WithSyncHooks_InvalidWaitPath(t *testing.T) {

--- a/test/cri-containerd/policy_test.go
+++ b/test/cri-containerd/policy_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 
@@ -232,13 +233,30 @@ func Test_RunContainers_WithSyncHooks_ValidWaitPath(t *testing.T) {
 	cidWriter := createContainer(t, client, ctx, writerReq)
 	cidWaiter := createContainer(t, client, ctx, waiterReq)
 
-	startContainer(t, client, ctx, cidWaiter)
-	defer removeContainer(t, client, ctx, cidWaiter)
-	defer stopContainer(t, client, ctx, cidWaiter)
+	errChan := make(chan error)
+	go func() {
+		_, err := client.StartContainer(ctx, &runtime.StartContainerRequest{ContainerId: cidWaiter})
+		errChan <- err
+		defer removeContainer(t, client, ctx, cidWaiter)
+		defer stopContainer(t, client, ctx, cidWaiter)
+	}()
 
-	startContainer(t, client, ctx, cidWriter)
-	defer removeContainer(t, client, ctx, cidWriter)
-	defer stopContainer(t, client, ctx, cidWriter)
+	// give some time for the first go routine to kick in.
+	time.Sleep(time.Second)
+
+	go func() {
+		_, err := client.StartContainer(ctx, &runtime.StartContainerRequest{ContainerId: cidWriter})
+		errChan <- err
+		defer removeContainer(t, client, ctx, cidWriter)
+		defer stopContainer(t, client, ctx, cidWriter)
+	}()
+
+	for i := 0; i < 2; i++ {
+		if err := <-errChan; err != nil {
+			close(errChan)
+			t.Fatalf("failed to start container: %s", err)
+		}
+	}
 }
 
 func Test_RunContainers_WithSyncHooks_InvalidWaitPath(t *testing.T) {


### PR DESCRIPTION
Prior to this change, GCS allowed only one CreateContainer operation
at a time. This isn't an issue in general case, however this doesn't
work properly with synchronization via OCI runtime hook.

Synchronization via runtime hook was introduced in:
https://github.com/microsoft/hcsshim/pull/1258
It injects a CreateRuntime OCI hook, if security policy provides
wait paths.
This allows container-A to run after container-B, where container-B
writes to an empty directory volume shared between the two containers
to signal that it's done some setup container-A depends on.
In general case, container-A can be started before container-B which
results in a deadlock, because CreateContainer request holds a lock
to a map, which keeps track of running containers.

To resolve the issue, the code has been updated to do a more granular
locking when reading/updating the containers map:
  - Add a new "Status" field to Container object, which can be either
    "Creating" or "Created".
  - Remove locking from CreateContainer function
  - Rework "GetContainer" to "GetCreatedContainer", which returns
    the container object only when it's in "Created" state, otherwise
    either `gcserr.HrVmcomputeSystemNotFound` or `gcserr.HrVmcomputeInvalidState`
    error returned.
  - Add new "AddContainer(id, container)" function, which updates the
    containers map with new container instances.
  - Rework CreateContainer to initially add new container objects into
    the containers map and set the "Status" to "Creating" at the start
    of the function and set it to "Created" only when the container
    was successfully created.

Reworking "GetContainer" to "GetCreatedContainer" seemed to be the least
invasive change, which allows us to limit updates in the affected places.
If "GetContainer" is left unchanged, then handling of containers in status
"Creating" needs to take place and this requires handling cases when (e.g.)
a modification request is sent to a container which hasn't been created yet.

Signed-off-by: Maksim An <maksiman@microsoft.com>