### PR TITLE
Linux GCS flags use 1 -, not 2

### DIFF
--- a/internal/uvm/create_lcow.go
+++ b/internal/uvm/create_lcow.go
@@ -660,11 +660,11 @@ func makeLCOWDoc(ctx context.Context, opts *OptionsLCOW, uvm *UtilityVM) (_ *hcs
 	}
 
 	if opts.DisableTimeSyncService {
-		opts.ExecCommandLine = fmt.Sprintf("%s --disable-time-sync", opts.ExecCommandLine)
+		opts.ExecCommandLine = fmt.Sprintf("%s -disable-time-sync", opts.ExecCommandLine)
 	}
 
 	if log.IsScrubbingEnabled() {
-		opts.ExecCommandLine += " --scrub-logs"
+		opts.ExecCommandLine += " -scrub-logs"
 	}
 
 	execCmdArgs += " " + opts.ExecCommandLine

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/uvm/create_lcow.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/uvm/create_lcow.go
@@ -660,11 +660,11 @@ func makeLCOWDoc(ctx context.Context, opts *OptionsLCOW, uvm *UtilityVM) (_ *hcs
 	}
 
 	if opts.DisableTimeSyncService {
-		opts.ExecCommandLine = fmt.Sprintf("%s --disable-time-sync", opts.ExecCommandLine)
+		opts.ExecCommandLine = fmt.Sprintf("%s -disable-time-sync", opts.ExecCommandLine)
 	}
 
 	if log.IsScrubbingEnabled() {
-		opts.ExecCommandLine += " --scrub-logs"
+		opts.ExecCommandLine += " -scrub-logs"
 	}
 
 	execCmdArgs += " " + opts.ExecCommandLine


### PR DESCRIPTION
Signed-off-by: Hamza El-Saawy <hamzaelsaawy@microsoft.com>