### PR TITLE
uvmboot functionality

### DIFF
--- a/internal/tools/uvmboot/main.go
+++ b/internal/tools/uvmboot/main.go
@@ -88,7 +88,7 @@ func main() {
 	}
 
 	app.Before = func(c *cli.Context) error {
-		if !winapi.IsEvelated() {
+		if !winapi.IsElevated() {
 			log.Fatal(c.App.Name + " must be run in an elevated context")
 		}
 

--- a/internal/tools/uvmboot/main.go
+++ b/internal/tools/uvmboot/main.go
@@ -4,11 +4,13 @@ package main
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"sync"
 	"time"
 
 	"github.com/Microsoft/hcsshim/internal/uvm"
+	"github.com/Microsoft/hcsshim/internal/winapi"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 )
@@ -21,11 +23,16 @@ const (
 	measureArgName              = "measure"
 	parallelArgName             = "parallel"
 	countArgName                = "count"
-	debugArgName                = "debug"
-	gcsArgName                  = "gcs"
 
 	execCommandLineArgName = "exec"
 )
+
+var (
+	debug  bool
+	useGCS bool
+)
+
+type uvmRunFunc func(string) error
 
 func main() {
 	app := cli.NewApp()
@@ -64,12 +71,14 @@ func main() {
 			Usage: "Enable deferred commit on the UVM",
 		},
 		cli.BoolFlag{
-			Name:  debugArgName,
-			Usage: "Enable debug level logging in HCSShim",
+			Name:        "debug",
+			Usage:       "Enable debug information",
+			Destination: &debug,
 		},
 		cli.BoolFlag{
-			Name:  gcsArgName,
-			Usage: "Launch the GCS and perform requested operations via its RPC interface",
+			Name:        "gcs",
+			Usage:       "Launch the GCS and perform requested operations via its RPC interface",
+			Destination: &useGCS,
 		},
 	}
 
@@ -79,17 +88,21 @@ func main() {
 	}
 
 	app.Before = func(c *cli.Context) error {
-		if c.GlobalBool("debug") {
+		if !winapi.IsEvelated() {
+			log.Fatal(c.App.Name + " must be run in an elevated context")
+		}
+
+		if debug {
 			logrus.SetLevel(logrus.DebugLevel)
 		} else {
 			logrus.SetLevel(logrus.WarnLevel)
 		}
+
 		return nil
 	}
 
-	err := app.Run(os.Args)
-	if err != nil {
-		logrus.Fatal(err)
+	if err := app.Run(os.Args); err != nil {
+		logrus.Fatalf("%v\n", err)
 	}
 }
 
@@ -108,7 +121,9 @@ func setGlobalOptions(c *cli.Context, options *uvm.Options) {
 	}
 }
 
-func runMany(c *cli.Context, runFunc func(id string) error) {
+// todo: add a context here to propagate cancel/timeouts to runFunc uvm
+
+func runMany(c *cli.Context, runFunc uvmRunFunc) {
 	parallelCount := c.GlobalInt(parallelArgName)
 
 	var wg sync.WaitGroup
@@ -118,8 +133,7 @@ func runMany(c *cli.Context, runFunc func(id string) error) {
 		go func() {
 			for i := range workChan {
 				id := fmt.Sprintf("uvmboot-%d", i)
-				err := runFunc(id)
-				if err != nil {
+				if err := runFunc(id); err != nil {
 					logrus.WithField("uvm-id", id).WithError(err).Error("failed to run UVM")
 				}
 			}
@@ -137,4 +151,8 @@ func runMany(c *cli.Context, runFunc func(id string) error) {
 	if c.GlobalBool(measureArgName) {
 		fmt.Println("Elapsed time:", time.Since(start))
 	}
+}
+
+func unrecognizedError(name, value string) error {
+	return fmt.Errorf("unrecognized value '%s' for option %s", name, value)
 }

--- a/internal/tools/uvmboot/mounts.go
+++ b/internal/tools/uvmboot/mounts.go
@@ -4,7 +4,6 @@ package main
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strings"
 
@@ -94,17 +93,22 @@ func parseMounts(c *cli.Context, n string) []mount {
 func mountFromString(s string) (m mount, _ error) {
 	ps := strings.Split(s, ",")
 
-	if len(ps) >= 3 {
-		return m, errors.New("too many parts")
+	l := len(ps)
+	if l == 0 { // shouldn't happen, but just in case
+		return m, fmt.Errorf("could not parse string %q", s)
+	}
+
+	if l > 3 {
+		return m, fmt.Errorf("too many parts in %q", s)
 	}
 
 	m.host = ps[0]
 
-	if len(ps) == 2 {
+	if l >= 2 {
 		m.guest = ps[1]
 	}
 
-	if len(ps) == 3 && strings.ToLower(ps[2]) == "w" {
+	if l == 3 && strings.ToLower(ps[2]) == "w" {
 		m.writable = true
 	}
 

--- a/internal/tools/uvmboot/mounts.go
+++ b/internal/tools/uvmboot/mounts.go
@@ -1,0 +1,112 @@
+//go:build windows
+
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/Microsoft/hcsshim/internal/uvm"
+	"github.com/sirupsen/logrus"
+	"github.com/urfave/cli"
+)
+
+func mountSCSI(ctx context.Context, c *cli.Context, vm *uvm.UtilityVM) error {
+	for _, m := range parseMounts(c, scsiMountsArgName) {
+		if _, err := vm.AddSCSI(
+			ctx,
+			m.host,
+			m.guest,
+			!m.writable,
+			false, // encrypted
+			[]string{},
+			uvm.VMAccessTypeIndividual,
+		); err != nil {
+			return fmt.Errorf("could not mount disk %s: %w", m.host, err)
+		} else {
+			logrus.WithFields(logrus.Fields{
+				"host":     m.host,
+				"guest":    m.guest,
+				"writable": m.writable,
+			}).Debug("Mounted SCSI disk")
+		}
+	}
+
+	return nil
+}
+
+func shareFiles(ctx context.Context, c *cli.Context, vm *uvm.UtilityVM) error {
+	switch os := vm.OS(); os {
+	case "linux":
+		return shareFilesLCOW(ctx, c, vm)
+	default:
+		return fmt.Errorf("file shares are not supported for %s UVMs", os)
+	}
+}
+
+func shareFilesLCOW(ctx context.Context, c *cli.Context, vm *uvm.UtilityVM) error {
+	for _, s := range parseMounts(c, shareFilesArgName) {
+		if s.guest == "" {
+			return fmt.Errorf("file shares %q has invalid quest destination: %q", s.host, s.guest)
+		}
+
+		if err := vm.Share(ctx, s.host, s.guest, !s.writable); err != nil {
+			return fmt.Errorf("could not share file or directory %s: %w", s.host, err)
+		} else {
+			logrus.WithFields(logrus.Fields{
+				"host":     s.host,
+				"guest":    s.guest,
+				"writable": s.writable,
+			}).Debug("Shared path")
+		}
+	}
+
+	return nil
+}
+
+type mount struct {
+	host     string
+	guest    string
+	writable bool
+}
+
+// parseMounts parses the mounts stored under the cli StringSlice argument, `n`
+func parseMounts(c *cli.Context, n string) []mount {
+	if c.IsSet(n) {
+		ss := c.StringSlice(n)
+		ms := make([]mount, 0, len(ss))
+		for _, s := range ss {
+			logrus.Debugf("parsing %q", s)
+
+			if m, err := mountFromString(s); err == nil {
+				ms = append(ms, m)
+			}
+		}
+
+		return ms
+	}
+
+	return nil
+}
+
+func mountFromString(s string) (m mount, _ error) {
+	ps := strings.Split(s, ",")
+
+	if len(ps) >= 3 {
+		return m, errors.New("too many parts")
+	}
+
+	m.host = ps[0]
+
+	if len(ps) == 2 {
+		m.guest = ps[1]
+	}
+
+	if len(ps) == 3 && strings.ToLower(ps[2]) == "w" {
+		m.writable = true
+	}
+
+	return m, nil
+}

--- a/internal/winapi/elevation.go
+++ b/internal/winapi/elevation.go
@@ -1,0 +1,11 @@
+//go:build windows
+
+package winapi
+
+import (
+	"golang.org/x/sys/windows"
+)
+
+func IsEvelated() bool {
+	return windows.GetCurrentProcessToken().IsElevated()
+}

--- a/internal/winapi/elevation.go
+++ b/internal/winapi/elevation.go
@@ -6,6 +6,6 @@ import (
 	"golang.org/x/sys/windows"
 )
 
-func IsEvelated() bool {
+func IsElevated() bool {
 	return windows.GetCurrentProcessToken().IsElevated()
 }

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/winapi/elevation.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/winapi/elevation.go
@@ -1,0 +1,11 @@
+//go:build windows
+
+package winapi
+
+import (
+	"golang.org/x/sys/windows"
+)
+
+func IsEvelated() bool {
+	return windows.GetCurrentProcessToken().IsElevated()
+}

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/winapi/elevation.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/winapi/elevation.go
@@ -6,6 +6,6 @@ import (
 	"golang.org/x/sys/windows"
 )
 
-func IsEvelated() bool {
+func IsElevated() bool {
 	return windows.GetCurrentProcessToken().IsElevated()
 }


### PR DESCRIPTION
Added functionality to internal\tools\uvmboot for LCOW:
* specifying boot file path;
* picking kernel or vmlinux file;
* mounting SCSI VHDS and sharing files into the uVM;
* disabling the time sync;
* setting the uVM security policy.

Added `IsElevated() bool` function to `internal/winapi` to quit early
if the command is not run with admin privileges rather than returning a
cryptic error.

This is to support testing and benchmarking the Linux GCS.

Signed-off-by: Hamza El-Saawy <hamzaelsaawy@microsoft.com>