### PR TITLE
Split out GCS test and build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,6 +189,9 @@ jobs:
         with:
           go-version: '^1.17.0'
 
+      - name: Test
+        run: make test
+
       - name: Pull busybox image
         run: docker pull busybox
 
@@ -199,7 +202,5 @@ jobs:
         run: |
           docker export base_image_container | gzip > base.tar.gz
 
-      - name: Build And Test
-        run: |
-          BASE=./base.tar.gz
-          make all test
+      - name: Build
+        run: make BASE=./base.tar.gz all


### PR DESCRIPTION
Testing GCS code before building rootfs, and making it easier to parse test and make failures by separating the two.

Signed-off-by: Hamza El-Saawy <hamzaelsaawy@microsoft.com>