### PR TITLE
Include CommandLine in CreateProcess errors

### DIFF
--- a/internal/hcs/system.go
+++ b/internal/hcs/system.go
@@ -458,6 +458,11 @@ func (computeSystem *System) createProcess(ctx context.Context, operation string
 	processInfo, processHandle, resultJSON, err := vmcompute.HcsCreateProcess(ctx, computeSystem.handle, configuration)
 	events := processHcsResult(ctx, resultJSON)
 	if err != nil {
+		if v2, ok := c.(*hcsschema.ProcessParameters); ok {
+			operation += ": " + v2.CommandLine
+		} else if v1, ok := c.(*schema1.ProcessConfig); ok {
+			operation += ": " + v1.CommandLine
+		}
 		return nil, nil, makeSystemError(computeSystem, operation, err, events)
 	}
 

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/hcs/system.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/hcs/system.go
@@ -458,6 +458,11 @@ func (computeSystem *System) createProcess(ctx context.Context, operation string
 	processInfo, processHandle, resultJSON, err := vmcompute.HcsCreateProcess(ctx, computeSystem.handle, configuration)
 	events := processHcsResult(ctx, resultJSON)
 	if err != nil {
+		if v2, ok := c.(*hcsschema.ProcessParameters); ok {
+			operation += ": " + v2.CommandLine
+		} else if v1, ok := c.(*schema1.ProcessConfig); ok {
+			operation += ": " + v1.CommandLine
+		}
 		return nil, nil, makeSystemError(computeSystem, operation, err, events)
 	}
 


### PR DESCRIPTION
Hey team,

It can be horribly annoying without verbose logs for a user to figure out what exactly was being executed when running a command in a container. How do we feel about including the `CommandLine` in the main error?

Without:
```
ctr run --rm mcr.microsoft.com/windows/nanoserver:ltsc2022 test powershell -Command { Write-Host Here }
ctr: hcs::System::CreateProcess test: The system cannot find the file specified.: unknown
```

With:
```
ctr run --rm mcr.microsoft.com/windows/nanoserver:ltsc2022 test powershell -Command { Write-Host Here }
ctr: hcs::System::CreateProcess: powershell -Command { Write-Host Here } test: The system cannot find the file specified.: unknown
```

The second example more clearly illustrates to the caller that "powershell" was the file that was not found.

Signed-off-by: Justin Terry <jlterry@amazon.com>