### PR TITLE
Add security policy config to allow containers to run in privileged mode

### DIFF
--- a/internal/guest/policy/default.go
+++ b/internal/guest/policy/default.go
@@ -78,7 +78,8 @@ func DefaultCRIMounts() []oci.Mount {
 	}
 }
 
-// DefaultCRIPrivilegedMounts returns a slice of mounts that
+// DefaultCRIPrivilegedMounts returns a slice of mounts which are added to the
+// linux container spec when a container runs in a privileged mode.
 func DefaultCRIPrivilegedMounts() []oci.Mount {
 	return []oci.Mount{
 		{

--- a/internal/guest/policy/default.go
+++ b/internal/guest/policy/default.go
@@ -77,3 +77,21 @@ func DefaultCRIMounts() []oci.Mount {
 		},
 	}
 }
+
+// DefaultCRIPrivilegedMounts returns a slice of mounts that
+func DefaultCRIPrivilegedMounts() []oci.Mount {
+	return []oci.Mount{
+		{
+			Source:      "cgroup",
+			Destination: "/sys/fs/cgroup",
+			Type:        "cgroup",
+			Options:     []string{"nosuid", "noexec", "nodev", "relatime", "rw"},
+		},
+		{
+			Destination: "/sys",
+			Type:        "sysfs",
+			Source:      "sysfs",
+			Options:     []string{"nosuid", "noexec", "nodev", "rw"},
+		},
+	}
+}

--- a/internal/guest/runtime/hcsv2/uvm.go
+++ b/internal/guest/runtime/hcsv2/uvm.go
@@ -91,7 +91,10 @@ func (h *Host) SetSecurityPolicy(base64Policy string) error {
 		return err
 	}
 
-	p, err := securitypolicy.NewSecurityPolicyEnforcer(*securityPolicyState)
+	p, err := securitypolicy.NewSecurityPolicyEnforcer(
+		*securityPolicyState,
+		securitypolicy.WithPrivilegedMounts(policy.DefaultCRIPrivilegedMounts()),
+	)
 	if err != nil {
 		return err
 	}

--- a/internal/tools/securitypolicy/helpers/helpers.go
+++ b/internal/tools/securitypolicy/helpers/helpers.go
@@ -68,15 +68,10 @@ func ParseEnvFromImage(img v1.Image) ([]string, error) {
 // be included by default in the security policy.
 // The slice includes only a sandbox pause container.
 func DefaultContainerConfigs() []securitypolicy.ContainerConfig {
-	pause := securitypolicy.NewContainerConfig(
-		"k8s.gcr.io/pause:3.1",
-		[]string{"/pause"},
-		[]securitypolicy.EnvRuleConfig{},
-		securitypolicy.AuthConfig{},
-		"",
-		[]string{},
-		[]securitypolicy.MountConfig{},
-	)
+	pause := securitypolicy.ContainerConfig{
+		ImageName: "k8s.gcr.io/pause:3.1",
+		Command:   []string{"/pause"},
+	}
 	return []securitypolicy.ContainerConfig{pause}
 }
 
@@ -165,6 +160,7 @@ func PolicyContainersFromConfigs(containerConfigs []securitypolicy.ContainerConf
 			workingDir,
 			containerConfig.ExpectedMounts,
 			containerConfig.Mounts,
+			containerConfig.AllowElevated,
 		)
 		if err != nil {
 			return nil, err

--- a/pkg/securitypolicy/opts.go
+++ b/pkg/securitypolicy/opts.go
@@ -34,3 +34,11 @@ func WithMountConstraints(mc []MountConfig) ContainerConfigOpt {
 		return nil
 	}
 }
+
+// WithAllowElevated allows container to run in an elevated/privileged mode.
+func WithAllowElevated(elevated bool) ContainerConfigOpt {
+	return func(c *ContainerConfig) error {
+		c.AllowElevated = elevated
+		return nil
+	}
+}

--- a/pkg/securitypolicy/securitypolicy.go
+++ b/pkg/securitypolicy/securitypolicy.go
@@ -49,6 +49,7 @@ type ContainerConfig struct {
 	WorkingDir     string          `json:"working_dir" toml:"working_dir"`
 	ExpectedMounts []string        `json:"expected_mounts" toml:"expected_mounts"`
 	Mounts         []MountConfig   `json:"mounts" toml:"mount"`
+	AllowElevated  bool            `json:"allow_elevated" toml:"allow_elevated"`
 }
 
 // MountConfig contains toml or JSON config for mount security policy
@@ -57,27 +58,6 @@ type MountConfig struct {
 	HostPath      string `json:"host_path" toml:"host_path"`
 	ContainerPath string `json:"container_path" toml:"container_path"`
 	Readonly      bool   `json:"readonly" toml:"readonly"`
-}
-
-// NewContainerConfig creates a new ContainerConfig from the given values.
-func NewContainerConfig(
-	imageName string,
-	command []string,
-	envRules []EnvRuleConfig,
-	auth AuthConfig,
-	workingDir string,
-	expectedMounts []string,
-	mounts []MountConfig,
-) ContainerConfig {
-	return ContainerConfig{
-		ImageName:      imageName,
-		Command:        command,
-		EnvRules:       envRules,
-		Auth:           auth,
-		WorkingDir:     workingDir,
-		ExpectedMounts: expectedMounts,
-		Mounts:         mounts,
-	}
 }
 
 // NewEnvVarRules creates slice of EnvRuleConfig's from environment variables
@@ -196,6 +176,7 @@ type Container struct {
 	WorkingDir     string         `json:"working_dir"`
 	ExpectedMounts ExpectedMounts `json:"expected_mounts"`
 	Mounts         Mounts         `json:"mounts"`
+	AllowElevated  bool           `json:"allow_elevated"`
 }
 
 // StringArrayMap wraps an array of strings as a string map.
@@ -237,6 +218,7 @@ func CreateContainerPolicy(
 	workingDir string,
 	eMounts []string,
 	mounts []MountConfig,
+	allowElevated bool,
 ) (*Container, error) {
 	if err := validateEnvRules(envRules); err != nil {
 		return nil, err
@@ -251,6 +233,7 @@ func CreateContainerPolicy(
 		WorkingDir:     workingDir,
 		ExpectedMounts: newExpectedMounts(eMounts),
 		Mounts:         newMountConstraints(mounts),
+		AllowElevated:  allowElevated,
 	}, nil
 }
 

--- a/pkg/securitypolicy/securitypolicy_test.go
+++ b/pkg/securitypolicy/securitypolicy_test.go
@@ -288,11 +288,11 @@ func Test_EnforceOverlayMountPolicy_Overlay_Single_Container_Twice(t *testing.T)
 // all 13 should be allowed.
 func Test_EnforceOverlayMountPolicy_Multiple_Instances_Same_Container(t *testing.T) {
 	for containersToCreate := 2; containersToCreate <= maxContainersInGeneratedPolicy; containersToCreate++ {
-		var containers []securityPolicyContainer
+		var containers []*securityPolicyContainer
 
 		for i := 1; i <= containersToCreate; i++ {
 			arg := "command " + strconv.Itoa(i)
-			c := securityPolicyContainer{
+			c := &securityPolicyContainer{
 				Command: []string{arg},
 				Layers:  []string{"1", "2"},
 			}
@@ -806,7 +806,7 @@ func (*generatedContainers) Generate(r *rand.Rand, _ int) reflect.Value {
 }
 
 type testConfig struct {
-	container   securityPolicyContainer
+	container   *securityPolicyContainer
 	layers      []string
 	containerID string
 	policy      *StandardSecurityPolicyEnforcer
@@ -840,7 +840,7 @@ func setupContainerWithOverlay(gc *generatedContainers, valid bool) (tc *testCon
 }
 
 func generateContainers(r *rand.Rand, upTo int32) *generatedContainers {
-	var containers []securityPolicyContainer
+	var containers []*securityPolicyContainer
 
 	numContainers := (int)(atLeastOneAtMost(r, upTo))
 	for i := 0; i < numContainers; i++ {
@@ -852,7 +852,7 @@ func generateContainers(r *rand.Rand, upTo int32) *generatedContainers {
 	}
 }
 
-func generateContainersContainer(r *rand.Rand, size int32) securityPolicyContainer {
+func generateContainersContainer(r *rand.Rand, size int32) *securityPolicyContainer {
 	c := securityPolicyContainer{}
 	c.Command = generateCommand(r)
 	c.EnvRules = generateEnvironmentVariableRules(r)
@@ -862,7 +862,7 @@ func generateContainersContainer(r *rand.Rand, size int32) securityPolicyContain
 		c.Layers = append(c.Layers, generateRootHash(r))
 	}
 
-	return c
+	return &c
 }
 
 func generateRootHash(r *rand.Rand) string {
@@ -911,7 +911,7 @@ func generateNeverMatchingEnvironmentVariable(r *rand.Rand) string {
 	return randString(r, maxGeneratedEnvironmentVariableRuleLength+1)
 }
 
-func buildEnvironmentVariablesFromContainerRules(c securityPolicyContainer, r *rand.Rand) []string {
+func buildEnvironmentVariablesFromContainerRules(c *securityPolicyContainer, r *rand.Rand) []string {
 	vars := make([]string, 0)
 
 	// Select some number of the valid, matching rules to be environment
@@ -973,12 +973,12 @@ func generateContainerID(r *rand.Rand) string {
 	return strconv.FormatInt(int64(id), 10)
 }
 
-func selectContainerFromContainers(containers *generatedContainers, r *rand.Rand) securityPolicyContainer {
+func selectContainerFromContainers(containers *generatedContainers, r *rand.Rand) *securityPolicyContainer {
 	numberOfContainersInPolicy := len(containers.containers)
 	return containers.containers[r.Intn(numberOfContainersInPolicy)]
 }
 
-func createValidOverlayForContainer(enforcer SecurityPolicyEnforcer, container securityPolicyContainer, r *rand.Rand) ([]string, error) {
+func createValidOverlayForContainer(enforcer SecurityPolicyEnforcer, container *securityPolicyContainer, r *rand.Rand) ([]string, error) {
 	// storage for our mount paths
 	overlay := make([]string, len(container.Layers))
 
@@ -995,7 +995,7 @@ func createValidOverlayForContainer(enforcer SecurityPolicyEnforcer, container s
 	return overlay, nil
 }
 
-func createInvalidOverlayForContainer(enforcer SecurityPolicyEnforcer, container securityPolicyContainer, r *rand.Rand) ([]string, error) {
+func createInvalidOverlayForContainer(enforcer SecurityPolicyEnforcer, container *securityPolicyContainer, r *rand.Rand) ([]string, error) {
 	method := r.Intn(3)
 	if method == 0 {
 		return invalidOverlaySameSizeWrongMounts(enforcer, container, r)
@@ -1006,7 +1006,7 @@ func createInvalidOverlayForContainer(enforcer SecurityPolicyEnforcer, container
 	}
 }
 
-func invalidOverlaySameSizeWrongMounts(enforcer SecurityPolicyEnforcer, container securityPolicyContainer, r *rand.Rand) ([]string, error) {
+func invalidOverlaySameSizeWrongMounts(enforcer SecurityPolicyEnforcer, container *securityPolicyContainer, r *rand.Rand) ([]string, error) {
 	// storage for our mount paths
 	overlay := make([]string, len(container.Layers))
 
@@ -1024,7 +1024,7 @@ func invalidOverlaySameSizeWrongMounts(enforcer SecurityPolicyEnforcer, containe
 	return overlay, nil
 }
 
-func invalidOverlayCorrectDevicesWrongOrderSomeMissing(enforcer SecurityPolicyEnforcer, container securityPolicyContainer, r *rand.Rand) ([]string, error) {
+func invalidOverlayCorrectDevicesWrongOrderSomeMissing(enforcer SecurityPolicyEnforcer, container *securityPolicyContainer, r *rand.Rand) ([]string, error) {
 	if len(container.Layers) == 1 {
 		// won't work with only 1, we need to bail out to another method
 		return invalidOverlayRandomJunk(enforcer, container, r)
@@ -1047,7 +1047,7 @@ func invalidOverlayCorrectDevicesWrongOrderSomeMissing(enforcer SecurityPolicyEn
 	return overlay, nil
 }
 
-func invalidOverlayRandomJunk(enforcer SecurityPolicyEnforcer, container securityPolicyContainer, r *rand.Rand) ([]string, error) {
+func invalidOverlayRandomJunk(enforcer SecurityPolicyEnforcer, container *securityPolicyContainer, r *rand.Rand) ([]string, error) {
 	// create "junk" for entry
 	layersToCreate := r.Int31n(maxLayersInGeneratedContainer)
 	overlay := make([]string, layersToCreate)
@@ -1095,5 +1095,5 @@ func atMost(r *rand.Rand, most int32) int32 {
 
 // a type to hold a list of generated containers
 type generatedContainers struct {
-	containers []securityPolicyContainer
+	containers []*securityPolicyContainer
 }

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/tools/securitypolicy/helpers/helpers.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/tools/securitypolicy/helpers/helpers.go
@@ -68,15 +68,10 @@ func ParseEnvFromImage(img v1.Image) ([]string, error) {
 // be included by default in the security policy.
 // The slice includes only a sandbox pause container.
 func DefaultContainerConfigs() []securitypolicy.ContainerConfig {
-	pause := securitypolicy.NewContainerConfig(
-		"k8s.gcr.io/pause:3.1",
-		[]string{"/pause"},
-		[]securitypolicy.EnvRuleConfig{},
-		securitypolicy.AuthConfig{},
-		"",
-		[]string{},
-		[]securitypolicy.MountConfig{},
-	)
+	pause := securitypolicy.ContainerConfig{
+		ImageName: "k8s.gcr.io/pause:3.1",
+		Command:   []string{"/pause"},
+	}
 	return []securitypolicy.ContainerConfig{pause}
 }
 
@@ -165,6 +160,7 @@ func PolicyContainersFromConfigs(containerConfigs []securitypolicy.ContainerConf
 			workingDir,
 			containerConfig.ExpectedMounts,
 			containerConfig.Mounts,
+			containerConfig.AllowElevated,
 		)
 		if err != nil {
 			return nil, err

--- a/test/vendor/github.com/Microsoft/hcsshim/pkg/securitypolicy/opts.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/pkg/securitypolicy/opts.go
@@ -34,3 +34,11 @@ func WithMountConstraints(mc []MountConfig) ContainerConfigOpt {
 		return nil
 	}
 }
+
+// WithAllowElevated allows container to run in an elevated/privileged mode.
+func WithAllowElevated(elevated bool) ContainerConfigOpt {
+	return func(c *ContainerConfig) error {
+		c.AllowElevated = elevated
+		return nil
+	}
+}

--- a/test/vendor/github.com/Microsoft/hcsshim/pkg/securitypolicy/securitypolicy.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/pkg/securitypolicy/securitypolicy.go
@@ -49,6 +49,7 @@ type ContainerConfig struct {
 	WorkingDir     string          `json:"working_dir" toml:"working_dir"`
 	ExpectedMounts []string        `json:"expected_mounts" toml:"expected_mounts"`
 	Mounts         []MountConfig   `json:"mounts" toml:"mount"`
+	AllowElevated  bool            `json:"allow_elevated" toml:"allow_elevated"`
 }
 
 // MountConfig contains toml or JSON config for mount security policy
@@ -57,27 +58,6 @@ type MountConfig struct {
 	HostPath      string `json:"host_path" toml:"host_path"`
 	ContainerPath string `json:"container_path" toml:"container_path"`
 	Readonly      bool   `json:"readonly" toml:"readonly"`
-}
-
-// NewContainerConfig creates a new ContainerConfig from the given values.
-func NewContainerConfig(
-	imageName string,
-	command []string,
-	envRules []EnvRuleConfig,
-	auth AuthConfig,
-	workingDir string,
-	expectedMounts []string,
-	mounts []MountConfig,
-) ContainerConfig {
-	return ContainerConfig{
-		ImageName:      imageName,
-		Command:        command,
-		EnvRules:       envRules,
-		Auth:           auth,
-		WorkingDir:     workingDir,
-		ExpectedMounts: expectedMounts,
-		Mounts:         mounts,
-	}
 }
 
 // NewEnvVarRules creates slice of EnvRuleConfig's from environment variables
@@ -196,6 +176,7 @@ type Container struct {
 	WorkingDir     string         `json:"working_dir"`
 	ExpectedMounts ExpectedMounts `json:"expected_mounts"`
 	Mounts         Mounts         `json:"mounts"`
+	AllowElevated  bool           `json:"allow_elevated"`
 }
 
 // StringArrayMap wraps an array of strings as a string map.
@@ -237,6 +218,7 @@ func CreateContainerPolicy(
 	workingDir string,
 	eMounts []string,
 	mounts []MountConfig,
+	allowElevated bool,
 ) (*Container, error) {
 	if err := validateEnvRules(envRules); err != nil {
 		return nil, err
@@ -251,6 +233,7 @@ func CreateContainerPolicy(
 		WorkingDir:     workingDir,
 		ExpectedMounts: newExpectedMounts(eMounts),
 		Mounts:         newMountConstraints(mounts),
+		AllowElevated:  allowElevated,
 	}, nil
 }
 


### PR DESCRIPTION
Add new container security policy config "AllowElevated", which when set
allows running container in privileged mode. As an initial implementation
this adds sysfs and cgroup mount constraints with "rw" mount option to
the container's mount policy. Later, more thorough container spec validation
for privileged containers should be added (e.g. validating capabilities in
container spec).
Introduce `standardEnforcerOpt` type which allows updating internal
security policy representation and add an opt to append mount constraints for
privileged container mounts,`NewSecurityPolicy` now accepts enforcer options.
securitypolicy.Containers.toInternal now returns a slice of pointers rather
than objects. This makes sure that modification through enforcer options are
presereved.

Add CRI tests to cover the new functionality.

Signed-off-by: Maksim An <maksiman@microsoft.com>