### PR TITLE
Revert "Fix working_dir negative test error expectation (#1348)"

### DIFF
--- a/test/cri-containerd/policy_test.go
+++ b/test/cri-containerd/policy_test.go
@@ -382,7 +382,7 @@ func Test_RunContainer_InvalidContainerConfigs_NotAllowed(t *testing.T) {
 				req.Config.WorkingDir = "/non/existent"
 				return nil
 			},
-			expectedError: "working_dir /non/existent unmatched by policy rule",
+			expectedError: "working_dir \"/non/existent\" unmatched by policy rule",
 		},
 		{
 			name: "InvalidCommand",


### PR DESCRIPTION
This reverts commit 2028de8b8d5e0516e0e65664f9085dab02a6a5e2.
