### PR TITLE
Fix for port conflict with docker daemon. 

### DIFF
--- a/internal/hns/hnspolicy.go
+++ b/internal/hns/hnspolicy.go
@@ -21,10 +21,11 @@ const (
 )
 
 type NatPolicy struct {
-	Type         PolicyType `json:"Type"`
-	Protocol     string     `json:",omitempty"`
-	InternalPort uint16     `json:",omitempty"`
-	ExternalPort uint16     `json:",omitempty"`
+	Type                 PolicyType `json:"Type"`
+	Protocol             string     `json:",omitempty"`
+	InternalPort         uint16     `json:",omitempty"`
+	ExternalPort         uint16     `json:",omitempty"`
+	ExternalPortReserved bool       `json:",omitempty"`
 }
 
 type QosPolicy struct {

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/hns/hnspolicy.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/hns/hnspolicy.go
@@ -21,10 +21,11 @@ const (
 )
 
 type NatPolicy struct {
-	Type         PolicyType `json:"Type"`
-	Protocol     string     `json:",omitempty"`
-	InternalPort uint16     `json:",omitempty"`
-	ExternalPort uint16     `json:",omitempty"`
+	Type                 PolicyType `json:"Type"`
+	Protocol             string     `json:",omitempty"`
+	InternalPort         uint16     `json:",omitempty"`
+	ExternalPort         uint16     `json:",omitempty"`
+	ExternalPortReserved bool       `json:",omitempty"`
 }
 
 type QosPolicy struct {


### PR DESCRIPTION
The libnetwork logic uses a dummy proxy to bind the ports for communication between container and host. WS 2019 Aug 2020 patch onwards, Windows started doing an early port reservation which conflicts with the aforementioned logic for overlay and host publish mode for the ports.

Adding ExternalPortReserved flag to NatPolicy for HNS API V1. This is a flag exposed for docker to avoid port reservation conflict with external port

HNS API V2 will use NatFlags to check and see if ExternalPortReserved is set

(cherry picked from commit b85f3fdc17dad534a2cebbc67e0c18f77fb0fca8)
Signed-off-by: Ameya Gawde <agawde@mirantis.com>

Verified the fix with private HostNetSvc.dll from Windows networking team and corresponding change on libnetwork to send down the flag `ExternalPortReserved`