### PR TITLE
Random fixes broken out of base layer work

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,13 +170,15 @@ jobs:
             containerd-shim-runhcs-v1.exe
             runhcs.exe
             tar2ext4.exe
-            device-util.exe
             wclayer.exe
+            device-util.exe
+            ncproxy.exe
+            dmverity-vhd.exe
             grantvmgroupaccess.exe
             networkagent.exe
+            securitypolicy.exe
             uvmboot.exe
             zapdir.exe
-            ncproxy.exe
 
   build_gcs:
     runs-on: ubuntu-latest

--- a/internal/safefile/safeopen.go
+++ b/internal/safefile/safeopen.go
@@ -340,6 +340,34 @@ func MkdirRelative(path string, root *os.File) error {
 	return err
 }
 
+// MkdirAllRelative creates each directory in the path relative to a root, failing if
+// any existing intermediate path components are reparse points.
+func MkdirAllRelative(path string, root *os.File) error {
+	pathParts := strings.Split(filepath.Clean(path), (string)(filepath.Separator))
+	for index := range pathParts {
+
+		partialPath := filepath.Join(pathParts[0 : index+1]...)
+		stat, err := LstatRelative(partialPath, root)
+
+		if err != nil {
+			if os.IsNotExist(err) {
+				if err := MkdirRelative(partialPath, root); err != nil {
+					return err
+				}
+				continue
+			}
+			return err
+		}
+
+		if !stat.IsDir() {
+			fullPath := filepath.Join(root.Name(), partialPath)
+			return &os.PathError{Op: "mkdir", Path: fullPath, Err: syscall.ENOTDIR}
+		}
+	}
+
+	return nil
+}
+
 // LstatRelative performs a stat operation on a file relative to a root, failing
 // if any intermediate path components are reparse points.
 func LstatRelative(path string, root *os.File) (os.FileInfo, error) {

--- a/internal/safefile/safeopen_admin_test.go
+++ b/internal/safefile/safeopen_admin_test.go
@@ -36,6 +36,12 @@ func TestOpenRelative(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// Create a directory stack
+	err = MkdirAllRelative("dir/and/then/some/subdir", root)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	// Create a file in the bad root
 	f, err = os.Create(filepath.Join(badroot.Name(), "badfile"))
 	if err != nil {
@@ -60,6 +66,13 @@ func TestOpenRelative(t *testing.T) {
 	if err == nil {
 		f.Close()
 		t.Fatal("created file in wrong tree!")
+	}
+	t.Log(err)
+
+	// Make sure directory stacks cannot pass through a symlink
+	err = MkdirAllRelative("dsymlink/and/then/some/subdir", root)
+	if err == nil {
+		t.Fatal("created a directory tree through a symlink")
 	}
 	t.Log(err)
 

--- a/internal/wclayer/exportlayer.go
+++ b/internal/wclayer/exportlayer.go
@@ -42,9 +42,14 @@ func ExportLayer(ctx context.Context, path string, exportFolderPath string, pare
 	return nil
 }
 
+// LayerReader is an interface that supports reading an existing container image layer.
 type LayerReader interface {
+	// Next advances to the next file and returns the name, size, and file info
 	Next() (string, int64, *winio.FileBasicInfo, error)
+	// Read reads data from the current file, in the format of a Win32 backup stream, and
+	// returns the number of bytes read.
 	Read(b []byte) (int, error)
+	// Close finishes the layer reading process and releases any resources.
 	Close() error
 }
 

--- a/internal/wclayer/legacy.go
+++ b/internal/wclayer/legacy.go
@@ -350,7 +350,7 @@ type legacyLayerWriter struct {
 	currentIsDir    bool
 }
 
-// newLegacyLayerWriter returns a LayerWriter that can write the contaler layer
+// newLegacyLayerWriter returns a LayerWriter that can write the container layer
 // transport format to disk.
 func newLegacyLayerWriter(root string, parentRoots []string, destRoot string) (w *legacyLayerWriter, err error) {
 	w = &legacyLayerWriter{

--- a/internal/wclayer/legacy.go
+++ b/internal/wclayer/legacy.go
@@ -731,7 +731,7 @@ func (w *legacyLayerWriter) AddLink(name string, target string) error {
 		return errors.New("invalid hard link in layer")
 	}
 
-	// Find to try the target of the link in a previously added file. If that
+	// Try to find the target of the link in a previously added file. If that
 	// fails, search in parent layers.
 	var selectedRoot *os.File
 	if _, ok := w.addedFiles[target]; ok {

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/safefile/safeopen.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/safefile/safeopen.go
@@ -340,6 +340,34 @@ func MkdirRelative(path string, root *os.File) error {
 	return err
 }
 
+// MkdirAllRelative creates each directory in the path relative to a root, failing if
+// any existing intermediate path components are reparse points.
+func MkdirAllRelative(path string, root *os.File) error {
+	pathParts := strings.Split(filepath.Clean(path), (string)(filepath.Separator))
+	for index := range pathParts {
+
+		partialPath := filepath.Join(pathParts[0 : index+1]...)
+		stat, err := LstatRelative(partialPath, root)
+
+		if err != nil {
+			if os.IsNotExist(err) {
+				if err := MkdirRelative(partialPath, root); err != nil {
+					return err
+				}
+				continue
+			}
+			return err
+		}
+
+		if !stat.IsDir() {
+			fullPath := filepath.Join(root.Name(), partialPath)
+			return &os.PathError{Op: "mkdir", Path: fullPath, Err: syscall.ENOTDIR}
+		}
+	}
+
+	return nil
+}
+
 // LstatRelative performs a stat operation on a file relative to a root, failing
 // if any intermediate path components are reparse points.
 func LstatRelative(path string, root *os.File) (os.FileInfo, error) {

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/wclayer/exportlayer.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/wclayer/exportlayer.go
@@ -42,9 +42,14 @@ func ExportLayer(ctx context.Context, path string, exportFolderPath string, pare
 	return nil
 }
 
+// LayerReader is an interface that supports reading an existing container image layer.
 type LayerReader interface {
+	// Next advances to the next file and returns the name, size, and file info
 	Next() (string, int64, *winio.FileBasicInfo, error)
+	// Read reads data from the current file, in the format of a Win32 backup stream, and
+	// returns the number of bytes read.
 	Read(b []byte) (int, error)
+	// Close finishes the layer reading process and releases any resources.
 	Close() error
 }
 

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/wclayer/legacy.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/wclayer/legacy.go
@@ -350,7 +350,7 @@ type legacyLayerWriter struct {
 	currentIsDir    bool
 }
 
-// newLegacyLayerWriter returns a LayerWriter that can write the contaler layer
+// newLegacyLayerWriter returns a LayerWriter that can write the container layer
 // transport format to disk.
 func newLegacyLayerWriter(root string, parentRoots []string, destRoot string) (w *legacyLayerWriter, err error) {
 	w = &legacyLayerWriter{

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/wclayer/legacy.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/wclayer/legacy.go
@@ -731,7 +731,7 @@ func (w *legacyLayerWriter) AddLink(name string, target string) error {
 		return errors.New("invalid hard link in layer")
 	}
 
-	// Find to try the target of the link in a previously added file. If that
+	// Try to find the target of the link in a previously added file. If that
 	// fails, search in parent layers.
 	var selectedRoot *os.File
 	if _, ok := w.addedFiles[target]; ok {


### PR DESCRIPTION
A small batch of fixes that I've broken out of #901 to reduce the scope of that PR to only those parts that introduce not-yet-acceptible features.

This reduces the depth of the branches I have to manage and rebase.

Mostly documentation and CI, but also introduces a new SafeOpen API used by #901.