### PR TITLE
Unset text attribute for vendored files in gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,3 @@
 * text=auto eol=lf
+vendor/** -text
+test/vendor/** -text

--- a/test/vendor/github.com/Microsoft/hcsshim/.gitattributes
+++ b/test/vendor/github.com/Microsoft/hcsshim/.gitattributes
@@ -1,1 +1,3 @@
 * text=auto eol=lf
+vendor/** -text
+test/vendor/** -text


### PR DESCRIPTION
This PR fixes the issues in the `verify-test-vendor` ci job seen in https://github.com/microsoft/hcsshim/pull/1351 where a file was vendored with a crlf line ending but due to our git attributes settings, the file was pushed with lf line endings. This causes a file difference when checking if the modules are out of date in the ci job. 

Signed-off-by: Kathryn Baldauf <kabaldau@microsoft.com>