### PR TITLE
Always set SECURITY_POLICY env var, even for open door policy.

### DIFF
--- a/internal/guest/runtime/hcsv2/uvm.go
+++ b/internal/guest/runtime/hcsv2/uvm.go
@@ -294,13 +294,11 @@ func (h *Host) CreateContainer(ctx context.Context, id string, settings *prot.VM
 	// containers can have access to it. The security policy is required by containers which need to extract
 	// init-time claims found in the security policy.
 	//
-	// We append the variable after the security policy enforcing logic completes so as to bypass it; the
+	// We append the variable after the security policy enforcing logic completes to bypass it; the
 	// security policy variable cannot be included in the security policy as its value is not available
 	// security policy construction time.
-	if policyEnforcer, ok := (h.securityPolicyEnforcer).(*securitypolicy.StandardSecurityPolicyEnforcer); ok {
-		secPolicyEnv := fmt.Sprintf("SECURITY_POLICY=%s", policyEnforcer.EncodedSecurityPolicy)
-		settings.OCISpecification.Process.Env = append(settings.OCISpecification.Process.Env, secPolicyEnv)
-	}
+	secPolicyEnv := fmt.Sprintf("SECURITY_POLICY=%s", h.securityPolicyEnforcer.EncodedSecurityPolicy())
+	settings.OCISpecification.Process.Env = append(settings.OCISpecification.Process.Env, secPolicyEnv)
 
 	// Sandbox mount paths need to be resolved in the spec before expected mounts policy can be enforced.
 	if err = h.securityPolicyEnforcer.EnforceWaitMountPointsPolicy(id, settings.OCISpecification); err != nil {

--- a/internal/guest/runtime/hcsv2/uvm.go
+++ b/internal/guest/runtime/hcsv2/uvm.go
@@ -12,7 +12,6 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
-	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -30,6 +29,7 @@ import (
 	"github.com/Microsoft/hcsshim/internal/guest/storage/pmem"
 	"github.com/Microsoft/hcsshim/internal/guest/storage/scsi"
 	"github.com/Microsoft/hcsshim/internal/guest/transport"
+	"github.com/Microsoft/hcsshim/internal/oci"
 	"github.com/Microsoft/hcsshim/internal/protocol/guestrequest"
 	"github.com/Microsoft/hcsshim/internal/protocol/guestresource"
 	"github.com/Microsoft/hcsshim/pkg/annotations"
@@ -298,7 +298,7 @@ func (h *Host) CreateContainer(ctx context.Context, id string, settings *prot.VM
 	// We append the variable after the security policy enforcing logic completes to bypass it; the
 	// security policy variable cannot be included in the security policy as its value is not available
 	// security policy construction time.
-	if val, ok := settings.OCISpecification.Annotations[annotations.SecurityPolicyEnv]; ok && strings.ToLower(val) == "true" {
+	if oci.ParseAnnotationsBool(ctx, settings.OCISpecification.Annotations, annotations.SecurityPolicyEnv, false) {
 		secPolicyEnv := fmt.Sprintf("SECURITY_POLICY=%s", h.securityPolicyEnforcer.EncodedSecurityPolicy())
 		settings.OCISpecification.Process.Env = append(settings.OCISpecification.Process.Env, secPolicyEnv)
 	}

--- a/internal/guest/storage/test/policy/mountmonitoringsecuritypolicyenforcer.go
+++ b/internal/guest/storage/test/policy/mountmonitoringsecuritypolicyenforcer.go
@@ -50,3 +50,7 @@ func (MountMonitoringSecurityPolicyEnforcer) EnforceWaitMountPointsPolicy(_ stri
 func (MountMonitoringSecurityPolicyEnforcer) ExtendDefaultMounts(_ []oci.Mount) error {
 	return nil
 }
+
+func (MountMonitoringSecurityPolicyEnforcer) EncodedSecurityPolicy() string {
+	return ""
+}

--- a/internal/oci/annotations.go
+++ b/internal/oci/annotations.go
@@ -57,14 +57,14 @@ func ProcessAnnotations(ctx context.Context, s *specs.Spec) (err error) {
 // if providing a gMSA credential should be disallowed. Returns the value found,
 // if parsable, otherwise returns false otherwise.
 func ParseAnnotationsDisableGMSA(ctx context.Context, s *specs.Spec) bool {
-	return parseAnnotationsBool(ctx, s.Annotations, annotations.WCOWDisableGMSA, false)
+	return ParseAnnotationsBool(ctx, s.Annotations, annotations.WCOWDisableGMSA, false)
 }
 
 // ParseAnnotationsSaveAsTemplate searches for the boolean value which specifies
 // if this create request should be considered as a template creation request. If value
 // is found the returns the actual value, returns false otherwise.
 func ParseAnnotationsSaveAsTemplate(ctx context.Context, s *specs.Spec) bool {
-	return parseAnnotationsBool(ctx, s.Annotations, annotations.SaveAsTemplate, false)
+	return ParseAnnotationsBool(ctx, s.Annotations, annotations.SaveAsTemplate, false)
 }
 
 // ParseAnnotationsTemplateID searches for the templateID in the create request. If the
@@ -75,9 +75,9 @@ func ParseAnnotationsTemplateID(ctx context.Context, s *specs.Spec) string {
 
 // general annotation parsing
 
-// parseAnnotationsBool searches `a` for `key` and if found verifies that the
+// ParseAnnotationsBool searches `a` for `key` and if found verifies that the
 // value is `true` or `false` in any case. If `key` is not found returns `def`.
-func parseAnnotationsBool(ctx context.Context, a map[string]string, key string, def bool) bool {
+func ParseAnnotationsBool(ctx context.Context, a map[string]string, key string, def bool) bool {
 	if v, ok := a[key]; ok {
 		switch strings.ToLower(v) {
 		case "true":

--- a/internal/oci/uvm.go
+++ b/internal/oci/uvm.go
@@ -158,7 +158,7 @@ func ParseCloneAnnotations(ctx context.Context, s *specs.Spec) (isTemplate bool,
 // handleAnnotationKernelDirectBoot handles parsing annotationKernelDirectBoot and setting
 // implied annotations from the result.
 func handleAnnotationKernelDirectBoot(ctx context.Context, a map[string]string, lopts *uvm.OptionsLCOW) {
-	lopts.KernelDirect = parseAnnotationsBool(ctx, a, annotations.KernelDirectBoot, lopts.KernelDirect)
+	lopts.KernelDirect = ParseAnnotationsBool(ctx, a, annotations.KernelDirectBoot, lopts.KernelDirect)
 	if !lopts.KernelDirect {
 		lopts.KernelFile = uvm.KernelFile
 	}
@@ -181,7 +181,7 @@ func handleAnnotationPreferredRootFSType(ctx context.Context, a map[string]strin
 func handleAnnotationFullyPhysicallyBacked(ctx context.Context, a map[string]string, opts interface{}) {
 	switch options := opts.(type) {
 	case *uvm.OptionsLCOW:
-		options.FullyPhysicallyBacked = parseAnnotationsBool(ctx, a, annotations.FullyPhysicallyBacked, options.FullyPhysicallyBacked)
+		options.FullyPhysicallyBacked = ParseAnnotationsBool(ctx, a, annotations.FullyPhysicallyBacked, options.FullyPhysicallyBacked)
 		if options.FullyPhysicallyBacked {
 			options.AllowOvercommit = false
 			options.PreferredRootFSType = uvm.PreferredRootFSTypeInitRd
@@ -189,7 +189,7 @@ func handleAnnotationFullyPhysicallyBacked(ctx context.Context, a map[string]str
 			options.VPMemDeviceCount = 0
 		}
 	case *uvm.OptionsWCOW:
-		options.FullyPhysicallyBacked = parseAnnotationsBool(ctx, a, annotations.FullyPhysicallyBacked, options.FullyPhysicallyBacked)
+		options.FullyPhysicallyBacked = ParseAnnotationsBool(ctx, a, annotations.FullyPhysicallyBacked, options.FullyPhysicallyBacked)
 		if options.FullyPhysicallyBacked {
 			options.AllowOvercommit = false
 		}
@@ -199,7 +199,7 @@ func handleAnnotationFullyPhysicallyBacked(ctx context.Context, a map[string]str
 // handleCloneAnnotations handles parsing annotations related to template creation and cloning
 // Since late cloning is only supported for WCOW this function only deals with WCOW options.
 func handleCloneAnnotations(ctx context.Context, a map[string]string, wopts *uvm.OptionsWCOW) (err error) {
-	wopts.IsTemplate = parseAnnotationsBool(ctx, a, annotations.SaveAsTemplate, false)
+	wopts.IsTemplate = ParseAnnotationsBool(ctx, a, annotations.SaveAsTemplate, false)
 	templateID := parseAnnotationsString(a, annotations.TemplateID, "")
 	if templateID != "" {
 		tc, err := clone.FetchTemplateConfig(ctx, templateID)
@@ -222,7 +222,7 @@ func handleSecurityPolicy(ctx context.Context, a map[string]string, lopts *uvm.O
 	lopts.SecurityPolicy = parseAnnotationsString(a, annotations.SecurityPolicy, lopts.SecurityPolicy)
 	// allow actual isolated boot etc to be ignored if we have no hardware. Required for dev
 	// this is not a security issue as the attestation will fail without a genuine report
-	noSecurityHardware := parseAnnotationsBool(ctx, a, annotations.NoSecurityHardware, false)
+	noSecurityHardware := ParseAnnotationsBool(ctx, a, annotations.NoSecurityHardware, false)
 
 	// if there is a security policy (and SNP) we currently boot in a way that doesn't support any boot options
 	// this might change if the building of the vmgs file were to be done on demand but that is likely
@@ -246,8 +246,8 @@ func specToUVMCreateOptionsCommon(ctx context.Context, opts *uvm.Options, s *spe
 	opts.LowMMIOGapInMB = parseAnnotationsUint64(ctx, s.Annotations, annotations.MemoryLowMMIOGapInMB, opts.LowMMIOGapInMB)
 	opts.HighMMIOBaseInMB = parseAnnotationsUint64(ctx, s.Annotations, annotations.MemoryHighMMIOBaseInMB, opts.HighMMIOBaseInMB)
 	opts.HighMMIOGapInMB = parseAnnotationsUint64(ctx, s.Annotations, annotations.MemoryHighMMIOGapInMB, opts.HighMMIOGapInMB)
-	opts.AllowOvercommit = parseAnnotationsBool(ctx, s.Annotations, annotations.AllowOvercommit, opts.AllowOvercommit)
-	opts.EnableDeferredCommit = parseAnnotationsBool(ctx, s.Annotations, annotations.EnableDeferredCommit, opts.EnableDeferredCommit)
+	opts.AllowOvercommit = ParseAnnotationsBool(ctx, s.Annotations, annotations.AllowOvercommit, opts.AllowOvercommit)
+	opts.EnableDeferredCommit = ParseAnnotationsBool(ctx, s.Annotations, annotations.EnableDeferredCommit, opts.EnableDeferredCommit)
 	opts.ProcessorCount = ParseAnnotationsCPUCount(ctx, s, annotations.ProcessorCount, opts.ProcessorCount)
 	opts.ProcessorLimit = ParseAnnotationsCPULimit(ctx, s, annotations.ProcessorLimit, opts.ProcessorLimit)
 	opts.ProcessorWeight = ParseAnnotationsCPUWeight(ctx, s, annotations.ProcessorWeight, opts.ProcessorWeight)
@@ -256,7 +256,7 @@ func specToUVMCreateOptionsCommon(ctx context.Context, opts *uvm.Options, s *spe
 	opts.CPUGroupID = parseAnnotationsString(s.Annotations, annotations.CPUGroupID, opts.CPUGroupID)
 	opts.NetworkConfigProxy = parseAnnotationsString(s.Annotations, annotations.NetworkConfigProxy, opts.NetworkConfigProxy)
 	opts.ProcessDumpLocation = parseAnnotationsString(s.Annotations, annotations.ContainerProcessDumpLocation, opts.ProcessDumpLocation)
-	opts.NoWritableFileShares = parseAnnotationsBool(ctx, s.Annotations, annotations.DisableWritableFileShares, opts.NoWritableFileShares)
+	opts.NoWritableFileShares = ParseAnnotationsBool(ctx, s.Annotations, annotations.DisableWritableFileShares, opts.NoWritableFileShares)
 }
 
 // SpecToUVMCreateOpts parses `s` and returns either `*uvm.OptionsLCOW` or
@@ -269,16 +269,16 @@ func SpecToUVMCreateOpts(ctx context.Context, s *specs.Spec, id, owner string) (
 		lopts := uvm.NewDefaultOptionsLCOW(id, owner)
 		specToUVMCreateOptionsCommon(ctx, lopts.Options, s)
 
-		lopts.EnableColdDiscardHint = parseAnnotationsBool(ctx, s.Annotations, annotations.EnableColdDiscardHint, lopts.EnableColdDiscardHint)
+		lopts.EnableColdDiscardHint = ParseAnnotationsBool(ctx, s.Annotations, annotations.EnableColdDiscardHint, lopts.EnableColdDiscardHint)
 		lopts.VPMemDeviceCount = parseAnnotationsUint32(ctx, s.Annotations, annotations.VPMemCount, lopts.VPMemDeviceCount)
 		lopts.VPMemSizeBytes = parseAnnotationsUint64(ctx, s.Annotations, annotations.VPMemSize, lopts.VPMemSizeBytes)
-		lopts.VPMemNoMultiMapping = parseAnnotationsBool(ctx, s.Annotations, annotations.VPMemNoMultiMapping, lopts.VPMemNoMultiMapping)
-		lopts.VPCIEnabled = parseAnnotationsBool(ctx, s.Annotations, annotations.VPCIEnabled, lopts.VPCIEnabled)
+		lopts.VPMemNoMultiMapping = ParseAnnotationsBool(ctx, s.Annotations, annotations.VPMemNoMultiMapping, lopts.VPMemNoMultiMapping)
+		lopts.VPCIEnabled = ParseAnnotationsBool(ctx, s.Annotations, annotations.VPCIEnabled, lopts.VPCIEnabled)
 		lopts.BootFilesPath = parseAnnotationsString(s.Annotations, annotations.BootFilesRootPath, lopts.BootFilesPath)
-		lopts.EnableScratchEncryption = parseAnnotationsBool(ctx, s.Annotations, annotations.EncryptedScratchDisk, lopts.EnableScratchEncryption)
+		lopts.EnableScratchEncryption = ParseAnnotationsBool(ctx, s.Annotations, annotations.EncryptedScratchDisk, lopts.EnableScratchEncryption)
 		lopts.SecurityPolicy = parseAnnotationsString(s.Annotations, annotations.SecurityPolicy, lopts.SecurityPolicy)
 		lopts.KernelBootOptions = parseAnnotationsString(s.Annotations, annotations.KernelBootOptions, lopts.KernelBootOptions)
-		lopts.DisableTimeSyncService = parseAnnotationsBool(ctx, s.Annotations, annotations.DisableLCOWTimeSyncService, lopts.DisableTimeSyncService)
+		lopts.DisableTimeSyncService = ParseAnnotationsBool(ctx, s.Annotations, annotations.DisableLCOWTimeSyncService, lopts.DisableTimeSyncService)
 		handleAnnotationPreferredRootFSType(ctx, s.Annotations, lopts)
 		handleAnnotationKernelDirectBoot(ctx, s.Annotations, lopts)
 
@@ -297,9 +297,9 @@ func SpecToUVMCreateOpts(ctx context.Context, s *specs.Spec, id, owner string) (
 		wopts := uvm.NewDefaultOptionsWCOW(id, owner)
 		specToUVMCreateOptionsCommon(ctx, wopts.Options, s)
 
-		wopts.DisableCompartmentNamespace = parseAnnotationsBool(ctx, s.Annotations, annotations.DisableCompartmentNamespace, wopts.DisableCompartmentNamespace)
-		wopts.NoDirectMap = parseAnnotationsBool(ctx, s.Annotations, annotations.VSMBNoDirectMap, wopts.NoDirectMap)
-		wopts.NoInheritHostTimezone = parseAnnotationsBool(ctx, s.Annotations, annotations.NoInheritHostTimezone, wopts.NoInheritHostTimezone)
+		wopts.DisableCompartmentNamespace = ParseAnnotationsBool(ctx, s.Annotations, annotations.DisableCompartmentNamespace, wopts.DisableCompartmentNamespace)
+		wopts.NoDirectMap = ParseAnnotationsBool(ctx, s.Annotations, annotations.VSMBNoDirectMap, wopts.NoDirectMap)
+		wopts.NoInheritHostTimezone = ParseAnnotationsBool(ctx, s.Annotations, annotations.NoInheritHostTimezone, wopts.NoInheritHostTimezone)
 		handleAnnotationFullyPhysicallyBacked(ctx, s.Annotations, wopts)
 		if err := handleCloneAnnotations(ctx, s.Annotations, wopts); err != nil {
 			return nil, err

--- a/pkg/annotations/annotations.go
+++ b/pkg/annotations/annotations.go
@@ -267,6 +267,9 @@ const (
 	// GuestStateFile specifies the path of the vmgs file to use if required. Only applies in SNP mode.
 	GuestStateFile = "io.microsoft.virtualmachine.lcow.gueststatefile"
 
+	// SecurityPolicyEnv specifies if SECURITY_POLICY variable should be injected for a container.
+	SecurityPolicyEnv = "io.microsoft.virtualmachine.lcow.securitypolicy.env"
+
 	// DisableLCOWTimeSyncService is used to disable the chronyd time
 	// synchronization service inside the LCOW UVM.
 	DisableLCOWTimeSyncService = "io.microsoft.virtualmachine.lcow.timesync.disable"

--- a/pkg/securitypolicy/opts.go
+++ b/pkg/securitypolicy/opts.go
@@ -42,3 +42,11 @@ func WithAllowElevated(elevated bool) ContainerConfigOpt {
 		return nil
 	}
 }
+
+// WithCommand sets ContainerConfig.Command in container policy config.
+func WithCommand(cmd []string) ContainerConfigOpt {
+	return func(c *ContainerConfig) error {
+		c.Command = cmd
+		return nil
+	}
+}

--- a/pkg/securitypolicy/securitypolicy.go
+++ b/pkg/securitypolicy/securitypolicy.go
@@ -13,6 +13,8 @@ import (
 	"github.com/pkg/errors"
 )
 
+var ErrInvalidAllowAllPolicy = errors.New("allow_all cannot be set to 'true' when Containers are non-empty")
+
 type EnvVarRule string
 
 const (


### PR DESCRIPTION
Previously SECURITY_POLICY env var was set for container init process
only when StandardSecurityPolicyEnforcer was in use, however the
environment variable is useful even with OpenDoor enforcer.

Address this gap by updating enforcers and adding an accessor
method.

The `SECURITY_POLICY` environment variable will be set only when
the appropriate annotation says so:
`"io.microsoft.virtualmachine.lcow.securitypolicy.env"`

Signed-off-by: Maksim An <maksiman@microsoft.com>