### PR TITLE
Fix nil deref if no shim options were specified

### DIFF
--- a/cmd/containerd-shim-runhcs-v1/service_internal.go
+++ b/cmd/containerd-shim-runhcs-v1/service_internal.go
@@ -75,7 +75,7 @@ func (s *service) stateInternal(ctx context.Context, req *task.StateRequest) (*t
 func (s *service) createInternal(ctx context.Context, req *task.CreateTaskRequest) (*task.CreateTaskResponse, error) {
 	setupDebuggerEvent()
 
-	var shimOpts *runhcsopts.Options
+	shimOpts := &runhcsopts.Options{}
 	if req.Options != nil {
 		v, err := typeurl.UnmarshalAny(req.Options)
 		if err != nil {
@@ -107,7 +107,7 @@ func (s *service) createInternal(ctx context.Context, req *task.CreateTaskReques
 	// If sandbox isolation is set to hypervisor, make sure the HyperV option
 	// is filled in. This lessens the burden on Containerd to parse our shims
 	// options if we can set this ourselves.
-	if shimOpts != nil && shimOpts.SandboxIsolation == runhcsopts.Options_HYPERVISOR {
+	if shimOpts.SandboxIsolation == runhcsopts.Options_HYPERVISOR {
 		if spec.Windows == nil {
 			spec.Windows = &specs.Windows{}
 		}

--- a/cmd/containerd-shim-runhcs-v1/service_internal.go
+++ b/cmd/containerd-shim-runhcs-v1/service_internal.go
@@ -107,7 +107,7 @@ func (s *service) createInternal(ctx context.Context, req *task.CreateTaskReques
 	// If sandbox isolation is set to hypervisor, make sure the HyperV option
 	// is filled in. This lessens the burden on Containerd to parse our shims
 	// options if we can set this ourselves.
-	if shimOpts.SandboxIsolation == runhcsopts.Options_HYPERVISOR {
+	if shimOpts != nil && shimOpts.SandboxIsolation == runhcsopts.Options_HYPERVISOR {
 		if spec.Windows == nil {
 			spec.Windows = &specs.Windows{}
 		}


### PR DESCRIPTION
This fixes a nil deref possible if no shim options for the runtime
specified were supplied. For example:

[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runhcs-wcow-process.options]

vs.

[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runhcs-wcow-process.options]
    SandboxIsolation = 0