### PR TITLE
Fix Hyper-V check in late clone spec comparisons

### DIFF
--- a/internal/hcsoci/create.go
+++ b/internal/hcsoci/create.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strconv"
 
 	"github.com/Microsoft/go-winio/pkg/guid"
@@ -101,33 +102,34 @@ func verifyCloneContainerSpecs(templateSpec, cloneSpec *specs.Spec) error {
 
 	// for annotations check that the values of memory & cpu annotations are same
 	if templateSpec.Annotations[annotations.ContainerMemorySizeInMB] != cloneSpec.Annotations[annotations.ContainerMemorySizeInMB] {
-		return fmt.Errorf("memory size limit for template and clone containers can not be different")
+		return errors.New("memory size limit for template and clone containers can not be different")
 	}
 	if templateSpec.Annotations[annotations.ContainerProcessorCount] != cloneSpec.Annotations[annotations.ContainerProcessorCount] {
-		return fmt.Errorf("processor count for template and clone containers can not be different")
+		return errors.New("processor count for template and clone containers can not be different")
 	}
 	if templateSpec.Annotations[annotations.ContainerProcessorLimit] != cloneSpec.Annotations[annotations.ContainerProcessorLimit] {
-		return fmt.Errorf("processor limit for template and clone containers can not be different")
+		return errors.New("processor limit for template and clone containers can not be different")
 	}
 
 	// LayerFolders should be identical except for the last element.
 	if !cmpSlices(templateSpec.Windows.LayerFolders[:len(templateSpec.Windows.LayerFolders)-1], cloneSpec.Windows.LayerFolders[:len(cloneSpec.Windows.LayerFolders)-1]) {
-		return fmt.Errorf("layers provided for template container and clone container don't match. Check the image specified in container config")
+		return errors.New("layers provided for template container and clone container don't match. Check the image specified in container config")
 	}
 
-	if templateSpec.Windows.HyperV != cloneSpec.Windows.HyperV {
-		return fmt.Errorf("HyperV spec for template and clone containers can not be different")
+	if !reflect.DeepEqual(templateSpec.Windows.HyperV, cloneSpec.Windows.HyperV) {
+		return errors.New("HyperV spec for template and clone containers can not be different")
 	}
 
 	if templateSpec.Windows.Network.AllowUnqualifiedDNSQuery != cloneSpec.Windows.Network.AllowUnqualifiedDNSQuery {
-		return fmt.Errorf("different values for allow unqualified DNS query can not be provided for template and clones")
+		return errors.New("different values for allow unqualified DNS query can not be provided for template and clones")
 	}
 	if templateSpec.Windows.Network.NetworkSharedContainerName != cloneSpec.Windows.Network.NetworkSharedContainerName {
-		return fmt.Errorf("different network shared name can not be provided for template and clones")
+		return errors.New("different network shared name can not be provided for template and clones")
 	}
 	if !cmpSlices(templateSpec.Windows.Network.DNSSearchList, cloneSpec.Windows.Network.DNSSearchList) {
-		return fmt.Errorf("different DNS search list can not be provided for template and clones")
+		return errors.New("different DNS search list can not be provided for template and clones")
 	}
+
 	return nil
 }
 

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/hcsoci/create.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/hcsoci/create.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strconv"
 
 	"github.com/Microsoft/go-winio/pkg/guid"
@@ -101,33 +102,34 @@ func verifyCloneContainerSpecs(templateSpec, cloneSpec *specs.Spec) error {
 
 	// for annotations check that the values of memory & cpu annotations are same
 	if templateSpec.Annotations[annotations.ContainerMemorySizeInMB] != cloneSpec.Annotations[annotations.ContainerMemorySizeInMB] {
-		return fmt.Errorf("memory size limit for template and clone containers can not be different")
+		return errors.New("memory size limit for template and clone containers can not be different")
 	}
 	if templateSpec.Annotations[annotations.ContainerProcessorCount] != cloneSpec.Annotations[annotations.ContainerProcessorCount] {
-		return fmt.Errorf("processor count for template and clone containers can not be different")
+		return errors.New("processor count for template and clone containers can not be different")
 	}
 	if templateSpec.Annotations[annotations.ContainerProcessorLimit] != cloneSpec.Annotations[annotations.ContainerProcessorLimit] {
-		return fmt.Errorf("processor limit for template and clone containers can not be different")
+		return errors.New("processor limit for template and clone containers can not be different")
 	}
 
 	// LayerFolders should be identical except for the last element.
 	if !cmpSlices(templateSpec.Windows.LayerFolders[:len(templateSpec.Windows.LayerFolders)-1], cloneSpec.Windows.LayerFolders[:len(cloneSpec.Windows.LayerFolders)-1]) {
-		return fmt.Errorf("layers provided for template container and clone container don't match. Check the image specified in container config")
+		return errors.New("layers provided for template container and clone container don't match. Check the image specified in container config")
 	}
 
-	if templateSpec.Windows.HyperV != cloneSpec.Windows.HyperV {
-		return fmt.Errorf("HyperV spec for template and clone containers can not be different")
+	if !reflect.DeepEqual(templateSpec.Windows.HyperV, cloneSpec.Windows.HyperV) {
+		return errors.New("HyperV spec for template and clone containers can not be different")
 	}
 
 	if templateSpec.Windows.Network.AllowUnqualifiedDNSQuery != cloneSpec.Windows.Network.AllowUnqualifiedDNSQuery {
-		return fmt.Errorf("different values for allow unqualified DNS query can not be provided for template and clones")
+		return errors.New("different values for allow unqualified DNS query can not be provided for template and clones")
 	}
 	if templateSpec.Windows.Network.NetworkSharedContainerName != cloneSpec.Windows.Network.NetworkSharedContainerName {
-		return fmt.Errorf("different network shared name can not be provided for template and clones")
+		return errors.New("different network shared name can not be provided for template and clones")
 	}
 	if !cmpSlices(templateSpec.Windows.Network.DNSSearchList, cloneSpec.Windows.Network.DNSSearchList) {
-		return fmt.Errorf("different DNS search list can not be provided for template and clones")
+		return errors.New("different DNS search list can not be provided for template and clones")
 	}
+
 	return nil
 }
 


### PR DESCRIPTION
In the function that handles checking if the cloned containers spec retrieved from the registry matches the current spec, it was comparing the hyperv field on the runtime spec using the != operator. This won't work as the hyperv field is a pointer so it would just be comparing the address and not the contents. 

This became an 'issue' as we set the hyperv field now if in our shim options the SandboxIsolation field is set to the HYPERVISOR option. This doesn't have much of an effect being set for containers that are going to be launched IN the UVM, so this is mostly just a bug that was surfaced from a field that didn't use to be set. This was causing the late clone spec comparisons to fail at the hyperv field, and thus the late clone tests.

This additionally changes to errors.New instead of fmt.Errorf where there was no formatting in the error.