### PR TITLE
Pass span context in ociwclayer

### DIFF
--- a/pkg/ociwclayer/export.go
+++ b/pkg/ociwclayer/export.go
@@ -9,10 +9,8 @@ import (
 	"path/filepath"
 
 	"github.com/Microsoft/go-winio/backuptar"
-	"github.com/Microsoft/hcsshim"
+	"github.com/Microsoft/hcsshim/internal/wclayer"
 )
-
-var driverInfo = hcsshim.DriverInfo{}
 
 // ExportLayerToTar writes an OCI layer tar stream from the provided on-disk layer.
 // The caller must specify the parent layers, if any, ordered from lowest to
@@ -21,25 +19,25 @@ var driverInfo = hcsshim.DriverInfo{}
 // The layer will be mounted for this process, so the caller should ensure that
 // it is not currently mounted.
 func ExportLayerToTar(ctx context.Context, w io.Writer, path string, parentLayerPaths []string) error {
-	err := hcsshim.ActivateLayer(driverInfo, path)
+	err := wclayer.ActivateLayer(ctx, path)
 	if err != nil {
 		return err
 	}
 	defer func() {
-		_ = hcsshim.DeactivateLayer(driverInfo, path)
+		_ = wclayer.DeactivateLayer(ctx, path)
 	}()
 
 	// Prepare and unprepare the layer to ensure that it has been initialized.
-	err = hcsshim.PrepareLayer(driverInfo, path, parentLayerPaths)
+	err = wclayer.PrepareLayer(ctx, path, parentLayerPaths)
 	if err != nil {
 		return err
 	}
-	err = hcsshim.UnprepareLayer(driverInfo, path)
+	err = wclayer.UnprepareLayer(ctx, path)
 	if err != nil {
 		return err
 	}
 
-	r, err := hcsshim.NewLayerReader(driverInfo, path, parentLayerPaths)
+	r, err := wclayer.NewLayerReader(ctx, path, parentLayerPaths)
 	if err != nil {
 		return err
 	}
@@ -52,7 +50,7 @@ func ExportLayerToTar(ctx context.Context, w io.Writer, path string, parentLayer
 	return cerr
 }
 
-func writeTarFromLayer(ctx context.Context, r hcsshim.LayerReader, w io.Writer) error {
+func writeTarFromLayer(ctx context.Context, r wclayer.LayerReader, w io.Writer) error {
 	t := tar.NewWriter(w)
 	for {
 		select {

--- a/pkg/ociwclayer/import.go
+++ b/pkg/ociwclayer/import.go
@@ -14,7 +14,7 @@ import (
 
 	winio "github.com/Microsoft/go-winio"
 	"github.com/Microsoft/go-winio/backuptar"
-	"github.com/Microsoft/hcsshim"
+	"github.com/Microsoft/hcsshim/internal/wclayer"
 )
 
 const whiteoutPrefix = ".wh."
@@ -43,7 +43,7 @@ func ImportLayerFromTar(ctx context.Context, r io.Reader, path string, parentLay
 	if err != nil {
 		return 0, err
 	}
-	w, err := hcsshim.NewLayerWriter(hcsshim.DriverInfo{}, path, parentLayerPaths)
+	w, err := wclayer.NewLayerWriter(ctx, path, parentLayerPaths)
 	if err != nil {
 		return 0, err
 	}
@@ -58,7 +58,7 @@ func ImportLayerFromTar(ctx context.Context, r io.Reader, path string, parentLay
 	return n, nil
 }
 
-func writeLayerFromTar(ctx context.Context, r io.Reader, w hcsshim.LayerWriter, root string) (int64, error) {
+func writeLayerFromTar(ctx context.Context, r io.Reader, w wclayer.LayerWriter, root string) (int64, error) {
 	t := tar.NewReader(r)
 	hdr, err := t.Next()
 	totalSize := int64(0)

--- a/test/vendor/github.com/Microsoft/hcsshim/pkg/ociwclayer/export.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/pkg/ociwclayer/export.go
@@ -9,10 +9,8 @@ import (
 	"path/filepath"
 
 	"github.com/Microsoft/go-winio/backuptar"
-	"github.com/Microsoft/hcsshim"
+	"github.com/Microsoft/hcsshim/internal/wclayer"
 )
-
-var driverInfo = hcsshim.DriverInfo{}
 
 // ExportLayerToTar writes an OCI layer tar stream from the provided on-disk layer.
 // The caller must specify the parent layers, if any, ordered from lowest to
@@ -21,25 +19,25 @@ var driverInfo = hcsshim.DriverInfo{}
 // The layer will be mounted for this process, so the caller should ensure that
 // it is not currently mounted.
 func ExportLayerToTar(ctx context.Context, w io.Writer, path string, parentLayerPaths []string) error {
-	err := hcsshim.ActivateLayer(driverInfo, path)
+	err := wclayer.ActivateLayer(ctx, path)
 	if err != nil {
 		return err
 	}
 	defer func() {
-		_ = hcsshim.DeactivateLayer(driverInfo, path)
+		_ = wclayer.DeactivateLayer(ctx, path)
 	}()
 
 	// Prepare and unprepare the layer to ensure that it has been initialized.
-	err = hcsshim.PrepareLayer(driverInfo, path, parentLayerPaths)
+	err = wclayer.PrepareLayer(ctx, path, parentLayerPaths)
 	if err != nil {
 		return err
 	}
-	err = hcsshim.UnprepareLayer(driverInfo, path)
+	err = wclayer.UnprepareLayer(ctx, path)
 	if err != nil {
 		return err
 	}
 
-	r, err := hcsshim.NewLayerReader(driverInfo, path, parentLayerPaths)
+	r, err := wclayer.NewLayerReader(ctx, path, parentLayerPaths)
 	if err != nil {
 		return err
 	}
@@ -52,7 +50,7 @@ func ExportLayerToTar(ctx context.Context, w io.Writer, path string, parentLayer
 	return cerr
 }
 
-func writeTarFromLayer(ctx context.Context, r hcsshim.LayerReader, w io.Writer) error {
+func writeTarFromLayer(ctx context.Context, r wclayer.LayerReader, w io.Writer) error {
 	t := tar.NewWriter(w)
 	for {
 		select {

--- a/test/vendor/github.com/Microsoft/hcsshim/pkg/ociwclayer/import.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/pkg/ociwclayer/import.go
@@ -14,7 +14,7 @@ import (
 
 	winio "github.com/Microsoft/go-winio"
 	"github.com/Microsoft/go-winio/backuptar"
-	"github.com/Microsoft/hcsshim"
+	"github.com/Microsoft/hcsshim/internal/wclayer"
 )
 
 const whiteoutPrefix = ".wh."
@@ -43,7 +43,7 @@ func ImportLayerFromTar(ctx context.Context, r io.Reader, path string, parentLay
 	if err != nil {
 		return 0, err
 	}
-	w, err := hcsshim.NewLayerWriter(hcsshim.DriverInfo{}, path, parentLayerPaths)
+	w, err := wclayer.NewLayerWriter(ctx, path, parentLayerPaths)
 	if err != nil {
 		return 0, err
 	}
@@ -58,7 +58,7 @@ func ImportLayerFromTar(ctx context.Context, r io.Reader, path string, parentLay
 	return n, nil
 }
 
-func writeLayerFromTar(ctx context.Context, r io.Reader, w hcsshim.LayerWriter, root string) (int64, error) {
+func writeLayerFromTar(ctx context.Context, r io.Reader, w wclayer.LayerWriter, root string) (int64, error) {
 	t := tar.NewReader(r)
 	hdr, err := t.Next()
 	totalSize := int64(0)


### PR DESCRIPTION
Bypass function in base package (`.\layers.go`) and use layer functions
defined in `.\internal\wclayer`, since those allow propagating (span)
context.

Signed-off-by: Hamza El-Saawy <hamzaelsaawy@microsoft.com>