### PR TITLE
Don't use unsafe.Sizeof where encoding/binary.Size suffices

### DIFF
--- a/ext4/dmverity/dmverity.go
+++ b/ext4/dmverity/dmverity.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"unsafe"
 
 	"github.com/pkg/errors"
 
@@ -27,7 +26,10 @@ const (
 	VeritySignature = "verity"
 )
 
-var salt = bytes.Repeat([]byte{0}, 32)
+var (
+	salt   = bytes.Repeat([]byte{0}, 32)
+	sbSize = binary.Size(dmveritySuperblock{})
+)
 
 var (
 	ErrSuperBlockReadFailure  = errors.New("failed to read dm-verity super block")
@@ -234,7 +236,6 @@ func ComputeAndWriteHashDevice(r io.ReadSeeker, w io.WriteSeeker) error {
 		return errors.Wrap(err, "failed to write dm-verity super-block")
 	}
 	// write super-block padding
-	sbSize := int(unsafe.Sizeof(*dmVeritySB))
 	padding := bytes.Repeat([]byte{0}, blockSize-(sbSize%blockSize))
 	if _, err = w.Write(padding); err != nil {
 		return err

--- a/ext4/dmverity/dmverity_test.go
+++ b/ext4/dmverity/dmverity_test.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"strings"
 	"testing"
-	"unsafe"
 
 	"github.com/pkg/errors"
 )
@@ -45,7 +44,6 @@ func writeDMVeritySuperBlock(filename string) (*os.File, error) {
 	if err := binary.Write(out, binary.LittleEndian, sb); err != nil {
 		return nil, err
 	}
-	sbSize := int(unsafe.Sizeof(*sb))
 	padding := bytes.Repeat([]byte{0}, blockSize-(sbSize%blockSize))
 	if _, err = out.Write(padding); err != nil {
 		return nil, err

--- a/test/vendor/github.com/Microsoft/hcsshim/ext4/dmverity/dmverity.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/ext4/dmverity/dmverity.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"unsafe"
 
 	"github.com/pkg/errors"
 
@@ -27,7 +26,10 @@ const (
 	VeritySignature = "verity"
 )
 
-var salt = bytes.Repeat([]byte{0}, 32)
+var (
+	salt   = bytes.Repeat([]byte{0}, 32)
+	sbSize = binary.Size(dmveritySuperblock{})
+)
 
 var (
 	ErrSuperBlockReadFailure  = errors.New("failed to read dm-verity super block")
@@ -234,7 +236,6 @@ func ComputeAndWriteHashDevice(r io.ReadSeeker, w io.WriteSeeker) error {
 		return errors.Wrap(err, "failed to write dm-verity super-block")
 	}
 	// write super-block padding
-	sbSize := int(unsafe.Sizeof(*dmVeritySB))
 	padding := bytes.Repeat([]byte{0}, blockSize-(sbSize%blockSize))
 	if _, err = w.Write(padding); err != nil {
 		return err


### PR DESCRIPTION
`unsafe.Sizeof` depends on ABI details, but we're not actually using the raw memory layout of `dmveritySuperblock`. We're just writing it out with `encoding/binary.Write`, so `encoding/binary.Size` gives the relevant size.