### PR TITLE
Add policy enforcement to enable/disable GCS logging

### DIFF
--- a/internal/guest/runtime/hcsv2/uvm.go
+++ b/internal/guest/runtime/hcsv2/uvm.go
@@ -94,10 +94,10 @@ func (h *Host) SetSecurityPolicy(base64Policy string) error {
 	opts := []securitypolicy.StandardEnforcerOpt{
 		securitypolicy.WithPrivilegedMounts(policy.DefaultCRIPrivilegedMounts()),
 	}
-	if securityPolicyState.SecurityPolicy.LoggingEnabled {
-		opts = append(opts, securitypolicy.WithLoggingEnabled())
+	if securityPolicyState.SecurityPolicy.AllowLogging {
+		opts = append(opts, securitypolicy.WithAllowLogging())
 	}
-	p, err := securitypolicy.NewSecurityPolicyEnforcer(*securityPolicyState, opts...)
+	p, err := securitypolicy.CreateSecurityPolicyEnforcer(*securityPolicyState, opts...)
 	if err != nil {
 		return err
 	}
@@ -115,7 +115,7 @@ func (h *Host) SetSecurityPolicy(base64Policy string) error {
 		return err
 	}
 
-	if err := p.EnforceLogging(); err != nil {
+	if err := p.EnforceLoggingPolicy(); err != nil {
 		return err
 	}
 

--- a/internal/guest/runtime/hcsv2/uvm.go
+++ b/internal/guest/runtime/hcsv2/uvm.go
@@ -91,10 +91,13 @@ func (h *Host) SetSecurityPolicy(base64Policy string) error {
 		return err
 	}
 
-	p, err := securitypolicy.NewSecurityPolicyEnforcer(
-		*securityPolicyState,
+	opts := []securitypolicy.StandardEnforcerOpt{
 		securitypolicy.WithPrivilegedMounts(policy.DefaultCRIPrivilegedMounts()),
-	)
+	}
+	if securityPolicyState.SecurityPolicy.LoggingEnabled {
+		opts = append(opts, securitypolicy.WithLoggingEnabled())
+	}
+	p, err := securitypolicy.NewSecurityPolicyEnforcer(*securityPolicyState, opts...)
 	if err != nil {
 		return err
 	}
@@ -109,6 +112,10 @@ func (h *Host) SetSecurityPolicy(base64Policy string) error {
 	}
 
 	if err := p.ExtendDefaultMounts(policy.DefaultCRIMounts()); err != nil {
+		return err
+	}
+
+	if err := p.EnforceLogging(); err != nil {
 		return err
 	}
 

--- a/internal/guest/storage/test/policy/mountmonitoringsecuritypolicyenforcer.go
+++ b/internal/guest/storage/test/policy/mountmonitoringsecuritypolicyenforcer.go
@@ -50,3 +50,7 @@ func (MountMonitoringSecurityPolicyEnforcer) EnforceWaitMountPointsPolicy(_ stri
 func (MountMonitoringSecurityPolicyEnforcer) ExtendDefaultMounts(_ []oci.Mount) error {
 	return nil
 }
+
+func (MountMonitoringSecurityPolicyEnforcer) EnforceLogging() error {
+	return nil
+}

--- a/internal/guest/storage/test/policy/mountmonitoringsecuritypolicyenforcer.go
+++ b/internal/guest/storage/test/policy/mountmonitoringsecuritypolicyenforcer.go
@@ -51,6 +51,6 @@ func (MountMonitoringSecurityPolicyEnforcer) ExtendDefaultMounts(_ []oci.Mount) 
 	return nil
 }
 
-func (MountMonitoringSecurityPolicyEnforcer) EnforceLogging() error {
+func (MountMonitoringSecurityPolicyEnforcer) EnforceLoggingPolicy() error {
 	return nil
 }

--- a/internal/tools/securitypolicy/README.md
+++ b/internal/tools/securitypolicy/README.md
@@ -17,6 +17,8 @@ be downloaded, turned into an ext4, and finally a dm-verity root hash calculated
 ## Example TOML configuration file
 
 ```toml
+logging = true
+
 [[container]]
 image_name = "rust:1.52.1"
 command = ["rustc", "--help"]
@@ -46,6 +48,7 @@ represented in JSON.
 ```json
 {
   "allow_all": false,
+  "logging": true,
   "containers": {
     "length": 2,
     "elements": {
@@ -116,7 +119,7 @@ represented in JSON.
                 "length": 3,
                 "elements": {
                   "0": "rbind",
-                  "1": "rprivate",
+                  "1": "rshared",
                   "2": "rw"
                 }
               }
@@ -129,13 +132,14 @@ represented in JSON.
                 "length": 3,
                 "elements": {
                   "0": "rbind",
-                  "1": "rprivate",
+                  "1": "rshared",
                   "2": "ro"
                 }
               }
             }
           }
-        }
+        },
+        "allow_elevated": false
       },
       "1": {
         "command": {
@@ -171,7 +175,8 @@ represented in JSON.
         "mounts": {
           "length": 0,
           "elements": {}
-        }
+        },
+        "allow_elevated": false
       }
     }
   }

--- a/internal/tools/securitypolicy/README.md
+++ b/internal/tools/securitypolicy/README.md
@@ -48,7 +48,7 @@ represented in JSON.
 ```json
 {
   "allow_all": false,
-  "logging": true,
+  "allow_logging": true,
   "containers": {
     "length": 2,
     "elements": {

--- a/internal/tools/securitypolicy/main.go
+++ b/internal/tools/securitypolicy/main.go
@@ -79,5 +79,5 @@ func createPolicyFromConfig(config *securitypolicy.PolicyConfig) (*securitypolic
 	if err != nil {
 		return nil, err
 	}
-	return securitypolicy.NewSecurityPolicy(false, config.LoggingEnabled, policyContainers), nil
+	return securitypolicy.NewSecurityPolicy(false, config.AllowLogging, policyContainers), nil
 }

--- a/internal/tools/securitypolicy/main.go
+++ b/internal/tools/securitypolicy/main.go
@@ -79,5 +79,5 @@ func createPolicyFromConfig(config *securitypolicy.PolicyConfig) (*securitypolic
 	if err != nil {
 		return nil, err
 	}
-	return securitypolicy.NewSecurityPolicy(false, policyContainers), nil
+	return securitypolicy.NewSecurityPolicy(false, config.LoggingEnabled, policyContainers), nil
 }

--- a/pkg/securitypolicy/securitypolicy.go
+++ b/pkg/securitypolicy/securitypolicy.go
@@ -22,9 +22,9 @@ const (
 
 // PolicyConfig contains toml or JSON config for security policy.
 type PolicyConfig struct {
-	AllowAll       bool              `json:"allow_all" toml:"allow_all"`
-	LoggingEnabled bool              `json:"logging" toml:"logging"`
-	Containers     []ContainerConfig `json:"containers" toml:"container"`
+	AllowAll     bool              `json:"allow_all" toml:"allow_all"`
+	AllowLogging bool              `json:"allow_logging" toml:"allow_logging"`
+	Containers   []ContainerConfig `json:"containers" toml:"container"`
 }
 
 // AuthConfig contains toml or JSON config for registry authentication.
@@ -78,8 +78,8 @@ func NewEnvVarRules(envVars []string) []EnvRuleConfig {
 // NewOpenDoorPolicy creates a new SecurityPolicy with AllowAll set to `true`
 func NewOpenDoorPolicy() *SecurityPolicy {
 	return &SecurityPolicy{
-		AllowAll:       true,
-		LoggingEnabled: true,
+		AllowAll:     true,
+		AllowLogging: true,
 	}
 }
 
@@ -152,8 +152,8 @@ type SecurityPolicy struct {
 	// to true, thus making policy enforcement effectively "off" from a logical
 	// standpoint. Policy enforcement isn't actually off as the policy is "allow
 	// everything".
-	AllowAll       bool `json:"allow_all"`
-	LoggingEnabled bool `json:"logging"`
+	AllowAll     bool `json:"allow_all"`
+	AllowLogging bool `json:"allow_logging"`
 	// One or more containers that are allowed to run
 	Containers Containers `json:"containers"`
 }
@@ -241,14 +241,14 @@ func CreateContainerPolicy(
 }
 
 // NewSecurityPolicy creates a new SecurityPolicy from the provided values.
-func NewSecurityPolicy(allowAll bool, logging bool, containers []*Container) *SecurityPolicy {
+func NewSecurityPolicy(allowAll bool, allowLogging bool, containers []*Container) *SecurityPolicy {
 	containersMap := map[string]Container{}
 	for i, c := range containers {
 		containersMap[strconv.Itoa(i)] = *c
 	}
 	return &SecurityPolicy{
-		AllowAll:       allowAll,
-		LoggingEnabled: logging,
+		AllowAll:     allowAll,
+		AllowLogging: allowLogging,
 		Containers: Containers{
 			Elements: containersMap,
 		},

--- a/pkg/securitypolicy/securitypolicy.go
+++ b/pkg/securitypolicy/securitypolicy.go
@@ -22,8 +22,9 @@ const (
 
 // PolicyConfig contains toml or JSON config for security policy.
 type PolicyConfig struct {
-	AllowAll   bool              `json:"allow_all" toml:"allow_all"`
-	Containers []ContainerConfig `json:"containers" toml:"container"`
+	AllowAll       bool              `json:"allow_all" toml:"allow_all"`
+	LoggingEnabled bool              `json:"logging" toml:"logging"`
+	Containers     []ContainerConfig `json:"containers" toml:"container"`
 }
 
 // AuthConfig contains toml or JSON config for registry authentication.
@@ -77,7 +78,8 @@ func NewEnvVarRules(envVars []string) []EnvRuleConfig {
 // NewOpenDoorPolicy creates a new SecurityPolicy with AllowAll set to `true`
 func NewOpenDoorPolicy() *SecurityPolicy {
 	return &SecurityPolicy{
-		AllowAll: true,
+		AllowAll:       true,
+		LoggingEnabled: true,
 	}
 }
 
@@ -150,7 +152,8 @@ type SecurityPolicy struct {
 	// to true, thus making policy enforcement effectively "off" from a logical
 	// standpoint. Policy enforcement isn't actually off as the policy is "allow
 	// everything".
-	AllowAll bool `json:"allow_all"`
+	AllowAll       bool `json:"allow_all"`
+	LoggingEnabled bool `json:"logging"`
 	// One or more containers that are allowed to run
 	Containers Containers `json:"containers"`
 }
@@ -238,13 +241,14 @@ func CreateContainerPolicy(
 }
 
 // NewSecurityPolicy creates a new SecurityPolicy from the provided values.
-func NewSecurityPolicy(allowAll bool, containers []*Container) *SecurityPolicy {
+func NewSecurityPolicy(allowAll bool, logging bool, containers []*Container) *SecurityPolicy {
 	containersMap := map[string]Container{}
 	for i, c := range containers {
 		containersMap[strconv.Itoa(i)] = *c
 	}
 	return &SecurityPolicy{
-		AllowAll: allowAll,
+		AllowAll:       allowAll,
+		LoggingEnabled: logging,
 		Containers: Containers{
 			Elements: containersMap,
 		},

--- a/pkg/securitypolicy/securitypolicy_test.go
+++ b/pkg/securitypolicy/securitypolicy_test.go
@@ -111,10 +111,7 @@ func Test_StandardSecurityPolicyEnforcer_From_Security_Policy_Conversion(t *test
 // StandardSecurityPolicyEnforcer
 func Test_StandardSecurityPolicyEnforcer_Devices_Initialization(t *testing.T) {
 	f := func(p *generatedContainers) bool {
-		policy, err := NewStandardSecurityPolicyEnforcer(p.containers, ignoredEncodedPolicyString)
-		if err != nil {
-			return false
-		}
+		policy := NewStandardSecurityPolicyEnforcer(p.containers, ignoredEncodedPolicyString)
 
 		// there should be a device entry for each container
 		if len(p.containers) != len(policy.Devices) {
@@ -141,16 +138,13 @@ func Test_StandardSecurityPolicyEnforcer_Devices_Initialization(t *testing.T) {
 // return an error when there's no matching root hash in the policy
 func Test_EnforceDeviceMountPolicy_No_Matches(t *testing.T) {
 	f := func(p *generatedContainers) bool {
-		policy, err := NewStandardSecurityPolicyEnforcer(p.containers, ignoredEncodedPolicyString)
-		if err != nil {
-			return false
-		}
+		policy := NewStandardSecurityPolicyEnforcer(p.containers, ignoredEncodedPolicyString)
 
 		r := rand.New(rand.NewSource(time.Now().UnixNano()))
 		target := generateMountTarget(r)
 		rootHash := generateInvalidRootHash(r)
 
-		err = policy.EnforceDeviceMountPolicy(target, rootHash)
+		err := policy.EnforceDeviceMountPolicy(target, rootHash)
 
 		// we expect an error, not getting one means something is broken
 		return err != nil
@@ -165,16 +159,13 @@ func Test_EnforceDeviceMountPolicy_No_Matches(t *testing.T) {
 // return an error when there's a matching root hash in the policy
 func Test_EnforceDeviceMountPolicy_Matches(t *testing.T) {
 	f := func(p *generatedContainers) bool {
-		policy, err := NewStandardSecurityPolicyEnforcer(p.containers, ignoredEncodedPolicyString)
-		if err != nil {
-			return false
-		}
+		policy := NewStandardSecurityPolicyEnforcer(p.containers, ignoredEncodedPolicyString)
 
 		r := rand.New(rand.NewSource(time.Now().UnixNano()))
 		target := generateMountTarget(r)
 		rootHash := selectRootHashFromContainers(p, r)
 
-		err = policy.EnforceDeviceMountPolicy(target, rootHash)
+		err := policy.EnforceDeviceMountPolicy(target, rootHash)
 
 		// getting an error means something is broken
 		return err == nil
@@ -187,16 +178,13 @@ func Test_EnforceDeviceMountPolicy_Matches(t *testing.T) {
 
 func Test_EnforceDeviceUmountPolicy_Removes_Device_Entries(t *testing.T) {
 	f := func(p *generatedContainers) bool {
-		policy, err := NewStandardSecurityPolicyEnforcer(p.containers, ignoredEncodedPolicyString)
-		if err != nil {
-			return false
-		}
+		policy := NewStandardSecurityPolicyEnforcer(p.containers, ignoredEncodedPolicyString)
 
 		r := rand.New(rand.NewSource(time.Now().UnixNano()))
 		target := generateMountTarget(r)
 		rootHash := selectRootHashFromContainers(p, r)
 
-		err = policy.EnforceDeviceMountPolicy(target, rootHash)
+		err := policy.EnforceDeviceMountPolicy(target, rootHash)
 		if err != nil {
 			return false
 		}
@@ -312,10 +300,7 @@ func Test_EnforceOverlayMountPolicy_Multiple_Instances_Same_Container(t *testing
 			containers = append(containers, c)
 		}
 
-		sp, err := NewStandardSecurityPolicyEnforcer(containers, "")
-		if err != nil {
-			t.Fatalf("failed to create standard enforcer: %s", err)
-		}
+		sp := NewStandardSecurityPolicyEnforcer(containers, ignoredEncodedPolicyString)
 
 		idsUsed := map[string]bool{}
 		for i := 0; i < len(containers); i++ {
@@ -348,10 +333,7 @@ func Test_EnforceOverlayMountPolicy_Multiple_Instances_Same_Container(t *testing
 // but no more than that one.
 func Test_EnforceOverlayMountPolicy_Overlay_Single_Container_Twice_With_Different_IDs(t *testing.T) {
 	p := generateContainers(testRand, 1)
-	sp, err := NewStandardSecurityPolicyEnforcer(p.containers, ignoredEncodedPolicyString)
-	if err != nil {
-		t.Fatalf("failed to create standard enforcer: %s", err)
-	}
+	sp := NewStandardSecurityPolicyEnforcer(p.containers, ignoredEncodedPolicyString)
 
 	var containerIDOne, containerIDTwo string
 
@@ -445,10 +427,7 @@ func Test_EnforceCommandPolicy_NarrowingMatches(t *testing.T) {
 		// add new containers to policy before creating enforcer
 		p.containers = append(p.containers, testContainerOne, testContainerTwo)
 
-		policy, err := NewStandardSecurityPolicyEnforcer(p.containers, ignoredEncodedPolicyString)
-		if err != nil {
-			return false
-		}
+		policy := NewStandardSecurityPolicyEnforcer(p.containers, ignoredEncodedPolicyString)
 
 		testContainerOneID := ""
 		testContainerTwoID := ""
@@ -502,7 +481,7 @@ func Test_EnforceCommandPolicy_NarrowingMatches(t *testing.T) {
 
 		// enforce command policy for containerOne
 		// this will narrow our list of possible ids down
-		err = policy.enforceCommandPolicy(testContainerOneID, testContainerOne.Command)
+		err := policy.enforceCommandPolicy(testContainerOneID, testContainerOne.Command)
 		if err != nil {
 			return false
 		}
@@ -565,10 +544,7 @@ func Test_EnforceEnvironmentVariablePolicy_Re2Match(t *testing.T) {
 	container.EnvRules = append(container.EnvRules, re2MatchRule)
 	p.containers = append(p.containers, container)
 
-	policy, err := NewStandardSecurityPolicyEnforcer(p.containers, ignoredEncodedPolicyString)
-	if err != nil {
-		t.Fatalf("failed to create standard enforcer: %s", err)
-	}
+	policy := NewStandardSecurityPolicyEnforcer(p.containers, ignoredEncodedPolicyString)
 
 	containerID := generateContainerID(testRand)
 
@@ -638,10 +614,7 @@ func Test_EnforceEnvironmentVariablePolicy_NarrowingMatches(t *testing.T) {
 		// add new containers to policy before creating enforcer
 		p.containers = append(p.containers, testContainerOne, testContainerTwo)
 
-		policy, err := NewStandardSecurityPolicyEnforcer(p.containers, ignoredEncodedPolicyString)
-		if err != nil {
-			return false
-		}
+		policy := NewStandardSecurityPolicyEnforcer(p.containers, ignoredEncodedPolicyString)
 
 		testContainerOneID := ""
 		testContainerTwoID := ""
@@ -696,7 +669,7 @@ func Test_EnforceEnvironmentVariablePolicy_NarrowingMatches(t *testing.T) {
 		// enforce command policy for containerOne
 		// this will narrow our list of possible ids down
 		envVars := buildEnvironmentVariablesFromContainerRules(testContainerOne, r)
-		err = policy.enforceEnvironmentVariablePolicy(testContainerOneID, envVars)
+		err := policy.enforceEnvironmentVariablePolicy(testContainerOneID, envVars)
 		if err != nil {
 			return false
 		}
@@ -840,10 +813,7 @@ type testConfig struct {
 }
 
 func setupContainerWithOverlay(gc *generatedContainers, valid bool) (tc *testConfig, err error) {
-	sp, err := NewStandardSecurityPolicyEnforcer(gc.containers, ignoredEncodedPolicyString)
-	if err != nil {
-		return nil, err
-	}
+	sp := NewStandardSecurityPolicyEnforcer(gc.containers, ignoredEncodedPolicyString)
 
 	containerID := generateContainerID(testRand)
 	c := selectContainerFromContainers(gc, testRand)

--- a/test/cri-containerd/policy_test.go
+++ b/test/cri-containerd/policy_test.go
@@ -28,7 +28,7 @@ func securityPolicyFromContainers(containers []securitypolicy.ContainerConfig) (
 	if err != nil {
 		return "", err
 	}
-	p := securitypolicy.NewSecurityPolicy(false, pc)
+	p := securitypolicy.NewSecurityPolicy(false, true, pc)
 	pString, err := p.EncodeToString()
 	if err != nil {
 		return "", err

--- a/test/vendor/github.com/Microsoft/hcsshim/pkg/securitypolicy/securitypolicy.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/pkg/securitypolicy/securitypolicy.go
@@ -22,9 +22,9 @@ const (
 
 // PolicyConfig contains toml or JSON config for security policy.
 type PolicyConfig struct {
-	AllowAll       bool              `json:"allow_all" toml:"allow_all"`
-	LoggingEnabled bool              `json:"logging" toml:"logging"`
-	Containers     []ContainerConfig `json:"containers" toml:"container"`
+	AllowAll     bool              `json:"allow_all" toml:"allow_all"`
+	AllowLogging bool              `json:"allow_logging" toml:"allow_logging"`
+	Containers   []ContainerConfig `json:"containers" toml:"container"`
 }
 
 // AuthConfig contains toml or JSON config for registry authentication.
@@ -78,8 +78,8 @@ func NewEnvVarRules(envVars []string) []EnvRuleConfig {
 // NewOpenDoorPolicy creates a new SecurityPolicy with AllowAll set to `true`
 func NewOpenDoorPolicy() *SecurityPolicy {
 	return &SecurityPolicy{
-		AllowAll:       true,
-		LoggingEnabled: true,
+		AllowAll:     true,
+		AllowLogging: true,
 	}
 }
 
@@ -152,8 +152,8 @@ type SecurityPolicy struct {
 	// to true, thus making policy enforcement effectively "off" from a logical
 	// standpoint. Policy enforcement isn't actually off as the policy is "allow
 	// everything".
-	AllowAll       bool `json:"allow_all"`
-	LoggingEnabled bool `json:"logging"`
+	AllowAll     bool `json:"allow_all"`
+	AllowLogging bool `json:"allow_logging"`
 	// One or more containers that are allowed to run
 	Containers Containers `json:"containers"`
 }
@@ -241,14 +241,14 @@ func CreateContainerPolicy(
 }
 
 // NewSecurityPolicy creates a new SecurityPolicy from the provided values.
-func NewSecurityPolicy(allowAll bool, logging bool, containers []*Container) *SecurityPolicy {
+func NewSecurityPolicy(allowAll bool, allowLogging bool, containers []*Container) *SecurityPolicy {
 	containersMap := map[string]Container{}
 	for i, c := range containers {
 		containersMap[strconv.Itoa(i)] = *c
 	}
 	return &SecurityPolicy{
-		AllowAll:       allowAll,
-		LoggingEnabled: logging,
+		AllowAll:     allowAll,
+		AllowLogging: allowLogging,
 		Containers: Containers{
 			Elements: containersMap,
 		},

--- a/test/vendor/github.com/Microsoft/hcsshim/pkg/securitypolicy/securitypolicy.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/pkg/securitypolicy/securitypolicy.go
@@ -22,8 +22,9 @@ const (
 
 // PolicyConfig contains toml or JSON config for security policy.
 type PolicyConfig struct {
-	AllowAll   bool              `json:"allow_all" toml:"allow_all"`
-	Containers []ContainerConfig `json:"containers" toml:"container"`
+	AllowAll       bool              `json:"allow_all" toml:"allow_all"`
+	LoggingEnabled bool              `json:"logging" toml:"logging"`
+	Containers     []ContainerConfig `json:"containers" toml:"container"`
 }
 
 // AuthConfig contains toml or JSON config for registry authentication.
@@ -77,7 +78,8 @@ func NewEnvVarRules(envVars []string) []EnvRuleConfig {
 // NewOpenDoorPolicy creates a new SecurityPolicy with AllowAll set to `true`
 func NewOpenDoorPolicy() *SecurityPolicy {
 	return &SecurityPolicy{
-		AllowAll: true,
+		AllowAll:       true,
+		LoggingEnabled: true,
 	}
 }
 
@@ -150,7 +152,8 @@ type SecurityPolicy struct {
 	// to true, thus making policy enforcement effectively "off" from a logical
 	// standpoint. Policy enforcement isn't actually off as the policy is "allow
 	// everything".
-	AllowAll bool `json:"allow_all"`
+	AllowAll       bool `json:"allow_all"`
+	LoggingEnabled bool `json:"logging"`
 	// One or more containers that are allowed to run
 	Containers Containers `json:"containers"`
 }
@@ -238,13 +241,14 @@ func CreateContainerPolicy(
 }
 
 // NewSecurityPolicy creates a new SecurityPolicy from the provided values.
-func NewSecurityPolicy(allowAll bool, containers []*Container) *SecurityPolicy {
+func NewSecurityPolicy(allowAll bool, logging bool, containers []*Container) *SecurityPolicy {
 	containersMap := map[string]Container{}
 	for i, c := range containers {
 		containersMap[strconv.Itoa(i)] = *c
 	}
 	return &SecurityPolicy{
-		AllowAll: allowAll,
+		AllowAll:       allowAll,
+		LoggingEnabled: logging,
 		Containers: Containers{
 			Elements: containersMap,
 		},


### PR DESCRIPTION
Security policy has been extended to support "logging" flag,
which will enable logging inside GCS when set to "true".
By default the logging will be disabled once security policy
becomes available, unless otherwise specified.
Although GCS shouldn't be logging any sensitive information
this change adds extra guarantees that nothing is leaked.

The logging is disabled by setting the logrus output to
io.Discard.
The only drawback is that in SNP scenario the gcs command
is hardcoded and there's a window between the initial
logging configuration inside gcs main and when it's
disabled during setting the security policy. In this case
the vsock dial messages and UVM boot sequence might end up
in the logs, but that shouldn't expose anything.

Container logging will be disabled in a separate PR.

Signed-off-by: Maksim An <maksiman@microsoft.com>