### PR TITLE
Rename ExpectedMounts to WaitMountPoints

### DIFF
--- a/internal/guest/runtime/hcsv2/uvm.go
+++ b/internal/guest/runtime/hcsv2/uvm.go
@@ -302,7 +302,7 @@ func (h *Host) CreateContainer(ctx context.Context, id string, settings *prot.VM
 	}
 
 	// Sandbox mount paths need to be resolved in the spec before expected mounts policy can be enforced.
-	if err = h.securityPolicyEnforcer.EnforceExpectedMountsPolicy(id, settings.OCISpecification); err != nil {
+	if err = h.securityPolicyEnforcer.EnforceWaitMountPointsPolicy(id, settings.OCISpecification); err != nil {
 		return nil, errors.Wrapf(err, "container creation denied due to policy")
 	}
 

--- a/internal/guest/storage/test/policy/mountmonitoringsecuritypolicyenforcer.go
+++ b/internal/guest/storage/test/policy/mountmonitoringsecuritypolicyenforcer.go
@@ -43,7 +43,7 @@ func (MountMonitoringSecurityPolicyEnforcer) EnforceMountPolicy(_, _ string, _ *
 	return nil
 }
 
-func (MountMonitoringSecurityPolicyEnforcer) EnforceExpectedMountsPolicy(_ string, _ *oci.Spec) error {
+func (MountMonitoringSecurityPolicyEnforcer) EnforceWaitMountPointsPolicy(_ string, _ *oci.Spec) error {
 	return nil
 }
 

--- a/internal/tools/securitypolicy/README.md
+++ b/internal/tools/securitypolicy/README.md
@@ -21,7 +21,7 @@ be downloaded, turned into an ext4, and finally a dm-verity root hash calculated
 image_name = "rust:1.52.1"
 command = ["rustc", "--help"]
 working_dir = "/home/user"
-expected_mounts = ["/path/to/container/mount-1", "/path/to/container/mount-2"]
+wait_mount_points = ["/path/to/container/mount-1", "/path/to/container/mount-2"]
 
 [[container.env_rule]]
 strategy = "re2"
@@ -98,7 +98,7 @@ represented in JSON.
           }
         },
         "working_dir": "/home/user",
-        "expected_mounts": {
+        "wait_mount_points": {
           "length": 2,
           "elements": {
             "0": "/path/to/container/mount-1",
@@ -164,7 +164,7 @@ represented in JSON.
           }
         },
         "working_dir": "/",
-        "expected_mounts": {
+        "wait_mount_points": {
           "length": 0,
           "elements": {}
         },

--- a/internal/tools/securitypolicy/helpers/helpers.go
+++ b/internal/tools/securitypolicy/helpers/helpers.go
@@ -158,7 +158,7 @@ func PolicyContainersFromConfigs(containerConfigs []securitypolicy.ContainerConf
 			layerHashes,
 			envRules,
 			workingDir,
-			containerConfig.ExpectedMounts,
+			containerConfig.WaitMountPoints,
 			containerConfig.Mounts,
 			containerConfig.AllowElevated,
 		)

--- a/pkg/securitypolicy/opts.go
+++ b/pkg/securitypolicy/opts.go
@@ -10,10 +10,10 @@ func WithEnvVarRules(envs []EnvRuleConfig) ContainerConfigOpt {
 	}
 }
 
-// WithExpectedMounts adds expected mounts to container policy config.
-func WithExpectedMounts(em []string) ContainerConfigOpt {
+// WithWaitMountPoints adds expected mounts to container policy config.
+func WithWaitMountPoints(em []string) ContainerConfigOpt {
 	return func(c *ContainerConfig) error {
-		c.ExpectedMounts = append(c.ExpectedMounts, em...)
+		c.WaitMountPoints = append(c.WaitMountPoints, em...)
 		return nil
 	}
 }

--- a/pkg/securitypolicy/securitypolicy.go
+++ b/pkg/securitypolicy/securitypolicy.go
@@ -42,14 +42,14 @@ type EnvRuleConfig struct {
 // ContainerConfig contains toml or JSON config for container described
 // in security policy.
 type ContainerConfig struct {
-	ImageName      string          `json:"image_name" toml:"image_name"`
-	Command        []string        `json:"command" toml:"command"`
-	Auth           AuthConfig      `json:"auth" toml:"auth"`
-	EnvRules       []EnvRuleConfig `json:"env_rules" toml:"env_rule"`
-	WorkingDir     string          `json:"working_dir" toml:"working_dir"`
-	ExpectedMounts []string        `json:"expected_mounts" toml:"expected_mounts"`
-	Mounts         []MountConfig   `json:"mounts" toml:"mount"`
-	AllowElevated  bool            `json:"allow_elevated" toml:"allow_elevated"`
+	ImageName       string          `json:"image_name" toml:"image_name"`
+	Command         []string        `json:"command" toml:"command"`
+	Auth            AuthConfig      `json:"auth" toml:"auth"`
+	EnvRules        []EnvRuleConfig `json:"env_rules" toml:"env_rule"`
+	WorkingDir      string          `json:"working_dir" toml:"working_dir"`
+	WaitMountPoints []string        `json:"wait_mount_points" toml:"wait_mount_points"`
+	Mounts          []MountConfig   `json:"mounts" toml:"mount"`
+	AllowElevated   bool            `json:"allow_elevated" toml:"allow_elevated"`
 }
 
 // MountConfig contains toml or JSON config for mount security policy
@@ -170,13 +170,13 @@ type Containers struct {
 }
 
 type Container struct {
-	Command        CommandArgs    `json:"command"`
-	EnvRules       EnvRules       `json:"env_rules"`
-	Layers         Layers         `json:"layers"`
-	WorkingDir     string         `json:"working_dir"`
-	ExpectedMounts ExpectedMounts `json:"expected_mounts"`
-	Mounts         Mounts         `json:"mounts"`
-	AllowElevated  bool           `json:"allow_elevated"`
+	Command         CommandArgs     `json:"command"`
+	EnvRules        EnvRules        `json:"env_rules"`
+	Layers          Layers          `json:"layers"`
+	WorkingDir      string          `json:"working_dir"`
+	WaitMountPoints WaitMountPoints `json:"wait_mount_points"`
+	Mounts          Mounts          `json:"mounts"`
+	AllowElevated   bool            `json:"allow_elevated"`
 }
 
 // StringArrayMap wraps an array of strings as a string map.
@@ -189,7 +189,7 @@ type Layers StringArrayMap
 
 type CommandArgs StringArrayMap
 
-type ExpectedMounts StringArrayMap
+type WaitMountPoints StringArrayMap
 
 type Options StringArrayMap
 
@@ -227,13 +227,13 @@ func CreateContainerPolicy(
 		return nil, err
 	}
 	return &Container{
-		Command:        newCommandArgs(command),
-		Layers:         newLayers(layers),
-		EnvRules:       newEnvRules(envRules),
-		WorkingDir:     workingDir,
-		ExpectedMounts: newExpectedMounts(eMounts),
-		Mounts:         newMountConstraints(mounts),
-		AllowElevated:  allowElevated,
+		Command:         newCommandArgs(command),
+		Layers:          newLayers(layers),
+		EnvRules:        newEnvRules(envRules),
+		WorkingDir:      workingDir,
+		WaitMountPoints: newWaitMountPoints(eMounts),
+		Mounts:          newMountConstraints(mounts),
+		AllowElevated:   allowElevated,
 	}, nil
 }
 
@@ -302,12 +302,12 @@ func newLayers(ls []string) Layers {
 	}
 }
 
-func newExpectedMounts(em []string) ExpectedMounts {
+func newWaitMountPoints(em []string) WaitMountPoints {
 	mounts := map[string]string{}
 	for i, m := range em {
 		mounts[strconv.Itoa(i)] = m
 	}
-	return ExpectedMounts{
+	return WaitMountPoints{
 		Elements: mounts,
 	}
 }
@@ -428,8 +428,8 @@ func (o Options) MarshalJSON() ([]byte, error) {
 	return json.Marshal(StringArrayMap(o))
 }
 
-func (em ExpectedMounts) MarshalJSON() ([]byte, error) {
-	return json.Marshal(StringArrayMap(em))
+func (wm WaitMountPoints) MarshalJSON() ([]byte, error) {
+	return json.Marshal(StringArrayMap(wm))
 }
 
 func (m Mounts) MarshalJSON() ([]byte, error) {

--- a/test/cri-containerd/policy_test.go
+++ b/test/cri-containerd/policy_test.go
@@ -150,9 +150,9 @@ func syncContainerConfigs(writePath, waitPath string) (writer, waiter *securityp
 	// create container #2 that waits for a path to appear
 	echoCmdArgs := []string{"ash", "-c", "while true; do echo hello2; sleep 1; done"}
 	waiter = &securitypolicy.ContainerConfig{
-		ImageName:      "alpine:latest",
-		Command:        echoCmdArgs,
-		ExpectedMounts: []string{waitPath},
+		ImageName:       "alpine:latest",
+		Command:         echoCmdArgs,
+		WaitMountPoints: []string{waitPath},
 		Mounts: []securitypolicy.MountConfig{
 			{
 				HostPath:      "sandbox://host/path",

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/tools/securitypolicy/helpers/helpers.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/tools/securitypolicy/helpers/helpers.go
@@ -158,7 +158,7 @@ func PolicyContainersFromConfigs(containerConfigs []securitypolicy.ContainerConf
 			layerHashes,
 			envRules,
 			workingDir,
-			containerConfig.ExpectedMounts,
+			containerConfig.WaitMountPoints,
 			containerConfig.Mounts,
 			containerConfig.AllowElevated,
 		)

--- a/test/vendor/github.com/Microsoft/hcsshim/pkg/securitypolicy/opts.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/pkg/securitypolicy/opts.go
@@ -10,10 +10,10 @@ func WithEnvVarRules(envs []EnvRuleConfig) ContainerConfigOpt {
 	}
 }
 
-// WithExpectedMounts adds expected mounts to container policy config.
-func WithExpectedMounts(em []string) ContainerConfigOpt {
+// WithWaitMountPoints adds expected mounts to container policy config.
+func WithWaitMountPoints(em []string) ContainerConfigOpt {
 	return func(c *ContainerConfig) error {
-		c.ExpectedMounts = append(c.ExpectedMounts, em...)
+		c.WaitMountPoints = append(c.WaitMountPoints, em...)
 		return nil
 	}
 }

--- a/test/vendor/github.com/Microsoft/hcsshim/pkg/securitypolicy/securitypolicy.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/pkg/securitypolicy/securitypolicy.go
@@ -42,14 +42,14 @@ type EnvRuleConfig struct {
 // ContainerConfig contains toml or JSON config for container described
 // in security policy.
 type ContainerConfig struct {
-	ImageName      string          `json:"image_name" toml:"image_name"`
-	Command        []string        `json:"command" toml:"command"`
-	Auth           AuthConfig      `json:"auth" toml:"auth"`
-	EnvRules       []EnvRuleConfig `json:"env_rules" toml:"env_rule"`
-	WorkingDir     string          `json:"working_dir" toml:"working_dir"`
-	ExpectedMounts []string        `json:"expected_mounts" toml:"expected_mounts"`
-	Mounts         []MountConfig   `json:"mounts" toml:"mount"`
-	AllowElevated  bool            `json:"allow_elevated" toml:"allow_elevated"`
+	ImageName       string          `json:"image_name" toml:"image_name"`
+	Command         []string        `json:"command" toml:"command"`
+	Auth            AuthConfig      `json:"auth" toml:"auth"`
+	EnvRules        []EnvRuleConfig `json:"env_rules" toml:"env_rule"`
+	WorkingDir      string          `json:"working_dir" toml:"working_dir"`
+	WaitMountPoints []string        `json:"wait_mount_points" toml:"wait_mount_points"`
+	Mounts          []MountConfig   `json:"mounts" toml:"mount"`
+	AllowElevated   bool            `json:"allow_elevated" toml:"allow_elevated"`
 }
 
 // MountConfig contains toml or JSON config for mount security policy
@@ -170,13 +170,13 @@ type Containers struct {
 }
 
 type Container struct {
-	Command        CommandArgs    `json:"command"`
-	EnvRules       EnvRules       `json:"env_rules"`
-	Layers         Layers         `json:"layers"`
-	WorkingDir     string         `json:"working_dir"`
-	ExpectedMounts ExpectedMounts `json:"expected_mounts"`
-	Mounts         Mounts         `json:"mounts"`
-	AllowElevated  bool           `json:"allow_elevated"`
+	Command         CommandArgs     `json:"command"`
+	EnvRules        EnvRules        `json:"env_rules"`
+	Layers          Layers          `json:"layers"`
+	WorkingDir      string          `json:"working_dir"`
+	WaitMountPoints WaitMountPoints `json:"wait_mount_points"`
+	Mounts          Mounts          `json:"mounts"`
+	AllowElevated   bool            `json:"allow_elevated"`
 }
 
 // StringArrayMap wraps an array of strings as a string map.
@@ -189,7 +189,7 @@ type Layers StringArrayMap
 
 type CommandArgs StringArrayMap
 
-type ExpectedMounts StringArrayMap
+type WaitMountPoints StringArrayMap
 
 type Options StringArrayMap
 
@@ -227,13 +227,13 @@ func CreateContainerPolicy(
 		return nil, err
 	}
 	return &Container{
-		Command:        newCommandArgs(command),
-		Layers:         newLayers(layers),
-		EnvRules:       newEnvRules(envRules),
-		WorkingDir:     workingDir,
-		ExpectedMounts: newExpectedMounts(eMounts),
-		Mounts:         newMountConstraints(mounts),
-		AllowElevated:  allowElevated,
+		Command:         newCommandArgs(command),
+		Layers:          newLayers(layers),
+		EnvRules:        newEnvRules(envRules),
+		WorkingDir:      workingDir,
+		WaitMountPoints: newWaitMountPoints(eMounts),
+		Mounts:          newMountConstraints(mounts),
+		AllowElevated:   allowElevated,
 	}, nil
 }
 
@@ -302,12 +302,12 @@ func newLayers(ls []string) Layers {
 	}
 }
 
-func newExpectedMounts(em []string) ExpectedMounts {
+func newWaitMountPoints(em []string) WaitMountPoints {
 	mounts := map[string]string{}
 	for i, m := range em {
 		mounts[strconv.Itoa(i)] = m
 	}
-	return ExpectedMounts{
+	return WaitMountPoints{
 		Elements: mounts,
 	}
 }
@@ -428,8 +428,8 @@ func (o Options) MarshalJSON() ([]byte, error) {
 	return json.Marshal(StringArrayMap(o))
 }
 
-func (em ExpectedMounts) MarshalJSON() ([]byte, error) {
-	return json.Marshal(StringArrayMap(em))
+func (wm WaitMountPoints) MarshalJSON() ([]byte, error) {
+	return json.Marshal(StringArrayMap(wm))
 }
 
 func (m Mounts) MarshalJSON() ([]byte, error) {


### PR DESCRIPTION
`ExpectedMounts` was a poor name choice and was confusing in the
context of mount policy enforcement.

Signed-off-by: Maksim An <maksiman@microsoft.com>