### PR TITLE
Cleanup for shared container scratch

### DIFF
--- a/cmd/containerd-shim-runhcs-v1/task_hcs.go
+++ b/cmd/containerd-shim-runhcs-v1/task_hcs.go
@@ -625,6 +625,11 @@ func (ht *hcsTask) DeleteExec(ctx context.Context, eid string) (int, uint32, tim
 			// https://pkg.go.dev/sync#Map.Range
 			return true
 		})
+
+		// cleanup the container directories inside the UVM if required.
+		if err := ht.host.DeleteContainerState(ctx, ht.id); err != nil {
+			log.G(ctx).WithError(err).Errorf("failed to delete container state")
+		}
 	}
 
 	status := e.Status()

--- a/cmd/containerd-shim-runhcs-v1/task_hcs.go
+++ b/cmd/containerd-shim-runhcs-v1/task_hcs.go
@@ -627,8 +627,10 @@ func (ht *hcsTask) DeleteExec(ctx context.Context, eid string) (int, uint32, tim
 		})
 
 		// cleanup the container directories inside the UVM if required.
-		if err := ht.host.DeleteContainerState(ctx, ht.id); err != nil {
-			log.G(ctx).WithError(err).Errorf("failed to delete container state")
+		if ht.host != nil {
+			if err := ht.host.DeleteContainerState(ctx, ht.id); err != nil {
+				log.G(ctx).WithError(err).Errorf("failed to delete container state")
+			}
 		}
 	}
 

--- a/internal/guest/prot/protocol.go
+++ b/internal/guest/prot/protocol.go
@@ -746,6 +746,11 @@ type VMHostedContainerSettingsV2 struct {
 	SchemaVersion    SchemaVersion
 	OCIBundlePath    string    `json:"OciBundlePath,omitempty"`
 	OCISpecification *oci.Spec `json:"OciSpecification,omitempty"`
+	// ScratchDirPath represents the path inside the UVM at which the container scratch
+	// directory is present.  Usually, this is the path at which the container scratch
+	// VHD is mounted inside the UVM. But in case of scratch sharing this is a
+	// directory under the UVM scratch directory.
+	ScratchDirPath string
 }
 
 // ProcessParameters represents any process which may be started in the utility

--- a/internal/guest/runtime/hcsv2/container.go
+++ b/internal/guest/runtime/hcsv2/container.go
@@ -5,6 +5,7 @@ package hcsv2
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"sync"
 	"sync/atomic"
@@ -203,7 +204,9 @@ func (c *Container) Delete(ctx context.Context) error {
 	}
 
 	if err := os.RemoveAll(c.scratchDirPath); err != nil {
-		if retErr == nil {
+		if retErr != nil {
+			retErr = fmt.Errorf("errors deleting container state, %s & %s", retErr, err)
+		} else {
 			retErr = err
 		}
 	}

--- a/internal/guest/runtime/hcsv2/uvm.go
+++ b/internal/guest/runtime/hcsv2/uvm.go
@@ -193,13 +193,14 @@ func setupSandboxHugePageMountsPath(id string) error {
 func (h *Host) CreateContainer(ctx context.Context, id string, settings *prot.VMHostedContainerSettingsV2) (_ *Container, err error) {
 	criType, isCRI := settings.OCISpecification.Annotations[annotations.KubernetesContainerType]
 	c := &Container{
-		id:        id,
-		vsock:     h.vsock,
-		spec:      settings.OCISpecification,
-		isSandbox: criType == "sandbox",
-		exitType:  prot.NtUnexpectedExit,
-		processes: make(map[uint32]*containerProcess),
-		status:    containerCreating,
+		id:             id,
+		vsock:          h.vsock,
+		spec:           settings.OCISpecification,
+		isSandbox:      criType == "sandbox",
+		exitType:       prot.NtUnexpectedExit,
+		processes:      make(map[uint32]*containerProcess),
+		status:         containerCreating,
+		scratchDirPath: settings.ScratchDirPath,
 	}
 
 	if err := h.AddContainer(id, c); err != nil {

--- a/internal/hcsoci/create.go
+++ b/internal/hcsoci/create.go
@@ -334,7 +334,7 @@ func CreateContainer(ctx context.Context, createOptions *CreateOptions) (_ cow.C
 			log.G(ctx).WithError(err).Debug("failed to allocateLinuxResources")
 			return nil, r, err
 		}
-		gcsDocument, err = createLinuxContainerDocument(ctx, coi, r.ContainerRootInUVM())
+		gcsDocument, err = createLinuxContainerDocument(ctx, coi, r.ContainerRootInUVM(), r.LcowScratchPath())
 		if err != nil {
 			log.G(ctx).WithError(err).Debug("failed createHCSContainerDocument")
 			return nil, r, err

--- a/internal/hcsoci/hcsdoc_lcow.go
+++ b/internal/hcsoci/hcsdoc_lcow.go
@@ -75,9 +75,15 @@ type linuxHostedSystem struct {
 	SchemaVersion    *hcsschema.Version
 	OciBundlePath    string
 	OciSpecification *specs.Spec
+
+	// ScratchDirPath represents the path inside the UVM at which the container scratch
+	// directory is present.  Usually, this is the path at which the container scratch
+	// VHD is mounted inside the UVM. But in case of scratch sharing this is a
+	// directory under the UVM scratch directory.
+	ScratchDirPath string
 }
 
-func createLinuxContainerDocument(ctx context.Context, coi *createOptionsInternal, guestRoot string) (*linuxHostedSystem, error) {
+func createLinuxContainerDocument(ctx context.Context, coi *createOptionsInternal, guestRoot, scratchPath string) (*linuxHostedSystem, error) {
 	spec, err := createLCOWSpec(coi)
 	if err != nil {
 		return nil, err
@@ -88,5 +94,6 @@ func createLinuxContainerDocument(ctx context.Context, coi *createOptionsInterna
 		SchemaVersion:    schemaversion.SchemaV21(),
 		OciBundlePath:    guestRoot,
 		OciSpecification: spec,
+		ScratchDirPath:   scratchPath,
 	}, nil
 }

--- a/internal/hcsoci/resources_lcow.go
+++ b/internal/hcsoci/resources_lcow.go
@@ -30,13 +30,14 @@ func allocateLinuxResources(ctx context.Context, coi *createOptionsInternal, r *
 	containerRootInUVM := r.ContainerRootInUVM()
 	if coi.Spec.Windows != nil && len(coi.Spec.Windows.LayerFolders) > 0 {
 		log.G(ctx).Debug("hcsshim::allocateLinuxResources mounting storage")
-		rootPath, err := layers.MountContainerLayers(ctx, coi.actualID, coi.Spec.Windows.LayerFolders, containerRootInUVM, "", coi.HostingSystem)
+		rootPath, scratchPath, err := layers.MountLCOWLayers(ctx, coi.actualID, coi.Spec.Windows.LayerFolders, containerRootInUVM, "", coi.HostingSystem)
 		if err != nil {
 			return errors.Wrap(err, "failed to mount container storage")
 		}
 		coi.Spec.Root.Path = rootPath
 		layers := layers.NewImageLayers(coi.HostingSystem, containerRootInUVM, coi.Spec.Windows.LayerFolders, "", isSandbox)
 		r.SetLayers(layers)
+		r.SetLcowScratchPath(scratchPath)
 	} else if coi.Spec.Root.Path != "" {
 		// This is the "Plan 9" root filesystem.
 		// TODO: We need a test for this. Ask @jstarks how you can even lay this out on Windows.

--- a/internal/hcsoci/resources_wcow.go
+++ b/internal/hcsoci/resources_wcow.go
@@ -59,7 +59,7 @@ func allocateWindowsResources(ctx context.Context, coi *createOptionsInternal, r
 	if coi.Spec.Root.Path == "" && (coi.HostingSystem != nil || coi.Spec.Windows.HyperV == nil) {
 		log.G(ctx).Debug("hcsshim::allocateWindowsResources mounting storage")
 		containerRootInUVM := r.ContainerRootInUVM()
-		containerRootPath, err := layers.MountContainerLayers(ctx, coi.actualID, coi.Spec.Windows.LayerFolders, containerRootInUVM, "", coi.HostingSystem)
+		containerRootPath, err := layers.MountWCOWLayers(ctx, coi.actualID, coi.Spec.Windows.LayerFolders, containerRootInUVM, "", coi.HostingSystem)
 		if err != nil {
 			return errors.Wrap(err, "failed to mount container storage")
 		}

--- a/internal/jobcontainers/storage.go
+++ b/internal/jobcontainers/storage.go
@@ -43,7 +43,7 @@ func mountLayers(ctx context.Context, containerID string, s *specs.Spec, volumeM
 
 	if s.Root.Path == "" {
 		log.G(ctx).Debug("mounting job container storage")
-		containerRootPath, err := layers.MountContainerLayers(ctx, containerID, s.Windows.LayerFolders, "", volumeMountPath, nil)
+		containerRootPath, err := layers.MountWCOWLayers(ctx, containerID, s.Windows.LayerFolders, "", volumeMountPath, nil)
 		if err != nil {
 			return errors.Wrap(err, "failed to mount container storage")
 		}

--- a/internal/layers/layers.go
+++ b/internal/layers/layers.go
@@ -108,7 +108,7 @@ func MountLCOWLayers(ctx context.Context, containerID string, layerFolders []str
 	}
 
 	containerScratchPathInUVM := ospath.Join(vm.OS(), guestRoot)
-	hostPath, err := GetScratchVHDPath(layerFolders)
+	hostPath, err := getScratchVHDPath(layerFolders)
 	if err != nil {
 		return "", "", fmt.Errorf("failed to get scratch VHD path in layer folders: %s", err)
 	}
@@ -278,7 +278,7 @@ func MountWCOWLayers(ctx context.Context, containerID string, layerFolders []str
 	}
 
 	containerScratchPathInUVM := ospath.Join(vm.OS(), guestRoot)
-	hostPath, err := GetScratchVHDPath(layerFolders)
+	hostPath, err := getScratchVHDPath(layerFolders)
 	if err != nil {
 		return "", fmt.Errorf("failed to get scratch VHD path in layer folders: %s", err)
 	}
@@ -441,7 +441,7 @@ func UnmountContainerLayers(ctx context.Context, layerFolders []string, containe
 
 	// Unload the SCSI scratch path
 	if (op & UnmountOperationSCSI) == UnmountOperationSCSI {
-		hostScratchFile, err := GetScratchVHDPath(layerFolders)
+		hostScratchFile, err := getScratchVHDPath(layerFolders)
 		if err != nil {
 			return errors.Wrap(err, "failed to get scratch VHD path in layer folders")
 		}
@@ -514,7 +514,7 @@ func containerRootfsPath(vm *uvm.UtilityVM, rootPath string) string {
 	return ospath.Join(vm.OS(), rootPath, guestpath.RootfsPath)
 }
 
-func GetScratchVHDPath(layerFolders []string) (string, error) {
+func getScratchVHDPath(layerFolders []string) (string, error) {
 	hostPath := filepath.Join(layerFolders[len(layerFolders)-1], "sandbox.vhdx")
 	// For LCOW, we can reuse another container's scratch space (usually the sandbox container's).
 	//

--- a/test/functional/wcow_test.go
+++ b/test/functional/wcow_test.go
@@ -387,7 +387,7 @@ func TestWCOWArgonShim(t *testing.T) {
 
 	id := "argon"
 	// This is a cheat but stops us re-writing exactly the same code just for test
-	argonShimLocalMountPath, err := layerspkg.MountContainerLayers(context.Background(), id, append(imageLayers, argonShimScratchDir), "", "", nil)
+	argonShimLocalMountPath, err := layerspkg.MountWCOWLayers(context.Background(), id, append(imageLayers, argonShimScratchDir), "", "", nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/hcsoci/create.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/hcsoci/create.go
@@ -334,7 +334,7 @@ func CreateContainer(ctx context.Context, createOptions *CreateOptions) (_ cow.C
 			log.G(ctx).WithError(err).Debug("failed to allocateLinuxResources")
 			return nil, r, err
 		}
-		gcsDocument, err = createLinuxContainerDocument(ctx, coi, r.ContainerRootInUVM())
+		gcsDocument, err = createLinuxContainerDocument(ctx, coi, r.ContainerRootInUVM(), r.LcowScratchPath())
 		if err != nil {
 			log.G(ctx).WithError(err).Debug("failed createHCSContainerDocument")
 			return nil, r, err

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/hcsoci/hcsdoc_lcow.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/hcsoci/hcsdoc_lcow.go
@@ -75,9 +75,15 @@ type linuxHostedSystem struct {
 	SchemaVersion    *hcsschema.Version
 	OciBundlePath    string
 	OciSpecification *specs.Spec
+
+	// ScratchDirPath represents the path inside the UVM at which the container scratch
+	// directory is present.  Usually, this is the path at which the container scratch
+	// VHD is mounted inside the UVM. But in case of scratch sharing this is a
+	// directory under the UVM scratch directory.
+	ScratchDirPath string
 }
 
-func createLinuxContainerDocument(ctx context.Context, coi *createOptionsInternal, guestRoot string) (*linuxHostedSystem, error) {
+func createLinuxContainerDocument(ctx context.Context, coi *createOptionsInternal, guestRoot, scratchPath string) (*linuxHostedSystem, error) {
 	spec, err := createLCOWSpec(coi)
 	if err != nil {
 		return nil, err
@@ -88,5 +94,6 @@ func createLinuxContainerDocument(ctx context.Context, coi *createOptionsInterna
 		SchemaVersion:    schemaversion.SchemaV21(),
 		OciBundlePath:    guestRoot,
 		OciSpecification: spec,
+		ScratchDirPath:   scratchPath,
 	}, nil
 }

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/hcsoci/resources_lcow.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/hcsoci/resources_lcow.go
@@ -30,13 +30,14 @@ func allocateLinuxResources(ctx context.Context, coi *createOptionsInternal, r *
 	containerRootInUVM := r.ContainerRootInUVM()
 	if coi.Spec.Windows != nil && len(coi.Spec.Windows.LayerFolders) > 0 {
 		log.G(ctx).Debug("hcsshim::allocateLinuxResources mounting storage")
-		rootPath, err := layers.MountContainerLayers(ctx, coi.actualID, coi.Spec.Windows.LayerFolders, containerRootInUVM, "", coi.HostingSystem)
+		rootPath, scratchPath, err := layers.MountLCOWLayers(ctx, coi.actualID, coi.Spec.Windows.LayerFolders, containerRootInUVM, "", coi.HostingSystem)
 		if err != nil {
 			return errors.Wrap(err, "failed to mount container storage")
 		}
 		coi.Spec.Root.Path = rootPath
 		layers := layers.NewImageLayers(coi.HostingSystem, containerRootInUVM, coi.Spec.Windows.LayerFolders, "", isSandbox)
 		r.SetLayers(layers)
+		r.SetLcowScratchPath(scratchPath)
 	} else if coi.Spec.Root.Path != "" {
 		// This is the "Plan 9" root filesystem.
 		// TODO: We need a test for this. Ask @jstarks how you can even lay this out on Windows.

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/hcsoci/resources_wcow.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/hcsoci/resources_wcow.go
@@ -59,7 +59,7 @@ func allocateWindowsResources(ctx context.Context, coi *createOptionsInternal, r
 	if coi.Spec.Root.Path == "" && (coi.HostingSystem != nil || coi.Spec.Windows.HyperV == nil) {
 		log.G(ctx).Debug("hcsshim::allocateWindowsResources mounting storage")
 		containerRootInUVM := r.ContainerRootInUVM()
-		containerRootPath, err := layers.MountContainerLayers(ctx, coi.actualID, coi.Spec.Windows.LayerFolders, containerRootInUVM, "", coi.HostingSystem)
+		containerRootPath, err := layers.MountWCOWLayers(ctx, coi.actualID, coi.Spec.Windows.LayerFolders, containerRootInUVM, "", coi.HostingSystem)
 		if err != nil {
 			return errors.Wrap(err, "failed to mount container storage")
 		}

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/layers/layers.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/layers/layers.go
@@ -108,7 +108,7 @@ func MountLCOWLayers(ctx context.Context, containerID string, layerFolders []str
 	}
 
 	containerScratchPathInUVM := ospath.Join(vm.OS(), guestRoot)
-	hostPath, err := GetScratchVHDPath(layerFolders)
+	hostPath, err := getScratchVHDPath(layerFolders)
 	if err != nil {
 		return "", "", fmt.Errorf("failed to get scratch VHD path in layer folders: %s", err)
 	}
@@ -278,7 +278,7 @@ func MountWCOWLayers(ctx context.Context, containerID string, layerFolders []str
 	}
 
 	containerScratchPathInUVM := ospath.Join(vm.OS(), guestRoot)
-	hostPath, err := GetScratchVHDPath(layerFolders)
+	hostPath, err := getScratchVHDPath(layerFolders)
 	if err != nil {
 		return "", fmt.Errorf("failed to get scratch VHD path in layer folders: %s", err)
 	}
@@ -441,7 +441,7 @@ func UnmountContainerLayers(ctx context.Context, layerFolders []string, containe
 
 	// Unload the SCSI scratch path
 	if (op & UnmountOperationSCSI) == UnmountOperationSCSI {
-		hostScratchFile, err := GetScratchVHDPath(layerFolders)
+		hostScratchFile, err := getScratchVHDPath(layerFolders)
 		if err != nil {
 			return errors.Wrap(err, "failed to get scratch VHD path in layer folders")
 		}
@@ -514,7 +514,7 @@ func containerRootfsPath(vm *uvm.UtilityVM, rootPath string) string {
 	return ospath.Join(vm.OS(), rootPath, guestpath.RootfsPath)
 }
 
-func GetScratchVHDPath(layerFolders []string) (string, error) {
+func getScratchVHDPath(layerFolders []string) (string, error) {
 	hostPath := filepath.Join(layerFolders[len(layerFolders)-1], "sandbox.vhdx")
 	// For LCOW, we can reuse another container's scratch space (usually the sandbox container's).
 	//

--- a/test/vendor/modules.txt
+++ b/test/vendor/modules.txt
@@ -409,7 +409,6 @@ google.golang.org/protobuf/types/known/durationpb
 google.golang.org/protobuf/types/known/timestamppb
 # k8s.io/cri-api v0.20.6
 ## explicit; go 1.15
-k8s.io/cri-api/pkg/apis/runtime/v1
 k8s.io/cri-api/pkg/apis/runtime/v1alpha2
 # github.com/Microsoft/hcsshim => ../
 # google.golang.org/genproto => google.golang.org/genproto v0.0.0-20200224152610-e50cd9704f63

--- a/test/vendor/modules.txt
+++ b/test/vendor/modules.txt
@@ -409,6 +409,7 @@ google.golang.org/protobuf/types/known/durationpb
 google.golang.org/protobuf/types/known/timestamppb
 # k8s.io/cri-api v0.20.6
 ## explicit; go 1.15
+k8s.io/cri-api/pkg/apis/runtime/v1
 k8s.io/cri-api/pkg/apis/runtime/v1alpha2
 # github.com/Microsoft/hcsshim => ../
 # google.golang.org/genproto => google.golang.org/genproto v0.0.0-20200224152610-e50cd9704f63


### PR DESCRIPTION
Normally, container scratch is a separate VHD that is mounted at `/run/gcs/c/<CID>` The
mount vhd call to gcs creates this directory and mounts the disk at that path.  The modify
combined layers call creates the `upper` & `work` directories at `/run/gcs/c/<CID>/upper`
& `/run/gcs/c/<CID>/work` and also creates the rootfs directory at
`/run/gcs/c/<CID>/rootfs`. Finally, overlayfs is mounted at `/run/gcs/c/<CID>/rootfs` for
the container to run. The remove combined layers call will remove the
`/run/gcs/c/<CID>/rootfs` directory.  The unmount VHD will remove the `/run/gcs/c/<CID>`
directory. The `upper` & `work` directories continue to live on the container sandbox VHD
until that snapshot is removed.

However, when the container scratch VHD is shared with the UVM (the UVM scratch is mounted
at /run/gcs/c/<UVMID>) the container scratch vhd mount doesn't do anything since the VHD
is already mounted. It just increases the ref count of this VHD by 1. Hcsshim sets the
container scratch as `/run/gcs/c/<UVMID>/container_<CID>` and makes the combine layers
call.  The modify combine layers call creates the `upper` & `work` directories at
`/run/gcs/c/<UMVID>/container_<CID>/uppper`, `/run/gcs/c/<UMVID>/container_<CID>/work` and
the rootfs is created at `/run/gcs/c/<CID>/rootfs`. (Note that all of these are mkdirAll
calls so they create any non-existing parent directories too).  The remove combined layers
call removes the `/run/gcs/c/<CID>/rootfs` directory but the unmount VHD call doesn't
actually do anything, it just reduces the ref count by 1.  So, in this case, the
`/run/gcs/c/<UVMID>/container_<CID>` directory never gets cleaned up and continues to
occupy space on the UVM scratch VHD.

GCS currently doesn't know anything about the container scratch directory path, so it
never cleans it up. Even when `DeleteContainerState` request is made. This is okay when
the scratch is not shared since the container scratch VHD is separate and it will be
cleaned up when containerd removes the container snapshot. However, in the shared scratch
case these scratch directories are leaked.

To correctly handle this case, we need to cleanup the container scratch directory during
the `DeleteTask` call. This commit updates the container creation request doc to also
include the container scratch directory path so that gcs has this path when the
`DeleteContainerState` request is made to the GCS. Also, previously we called
`DeleteContainerState` during `ReleaseResources` call. However, `ReleaseResources` is
called during `KillTask`/`ShutdownTask` request and shouldn't delete any resources that
belong to the container so that call is removed.

Signed-off-by: Amit Barve <ambarve@microsoft.com>