### PR TITLE
Add annotations passthrough for host process containers

### DIFF
--- a/internal/oci/sandbox.go
+++ b/internal/oci/sandbox.go
@@ -58,6 +58,9 @@ func GetSandboxTypeAndID(specAnnotations map[string]string) (KubernetesContainer
 // RunPodSandbox request, so annotations that are meant to be available for use/checking for individual
 // containers need some way to know they were passed for the pod.
 func SandboxAnnotationsPassThrough(podAnnots map[string]string, containerAnnots map[string]string, vals ...string) {
+	if podAnnots == nil || containerAnnots == nil {
+		return
+	}
 	for _, val := range vals {
 		if v, ok := podAnnots[val]; ok {
 			containerAnnots[val] = v

--- a/internal/oci/sandbox.go
+++ b/internal/oci/sandbox.go
@@ -52,3 +52,15 @@ func GetSandboxTypeAndID(specAnnotations map[string]string) (KubernetesContainer
 	}
 	return ct, id, nil
 }
+
+// SandboxAnnotationsPassThrough passes through the annotations specified by 'vals' from the sandboxes set of
+// annotations through to every container in the pod. Kubernetes only passes metadata annotations to the
+// RunPodSandbox request, so annotations that are meant to be available for use/checking for individual
+// containers need some way to know they were passed for the pod.
+func SandboxAnnotationsPassThrough(podAnnots map[string]string, containerAnnots map[string]string, vals ...string) {
+	for _, val := range vals {
+		if v, ok := podAnnots[val]; ok {
+			containerAnnots[val] = v
+		}
+	}
+}

--- a/internal/oci/sandbox.go
+++ b/internal/oci/sandbox.go
@@ -57,7 +57,7 @@ func GetSandboxTypeAndID(specAnnotations map[string]string) (KubernetesContainer
 // annotations through to every container in the pod. Kubernetes only passes metadata annotations to the
 // RunPodSandbox request, so annotations that are meant to be available for use/checking for individual
 // containers need some way to know they were passed for the pod.
-func SandboxAnnotationsPassThrough(podAnnots map[string]string, containerAnnots map[string]string, vals ...string) {
+func SandboxAnnotationsPassThrough(podAnnots, containerAnnots map[string]string, vals ...string) {
 	if podAnnots == nil || containerAnnots == nil {
 		return
 	}


### PR DESCRIPTION
This changes adds in a way for annotations specified for a sandbox
container to be passed through to every container in the pod.
K8s only passes annotations to the RunPodSandbox call and not to individual
containers unfortunately. To accomplish this I cache the pod sandboxes OCI
spec on the pod object as well as expose a method that passes through
specific annotations from the pod spec through to an individual containers.

This is useful for a couple of host process containers annotations, like
microsoft.com/hostprocess-rootfs-location which specifies a non-default
path for the rootfs of the container to show up at.