### PR TITLE
Change bind filter API used

### DIFF
--- a/internal/jobobject/jobobject.go
+++ b/internal/jobobject/jobobject.go
@@ -490,10 +490,9 @@ func (job *JobObject) ApplyFileBinding(root, target string, merged bool) error {
 		flags |= winapi.BINDFLT_FLAG_MERGED_BIND_MAPPING
 	}
 
-	if err := winapi.BfSetupFilterEx(
-		flags,
+	if err := winapi.BfSetupFilter(
 		job.handle,
-		nil,
+		flags,
 		rootPtr,
 		targetPtr,
 		nil,

--- a/internal/winapi/bindflt.go
+++ b/internal/winapi/bindflt.go
@@ -7,14 +7,13 @@ const (
 )
 
 // HRESULT
-// BfSetupFilterEx(
-//     _In_ ULONG Flags,
+// BfSetupFilter(
 //     _In_opt_ HANDLE JobHandle,
-//     _In_opt_ PSID Sid,
+//     _In_ ULONG Flags,
 //     _In_ LPCWSTR VirtualizationRootPath,
 //     _In_ LPCWSTR VirtualizationTargetPath,
 //     _In_reads_opt_( VirtualizationExceptionPathCount ) LPCWSTR* VirtualizationExceptionPaths,
 //     _In_opt_ ULONG VirtualizationExceptionPathCount
 // );
 //
-//sys BfSetupFilterEx(flags uint32, jobHandle windows.Handle, sid *windows.SID, virtRootPath *uint16, virtTargetPath *uint16, virtExceptions **uint16, virtExceptionPathCount uint32) (hr error) = bindfltapi.BfSetupFilterEx?
+//sys BfSetupFilter(jobHandle windows.Handle, flags uint32, virtRootPath *uint16, virtTargetPath *uint16, virtExceptions **uint16, virtExceptionPathCount uint32) (hr error) = bindfltapi.BfSetupFilter?

--- a/internal/winapi/zsyscall_windows.go
+++ b/internal/winapi/zsyscall_windows.go
@@ -45,7 +45,7 @@ var (
 	modadvapi32   = windows.NewLazySystemDLL("advapi32.dll")
 	modcfgmgr32   = windows.NewLazySystemDLL("cfgmgr32.dll")
 
-	procBfSetupFilterEx                        = modbindfltapi.NewProc("BfSetupFilterEx")
+	procBfSetupFilter                          = modbindfltapi.NewProc("BfSetupFilter")
 	procNetLocalGroupGetInfo                   = modnetapi32.NewProc("NetLocalGroupGetInfo")
 	procNetUserAdd                             = modnetapi32.NewProc("NetUserAdd")
 	procNetUserDel                             = modnetapi32.NewProc("NetUserDel")
@@ -80,11 +80,11 @@ var (
 	procRtlNtStatusToDosError                  = modntdll.NewProc("RtlNtStatusToDosError")
 )
 
-func BfSetupFilterEx(flags uint32, jobHandle windows.Handle, sid *windows.SID, virtRootPath *uint16, virtTargetPath *uint16, virtExceptions **uint16, virtExceptionPathCount uint32) (hr error) {
-	if hr = procBfSetupFilterEx.Find(); hr != nil {
+func BfSetupFilter(jobHandle windows.Handle, flags uint32, virtRootPath *uint16, virtTargetPath *uint16, virtExceptions **uint16, virtExceptionPathCount uint32) (hr error) {
+	if hr = procBfSetupFilter.Find(); hr != nil {
 		return
 	}
-	r0, _, _ := syscall.Syscall9(procBfSetupFilterEx.Addr(), 7, uintptr(flags), uintptr(jobHandle), uintptr(unsafe.Pointer(sid)), uintptr(unsafe.Pointer(virtRootPath)), uintptr(unsafe.Pointer(virtTargetPath)), uintptr(unsafe.Pointer(virtExceptions)), uintptr(virtExceptionPathCount), 0, 0)
+	r0, _, _ := syscall.Syscall6(procBfSetupFilter.Addr(), 6, uintptr(jobHandle), uintptr(flags), uintptr(unsafe.Pointer(virtRootPath)), uintptr(unsafe.Pointer(virtTargetPath)), uintptr(unsafe.Pointer(virtExceptions)), uintptr(virtExceptionPathCount))
 	if int32(r0) < 0 {
 		if r0&0x1fff0000 == 0x00070000 {
 			r0 &= 0xffff


### PR DESCRIPTION
Change to using BfSetupFilter instead of BfSetupFilterEx. The Ex variant is
only useful if you want to pass a SID to perform the bind as a specific
user. We don't use this functionality, and it didn't exist on some
versions of Windows as well.