### PR TITLE
Update cri-containerd tests to use v1 cri api

### DIFF
--- a/test/cri-containerd/argsescaped_test.go
+++ b/test/cri-containerd/argsescaped_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	runtime "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
 func Test_ArgsEscaped_Exec(t *testing.T) {

--- a/test/cri-containerd/clone_test.go
+++ b/test/cri-containerd/clone_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/Microsoft/hcsshim/osversion"
 	"github.com/Microsoft/hcsshim/pkg/annotations"
 	testutilities "github.com/Microsoft/hcsshim/test/functional/utilities"
-	runtime "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
 // returns a request config for creating a template sandbox

--- a/test/cri-containerd/container_downlevel_test.go
+++ b/test/cri-containerd/container_downlevel_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/Microsoft/hcsshim/osversion"
 	testutilities "github.com/Microsoft/hcsshim/test/functional/utilities"
-	runtime "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
 func Test_CreateContainer_DownLevel_WCOW_Hypervisor(t *testing.T) {

--- a/test/cri-containerd/container_fileshare_test.go
+++ b/test/cri-containerd/container_fileshare_test.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/Microsoft/hcsshim/internal/hcs"
 	"github.com/Microsoft/hcsshim/pkg/annotations"
-	runtime "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
 func Test_Container_File_Share_Writable_WCOW(t *testing.T) {

--- a/test/cri-containerd/container_gmsa_test.go
+++ b/test/cri-containerd/container_gmsa_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/Microsoft/hcsshim/internal/hcs"
 	"github.com/Microsoft/hcsshim/pkg/annotations"
-	runtime "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
 func Test_RunContainer_GMSA_WCOW(t *testing.T) {

--- a/test/cri-containerd/container_network_test.go
+++ b/test/cri-containerd/container_network_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 	"time"
 
-	runtime "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
 func Test_Container_Network_LCOW(t *testing.T) {

--- a/test/cri-containerd/container_test.go
+++ b/test/cri-containerd/container_test.go
@@ -16,7 +16,7 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
-	runtime "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 
 	"github.com/Microsoft/hcsshim/internal/guestpath"
 	"github.com/Microsoft/hcsshim/pkg/annotations"

--- a/test/cri-containerd/container_update_test.go
+++ b/test/cri-containerd/container_update_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/Microsoft/hcsshim/osversion"
 	"github.com/Microsoft/hcsshim/pkg/annotations"
 	testutilities "github.com/Microsoft/hcsshim/test/functional/utilities"
-	runtime "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
 const processorWeightMax = 10000

--- a/test/cri-containerd/container_virtual_device_test.go
+++ b/test/cri-containerd/container_virtual_device_test.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/Microsoft/hcsshim/osversion"
 	"github.com/Microsoft/hcsshim/pkg/annotations"
-	runtime "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
 const containerDeviceUtilPath = "C:\\device-util.exe"

--- a/test/cri-containerd/containerdrestart_test.go
+++ b/test/cri-containerd/containerdrestart_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/Microsoft/hcsshim/pkg/annotations"
 	criAnnotations "github.com/kevpar/cri/pkg/annotations"
-	runtime "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
 // CRI will terminate any running containers when it is restarted.

--- a/test/cri-containerd/createcontainer_test.go
+++ b/test/cri-containerd/createcontainer_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/Microsoft/hcsshim/osversion"
 	"github.com/Microsoft/hcsshim/pkg/annotations"
 	testutilities "github.com/Microsoft/hcsshim/test/functional/utilities"
-	runtime "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
 func runCreateContainerTest(t *testing.T, runtimeHandler string, request *runtime.CreateContainerRequest) {

--- a/test/cri-containerd/disable_vpmem_test.go
+++ b/test/cri-containerd/disable_vpmem_test.go
@@ -13,7 +13,7 @@ import (
 	"time"
 
 	"github.com/Microsoft/hcsshim/pkg/annotations"
-	runtime "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
 // Use unique names for pods & containers so that if we run this test multiple times in parallel we don't

--- a/test/cri-containerd/execcontainer_test.go
+++ b/test/cri-containerd/execcontainer_test.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"testing"
 
-	runtime "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
 func runexecContainerTestWithSandbox(t *testing.T, sandboxRequest *runtime.RunPodSandboxRequest, request *runtime.CreateContainerRequest, execReq *runtime.ExecSyncRequest) *runtime.ExecSyncResponse {

--- a/test/cri-containerd/helper_container_test.go
+++ b/test/cri-containerd/helper_container_test.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"testing"
 
-	runtime "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
 func createContainer(t *testing.T, client runtime.RuntimeServiceClient, ctx context.Context, request *runtime.CreateContainerRequest) string {

--- a/test/cri-containerd/helper_exec_test.go
+++ b/test/cri-containerd/helper_exec_test.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/Microsoft/hcsshim/internal/cmd"
 	"github.com/Microsoft/hcsshim/internal/shimdiag"
-	runtime "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
 func execSync(t *testing.T, client runtime.RuntimeServiceClient, ctx context.Context, request *runtime.ExecSyncRequest) *runtime.ExecSyncResponse {

--- a/test/cri-containerd/helper_sandbox_test.go
+++ b/test/cri-containerd/helper_sandbox_test.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"testing"
 
-	runtime "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
 type SandboxConfigOpt func(*runtime.PodSandboxConfig) error

--- a/test/cri-containerd/helper_update_utilities_test.go
+++ b/test/cri-containerd/helper_update_utilities_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 
 	"github.com/Microsoft/hcsshim/internal/shimdiag"
-	runtime "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
 const podJobObjectUtilPath = "C:\\jobobject-util.exe"

--- a/test/cri-containerd/jobcontainer_test.go
+++ b/test/cri-containerd/jobcontainer_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/Microsoft/hcsshim/osversion"
 	"github.com/Microsoft/hcsshim/pkg/annotations"
 	testutilities "github.com/Microsoft/hcsshim/test/functional/utilities"
-	runtime "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
 func getJobContainerPodRequestWCOW(t *testing.T) *runtime.RunPodSandboxRequest {

--- a/test/cri-containerd/logging_binary_test.go
+++ b/test/cri-containerd/logging_binary_test.go
@@ -13,7 +13,7 @@ import (
 	"testing"
 	"time"
 
-	runtime "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
 // This test requires compiling a helper logging binary which can be found

--- a/test/cri-containerd/main_test.go
+++ b/test/cri-containerd/main_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/containerd/typeurl"
 	"github.com/gogo/protobuf/types"
 	"google.golang.org/grpc"
-	runtime "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
 const (

--- a/test/cri-containerd/pod_update_test.go
+++ b/test/cri-containerd/pod_update_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/Microsoft/hcsshim/internal/memory"
 	"github.com/Microsoft/hcsshim/internal/processorinfo"
 	"github.com/Microsoft/hcsshim/pkg/annotations"
-	runtime "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
 func Test_Pod_UpdateResources_Memory(t *testing.T) {

--- a/test/cri-containerd/policy_test.go
+++ b/test/cri-containerd/policy_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	runtime "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 
 	"github.com/Microsoft/hcsshim/internal/tools/securitypolicy/helpers"
 	"github.com/Microsoft/hcsshim/pkg/annotations"

--- a/test/cri-containerd/removepodsandbox_test.go
+++ b/test/cri-containerd/removepodsandbox_test.go
@@ -9,7 +9,7 @@ import (
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	runtime "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
 type TestConfig struct {

--- a/test/cri-containerd/runpodsandbox_test.go
+++ b/test/cri-containerd/runpodsandbox_test.go
@@ -25,7 +25,7 @@ import (
 	testutilities "github.com/Microsoft/hcsshim/test/functional/utilities"
 	"github.com/containerd/containerd/log"
 	"golang.org/x/sys/windows"
-	runtime "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
 func runPodSandboxTest(t *testing.T, request *runtime.RunPodSandboxRequest) {

--- a/test/cri-containerd/scale_cpu_limits_to_sandbox_test.go
+++ b/test/cri-containerd/scale_cpu_limits_to_sandbox_test.go
@@ -12,7 +12,7 @@ import (
 	"time"
 
 	"github.com/Microsoft/hcsshim/pkg/annotations"
-	criruntime "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	criruntime "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
 const imageWindowsMaxCPUWorkload = "cplatpublic.azurecr.io/golang-1.16.2-nanoserver-1809:max-cpu-workload"

--- a/test/cri-containerd/stats_test.go
+++ b/test/cri-containerd/stats_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/Microsoft/hcsshim/internal/memory"
 	"github.com/Microsoft/hcsshim/pkg/annotations"
 
-	runtime "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
 func runContainerAndQueryStats(t *testing.T, client runtime.RuntimeServiceClient, ctx context.Context, request *runtime.CreateContainerRequest) {

--- a/test/cri-containerd/stopcontainer_test.go
+++ b/test/cri-containerd/stopcontainer_test.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"testing"
 
-	runtime "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
 func Test_StopContainer_LCOW(t *testing.T) {


### PR DESCRIPTION
This PR depends on changes in https://github.com/kevpar/cri/pull/40.

Signed-off-by: Kathryn Baldauf <kabaldau@microsoft.com>