### PR TITLE
Safeguards on slicing hostprocess username

### DIFF
--- a/cmd/containerd-shim-runhcs-v1/delete.go
+++ b/cmd/containerd-shim-runhcs-v1/delete.go
@@ -107,15 +107,18 @@ The delete command will be executed in the container's bundle as its cwd.
 		// be deleted, but if the shim crashed unexpectedly (panic, terminated etc.) then the account may still be around.
 		// The username will be the container ID so try and delete it here. The username character limit is 20, so we need to
 		// slice down the container ID a bit.
-		username := idFlag[:winapi.UserNameCharLimit]
+		userName := idFlag
+		if len(userName) > winapi.UserNameCharLimit {
+			userName = userName[:winapi.UserNameCharLimit]
+		}
 
 		// Always try and delete the user, if it doesn't exist we'll get a specific error code that we can use to
 		// not log any warnings.
 		if err := winapi.NetUserDel(
 			"",
-			username,
+			userName,
 		); err != nil && err != winapi.NERR_UserNotFound {
-			fmt.Fprintf(os.Stderr, "failed to delete user %q: %v", username, err)
+			fmt.Fprintf(os.Stderr, "failed to delete user %q: %v", userName, err)
 		}
 
 		if data, err := proto.Marshal(&task.DeleteResponse{

--- a/internal/jobcontainers/logon.go
+++ b/internal/jobcontainers/logon.go
@@ -110,7 +110,10 @@ func (c *JobContainer) processToken(ctx context.Context, userOrGroup string) (wi
 	}
 
 	if groupExists(userOrGroup) {
-		userName = c.id[:winapi.UserNameCharLimit]
+		userName := c.id
+		if len(userName) > winapi.UserNameCharLimit {
+			userName = userName[:winapi.UserNameCharLimit]
+		}
 		pswd, err := makeLocalAccount(ctx, userName, userOrGroup)
 		if err != nil {
 			return 0, fmt.Errorf("failed to create local account for container: %w", err)


### PR DESCRIPTION
Adds some checks to make sure the container ID we get from the runtime
is greater than the max character limit for a username before slicing
it down.

HostProcess containers are a k8s feature for the most part and
Containerd's container ID generation for CRI outputs IDs that are
grater than 20 characters, however it's not good to rely on this implementation
detail. Other Containerd clients (ctr, nerdctl) trying to launch a
hostprocess container manually with a provided ID would panic here
if it was < 20 characters.