### PR TITLE
fix shared scratch scenario

### DIFF
--- a/internal/layers/layers.go
+++ b/internal/layers/layers.go
@@ -128,7 +128,6 @@ func MountLCOWLayers(ctx context.Context, containerID string, layerFolders []str
 		return "", "", fmt.Errorf("failed to add SCSI scratch VHD: %s", err)
 	}
 
-	containerScratchPathInUVM = scsiMount.UVMPath
 	// handles the case where we want to share a scratch disk for multiple containers instead
 	// of mounting a new one. Pass a unique value for `ScratchPath` to avoid container upper and
 	// work directories colliding in the UVM.


### PR DESCRIPTION
When mounting container layers we override containerScratchPathInUVM
with scsiMount.UVMPath after calling into vm.AddSCSI(...), which is
fine in scenarios when scratch disk isn't shared. In case when scratch
sharing is enabled, the scsiMount returned has sandbox container's
scratch path and we end up mounting all of the workload containers'
overlay at `/run/gcs/c/<podid>/container_<podid>` instead of
`/run/gcs/c/<podid>/container_<cid1>` and `/run/gcs/c/<podid>/container_<cid2>`.

Fix by removing the unnecessary assignment.

Signed-off-by: Maksim An <maksiman@microsoft.com>