### PR TITLE
Remove log file from runc commands

### DIFF
--- a/internal/guest/bridge/bridge_v2.go
+++ b/internal/guest/bridge/bridge_v2.go
@@ -518,11 +518,12 @@ func (b *Bridge) deleteContainerStateV2(r *Request) (_ RequestResponse, err erro
 	if err != nil {
 		return nil, err
 	}
+	// remove container state regardless of delete's success
+	defer b.hostState.RemoveContainer(request.ContainerID)
 
 	if err := c.Delete(ctx); err != nil {
 		return nil, err
 	}
 
-	b.hostState.RemoveContainer(request.ContainerID)
 	return &prot.MessageResponseBase{}, nil
 }


### PR DESCRIPTION
Certain runc commands (eg, Delete, State) do not need to use a log file
since runc does not consume the stdio and pass it to the container.
This PR switches the commands to consume the error directly from stderr,
without needing to parse from a file.

This fixes a bug where the directory containing the runc log file for a
container is deleted before the container itself can be deleted via the
runc command.
Runc errors that the directory containing the logfile does not exist, but since the returned error is `errors.Wrapf(runcErr,...)`, where `runcErr` is parsed from the logfile, it ends up being nil.
The fix is to read directly from stderr, skipping the log file.
Additionally, even if the runc delete command errors, the container is still deleted from the `gcs`, since if runc was able to delete successfully delete the container but still errored, future restarts will be successful.

Signed-off-by: Hamza El-Saawy <hamzaelsaawy@microsoft.com>