### PR TITLE
Correctly set silo field when opening job object

### DIFF
--- a/internal/jobobject/jobobject.go
+++ b/internal/jobobject/jobobject.go
@@ -195,7 +195,7 @@ func Open(ctx context.Context, options *Options) (_ *JobObject, err error) {
 		handle: jobHandle,
 	}
 
-	if job.isOpenedJobSilo() {
+	if isJobSilo(jobHandle) {
 		job.silo = 1
 	}
 
@@ -507,9 +507,9 @@ func (job *JobObject) ApplyFileBinding(root, target string, merged bool) error {
 	return nil
 }
 
-// isOpenedJobSilo is a helper to determine if a job object that was opened is a silo. This should ONLY be called
+// isJobSilo is a helper to determine if a job object that was opened is a silo. This should ONLY be called
 // from `Open` and any callers in this package afterwards should use `job.isSilo()``
-func (job *JobObject) isOpenedJobSilo() bool {
+func isJobSilo(h windows.Handle) bool {
 	// None of the information from the structure that this info class expects will be used, this is just used as
 	// the call will fail if the job hasn't been upgraded to a silo so we can use this to tell when we open a job
 	// if it's a silo or not. Because none of the info matters simply define a dummy struct with the size that the call
@@ -519,7 +519,7 @@ func (job *JobObject) isOpenedJobSilo() bool {
 	}
 	var siloInfo isSiloObj
 	err := winapi.QueryInformationJobObject(
-		job.handle,
+		h,
 		winapi.JobObjectSiloBasicInformation,
 		unsafe.Pointer(&siloInfo),
 		uint32(unsafe.Sizeof(siloInfo)),

--- a/internal/jobobject/jobobject_test.go
+++ b/internal/jobobject/jobobject_test.go
@@ -40,6 +40,31 @@ func TestJobCreateAndOpen(t *testing.T) {
 	defer jobOpen.Close()
 }
 
+func TestSiloCreateAndOpen(t *testing.T) {
+	var (
+		ctx     = context.Background()
+		options = &Options{
+			Name: "test",
+			Silo: true,
+		}
+	)
+	jobCreate, err := Create(ctx, options)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer jobCreate.Close()
+
+	jobOpen, err := Open(ctx, options)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer jobOpen.Close()
+
+	if !jobOpen.isSilo() {
+		t.Fatal("job is supposed to be a silo")
+	}
+}
+
 func createProcsAndAssign(num int, job *JobObject) (_ []*exec.Cmd, err error) {
 	var procs []*exec.Cmd
 

--- a/internal/winapi/jobobject.go
+++ b/internal/winapi/jobobject.go
@@ -58,6 +58,7 @@ const (
 	JobObjectMemoryUsageInformation          uint32 = 28
 	JobObjectNotificationLimitInformation2   uint32 = 33
 	JobObjectCreateSilo                      uint32 = 35
+	JobObjectSiloBasicInformation            uint32 = 36
 	JobObjectIoAttribution                   uint32 = 42
 )
 


### PR DESCRIPTION
We don't set the silo field on Open of an existing job object today.
This is useful if once opening a job we want to bind a file that only
that silo can see as it relies on atomically checking the `silo` u32
field to determine if we can carry out the operation.

The manner in which we check if the job is a silo is by using a new
jobobject information class with QueryInformationJobObject that fails
unless the job is a silo.