### PR TITLE
pkg/securitypolicy: minimal unittest fixes to get securitypolicy_test to pass.

### DIFF
--- a/pkg/securitypolicy/securitypolicy_test.go
+++ b/pkg/securitypolicy/securitypolicy_test.go
@@ -422,10 +422,10 @@ func Test_EnforceCommandPolicy_NarrowingMatches(t *testing.T) {
 		// create two additional containers that "share everything"
 		// except that they have different commands
 		testContainerOne := generateContainersContainer(testRand, 5)
-		testContainerTwo := testContainerOne
+		var testContainerTwo securityPolicyContainer = *testContainerOne
 		testContainerTwo.Command = generateCommand(testRand)
 		// add new containers to policy before creating enforcer
-		p.containers = append(p.containers, testContainerOne, testContainerTwo)
+		p.containers = append(p.containers, testContainerOne, &testContainerTwo)
 
 		policy := NewStandardSecurityPolicyEnforcer(p.containers, ignoredEncodedPolicyString)
 
@@ -452,7 +452,7 @@ func Test_EnforceCommandPolicy_NarrowingMatches(t *testing.T) {
 				testContainerOneID = containerID
 				indexForContainerOne = index
 			}
-			if cmp.Equal(container, testContainerTwo) {
+			if cmp.Equal(container, &testContainerTwo) {
 				testContainerTwoID = containerID
 				indexForContainerTwo = index
 			}
@@ -609,10 +609,10 @@ func Test_EnforceEnvironmentVariablePolicy_NarrowingMatches(t *testing.T) {
 		// create two additional containers that "share everything"
 		// except that they have different environment variables
 		testContainerOne := generateContainersContainer(r, 5)
-		testContainerTwo := testContainerOne
+		var testContainerTwo securityPolicyContainer = *testContainerOne
 		testContainerTwo.EnvRules = generateEnvironmentVariableRules(r)
 		// add new containers to policy before creating enforcer
-		p.containers = append(p.containers, testContainerOne, testContainerTwo)
+		p.containers = append(p.containers, testContainerOne, &testContainerTwo)
 
 		policy := NewStandardSecurityPolicyEnforcer(p.containers, ignoredEncodedPolicyString)
 
@@ -639,7 +639,7 @@ func Test_EnforceEnvironmentVariablePolicy_NarrowingMatches(t *testing.T) {
 				testContainerOneID = containerID
 				indexForContainerOne = index
 			}
-			if cmp.Equal(container, testContainerTwo) {
+			if cmp.Equal(container, &testContainerTwo) {
 				testContainerTwoID = containerID
 				indexForContainerTwo = index
 			}

--- a/pkg/securitypolicy/securitypolicyenforcer.go
+++ b/pkg/securitypolicy/securitypolicyenforcer.go
@@ -75,7 +75,7 @@ type standardEnforcerOpt func(e *StandardSecurityPolicyEnforcer) error
 func WithPrivilegedMounts(mounts []oci.Mount) standardEnforcerOpt {
 	return func(e *StandardSecurityPolicyEnforcer) error {
 		for _, c := range e.Containers {
-			if c.allowElevated {
+			if c.AllowElevated {
 				for _, m := range mounts {
 					mi := mountInternal{
 						Source:      m.Source,
@@ -110,7 +110,7 @@ type securityPolicyContainer struct {
 	WaitMountPoints []string
 	// A list of constraints for determining if a given mount is allowed.
 	Mounts        []mountInternal
-	allowElevated bool
+	AllowElevated bool
 }
 
 type StandardSecurityPolicyEnforcer struct {
@@ -279,7 +279,7 @@ func (c Container) toInternal() (securityPolicyContainer, error) {
 		WorkingDir:      c.WorkingDir,
 		WaitMountPoints: waitMounts,
 		Mounts:          mounts,
-		allowElevated:   c.AllowElevated,
+		AllowElevated:   c.AllowElevated,
 	}, nil
 }
 


### PR DESCRIPTION
An unexported struct field (allowElevated) was causing test failures.
Additionally, struct ref/value inconsistencies were causing test failures.