### PR TITLE
Update hcs errors to gov1.13 style

### DIFF
--- a/cmd/containerd-shim-runhcs-v1/task.go
+++ b/cmd/containerd-shim-runhcs-v1/task.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/Microsoft/hcsshim/cmd/containerd-shim-runhcs-v1/options"
 	"github.com/Microsoft/hcsshim/cmd/containerd-shim-runhcs-v1/stats"
-	"github.com/Microsoft/hcsshim/internal/gcs"
 	"github.com/Microsoft/hcsshim/internal/hcs"
 	"github.com/Microsoft/hcsshim/internal/shimdiag"
 	"github.com/Microsoft/hcsshim/pkg/ctrdtaskapi"
@@ -123,7 +122,6 @@ func isStatsNotFound(err error) bool {
 	return errdefs.IsNotFound(err) ||
 		hcs.IsNotExist(err) ||
 		hcs.IsOperationInvalidState(err) ||
-		gcs.IsNotExist(err) ||
 		hcs.IsAccessIsDenied(err) ||
 		hcs.IsErrorInvalidHandle(err)
 }

--- a/hcsshim.go
+++ b/hcsshim.go
@@ -6,7 +6,7 @@
 package hcsshim
 
 import (
-	"syscall"
+	"golang.org/x/sys/windows"
 
 	"github.com/Microsoft/hcsshim/internal/hcserror"
 )
@@ -19,9 +19,9 @@ const (
 	// Specific user-visible exit codes
 	WaitErrExecFailed = 32767
 
-	ERROR_GEN_FAILURE          = hcserror.ERROR_GEN_FAILURE
-	ERROR_SHUTDOWN_IN_PROGRESS = syscall.Errno(1115)
-	WSAEINVAL                  = syscall.Errno(10022)
+	ERROR_GEN_FAILURE          = windows.ERROR_GEN_FAILURE
+	ERROR_SHUTDOWN_IN_PROGRESS = windows.ERROR_SHUTDOWN_IN_PROGRESS
+	WSAEINVAL                  = windows.WSAEINVAL
 
 	// Timeout on wait calls
 	TimeoutInfinite = 0xFFFFFFFF

--- a/internal/hcs/errors.go
+++ b/internal/hcs/errors.go
@@ -170,7 +170,7 @@ func (e *HcsError) Unwrap() error {
 // Deprecated: net.Error.Temporary is deprecated.
 func (e *HcsError) Temporary() bool {
 	err := e.netError()
-	return (err != nil) && err.Temporary() //nolint:staticcheck // Temporary() is deprecated
+	return (err != nil) && err.Temporary()
 }
 
 func (e *HcsError) Timeout() bool {
@@ -203,7 +203,8 @@ func (e *SystemError) Error() string {
 
 func makeSystemError(system *System, op string, err error, events []ErrorEvent) error {
 	// Don't double wrap errors
-	if e := (&SystemError{}); errors.As(err, &e) {
+	var e *SystemError
+	if errors.As(err, &e) {
 		return err
 	}
 
@@ -236,7 +237,8 @@ func (e *ProcessError) Error() string {
 
 func makeProcessError(process *Process, op string, err error, events []ErrorEvent) error {
 	// Don't double wrap errors
-	if e := (&ProcessError{}); errors.As(err, &e) {
+	var e *ProcessError
+	if errors.As(err, &e) {
 		return err
 	}
 	return &ProcessError{

--- a/internal/hcs/errors.go
+++ b/internal/hcs/errors.go
@@ -87,7 +87,7 @@ var (
 	// ErrProcessAlreadyStopped is returned by hcs if the process we're trying to kill has already been stopped.
 	ErrProcessAlreadyStopped = syscall.Errno(0x8037011f)
 
-	// ErrInvalidHandle is an error that can be encountrered when querying the properties of a compute system when the handle to that
+	// ErrInvalidHandle is an error that can be encountered when querying the properties of a compute system when the handle to that
 	// compute system has already been closed.
 	ErrInvalidHandle = syscall.Errno(0x6)
 )
@@ -157,33 +157,38 @@ func (e *HcsError) Error() string {
 	return s
 }
 
+func (e *HcsError) Is(target error) bool {
+	return errors.Is(e.Err, target)
+}
+
+// unwrap isnt really needed, but helpful convince function
+
+func (e *HcsError) Unwrap() error {
+	return e.Err
+}
+
+// Deprecated: net.Error.Temporary is deprecated.
 func (e *HcsError) Temporary() bool {
-	err, ok := e.Err.(net.Error)
-	return ok && err.Temporary() //nolint:staticcheck
+	err := e.netError()
+	return (err != nil) && err.Temporary() //nolint:staticcheck // Temporary() is deprecated
 }
 
 func (e *HcsError) Timeout() bool {
-	err, ok := e.Err.(net.Error)
-	return ok && err.Timeout()
+	err := e.netError()
+	return (err != nil) && err.Timeout()
 }
 
-// ProcessError is an error encountered in HCS during an operation on a Process object
-type ProcessError struct {
-	SystemID string
-	Pid      int
-	Op       string
-	Err      error
-	Events   []ErrorEvent
+func (e *HcsError) netError() (err net.Error) {
+	if errors.As(e.Unwrap(), &err) {
+		return err
+	}
+	return nil
 }
-
-var _ net.Error = &ProcessError{}
 
 // SystemError is an error encountered in HCS during an operation on a Container object
 type SystemError struct {
-	ID     string
-	Op     string
-	Err    error
-	Events []ErrorEvent
+	HcsError
+	ID string
 }
 
 var _ net.Error = &SystemError{}
@@ -196,28 +201,30 @@ func (e *SystemError) Error() string {
 	return s
 }
 
-func (e *SystemError) Temporary() bool {
-	err, ok := e.Err.(net.Error)
-	return ok && err.Temporary() //nolint:staticcheck
-}
-
-func (e *SystemError) Timeout() bool {
-	err, ok := e.Err.(net.Error)
-	return ok && err.Timeout()
-}
-
 func makeSystemError(system *System, op string, err error, events []ErrorEvent) error {
 	// Don't double wrap errors
-	if _, ok := err.(*SystemError); ok {
+	if e := (&SystemError{}); errors.As(err, &e) {
 		return err
 	}
+
 	return &SystemError{
-		ID:     system.ID(),
-		Op:     op,
-		Err:    err,
-		Events: events,
+		ID: system.ID(),
+		HcsError: HcsError{
+			Op:     op,
+			Err:    err,
+			Events: events,
+		},
 	}
 }
+
+// ProcessError is an error encountered in HCS during an operation on a Process object
+type ProcessError struct {
+	HcsError
+	SystemID string
+	Pid      int
+}
+
+var _ net.Error = &ProcessError{}
 
 func (e *ProcessError) Error() string {
 	s := fmt.Sprintf("%s %s:%d: %s", e.Op, e.SystemID, e.Pid, e.Err.Error())
@@ -227,27 +234,19 @@ func (e *ProcessError) Error() string {
 	return s
 }
 
-func (e *ProcessError) Temporary() bool {
-	err, ok := e.Err.(net.Error)
-	return ok && err.Temporary() //nolint:staticcheck
-}
-
-func (e *ProcessError) Timeout() bool {
-	err, ok := e.Err.(net.Error)
-	return ok && err.Timeout()
-}
-
 func makeProcessError(process *Process, op string, err error, events []ErrorEvent) error {
 	// Don't double wrap errors
-	if _, ok := err.(*ProcessError); ok {
+	if e := (&ProcessError{}); errors.As(err, &e) {
 		return err
 	}
 	return &ProcessError{
 		Pid:      process.Pid(),
 		SystemID: process.SystemID(),
-		Op:       op,
-		Err:      err,
-		Events:   events,
+		HcsError: HcsError{
+			Op:     op,
+			Err:    err,
+			Events: events,
+		},
 	}
 }
 
@@ -256,41 +255,41 @@ func makeProcessError(process *Process, op string, err error, events []ErrorEven
 // already exited, or does not exist. Both IsAlreadyStopped and IsNotExist
 // will currently return true when the error is ErrElementNotFound.
 func IsNotExist(err error) bool {
-	err = getInnerError(err)
-	return errors.Is(err, ErrComputeSystemDoesNotExist) ||
-		errors.Is(err, ErrElementNotFound)
+	return IsAny(err, ErrComputeSystemDoesNotExist, ErrElementNotFound)
 }
 
 // IsErrorInvalidHandle checks whether the error is the result of an operation carried
 // out on a handle that is invalid/closed. This error popped up while trying to query
 // stats on a container in the process of being stopped.
 func IsErrorInvalidHandle(err error) bool {
-	err = getInnerError(err)
 	return errors.Is(err, ErrInvalidHandle)
 }
 
 // IsAlreadyClosed checks if an error is caused by the Container or Process having been
 // already closed by a call to the Close() method.
 func IsAlreadyClosed(err error) bool {
-	err = getInnerError(err)
 	return errors.Is(err, ErrAlreadyClosed)
 }
 
 // IsPending returns a boolean indicating whether the error is that
 // the requested operation is being completed in the background.
 func IsPending(err error) bool {
-	err = getInnerError(err)
 	return errors.Is(err, ErrVmcomputeOperationPending)
 }
 
 // IsTimeout returns a boolean indicating whether the error is caused by
 // a timeout waiting for the operation to complete.
 func IsTimeout(err error) bool {
-	if err, ok := err.(net.Error); ok && err.Timeout() {
+	// HcsError and co. implement Timeout regardless of whether the errors they wrap do,
+	// so `errors.As(err, net.Error)`` will always be true.
+	// Using `errors.As(err.Unwrap(), net.Err)` wont work for general errors.
+	// So first check if there an `ErrTimeout` in the chain, then convert to a net error.
+	if errors.Is(err, ErrTimeout) {
 		return true
 	}
-	err = getInnerError(err)
-	return errors.Is(err, ErrTimeout)
+
+	var nerr net.Error
+	return errors.As(err, &nerr) && nerr.Timeout()
 }
 
 // IsAlreadyStopped returns a boolean indicating whether the error is caused by
@@ -299,10 +298,7 @@ func IsTimeout(err error) bool {
 // already exited, or does not exist. Both IsAlreadyStopped and IsNotExist
 // will currently return true when the error is ErrElementNotFound.
 func IsAlreadyStopped(err error) bool {
-	err = getInnerError(err)
-	return errors.Is(err, ErrVmcomputeAlreadyStopped) ||
-		errors.Is(err, ErrProcessAlreadyStopped) ||
-		errors.Is(err, ErrElementNotFound)
+	return IsAny(err, ErrVmcomputeAlreadyStopped, ErrProcessAlreadyStopped, ErrElementNotFound)
 }
 
 // IsNotSupported returns a boolean indicating whether the error is caused by
@@ -311,38 +307,28 @@ func IsAlreadyStopped(err error) bool {
 // ErrVmcomputeInvalidJSON, ErrInvalidData, ErrNotSupported or ErrVmcomputeUnknownMessage
 // is thrown from the Platform
 func IsNotSupported(err error) bool {
-	err = getInnerError(err)
 	// If Platform doesn't recognize or support the request sent, below errors are seen
-	return errors.Is(err, ErrVmcomputeInvalidJSON) ||
-		errors.Is(err, ErrInvalidData) ||
-		errors.Is(err, ErrNotSupported) ||
-		errors.Is(err, ErrVmcomputeUnknownMessage)
+	return IsAny(err, ErrVmcomputeInvalidJSON, ErrInvalidData, ErrNotSupported, ErrVmcomputeUnknownMessage)
 }
 
 // IsOperationInvalidState returns true when err is caused by
 // `ErrVmcomputeOperationInvalidState`.
 func IsOperationInvalidState(err error) bool {
-	err = getInnerError(err)
 	return errors.Is(err, ErrVmcomputeOperationInvalidState)
 }
 
 // IsAccessIsDenied returns true when err is caused by
 // `ErrVmcomputeOperationAccessIsDenied`.
 func IsAccessIsDenied(err error) bool {
-	err = getInnerError(err)
 	return errors.Is(err, ErrVmcomputeOperationAccessIsDenied)
 }
 
-func getInnerError(err error) error {
-	switch pe := err.(type) {
-	case nil:
-		return nil
-	case *HcsError:
-		err = pe.Err
-	case *SystemError:
-		err = pe.Err
-	case *ProcessError:
-		err = pe.Err
+// IsAny is a vectorized version of [errors.Is], it returns true if err is one of targets.
+func IsAny(err error, targets ...error) bool {
+	for _, e := range targets {
+		if errors.Is(err, e) {
+			return true
+		}
 	}
-	return err
+	return false
 }

--- a/internal/hcs/errors_test.go
+++ b/internal/hcs/errors_test.go
@@ -38,14 +38,16 @@ func TestHcsErrorUnwrap(t *testing.T) {
 				t.Errorf("error '%v' did not unwrap to %v", nerr, err)
 			}
 
-			if err2 := (&MyError{}); !(errors.As(nerr, &err2) && err2.S == err.S) {
-				t.Errorf("error '%v' did not unwrap '%v' properly", errors.Unwrap(nerr), err2)
+			var e *MyError
+			if !(errors.As(nerr, &e) && e.S == err.S) {
+				t.Errorf("error '%v' did not unwrap '%v' properly", errors.Unwrap(nerr), e)
 			}
 
 			if nerr.Timeout() {
 				t.Errorf("expected .Timeout() on '%v' to be false", nerr)
 			}
 
+			//nolint:staticcheck // Temporary() is deprecated
 			if nerr.Temporary() {
 				t.Errorf("expected .Temporary() on '%v' to be false", nerr)
 			}
@@ -88,6 +90,7 @@ func TestHcsErrorUnwrapTimeout(t *testing.T) {
 				t.Errorf("expected .Timeout() on '%v' to be false", nerr)
 			}
 
+			//nolint:staticcheck // Temporary() is deprecated
 			if nerr.Temporary() {
 				t.Errorf("expected .Temporary() on '%v' to be false", nerr)
 			}
@@ -138,6 +141,7 @@ func TestHcsErrorUnwrapNet(t *testing.T) {
 				t.Errorf("expected .Timeout() on '%v' to be true", nerr)
 			}
 
+			//nolint:staticcheck // Temporary() is deprecated
 			if !nerr.Temporary() {
 				t.Errorf("expected .Temporary() on '%v' to be true", nerr)
 			}

--- a/internal/hcs/errors_test.go
+++ b/internal/hcs/errors_test.go
@@ -1,0 +1,146 @@
+package hcs
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"testing"
+)
+
+type MyError struct {
+	S string
+}
+
+func (e *MyError) Error() string {
+	return fmt.Sprintf("error happened: %s", e.S)
+}
+
+func TestHcsErrorUnwrap(t *testing.T) {
+	err := &MyError{"test test"}
+	herr := HcsError{
+		Op:  t.Name(),
+		Err: err,
+	}
+
+	for _, nerr := range []net.Error{
+		&herr,
+		&SystemError{
+			ID:       t.Name(),
+			HcsError: herr,
+		},
+		&ProcessError{
+			SystemID: t.Name(),
+			HcsError: herr,
+		},
+	} {
+		t.Run(fmt.Sprintf("%T", nerr), func(t *testing.T) {
+			if !errors.Is(nerr, err) {
+				t.Errorf("error '%v' did not unwrap to %v", nerr, err)
+			}
+
+			if err2 := (&MyError{}); !(errors.As(nerr, &err2) && err2.S == err.S) {
+				t.Errorf("error '%v' did not unwrap '%v' properly", errors.Unwrap(nerr), err2)
+			}
+
+			if nerr.Timeout() {
+				t.Errorf("expected .Timeout() on '%v' to be false", nerr)
+			}
+
+			if nerr.Temporary() {
+				t.Errorf("expected .Temporary() on '%v' to be false", nerr)
+			}
+		})
+	}
+}
+
+func TestHcsErrorUnwrapTimeout(t *testing.T) {
+	err := fmt.Errorf("error: %w", ErrTimeout)
+	herr := HcsError{
+		Op:  "test",
+		Err: err,
+	}
+
+	for _, nerr := range []net.Error{
+		&herr,
+		&SystemError{
+			ID:       t.Name(),
+			HcsError: herr,
+		},
+		&ProcessError{
+			SystemID: t.Name(),
+			HcsError: herr,
+		},
+	} {
+		t.Run(fmt.Sprintf("%T", nerr), func(t *testing.T) {
+			if !errors.Is(nerr, ErrTimeout) {
+				t.Errorf("error '%v' did not unwrap to %v", nerr, ErrTimeout)
+			}
+
+			if !errors.Is(nerr, err) {
+				t.Errorf("error '%v' did not unwrap to %v", nerr, err)
+			}
+
+			if !IsTimeout(nerr) {
+				t.Errorf("expected error '%v' to be timeout", nerr)
+			}
+
+			if nerr.Timeout() {
+				t.Errorf("expected .Timeout() on '%v' to be false", nerr)
+			}
+
+			if nerr.Temporary() {
+				t.Errorf("expected .Temporary() on '%v' to be false", nerr)
+			}
+		})
+	}
+}
+
+var errNet = netError{}
+
+type netError struct{}
+
+func (e netError) Error() string   { return "temporary timeout" }
+func (e netError) Timeout() bool   { return true }
+func (e netError) Temporary() bool { return true }
+
+func TestHcsErrorUnwrapNet(t *testing.T) {
+	err := fmt.Errorf("error: %w", errNet)
+	herr := HcsError{
+		Op:  "test",
+		Err: err,
+	}
+
+	for _, nerr := range []net.Error{
+		&herr,
+		&SystemError{
+			ID:       t.Name(),
+			HcsError: herr,
+		},
+		&ProcessError{
+			SystemID: t.Name(),
+			HcsError: herr,
+		},
+	} {
+		t.Run(fmt.Sprintf("%T", nerr), func(t *testing.T) {
+			if !errors.Is(nerr, errNet) {
+				t.Errorf("error '%v' did not unwrap to %v", nerr, errNet)
+			}
+
+			if !errors.Is(nerr, err) {
+				t.Errorf("error '%v' did not unwrap to %v", nerr, err)
+			}
+
+			if !IsTimeout(nerr) {
+				t.Errorf("expected error '%v' to be timeout", nerr)
+			}
+
+			if !nerr.Timeout() {
+				t.Errorf("expected .Timeout() on '%v' to be true", nerr)
+			}
+
+			if !nerr.Temporary() {
+				t.Errorf("expected .Temporary() on '%v' to be true", nerr)
+			}
+		})
+	}
+}

--- a/internal/hcserror/hcserror.go
+++ b/internal/hcserror/hcserror.go
@@ -32,17 +32,20 @@ func (e *HcsError) Error() string {
 
 func New(err error, title, rest string) error {
 	// Pass through DLL errors directly since they do not originate from HCS.
-	if t := (&windows.DLLError{}); errors.As(err, &t) {
+	var e *windows.DLLError
+	if errors.As(err, &e) {
 		return err
 	}
 	return &HcsError{title, rest, err}
 }
 
 func Win32FromError(err error) uint32 {
-	if herr := (&HcsError{}); errors.As(err, &herr) {
+	var herr *HcsError
+	if errors.As(err, &herr) {
 		return Win32FromError(herr.Err)
 	}
-	if code := (windows.Errno(0)); errors.As(err, &code) {
+	var code windows.Errno
+	if errors.As(err, &code) {
 		return uint32(code)
 	}
 	return uint32(windows.ERROR_GEN_FAILURE)

--- a/internal/hcserror/hcserror.go
+++ b/internal/hcserror/hcserror.go
@@ -3,11 +3,11 @@
 package hcserror
 
 import (
+	"errors"
 	"fmt"
-	"syscall"
-)
 
-const ERROR_GEN_FAILURE = syscall.Errno(31)
+	"golang.org/x/sys/windows"
+)
 
 type HcsError struct {
 	title string
@@ -32,18 +32,18 @@ func (e *HcsError) Error() string {
 
 func New(err error, title, rest string) error {
 	// Pass through DLL errors directly since they do not originate from HCS.
-	if _, ok := err.(*syscall.DLLError); ok {
+	if t := (&windows.DLLError{}); errors.As(err, &t) {
 		return err
 	}
 	return &HcsError{title, rest, err}
 }
 
 func Win32FromError(err error) uint32 {
-	if herr, ok := err.(*HcsError); ok {
+	if herr := (&HcsError{}); errors.As(err, &herr) {
 		return Win32FromError(herr.Err)
 	}
-	if code, ok := err.(syscall.Errno); ok {
+	if code := (windows.Errno(0)); errors.As(err, &code) {
 		return uint32(code)
 	}
-	return uint32(ERROR_GEN_FAILURE)
+	return uint32(windows.ERROR_GEN_FAILURE)
 }

--- a/internal/uvm/start.go
+++ b/internal/uvm/start.go
@@ -93,7 +93,7 @@ func parseLogrus(vmid string) func(r io.Reader) {
 			if err != nil {
 				// Something went wrong. Read the rest of the data as a single
 				// string and log it at once -- it's probably a GCS panic stack.
-				if errors.Is(err, io.EOF) && !isDisconnectError(err) {
+				if !errors.Is(err, io.EOF) && !isDisconnectError(err) {
 					logrus.WithFields(logrus.Fields{
 						logfields.UVMID: vmid,
 						logrus.ErrorKey: err,

--- a/internal/uvm/start.go
+++ b/internal/uvm/start.go
@@ -7,17 +7,18 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
-	"os"
-	"syscall"
 	"time"
 
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sync/errgroup"
+	"golang.org/x/sys/windows"
 
 	"github.com/Microsoft/hcsshim/internal/gcs"
+	"github.com/Microsoft/hcsshim/internal/hcs"
 	"github.com/Microsoft/hcsshim/internal/hcs/schema1"
 	hcsschema "github.com/Microsoft/hcsshim/internal/hcs/schema2"
 	"github.com/Microsoft/hcsshim/internal/log"
@@ -75,12 +76,7 @@ func (e *gcsLogEntry) UnmarshalJSON(b []byte) error {
 }
 
 func isDisconnectError(err error) bool {
-	if o, ok := err.(*net.OpError); ok {
-		if s, ok := o.Err.(*os.SyscallError); ok {
-			return s.Err == syscall.WSAECONNABORTED || s.Err == syscall.WSAECONNRESET
-		}
-	}
-	return false
+	return hcs.IsAny(err, windows.WSAECONNABORTED, windows.WSAECONNRESET)
 }
 
 func parseLogrus(vmid string) func(r io.Reader) {
@@ -97,7 +93,7 @@ func parseLogrus(vmid string) func(r io.Reader) {
 			if err != nil {
 				// Something went wrong. Read the rest of the data as a single
 				// string and log it at once -- it's probably a GCS panic stack.
-				if err != io.EOF && !isDisconnectError(err) {
+				if errors.Is(err, io.EOF) && !isDisconnectError(err) {
 					logrus.WithFields(logrus.Fields{
 						logfields.UVMID: vmid,
 						logrus.ErrorKey: err,


### PR DESCRIPTION
Add `.Is(` and `.Unwrap(` to `internal\hcs\errors.go` and `internal\gcs\bridge.go` to using them with `errors.Is(` and `errors.As(`

Signed-off-by: Hamza El-Saawy <hamzaelsaawy@microsoft.com>