### PR TITLE
VPMem device unmap VHD, don't remove VPMem itself.

### DIFF
--- a/internal/uvm/vpmem_mapped.go
+++ b/internal/uvm/vpmem_mapped.go
@@ -124,11 +124,7 @@ func newMappedVPMemModifyRequest(
 		if pmem == nil {
 			return nil, errors.Errorf("no device found at location %d", deviceNumber)
 		}
-		if len(pmem.mappings) == 1 {
-			request.ResourcePath = fmt.Sprintf(resourcepaths.VPMemControllerResourceFormat, deviceNumber)
-		} else {
-			request.ResourcePath = fmt.Sprintf(resourcepaths.VPMemDeviceResourceFormat, deviceNumber, md.mappedRegion.Offset())
-		}
+		request.ResourcePath = fmt.Sprintf(resourcepaths.VPMemDeviceResourceFormat, deviceNumber, md.mappedRegion.Offset())
 	default:
 		return nil, errors.New("unsupported request type")
 	}


### PR DESCRIPTION
When using VPMem multi-mapping feature, we can end up in a
situation when a VHD at offset 0 is not the last VHD that
is being removed:
  1. Add the very first VHD (vhd1) and essentially VPMem
     (vpmem1) device itself will add the vhd1 at offset `0`.
     Mapped VHD count: `1`
  2. Add second VHD (vhd2), which be mapped at offset `N`.
     Mapped VHD count: `2`
  3. Remove vhd1 at offset `0`. Mapped VHD count: `1`
  4. Try removing vhd2 will result in removing the VPMem
     device itself, however, HCS API doesn't allow that.
     Which is most likely a bug. Removing VPMem with 0
     mapped VHDs also doesn't work.

As a work-around, keep the VPMem "intact" and just remove the
last mapped VHD. The VPMem can still be used later to map new
VHDs.

Signed-off-by: Maksim An <maksiman@microsoft.com>