### PR TITLE
Backwards compat for hostprocess cntrs mounts

### DIFF
--- a/internal/jobcontainers/jobcontainer.go
+++ b/internal/jobcontainers/jobcontainer.go
@@ -774,8 +774,7 @@ func (c *JobContainer) bindSetup(ctx context.Context, s *specs.Spec) (err error)
 	if err := c.job.PromoteToSilo(); err != nil {
 		return err
 	}
-	// Union the container layers. Luckily bindflt works fine with \\?\volume paths, so we don't need to
-	// mount the volume anywhere friendly (for example, somewhere under C:\) first.
+	// Union the container layers.
 	if err := c.mountLayers(ctx, c.id, s, ""); err != nil {
 		return fmt.Errorf("failed to mount container layers: %w", err)
 	}
@@ -783,7 +782,8 @@ func (c *JobContainer) bindSetup(ctx context.Context, s *specs.Spec) (err error)
 	if loc := customRootfsLocation(s.Annotations); loc != "" {
 		rootfsLocation = loc
 	}
-	if err := c.setupRootfsBinding(rootfsLocation, s.Root.Path+"\\"); err != nil {
+
+	if err := c.setupRootfsBinding(rootfsLocation, s.Root.Path); err != nil {
 		return err
 	}
 	c.rootfsLocation = rootfsLocation

--- a/internal/jobcontainers/mounts.go
+++ b/internal/jobcontainers/mounts.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/Microsoft/hcsshim/internal/layers"
 	"github.com/Microsoft/hcsshim/internal/log"
 	"github.com/Microsoft/hcsshim/internal/logfields"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
@@ -58,7 +59,6 @@ func fallbackMountSetup(spec *specs.Spec, sandboxVolumePath string) error {
 			return errors.Wrap(err, "failed to setup mount for job container")
 		}
 	}
-
 	return nil
 }
 
@@ -66,6 +66,28 @@ func fallbackMountSetup(spec *specs.Spec, sandboxVolumePath string) error {
 // mount.Source to mount.Destination as well as mounted from mount.Source to under the rootfs location
 // for backwards compat with systems that don't have the Bind Filter functionality available.
 func (c *JobContainer) setupMounts(ctx context.Context, spec *specs.Spec) error {
+	mountedDirPath, err := os.MkdirTemp("", "jobcontainer")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(mountedDirPath)
+	mountedDirPath += "\\"
+
+	// os.Mkdirall has troubles with volume paths on Windows it seems..
+	// For an example, it seems during the recursive portion when trying to
+	// figure out what parent directories to make, this is what gets spit out for
+	// three calls deep.
+	//
+	// First iteration: \\?\Volume{93df249b-ae90-4619-8e3c-28482c52729c}\blah
+	// Second: \\?\Volume{93df249b-ae90-4619-8e3c-28482c52729c}
+	// Third: \\?
+	//
+	// and then it will pass that to Mkdir and bail. So to avoid rolling our own
+	// mkdirall, just mount the volume somewhere and do the links and then dismount.
+	if err := layers.MountSandboxVolume(ctx, mountedDirPath, c.spec.Root.Path); err != nil {
+		return err
+	}
+
 	for _, mount := range spec.Mounts {
 		if mount.Destination == "" || mount.Source == "" {
 			return fmt.Errorf("invalid OCI spec - a mount must have both source and a destination: %+v", mount)
@@ -89,6 +111,21 @@ func (c *JobContainer) setupMounts(ctx context.Context, spec *specs.Spec) error 
 		if err := c.job.ApplyFileBinding(mount.Destination, mount.Source, false); err != nil {
 			return err
 		}
+
+		// For backwards compat with how mounts worked without the bind filter, additionally plop the directory/file
+		// to a relative path inside the containers rootfs.
+		fullCtrPath := filepath.Join(mountedDirPath, stripDriveLetter(mount.Destination))
+		// Make sure all of the dirs leading up to the full path exist.
+		strippedCtrPath := filepath.Dir(fullCtrPath)
+		if err := os.MkdirAll(strippedCtrPath, 0777); err != nil {
+			return fmt.Errorf("failed to make directory for job container mount: %w", err)
+		}
+
+		// Best effort; log if the backwards compatible symlink approach doesn't work.
+		if err := os.Symlink(mount.Source, fullCtrPath); err != nil {
+			log.G(ctx).WithError(err).Warnf("failed to setup symlink from %s to containers rootfs at %s", mount.Source, fullCtrPath)
+		}
 	}
-	return nil
+
+	return layers.RemoveSandboxMountPoint(ctx, mountedDirPath)
 }

--- a/internal/jobcontainers/storage.go
+++ b/internal/jobcontainers/storage.go
@@ -51,10 +51,11 @@ func (c *JobContainer) mountLayers(ctx context.Context, containerID string, s *s
 
 	if s.Root.Path == "" {
 		log.G(ctx).Debug("mounting job container storage")
-		s.Root.Path, err = layers.MountWCOWLayers(ctx, containerID, s.Windows.LayerFolders, "", volumeMountPath, nil)
+		rootPath, err := layers.MountWCOWLayers(ctx, containerID, s.Windows.LayerFolders, "", volumeMountPath, nil)
 		if err != nil {
 			return fmt.Errorf("failed to mount job container storage: %w", err)
 		}
+		s.Root.Path = rootPath + "\\"
 	}
 
 	return nil

--- a/internal/layers/layers.go
+++ b/internal/layers/layers.go
@@ -235,7 +235,7 @@ func MountWCOWLayers(ctx context.Context, containerID string, layerFolders []str
 
 		// Mount the volume to a directory on the host if requested. This is the case for job containers.
 		if volumeMountPath != "" {
-			if err := mountSandboxVolume(ctx, volumeMountPath, mountPath); err != nil {
+			if err := MountSandboxVolume(ctx, volumeMountPath, mountPath); err != nil {
 				return "", err
 			}
 		}
@@ -404,7 +404,7 @@ func UnmountContainerLayers(ctx context.Context, layerFolders []string, containe
 		// Remove the mount point if there is one. This is the fallback case for job containers
 		// if no bind mount support is available.
 		if volumeMountPath != "" {
-			if err := removeSandboxMountPoint(ctx, volumeMountPath); err != nil {
+			if err := RemoveSandboxMountPoint(ctx, volumeMountPath); err != nil {
 				return err
 			}
 		}
@@ -530,7 +530,7 @@ func getScratchVHDPath(layerFolders []string) (string, error) {
 }
 
 // Mount the sandbox vhd to a user friendly path.
-func mountSandboxVolume(ctx context.Context, hostPath, volumeName string) (err error) {
+func MountSandboxVolume(ctx context.Context, hostPath, volumeName string) (err error) {
 	log.G(ctx).WithFields(logrus.Fields{
 		"hostpath":   hostPath,
 		"volumeName": volumeName,
@@ -560,7 +560,7 @@ func mountSandboxVolume(ctx context.Context, hostPath, volumeName string) (err e
 }
 
 // Remove volume mount point. And remove folder afterwards.
-func removeSandboxMountPoint(ctx context.Context, hostPath string) error {
+func RemoveSandboxMountPoint(ctx context.Context, hostPath string) error {
 	log.G(ctx).WithFields(logrus.Fields{
 		"hostpath": hostPath,
 	}).Debug("removing volume mount point for container")


### PR DESCRIPTION
In beta, mounts couldn't be unique per silo so they were mounted
to a relative path under the rootfs for the container. There's a
bunch of pod specs/apps floating around that were written with that
in mind so as to make a smooth transition, additionally keep mounting
them under the rootfs for now via the same approach (symlink the dir/file).