### PR TITLE
Add IO tracking option for job objects

### DIFF
--- a/internal/jobcontainers/jobcontainer.go
+++ b/internal/jobcontainers/jobcontainer.go
@@ -118,8 +118,9 @@ func Create(ctx context.Context, id string, s *specs.Spec) (_ cow.Container, _ *
 
 	// Create the job object all processes will run in.
 	options := &jobobject.Options{
-		Name:          fmt.Sprintf(jobContainerNameFmt, id),
-		Notifications: true,
+		Name:             fmt.Sprintf(jobContainerNameFmt, id),
+		Notifications:    true,
+		EnableIOTracking: true,
 	}
 	container.job, err = jobobject.Create(ctx, options)
 	if err != nil {

--- a/internal/jobobject/jobobject.go
+++ b/internal/jobobject/jobobject.go
@@ -72,6 +72,9 @@ type Options struct {
 	// `Silo` specifies to promote the job to a silo. This additionally sets the flag
 	// JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE as it is required for the upgrade to complete.
 	Silo bool
+	// `IOTracking` enables tracking I/O statistics on the job object. More specifically this
+	// calls SetInformationJobObject with the JobObjectIoAttribution class.
+	EnableIOTracking bool
 }
 
 // Create creates a job object.
@@ -136,6 +139,12 @@ func Create(ctx context.Context, options *Options) (_ *JobObject, err error) {
 			return nil, err
 		}
 		job.mq = mq
+	}
+
+	if options.EnableIOTracking {
+		if err := enableIOTracking(jobHandle); err != nil {
+			return nil, err
+		}
 	}
 
 	if options.Silo {
@@ -433,7 +442,8 @@ func (job *JobObject) QueryProcessorStats() (*winapi.JOBOBJECT_BASIC_ACCOUNTING_
 	return &info, nil
 }
 
-// QueryStorageStats gets the storage (I/O) stats for the job object.
+// QueryStorageStats gets the storage (I/O) stats for the job object. job.SetIOTracking() must be
+// invoked or when the job was created `EnableIOTracking` must be set to true for this call to function.
 func (job *JobObject) QueryStorageStats() (*winapi.JOBOBJECT_IO_ATTRIBUTION_INFORMATION, error) {
 	job.handleLock.RLock()
 	defer job.handleLock.RUnlock()
@@ -627,4 +637,32 @@ func (job *JobObject) QueryPrivateWorkingSet() (uint64, error) {
 	}
 
 	return jobWorkingSetSize, nil
+}
+
+// SetIOTracking enables IO tracking for processes in the job object.
+// This enables use of the QueryStorageStats method.
+func (job *JobObject) SetIOTracking() error {
+	job.handleLock.RLock()
+	defer job.handleLock.RUnlock()
+
+	if job.handle == 0 {
+		return ErrAlreadyClosed
+	}
+
+	return enableIOTracking(job.handle)
+}
+
+func enableIOTracking(job windows.Handle) error {
+	info := winapi.JOBOBJECT_IO_ATTRIBUTION_INFORMATION{
+		ControlFlags: winapi.JOBOBJECT_IO_ATTRIBUTION_CONTROL_ENABLE,
+	}
+	if _, err := windows.SetInformationJobObject(
+		job,
+		winapi.JobObjectIoAttribution,
+		uintptr(unsafe.Pointer(&info)),
+		uint32(unsafe.Sizeof(info)),
+	); err != nil {
+		return fmt.Errorf("failed to enable IO tracking on job object: %w", err)
+	}
+	return nil
 }

--- a/internal/jobobject/jobobject.go
+++ b/internal/jobobject/jobobject.go
@@ -442,8 +442,9 @@ func (job *JobObject) QueryProcessorStats() (*winapi.JOBOBJECT_BASIC_ACCOUNTING_
 	return &info, nil
 }
 
-// QueryStorageStats gets the storage (I/O) stats for the job object. job.SetIOTracking() must be
-// invoked or when the job was created `EnableIOTracking` must be set to true for this call to function.
+// QueryStorageStats gets the storage (I/O) stats for the job object. This call will error
+// if either `EnableIOTracking` wasn't set to true on creation of the job, or SetIOTracking()
+// hasn't been called since creation of the job.
 func (job *JobObject) QueryStorageStats() (*winapi.JOBOBJECT_IO_ATTRIBUTION_INFORMATION, error) {
 	job.handleLock.RLock()
 	defer job.handleLock.RUnlock()

--- a/internal/jobobject/jobobject_test.go
+++ b/internal/jobobject/jobobject_test.go
@@ -65,6 +65,46 @@ func TestSiloCreateAndOpen(t *testing.T) {
 	}
 }
 
+func TestJobStats(t *testing.T) {
+	var (
+		ctx     = context.Background()
+		options = &Options{
+			Name:             "test",
+			Silo:             true,
+			EnableIOTracking: true,
+		}
+	)
+	job, err := Create(ctx, options)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer job.Close()
+
+	_, err = createProcsAndAssign(1, job)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = job.QueryMemoryStats()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = job.QueryProcessorStats()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = job.QueryStorageStats()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := job.Terminate(1); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func createProcsAndAssign(num int, job *JobObject) (_ []*exec.Cmd, err error) {
 	var procs []*exec.Cmd
 


### PR DESCRIPTION
HCS enables this to get more in depth IO stats for the silo of the
container, and is what is returned when asking for stats for the container. 
I'd swapped hostprocess containers to querying for these stats, but without 
the prerequisite of actually enabling them :)

This change adds a new option on jobobject.Options{} to enable this
functionality and adds a new test to ensure we can actually call
StorageStats now (It would return Element Not Found previously).