### PR TITLE
Readonly option for hostprocess mounts

### DIFF
--- a/internal/jobcontainers/mounts.go
+++ b/internal/jobcontainers/mounts.go
@@ -108,7 +108,14 @@ func (c *JobContainer) setupMounts(ctx context.Context, spec *specs.Spec) error 
 			}).Warn("job container mount destination exists and will be shadowed")
 		}
 
-		if err := c.job.ApplyFileBinding(mount.Destination, mount.Source, false); err != nil {
+		readOnly := false
+		for _, o := range mount.Options {
+			if strings.ToLower(o) == "ro" {
+				readOnly = true
+			}
+		}
+
+		if err := c.job.ApplyFileBinding(mount.Destination, mount.Source, readOnly); err != nil {
 			return err
 		}
 

--- a/internal/jobobject/jobobject.go
+++ b/internal/jobobject/jobobject.go
@@ -471,7 +471,7 @@ func (job *JobObject) QueryStorageStats() (*winapi.JOBOBJECT_IO_ATTRIBUTION_INFO
 // ApplyFileBinding makes a file binding using the Bind Filter from target to root. If the job has
 // not been upgraded to a silo this call will fail. The binding is only applied and visible for processes
 // running in the job, any processes on the host or in another job will not be able to see the binding.
-func (job *JobObject) ApplyFileBinding(root, target string, merged bool) error {
+func (job *JobObject) ApplyFileBinding(root, target string, readOnly bool) error {
 	job.handleLock.RLock()
 	defer job.handleLock.RUnlock()
 
@@ -501,8 +501,8 @@ func (job *JobObject) ApplyFileBinding(root, target string, merged bool) error {
 	}
 
 	flags := winapi.BINDFLT_FLAG_USE_CURRENT_SILO_MAPPING
-	if merged {
-		flags |= winapi.BINDFLT_FLAG_MERGED_BIND_MAPPING
+	if readOnly {
+		flags |= winapi.BINDFLT_FLAG_READ_ONLY_MAPPING
 	}
 
 	if err := winapi.BfSetupFilter(


### PR DESCRIPTION
Add in ability to parse read only mount options for hostprocess mounts.
Change the API of ApplyFileBinding to take in a readOnly bool instead of
it signifying a merged binding. We don't have any use for merged bindings
as the default for containers is to shadow the directory we're binding
to. We could alternatively pass in a set of options/flags as this argument,
but readonly seems to be the only thing needed as of now.