### PR TITLE
Remove uneccessary use of silos in jobobject tests

### DIFF
--- a/internal/jobobject/jobobject_test.go
+++ b/internal/jobobject/jobobject_test.go
@@ -70,7 +70,6 @@ func TestJobStats(t *testing.T) {
 		ctx     = context.Background()
 		options = &Options{
 			Name:             "test",
-			Silo:             true,
 			EnableIOTracking: true,
 		}
 	)
@@ -110,7 +109,6 @@ func TestIOTracking(t *testing.T) {
 		ctx     = context.Background()
 		options = &Options{
 			Name: "test",
-			Silo: true,
 		}
 	)
 	job, err := Create(ctx, options)


### PR DESCRIPTION
Two tests added recently by yours truly don't need to be running as
silos so remove the silo field set to true. Was running into this when
trying to backport a fix to a branch that doesn't have the silo work.