### PR TITLE
[release/0.9] Backport hostprocess fixes 

### DIFF
--- a/internal/jobcontainers/jobcontainer.go
+++ b/internal/jobcontainers/jobcontainer.go
@@ -108,8 +108,9 @@ func Create(ctx context.Context, id string, s *specs.Spec) (_ cow.Container, _ *
 
 	// Create the job object all processes will run in.
 	options := &jobobject.Options{
-		Name:          fmt.Sprintf(jobContainerNameFmt, id),
-		Notifications: true,
+		Name:             fmt.Sprintf(jobContainerNameFmt, id),
+		Notifications:    true,
+		EnableIOTracking: true,
 	}
 	job, err := jobobject.Create(ctx, options)
 	if err != nil {

--- a/internal/jobcontainers/jobcontainer.go
+++ b/internal/jobcontainers/jobcontainer.go
@@ -575,7 +575,7 @@ func systemProcessInformation() ([]*winapi.SYSTEM_PROCESS_INFORMATION, error) {
 		systemProcInfo = (*winapi.SYSTEM_PROCESS_INFORMATION)(unsafe.Pointer(&b[0]))
 		status := winapi.NtQuerySystemInformation(
 			winapi.SystemProcessInformation,
-			uintptr(unsafe.Pointer(systemProcInfo)),
+			unsafe.Pointer(systemProcInfo),
 			size,
 			&size,
 		)

--- a/internal/jobcontainers/jobcontainer.go
+++ b/internal/jobcontainers/jobcontainer.go
@@ -39,15 +39,6 @@ func splitArgs(cmdLine string) []string {
 	return r.FindAllString(cmdLine, -1)
 }
 
-// Convert environment map to a slice of environment variables in the form [Key1=val1, key2=val2]
-func envMapToSlice(m map[string]string) []string {
-	var s []string
-	for k, v := range m {
-		s = append(s, k+"="+v)
-	}
-	return s
-}
-
 const (
 	jobContainerNameFmt = "JobContainer_%s"
 	// Environment variable set in every process in the job detailing where the containers volume
@@ -233,7 +224,15 @@ func (c *JobContainer) CreateProcess(ctx context.Context, config interface{}) (_
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get default environment block")
 	}
-	env = append(env, envMapToSlice(conf.Environment)...)
+
+	// Convert environment map to a slice of environment variables in the form [Key1=val1, key2=val2]
+	var envs []string
+	for k, v := range conf.Environment {
+		expanded, _ := c.replaceWithMountPoint(v)
+		envs = append(envs, k+"="+expanded)
+	}
+	env = append(env, envs...)
+
 	env = append(env, sandboxMountPointEnvVar+"="+c.sandboxMount)
 
 	// exec.Cmd internally does its own path resolution and as part of this checks some well known file extensions on the file given (e.g. if
@@ -604,7 +603,7 @@ func systemProcessInformation() ([]*winapi.SYSTEM_PROCESS_INFORMATION, error) {
 	return procInfos, nil
 }
 
-// Takes a string and replaces any occurences of CONTAINER_SANDBOX_MOUNT_POINT with where the containers volume is mounted, as well as returning
+// Takes a string and replaces any occurrences of CONTAINER_SANDBOX_MOUNT_POINT with where the containers' volume is mounted, as well as returning
 // if the string actually contained the environment variable.
 func (c *JobContainer) replaceWithMountPoint(str string) (string, bool) {
 	newStr := strings.ReplaceAll(str, "%"+sandboxMountPointEnvVar+"%", c.sandboxMount[:len(c.sandboxMount)-1])

--- a/internal/jobobject/iocp.go
+++ b/internal/jobobject/iocp.go
@@ -57,7 +57,7 @@ func pollIOCP(ctx context.Context, iocpHandle windows.Handle) {
 				}).Warn("failed to parse job object message")
 				continue
 			}
-			if err := msq.Write(notification); err == queue.ErrQueueClosed {
+			if err := msq.Enqueue(notification); err == queue.ErrQueueClosed {
 				// Write will only return an error when the queue is closed.
 				// The only time a queue would ever be closed is when we call `Close` on
 				// the job it belongs to which also removes it from the jobMap, so something

--- a/internal/jobobject/jobobject.go
+++ b/internal/jobobject/jobobject.go
@@ -339,7 +339,7 @@ func (job *JobObject) Pids() ([]uint32, error) {
 	err := winapi.QueryInformationJobObject(
 		job.handle,
 		winapi.JobObjectBasicProcessIdList,
-		uintptr(unsafe.Pointer(&info)),
+		unsafe.Pointer(&info),
 		uint32(unsafe.Sizeof(info)),
 		nil,
 	)
@@ -365,7 +365,7 @@ func (job *JobObject) Pids() ([]uint32, error) {
 	if err = winapi.QueryInformationJobObject(
 		job.handle,
 		winapi.JobObjectBasicProcessIdList,
-		uintptr(unsafe.Pointer(&buf[0])),
+		unsafe.Pointer(&buf[0]),
 		uint32(len(buf)),
 		nil,
 	); err != nil {
@@ -393,7 +393,7 @@ func (job *JobObject) QueryMemoryStats() (*winapi.JOBOBJECT_MEMORY_USAGE_INFORMA
 	if err := winapi.QueryInformationJobObject(
 		job.handle,
 		winapi.JobObjectMemoryUsageInformation,
-		uintptr(unsafe.Pointer(&info)),
+		unsafe.Pointer(&info),
 		uint32(unsafe.Sizeof(info)),
 		nil,
 	); err != nil {
@@ -415,7 +415,7 @@ func (job *JobObject) QueryProcessorStats() (*winapi.JOBOBJECT_BASIC_ACCOUNTING_
 	if err := winapi.QueryInformationJobObject(
 		job.handle,
 		winapi.JobObjectBasicAccountingInformation,
-		uintptr(unsafe.Pointer(&info)),
+		unsafe.Pointer(&info),
 		uint32(unsafe.Sizeof(info)),
 		nil,
 	); err != nil {
@@ -441,7 +441,7 @@ func (job *JobObject) QueryStorageStats() (*winapi.JOBOBJECT_IO_ATTRIBUTION_INFO
 	if err := winapi.QueryInformationJobObject(
 		job.handle,
 		winapi.JobObjectIoAttribution,
-		uintptr(unsafe.Pointer(&info)),
+		unsafe.Pointer(&info),
 		uint32(unsafe.Sizeof(info)),
 		nil,
 	); err != nil {
@@ -487,7 +487,7 @@ func (job *JobObject) QueryPrivateWorkingSet() (uint64, error) {
 		status := winapi.NtQueryInformationProcess(
 			h,
 			winapi.ProcessVmCounters,
-			uintptr(unsafe.Pointer(&vmCounters)),
+			unsafe.Pointer(&vmCounters),
 			uint32(unsafe.Sizeof(vmCounters)),
 			nil,
 		)

--- a/internal/jobobject/jobobject.go
+++ b/internal/jobobject/jobobject.go
@@ -235,7 +235,7 @@ func (job *JobObject) PollNotification() (interface{}, error) {
 	if job.mq == nil {
 		return nil, ErrNotRegistered
 	}
-	return job.mq.ReadOrWait()
+	return job.mq.Dequeue()
 }
 
 // UpdateProcThreadAttribute updates the passed in ProcThreadAttributeList to contain what is necessary to

--- a/internal/jobobject/jobobject_test.go
+++ b/internal/jobobject/jobobject_test.go
@@ -42,7 +42,6 @@ func TestJobStats(t *testing.T) {
 		ctx     = context.Background()
 		options = &Options{
 			Name:             "test",
-			Silo:             true,
 			EnableIOTracking: true,
 		}
 	)
@@ -82,7 +81,6 @@ func TestIOTracking(t *testing.T) {
 		ctx     = context.Background()
 		options = &Options{
 			Name: "test",
-			Silo: true,
 		}
 	)
 	job, err := Create(ctx, options)

--- a/internal/jobobject/jobobject_test.go
+++ b/internal/jobobject/jobobject_test.go
@@ -37,6 +37,86 @@ func TestJobCreateAndOpen(t *testing.T) {
 	defer jobOpen.Close()
 }
 
+func TestJobStats(t *testing.T) {
+	var (
+		ctx     = context.Background()
+		options = &Options{
+			Name:             "test",
+			Silo:             true,
+			EnableIOTracking: true,
+		}
+	)
+	job, err := Create(ctx, options)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer job.Close()
+
+	_, err = createProcsAndAssign(1, job)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = job.QueryMemoryStats()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = job.QueryProcessorStats()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = job.QueryStorageStats()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := job.Terminate(1); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestIOTracking(t *testing.T) {
+	var (
+		ctx     = context.Background()
+		options = &Options{
+			Name: "test",
+			Silo: true,
+		}
+	)
+	job, err := Create(ctx, options)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer job.Close()
+
+	_, err = createProcsAndAssign(1, job)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = job.QueryStorageStats()
+	// Element not found is returned if IO tracking isn't enabled.
+	if err != nil && !errors.Is(err, windows.ERROR_NOT_FOUND) {
+		t.Fatal(err)
+	}
+
+	// Turn it on and now the call should function.
+	if err := job.SetIOTracking(); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = job.QueryStorageStats()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := job.Terminate(1); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func createProcsAndAssign(num int, job *JobObject) (_ []*exec.Cmd, err error) {
 	var procs []*exec.Cmd
 

--- a/internal/jobobject/limits.go
+++ b/internal/jobobject/limits.go
@@ -202,7 +202,7 @@ func (job *JobObject) getExtendedInformation() (*windows.JOBOBJECT_EXTENDED_LIMI
 	if err := winapi.QueryInformationJobObject(
 		job.handle,
 		windows.JobObjectExtendedLimitInformation,
-		uintptr(unsafe.Pointer(&info)),
+		unsafe.Pointer(&info),
 		uint32(unsafe.Sizeof(info)),
 		nil,
 	); err != nil {
@@ -224,7 +224,7 @@ func (job *JobObject) getCPURateControlInformation() (*winapi.JOBOBJECT_CPU_RATE
 	if err := winapi.QueryInformationJobObject(
 		job.handle,
 		windows.JobObjectCpuRateControlInformation,
-		uintptr(unsafe.Pointer(&info)),
+		unsafe.Pointer(&info),
 		uint32(unsafe.Sizeof(info)),
 		nil,
 	); err != nil {

--- a/internal/queue/mq.go
+++ b/internal/queue/mq.go
@@ -5,10 +5,7 @@ import (
 	"sync"
 )
 
-var (
-	ErrQueueClosed = errors.New("the queue is closed for reading and writing")
-	ErrQueueEmpty  = errors.New("the queue is empty")
-)
+var ErrQueueClosed = errors.New("the queue is closed for reading and writing")
 
 // MessageQueue represents a threadsafe message queue to be used to retrieve or
 // write messages to.
@@ -29,8 +26,8 @@ func NewMessageQueue() *MessageQueue {
 	}
 }
 
-// Write writes `msg` to the queue.
-func (mq *MessageQueue) Write(msg interface{}) error {
+// Enqueue writes `msg` to the queue.
+func (mq *MessageQueue) Enqueue(msg interface{}) error {
 	mq.m.Lock()
 	defer mq.m.Unlock()
 
@@ -43,55 +40,37 @@ func (mq *MessageQueue) Write(msg interface{}) error {
 	return nil
 }
 
-// Read will read a value from the queue if available, otherwise return an error.
-func (mq *MessageQueue) Read() (interface{}, error) {
+// Dequeue will read a value from the queue and remove it. If the queue
+// is empty, this will block until the queue is closed or a value gets enqueued.
+func (mq *MessageQueue) Dequeue() (interface{}, error) {
 	mq.m.Lock()
 	defer mq.m.Unlock()
+
+	for !mq.closed && mq.size() == 0 {
+		mq.c.Wait()
+	}
+
+	// We got woken up, check if it's because the queue got closed.
 	if mq.closed {
 		return nil, ErrQueueClosed
 	}
-	if mq.isEmpty() {
-		return nil, ErrQueueEmpty
-	}
+
 	val := mq.messages[0]
 	mq.messages[0] = nil
 	mq.messages = mq.messages[1:]
 	return val, nil
 }
 
-// ReadOrWait will read a value from the queue if available, else it will wait for a
-// value to become available. This will block forever if nothing gets written or until
-// the queue gets closed.
-func (mq *MessageQueue) ReadOrWait() (interface{}, error) {
-	mq.m.Lock()
-	if mq.closed {
-		mq.m.Unlock()
-		return nil, ErrQueueClosed
-	}
-	if mq.isEmpty() {
-		for !mq.closed && mq.isEmpty() {
-			mq.c.Wait()
-		}
-		mq.m.Unlock()
-		return mq.Read()
-	}
-	val := mq.messages[0]
-	mq.messages[0] = nil
-	mq.messages = mq.messages[1:]
-	mq.m.Unlock()
-	return val, nil
-}
-
-// IsEmpty returns if the queue is empty
-func (mq *MessageQueue) IsEmpty() bool {
+// Size returns the size of the queue.
+func (mq *MessageQueue) Size() int {
 	mq.m.RLock()
 	defer mq.m.RUnlock()
-	return len(mq.messages) == 0
+	return mq.size()
 }
 
-// Nonexported empty check that doesn't lock so we can call this in Read and Write.
-func (mq *MessageQueue) isEmpty() bool {
-	return len(mq.messages) == 0
+// Nonexported size check to check if the queue is empty inside already locked functions.
+func (mq *MessageQueue) size() int {
+	return len(mq.messages)
 }
 
 // Close closes the queue for future writes or reads. Any attempts to read or write from the
@@ -99,13 +78,15 @@ func (mq *MessageQueue) isEmpty() bool {
 func (mq *MessageQueue) Close() {
 	mq.m.Lock()
 	defer mq.m.Unlock()
-	// Already closed
+
+	// Already closed, noop
 	if mq.closed {
 		return
 	}
+
 	mq.messages = nil
 	mq.closed = true
-	// If there's anybody currently waiting on a value from ReadOrWait, we need to
+	// If there's anybody currently waiting on a value from Dequeue, we need to
 	// broadcast so the read(s) can return ErrQueueClosed.
 	mq.c.Broadcast()
 }

--- a/internal/queue/queue_test.go
+++ b/internal/queue/queue_test.go
@@ -1,105 +1,59 @@
 package queue
 
 import (
+	"fmt"
 	"sync"
 	"testing"
 	"time"
 )
 
-func TestReadWrite(t *testing.T) {
+func TestEnqueueDequeue(t *testing.T) {
 	q := NewMessageQueue()
 
-	// Reading from an empty queue should return ErrQueueEmpty
-	if _, err := q.Read(); err != ErrQueueEmpty {
-		t.Fatal("expected to receive `ErrQueueEmpty` for reading from empty queue")
+	vals := []int{1, 2, 3, 4, 5}
+	for _, val := range vals {
+		// Enqueue vals to the queue and read later.
+		if err := q.Enqueue(val); err != nil {
+			t.Fatal(err)
+		}
 	}
 
-	// Write 1 to the queue and read this later.
-	if err := q.Write(1); err != nil {
-		t.Fatal(err)
-	}
+	for _, val := range vals {
+		// Dequeueing from an empty queue should block forever until a write occurs.
+		qVal, err := q.Dequeue()
+		if err != nil {
+			t.Fatal(err)
+		}
 
-	// Read the value. Value will be dequeued.
-	if msg, err := q.Read(); err != nil || msg != 1 {
-		t.Fatal(err)
-	}
-
-	// We just read a value, now try and read again and verify that we get ErrQueueEmpty again.
-	if _, err := q.Read(); err != ErrQueueEmpty {
-		t.Fatal(err)
-	}
-
-	// Close the queue and verify that we get an error on write.
-	q.Close()
-	if err := q.Write(1); err != ErrQueueClosed {
-		t.Fatal(err)
+		if qVal != val {
+			t.Fatalf("expected %d, got: %d", val, qVal)
+		}
 	}
 }
 
-func TestReadOrWaitClose(t *testing.T) {
+func TestEnqueueDequeueClose(t *testing.T) {
 	q := NewMessageQueue()
 
+	vals := []int{1, 2, 3}
 	go func() {
-		_ = q.Write(1)
-		_ = q.Write(2)
-		_ = q.Write(3)
-		time.Sleep(time.Second * 5)
-		q.Close()
+		for _, val := range vals {
+			_ = q.Enqueue(val)
+		}
 	}()
-
-	time.Sleep(time.Second * 2)
 
 	read := 0
 	for {
-		if _, err := q.ReadOrWait(); err != nil {
-			if err == ErrQueueClosed && read == 3 {
-				break
+		if _, err := q.Dequeue(); err == nil {
+			read++
+			if read == len(vals) {
+				// Close after we've read all of our values, then on the next
+				// go around make sure we get ErrClosed()
+				q.Close()
 			}
-			t.Fatal(err)
+		} else if err != ErrQueueClosed {
+			t.Fatalf("expected to receive ErrQueueClosed, instead got: %s", err)
 		}
-		read++
-	}
-}
-
-func TestReadOrWait(t *testing.T) {
-	q := NewMessageQueue()
-
-	go func() {
-		_ = q.Write(1)
-		_ = q.Write(2)
-		_ = q.Write(3)
-		time.Sleep(time.Second * 5)
-		_ = q.Write(4)
-	}()
-
-	// Small sleep so that we can give time to ensure a value is written to the queue so we
-	// can test both states ReadOrWait could be in. These states being there is already a value
-	// ready for consumption and all we have to do is just read it, or we wait to get signalled of
-	// an available value.
-	time.Sleep(time.Second * 1)
-	timeout := time.After(time.Second * 20)
-	done := make(chan struct{})
-	readErr := make(chan error)
-
-	go func() {
-		for {
-			if msg, err := q.ReadOrWait(); err != nil {
-				readErr <- err
-			} else {
-				if msg == 4 {
-					done <- struct{}{}
-					break
-				}
-			}
-		}
-	}()
-
-	select {
-	case <-timeout:
-		t.Fatal("timed out waiting for all queue values to be read")
-	case <-done:
-	case err := <-readErr:
-		t.Fatal(err)
+		break
 	}
 }
 
@@ -109,7 +63,7 @@ func TestMultipleReaders(t *testing.T) {
 	done := make(chan struct{})
 	go func() {
 		for i := 0; i < 50; i++ {
-			if err := q.Write(1); err != nil {
+			if err := q.Enqueue(1); err != nil {
 				errChan <- err
 			}
 		}
@@ -121,7 +75,7 @@ func TestMultipleReaders(t *testing.T) {
 	// Reader 1
 	go func() {
 		for i := 0; i < 25; i++ {
-			if _, err := q.ReadOrWait(); err != nil {
+			if _, err := q.Dequeue(); err != nil {
 				errChan <- err
 			}
 		}
@@ -131,7 +85,7 @@ func TestMultipleReaders(t *testing.T) {
 	// Reader 2
 	go func() {
 		for i := 0; i < 25; i++ {
-			if _, err := q.ReadOrWait(); err != nil {
+			if _, err := q.Dequeue(); err != nil {
 				errChan <- err
 			}
 		}
@@ -143,13 +97,11 @@ func TestMultipleReaders(t *testing.T) {
 		done <- struct{}{}
 	}()
 
-	timeout := time.After(time.Second * 20)
-
 	select {
 	case err := <-errChan:
 		t.Fatalf("failed in read or write: %s", err)
 	case <-done:
-	case <-timeout:
+	case <-time.After(time.Second * 20):
 		t.Fatalf("timeout exceeded waiting for reads to complete")
 	}
 }
@@ -164,7 +116,7 @@ func TestMultipleReadersClose(t *testing.T) {
 
 	// Reader 1
 	go func() {
-		if _, err := q.ReadOrWait(); err != ErrQueueClosed {
+		if _, err := q.Dequeue(); err != ErrQueueClosed {
 			errChan <- err
 		}
 		wg.Done()
@@ -172,7 +124,7 @@ func TestMultipleReadersClose(t *testing.T) {
 
 	// Reader 2
 	go func() {
-		if _, err := q.ReadOrWait(); err != ErrQueueClosed {
+		if _, err := q.Dequeue(); err != ErrQueueClosed {
 			errChan <- err
 		}
 		wg.Done()
@@ -187,13 +139,43 @@ func TestMultipleReadersClose(t *testing.T) {
 	// Close the queue and this should signal both readers to return ErrQueueClosed.
 	q.Close()
 
-	timeout := time.After(time.Second * 20)
-
 	select {
 	case err := <-errChan:
 		t.Fatalf("failed in read or write: %s", err)
 	case <-done:
-	case <-timeout:
+	case <-time.After(time.Second * 20):
 		t.Fatalf("timeout exceeded waiting for reads to complete")
+	}
+}
+
+func TestDequeueBlock(t *testing.T) {
+	q := NewMessageQueue()
+	errChan := make(chan error)
+	testVal := 1
+
+	go func() {
+		// Intentionally dequeue right away with no elements so we know we actually block on
+		// no elements.
+		val, err := q.Dequeue()
+		if err != nil {
+			errChan <- err
+		}
+		if val != testVal {
+			errChan <- fmt.Errorf("expected %d, but got %d", testVal, val)
+		}
+		close(errChan)
+	}()
+
+	// Ensure dequeue has started
+	time.Sleep(time.Second * 3)
+	if err := q.Enqueue(testVal); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case err := <-errChan:
+		if err != nil {
+			t.Fatal(err)
+		}
 	}
 }

--- a/internal/queue/queue_test.go
+++ b/internal/queue/queue_test.go
@@ -50,6 +50,7 @@ func TestEnqueueDequeueClose(t *testing.T) {
 				// go around make sure we get ErrClosed()
 				q.Close()
 			}
+			continue
 		} else if err != ErrQueueClosed {
 			t.Fatalf("expected to receive ErrQueueClosed, instead got: %s", err)
 		}
@@ -177,5 +178,9 @@ func TestDequeueBlock(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+	case <-time.After(10 * time.Second):
+		// Closing the queue will finish the Dequeue go routine.
+		q.Close()
+		t.Fatal("timeout waiting for Dequeue go routine to complete")
 	}
 }

--- a/internal/winapi/jobobject.go
+++ b/internal/winapi/jobobject.go
@@ -175,7 +175,7 @@ type JOBOBJECT_ASSOCIATE_COMPLETION_PORT struct {
 //		LPDWORD            lpReturnLength
 // );
 //
-//sys QueryInformationJobObject(jobHandle windows.Handle, infoClass uint32, jobObjectInfo uintptr, jobObjectInformationLength uint32, lpReturnLength *uint32) (err error) = kernel32.QueryInformationJobObject
+//sys QueryInformationJobObject(jobHandle windows.Handle, infoClass uint32, jobObjectInfo unsafe.Pointer, jobObjectInformationLength uint32, lpReturnLength *uint32) (err error) = kernel32.QueryInformationJobObject
 
 // HANDLE OpenJobObjectW(
 //		DWORD   dwDesiredAccess,

--- a/internal/winapi/process.go
+++ b/internal/winapi/process.go
@@ -18,7 +18,7 @@ const ProcessVmCounters = 3
 // 	[out, optional] PULONG           ReturnLength
 // );
 //
-//sys NtQueryInformationProcess(processHandle windows.Handle, processInfoClass uint32, processInfo uintptr, processInfoLength uint32, returnLength *uint32) (status uint32) = ntdll.NtQueryInformationProcess
+//sys NtQueryInformationProcess(processHandle windows.Handle, processInfoClass uint32, processInfo unsafe.Pointer, processInfoLength uint32, returnLength *uint32) (status uint32) = ntdll.NtQueryInformationProcess
 
 // typedef struct _VM_COUNTERS_EX
 // {

--- a/internal/winapi/system.go
+++ b/internal/winapi/system.go
@@ -12,7 +12,8 @@ const STATUS_INFO_LENGTH_MISMATCH = 0xC0000004
 // 	ULONG                    SystemInformationLength,
 // 	PULONG                   ReturnLength
 // );
-//sys NtQuerySystemInformation(systemInfoClass int, systemInformation uintptr, systemInfoLength uint32, returnLength *uint32) (status uint32) = ntdll.NtQuerySystemInformation
+//
+//sys NtQuerySystemInformation(systemInfoClass int, systemInformation unsafe.Pointer, systemInfoLength uint32, returnLength *uint32) (status uint32) = ntdll.NtQuerySystemInformation
 
 type SYSTEM_PROCESS_INFORMATION struct {
 	NextEntryOffset              uint32         // ULONG

--- a/internal/winapi/zsyscall_windows.go
+++ b/internal/winapi/zsyscall_windows.go
@@ -100,7 +100,7 @@ func resizePseudoConsole(hPc windows.Handle, size uint32) (hr error) {
 	return
 }
 
-func NtQuerySystemInformation(systemInfoClass int, systemInformation uintptr, systemInfoLength uint32, returnLength *uint32) (status uint32) {
+func NtQuerySystemInformation(systemInfoClass int, systemInformation unsafe.Pointer, systemInfoLength uint32, returnLength *uint32) (status uint32) {
 	r0, _, _ := syscall.Syscall6(procNtQuerySystemInformation.Addr(), 4, uintptr(systemInfoClass), uintptr(systemInformation), uintptr(systemInfoLength), uintptr(unsafe.Pointer(returnLength)), 0, 0)
 	status = uint32(r0)
 	return
@@ -152,7 +152,7 @@ func IsProcessInJob(procHandle windows.Handle, jobHandle windows.Handle, result 
 	return
 }
 
-func QueryInformationJobObject(jobHandle windows.Handle, infoClass uint32, jobObjectInfo uintptr, jobObjectInformationLength uint32, lpReturnLength *uint32) (err error) {
+func QueryInformationJobObject(jobHandle windows.Handle, infoClass uint32, jobObjectInfo unsafe.Pointer, jobObjectInformationLength uint32, lpReturnLength *uint32) (err error) {
 	r1, _, e1 := syscall.Syscall6(procQueryInformationJobObject.Addr(), 5, uintptr(jobHandle), uintptr(infoClass), uintptr(jobObjectInfo), uintptr(jobObjectInformationLength), uintptr(unsafe.Pointer(lpReturnLength)), 0)
 	if r1 == 0 {
 		if e1 != 0 {
@@ -244,7 +244,7 @@ func LocalFree(ptr uintptr) {
 	return
 }
 
-func NtQueryInformationProcess(processHandle windows.Handle, processInfoClass uint32, processInfo uintptr, processInfoLength uint32, returnLength *uint32) (status uint32) {
+func NtQueryInformationProcess(processHandle windows.Handle, processInfoClass uint32, processInfo unsafe.Pointer, processInfoLength uint32, returnLength *uint32) (status uint32) {
 	r0, _, _ := syscall.Syscall6(procNtQueryInformationProcess.Addr(), 5, uintptr(processHandle), uintptr(processInfoClass), uintptr(processInfo), uintptr(processInfoLength), uintptr(unsafe.Pointer(returnLength)), 0)
 	status = uint32(r0)
 	return

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/jobobject/iocp.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/jobobject/iocp.go
@@ -57,7 +57,7 @@ func pollIOCP(ctx context.Context, iocpHandle windows.Handle) {
 				}).Warn("failed to parse job object message")
 				continue
 			}
-			if err := msq.Write(notification); err == queue.ErrQueueClosed {
+			if err := msq.Enqueue(notification); err == queue.ErrQueueClosed {
 				// Write will only return an error when the queue is closed.
 				// The only time a queue would ever be closed is when we call `Close` on
 				// the job it belongs to which also removes it from the jobMap, so something

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/jobobject/limits.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/jobobject/limits.go
@@ -202,7 +202,7 @@ func (job *JobObject) getExtendedInformation() (*windows.JOBOBJECT_EXTENDED_LIMI
 	if err := winapi.QueryInformationJobObject(
 		job.handle,
 		windows.JobObjectExtendedLimitInformation,
-		uintptr(unsafe.Pointer(&info)),
+		unsafe.Pointer(&info),
 		uint32(unsafe.Sizeof(info)),
 		nil,
 	); err != nil {
@@ -224,7 +224,7 @@ func (job *JobObject) getCPURateControlInformation() (*winapi.JOBOBJECT_CPU_RATE
 	if err := winapi.QueryInformationJobObject(
 		job.handle,
 		windows.JobObjectCpuRateControlInformation,
-		uintptr(unsafe.Pointer(&info)),
+		unsafe.Pointer(&info),
 		uint32(unsafe.Sizeof(info)),
 		nil,
 	); err != nil {

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/queue/mq.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/queue/mq.go
@@ -5,10 +5,7 @@ import (
 	"sync"
 )
 
-var (
-	ErrQueueClosed = errors.New("the queue is closed for reading and writing")
-	ErrQueueEmpty  = errors.New("the queue is empty")
-)
+var ErrQueueClosed = errors.New("the queue is closed for reading and writing")
 
 // MessageQueue represents a threadsafe message queue to be used to retrieve or
 // write messages to.
@@ -29,8 +26,8 @@ func NewMessageQueue() *MessageQueue {
 	}
 }
 
-// Write writes `msg` to the queue.
-func (mq *MessageQueue) Write(msg interface{}) error {
+// Enqueue writes `msg` to the queue.
+func (mq *MessageQueue) Enqueue(msg interface{}) error {
 	mq.m.Lock()
 	defer mq.m.Unlock()
 
@@ -43,55 +40,37 @@ func (mq *MessageQueue) Write(msg interface{}) error {
 	return nil
 }
 
-// Read will read a value from the queue if available, otherwise return an error.
-func (mq *MessageQueue) Read() (interface{}, error) {
+// Dequeue will read a value from the queue and remove it. If the queue
+// is empty, this will block until the queue is closed or a value gets enqueued.
+func (mq *MessageQueue) Dequeue() (interface{}, error) {
 	mq.m.Lock()
 	defer mq.m.Unlock()
+
+	for !mq.closed && mq.size() == 0 {
+		mq.c.Wait()
+	}
+
+	// We got woken up, check if it's because the queue got closed.
 	if mq.closed {
 		return nil, ErrQueueClosed
 	}
-	if mq.isEmpty() {
-		return nil, ErrQueueEmpty
-	}
+
 	val := mq.messages[0]
 	mq.messages[0] = nil
 	mq.messages = mq.messages[1:]
 	return val, nil
 }
 
-// ReadOrWait will read a value from the queue if available, else it will wait for a
-// value to become available. This will block forever if nothing gets written or until
-// the queue gets closed.
-func (mq *MessageQueue) ReadOrWait() (interface{}, error) {
-	mq.m.Lock()
-	if mq.closed {
-		mq.m.Unlock()
-		return nil, ErrQueueClosed
-	}
-	if mq.isEmpty() {
-		for !mq.closed && mq.isEmpty() {
-			mq.c.Wait()
-		}
-		mq.m.Unlock()
-		return mq.Read()
-	}
-	val := mq.messages[0]
-	mq.messages[0] = nil
-	mq.messages = mq.messages[1:]
-	mq.m.Unlock()
-	return val, nil
-}
-
-// IsEmpty returns if the queue is empty
-func (mq *MessageQueue) IsEmpty() bool {
+// Size returns the size of the queue.
+func (mq *MessageQueue) Size() int {
 	mq.m.RLock()
 	defer mq.m.RUnlock()
-	return len(mq.messages) == 0
+	return mq.size()
 }
 
-// Nonexported empty check that doesn't lock so we can call this in Read and Write.
-func (mq *MessageQueue) isEmpty() bool {
-	return len(mq.messages) == 0
+// Nonexported size check to check if the queue is empty inside already locked functions.
+func (mq *MessageQueue) size() int {
+	return len(mq.messages)
 }
 
 // Close closes the queue for future writes or reads. Any attempts to read or write from the
@@ -99,13 +78,15 @@ func (mq *MessageQueue) isEmpty() bool {
 func (mq *MessageQueue) Close() {
 	mq.m.Lock()
 	defer mq.m.Unlock()
-	// Already closed
+
+	// Already closed, noop
 	if mq.closed {
 		return
 	}
+
 	mq.messages = nil
 	mq.closed = true
-	// If there's anybody currently waiting on a value from ReadOrWait, we need to
+	// If there's anybody currently waiting on a value from Dequeue, we need to
 	// broadcast so the read(s) can return ErrQueueClosed.
 	mq.c.Broadcast()
 }

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/winapi/jobobject.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/winapi/jobobject.go
@@ -175,7 +175,7 @@ type JOBOBJECT_ASSOCIATE_COMPLETION_PORT struct {
 //		LPDWORD            lpReturnLength
 // );
 //
-//sys QueryInformationJobObject(jobHandle windows.Handle, infoClass uint32, jobObjectInfo uintptr, jobObjectInformationLength uint32, lpReturnLength *uint32) (err error) = kernel32.QueryInformationJobObject
+//sys QueryInformationJobObject(jobHandle windows.Handle, infoClass uint32, jobObjectInfo unsafe.Pointer, jobObjectInformationLength uint32, lpReturnLength *uint32) (err error) = kernel32.QueryInformationJobObject
 
 // HANDLE OpenJobObjectW(
 //		DWORD   dwDesiredAccess,

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/winapi/process.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/winapi/process.go
@@ -18,7 +18,7 @@ const ProcessVmCounters = 3
 // 	[out, optional] PULONG           ReturnLength
 // );
 //
-//sys NtQueryInformationProcess(processHandle windows.Handle, processInfoClass uint32, processInfo uintptr, processInfoLength uint32, returnLength *uint32) (status uint32) = ntdll.NtQueryInformationProcess
+//sys NtQueryInformationProcess(processHandle windows.Handle, processInfoClass uint32, processInfo unsafe.Pointer, processInfoLength uint32, returnLength *uint32) (status uint32) = ntdll.NtQueryInformationProcess
 
 // typedef struct _VM_COUNTERS_EX
 // {

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/winapi/system.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/winapi/system.go
@@ -12,7 +12,8 @@ const STATUS_INFO_LENGTH_MISMATCH = 0xC0000004
 // 	ULONG                    SystemInformationLength,
 // 	PULONG                   ReturnLength
 // );
-//sys NtQuerySystemInformation(systemInfoClass int, systemInformation uintptr, systemInfoLength uint32, returnLength *uint32) (status uint32) = ntdll.NtQuerySystemInformation
+//
+//sys NtQuerySystemInformation(systemInfoClass int, systemInformation unsafe.Pointer, systemInfoLength uint32, returnLength *uint32) (status uint32) = ntdll.NtQuerySystemInformation
 
 type SYSTEM_PROCESS_INFORMATION struct {
 	NextEntryOffset              uint32         // ULONG

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/winapi/zsyscall_windows.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/winapi/zsyscall_windows.go
@@ -100,7 +100,7 @@ func resizePseudoConsole(hPc windows.Handle, size uint32) (hr error) {
 	return
 }
 
-func NtQuerySystemInformation(systemInfoClass int, systemInformation uintptr, systemInfoLength uint32, returnLength *uint32) (status uint32) {
+func NtQuerySystemInformation(systemInfoClass int, systemInformation unsafe.Pointer, systemInfoLength uint32, returnLength *uint32) (status uint32) {
 	r0, _, _ := syscall.Syscall6(procNtQuerySystemInformation.Addr(), 4, uintptr(systemInfoClass), uintptr(systemInformation), uintptr(systemInfoLength), uintptr(unsafe.Pointer(returnLength)), 0, 0)
 	status = uint32(r0)
 	return
@@ -152,7 +152,7 @@ func IsProcessInJob(procHandle windows.Handle, jobHandle windows.Handle, result 
 	return
 }
 
-func QueryInformationJobObject(jobHandle windows.Handle, infoClass uint32, jobObjectInfo uintptr, jobObjectInformationLength uint32, lpReturnLength *uint32) (err error) {
+func QueryInformationJobObject(jobHandle windows.Handle, infoClass uint32, jobObjectInfo unsafe.Pointer, jobObjectInformationLength uint32, lpReturnLength *uint32) (err error) {
 	r1, _, e1 := syscall.Syscall6(procQueryInformationJobObject.Addr(), 5, uintptr(jobHandle), uintptr(infoClass), uintptr(jobObjectInfo), uintptr(jobObjectInformationLength), uintptr(unsafe.Pointer(lpReturnLength)), 0)
 	if r1 == 0 {
 		if e1 != 0 {
@@ -244,7 +244,7 @@ func LocalFree(ptr uintptr) {
 	return
 }
 
-func NtQueryInformationProcess(processHandle windows.Handle, processInfoClass uint32, processInfo uintptr, processInfoLength uint32, returnLength *uint32) (status uint32) {
+func NtQueryInformationProcess(processHandle windows.Handle, processInfoClass uint32, processInfo unsafe.Pointer, processInfoLength uint32, returnLength *uint32) (status uint32) {
 	r0, _, _ := syscall.Syscall6(procNtQueryInformationProcess.Addr(), 5, uintptr(processHandle), uintptr(processInfoClass), uintptr(processInfo), uintptr(processInfoLength), uintptr(unsafe.Pointer(returnLength)), 0)
 	status = uint32(r0)
 	return


### PR DESCRIPTION
This change brings a fix to make storage stats work for hostprocess containers, as well as some additional fixes to jobobjects/hpc along the way in the commit history. 

Commits cped:
1. 1154e47f9766102d3ffca283acf01bf28f8331ad
2. 52a4ea99865dd097d1c963e94bd7cfb14b5b8c96
3. 7fbb79f823aa5a039d6329501accc0b2c92a91d3
4. 566e3b0f89b2c769fc874ea3cc2a33ac5423ab08
5. f29964fb18afcd85c561494c04a8e797a1fdf2fd
6. 014849a4b0dcf88831921f34ba751b0400716203
7. 9d05b5b66d4cc3e678b4cd87b50a54977820101c

And one additional commit to vendor everything in test as release/0.9 still has the test vendor directory.