### PR TITLE
Set `snpSupported` field on the guest Host object

### DIFF
--- a/cmd/gcs/main.go
+++ b/cmd/gcs/main.go
@@ -14,6 +14,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/Microsoft/hcsshim/pkg/amdsevsnp"
 	"github.com/containerd/cgroups"
 	cgroupstats "github.com/containerd/cgroups/stats/v1"
 	oci "github.com/opencontainers/runtime-spec/specs-go"
@@ -263,7 +264,11 @@ func main() {
 		Handler:  mux,
 		EnableV4: *v4,
 	}
-	h := hcsv2.NewHost(rtime, tport)
+	var snpSupported bool
+	if _, err := amdsevsnp.FetchRawSNPReport(nil); !os.IsNotExist(err) {
+		snpSupported = true
+	}
+	h := hcsv2.NewHost(rtime, tport, snpSupported)
 	b.AssignHandlers(mux, h)
 
 	var bridgeIn io.ReadCloser

--- a/internal/guest/runtime/hcsv2/uvm.go
+++ b/internal/guest/runtime/hcsv2/uvm.go
@@ -59,9 +59,10 @@ type Host struct {
 	policyMutex               sync.Mutex
 	securityPolicyEnforcer    securitypolicy.SecurityPolicyEnforcer
 	securityPolicyEnforcerSet bool
+	snpSupported              bool
 }
 
-func NewHost(rtime runtime.Runtime, vsock transport.Transport) *Host {
+func NewHost(rtime runtime.Runtime, vsock transport.Transport, snpSupported bool) *Host {
 	return &Host{
 		containers:                make(map[string]*Container),
 		externalProcesses:         make(map[int]*externalProcess),
@@ -69,6 +70,7 @@ func NewHost(rtime runtime.Runtime, vsock transport.Transport) *Host {
 		vsock:                     vsock,
 		securityPolicyEnforcerSet: false,
 		securityPolicyEnforcer:    &securitypolicy.ClosedDoorSecurityPolicyEnforcer{},
+		snpSupported:              snpSupported,
 	}
 }
 


### PR DESCRIPTION
It's important to know if the guest has SEV-SNP support. Try
making fetch report ioctl and set `snpSupported` field when
the device exists. Assume SEV-SNP even in the case of a failed
ioctl, i.e. as long as the `/dev/sev` device exists, set the
field to `true`.

Signed-off-by: Maksim An <maksiman@microsoft.com>