### PR TITLE
enforcement: fix use case when the same target has different hashes

### DIFF
--- a/pkg/securitypolicy/securitypolicyenforcer.go
+++ b/pkg/securitypolicy/securitypolicyenforcer.go
@@ -380,6 +380,14 @@ func (pe *StandardSecurityPolicyEnforcer) EnforceDeviceMountPolicy(target string
 	for _, container := range pe.Containers {
 		for _, layer := range container.Layers {
 			if deviceHash == layer {
+				if existingHash := pe.Devices[target]; existingHash != "" {
+					return fmt.Errorf(
+						"conflicting device hashes for target %s: old=%s, new=%s",
+						target,
+						existingHash,
+						deviceHash,
+					)
+				}
 				pe.Devices[target] = deviceHash
 				return nil
 			}


### PR DESCRIPTION
Fix an issue when the same mount target could have different hashes
during device mount policy enforcement.
Although it's possible to mount different devices at the same mount
location, this doesn't make sense for read-only container layers.
The device mount enforcement logic has been updated to cover this
case.
This was discovered by randomized security policy unit tests.

The tests have been updated, to minimize the chance of it happening
by adding a minimal length for a random string and appropriate unit
test has been added to cover the change.

Signed-off-by: Maksim An <maksiman@microsoft.com>