### PR TITLE
add `-snp` flag to gcs binary

### DIFF
--- a/internal/guest/runtime/hcsv2/uvm.go
+++ b/internal/guest/runtime/hcsv2/uvm.go
@@ -59,9 +59,10 @@ type Host struct {
 	policyMutex               sync.Mutex
 	securityPolicyEnforcer    securitypolicy.SecurityPolicyEnforcer
 	securityPolicyEnforcerSet bool
+	snpSupported              bool
 }
 
-func NewHost(rtime runtime.Runtime, vsock transport.Transport) *Host {
+func NewHost(rtime runtime.Runtime, vsock transport.Transport, snpSupported bool) *Host {
 	return &Host{
 		containers:                make(map[string]*Container),
 		externalProcesses:         make(map[int]*externalProcess),
@@ -69,6 +70,7 @@ func NewHost(rtime runtime.Runtime, vsock transport.Transport) *Host {
 		vsock:                     vsock,
 		securityPolicyEnforcerSet: false,
 		securityPolicyEnforcer:    &securitypolicy.ClosedDoorSecurityPolicyEnforcer{},
+		snpSupported:              snpSupported,
 	}
 }
 


### PR DESCRIPTION
This PR adds a way to tell GCS that it is expected to be running
inside an SEV-SNP enabled linux.
In addition to the flag we also try making "get-snp-report" ioctl
and refuse to run when `-snp` is requested, but not supported or
when `-snp` is not requested, but supported.

Signed-off-by: Maksim An <maksiman@microsoft.com>