### PR TITLE
Remove wait mounts functionality

### DIFF
--- a/internal/guest/runtime/hcsv2/uvm.go
+++ b/internal/guest/runtime/hcsv2/uvm.go
@@ -303,11 +303,6 @@ func (h *Host) CreateContainer(ctx context.Context, id string, settings *prot.VM
 		settings.OCISpecification.Process.Env = append(settings.OCISpecification.Process.Env, secPolicyEnv)
 	}
 
-	// Sandbox mount paths need to be resolved in the spec before expected mounts policy can be enforced.
-	if err = h.securityPolicyEnforcer.EnforceWaitMountPointsPolicy(id, settings.OCISpecification); err != nil {
-		return nil, errors.Wrapf(err, "container creation denied due to policy")
-	}
-
 	// Create the BundlePath
 	if err := os.MkdirAll(settings.OCIBundlePath, 0700); err != nil {
 		return nil, errors.Wrapf(err, "failed to create OCIBundlePath: '%s'", settings.OCIBundlePath)

--- a/internal/guest/storage/test/policy/mountmonitoringsecuritypolicyenforcer.go
+++ b/internal/guest/storage/test/policy/mountmonitoringsecuritypolicyenforcer.go
@@ -43,10 +43,6 @@ func (MountMonitoringSecurityPolicyEnforcer) EnforceMountPolicy(_, _ string, _ *
 	return nil
 }
 
-func (MountMonitoringSecurityPolicyEnforcer) EnforceWaitMountPointsPolicy(_ string, _ *oci.Spec) error {
-	return nil
-}
-
 func (MountMonitoringSecurityPolicyEnforcer) ExtendDefaultMounts(_ []oci.Mount) error {
 	return nil
 }

--- a/internal/tools/securitypolicy/README.md
+++ b/internal/tools/securitypolicy/README.md
@@ -22,7 +22,6 @@ image_name = "rust:1.52.1"
 command = ["rustc", "--help"]
 working_dir = "/home/user"
 allow_elevated = true
-wait_mount_points = ["/path/to/container/mount-1", "/path/to/container/mount-2"]
 
 [[container.env_rule]]
 strategy = "re2"
@@ -99,13 +98,6 @@ represented in JSON.
           }
         },
         "working_dir": "/home/user",
-        "wait_mount_points": {
-          "length": 2,
-          "elements": {
-            "0": "/path/to/container/mount-1",
-            "1": "/path/to/container/mount-2"
-          }
-        },
         "mounts": {
           "length": 2,
           "elements": {
@@ -166,10 +158,6 @@ represented in JSON.
           }
         },
         "working_dir": "/",
-        "wait_mount_points": {
-          "length": 0,
-          "elements": {}
-        },
         "mounts": {
           "length": 0,
           "elements": {}

--- a/internal/tools/securitypolicy/helpers/helpers.go
+++ b/internal/tools/securitypolicy/helpers/helpers.go
@@ -158,7 +158,6 @@ func PolicyContainersFromConfigs(containerConfigs []securitypolicy.ContainerConf
 			layerHashes,
 			envRules,
 			workingDir,
-			containerConfig.WaitMountPoints,
 			containerConfig.Mounts,
 			containerConfig.AllowElevated,
 		)

--- a/pkg/securitypolicy/opts.go
+++ b/pkg/securitypolicy/opts.go
@@ -10,14 +10,6 @@ func WithEnvVarRules(envs []EnvRuleConfig) ContainerConfigOpt {
 	}
 }
 
-// WithWaitMountPoints adds expected mounts to container policy config.
-func WithWaitMountPoints(em []string) ContainerConfigOpt {
-	return func(c *ContainerConfig) error {
-		c.WaitMountPoints = append(c.WaitMountPoints, em...)
-		return nil
-	}
-}
-
 // WithWorkingDir sets working directory in container policy config.
 func WithWorkingDir(wd string) ContainerConfigOpt {
 	return func(c *ContainerConfig) error {

--- a/pkg/securitypolicy/securitypolicy.go
+++ b/pkg/securitypolicy/securitypolicy.go
@@ -44,14 +44,13 @@ type EnvRuleConfig struct {
 // ContainerConfig contains toml or JSON config for container described
 // in security policy.
 type ContainerConfig struct {
-	ImageName       string          `json:"image_name" toml:"image_name"`
-	Command         []string        `json:"command" toml:"command"`
-	Auth            AuthConfig      `json:"auth" toml:"auth"`
-	EnvRules        []EnvRuleConfig `json:"env_rules" toml:"env_rule"`
-	WorkingDir      string          `json:"working_dir" toml:"working_dir"`
-	WaitMountPoints []string        `json:"wait_mount_points" toml:"wait_mount_points"`
-	Mounts          []MountConfig   `json:"mounts" toml:"mount"`
-	AllowElevated   bool            `json:"allow_elevated" toml:"allow_elevated"`
+	ImageName     string          `json:"image_name" toml:"image_name"`
+	Command       []string        `json:"command" toml:"command"`
+	Auth          AuthConfig      `json:"auth" toml:"auth"`
+	EnvRules      []EnvRuleConfig `json:"env_rules" toml:"env_rule"`
+	WorkingDir    string          `json:"working_dir" toml:"working_dir"`
+	Mounts        []MountConfig   `json:"mounts" toml:"mount"`
+	AllowElevated bool            `json:"allow_elevated" toml:"allow_elevated"`
 }
 
 // MountConfig contains toml or JSON config for mount security policy
@@ -172,13 +171,12 @@ type Containers struct {
 }
 
 type Container struct {
-	Command         CommandArgs     `json:"command"`
-	EnvRules        EnvRules        `json:"env_rules"`
-	Layers          Layers          `json:"layers"`
-	WorkingDir      string          `json:"working_dir"`
-	WaitMountPoints WaitMountPoints `json:"wait_mount_points"`
-	Mounts          Mounts          `json:"mounts"`
-	AllowElevated   bool            `json:"allow_elevated"`
+	Command       CommandArgs `json:"command"`
+	EnvRules      EnvRules    `json:"env_rules"`
+	Layers        Layers      `json:"layers"`
+	WorkingDir    string      `json:"working_dir"`
+	Mounts        Mounts      `json:"mounts"`
+	AllowElevated bool        `json:"allow_elevated"`
 }
 
 // StringArrayMap wraps an array of strings as a string map.
@@ -190,8 +188,6 @@ type StringArrayMap struct {
 type Layers StringArrayMap
 
 type CommandArgs StringArrayMap
-
-type WaitMountPoints StringArrayMap
 
 type Options StringArrayMap
 
@@ -218,7 +214,6 @@ func CreateContainerPolicy(
 	command, layers []string,
 	envRules []EnvRuleConfig,
 	workingDir string,
-	eMounts []string,
 	mounts []MountConfig,
 	allowElevated bool,
 ) (*Container, error) {
@@ -229,13 +224,12 @@ func CreateContainerPolicy(
 		return nil, err
 	}
 	return &Container{
-		Command:         newCommandArgs(command),
-		Layers:          newLayers(layers),
-		EnvRules:        newEnvRules(envRules),
-		WorkingDir:      workingDir,
-		WaitMountPoints: newWaitMountPoints(eMounts),
-		Mounts:          newMountConstraints(mounts),
-		AllowElevated:   allowElevated,
+		Command:       newCommandArgs(command),
+		Layers:        newLayers(layers),
+		EnvRules:      newEnvRules(envRules),
+		WorkingDir:    workingDir,
+		Mounts:        newMountConstraints(mounts),
+		AllowElevated: allowElevated,
 	}, nil
 }
 
@@ -301,16 +295,6 @@ func newLayers(ls []string) Layers {
 	}
 	return Layers{
 		Elements: layers,
-	}
-}
-
-func newWaitMountPoints(em []string) WaitMountPoints {
-	mounts := map[string]string{}
-	for i, m := range em {
-		mounts[strconv.Itoa(i)] = m
-	}
-	return WaitMountPoints{
-		Elements: mounts,
 	}
 }
 
@@ -431,10 +415,6 @@ func (l Layers) MarshalJSON() ([]byte, error) {
 
 func (o Options) MarshalJSON() ([]byte, error) {
 	return json.Marshal(StringArrayMap(o))
-}
-
-func (wm WaitMountPoints) MarshalJSON() ([]byte, error) {
-	return json.Marshal(StringArrayMap(wm))
 }
 
 func (m Mounts) MarshalJSON() ([]byte, error) {

--- a/pkg/securitypolicy/securitypolicyenforcer.go
+++ b/pkg/securitypolicy/securitypolicyenforcer.go
@@ -6,8 +6,6 @@ package securitypolicy
 import (
 	"errors"
 	"fmt"
-	"os"
-	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
@@ -17,8 +15,6 @@ import (
 
 	specInternal "github.com/Microsoft/hcsshim/internal/guest/spec"
 	"github.com/Microsoft/hcsshim/internal/guestpath"
-	"github.com/Microsoft/hcsshim/internal/hooks"
-	"github.com/Microsoft/hcsshim/pkg/annotations"
 )
 
 type SecurityPolicyEnforcer interface {
@@ -26,7 +22,6 @@ type SecurityPolicyEnforcer interface {
 	EnforceDeviceUnmountPolicy(unmountTarget string) (err error)
 	EnforceOverlayMountPolicy(containerID string, layerPaths []string) (err error)
 	EnforceCreateContainerPolicy(containerID string, argList []string, envList []string, workingDir string) (err error)
-	EnforceWaitMountPointsPolicy(containerID string, spec *oci.Spec) error
 	EnforceMountPolicy(sandboxID, containerID string, spec *oci.Spec) error
 	ExtendDefaultMounts([]oci.Mount) error
 	EncodedSecurityPolicy() string
@@ -111,9 +106,6 @@ type securityPolicyContainer struct {
 	// WorkingDir is a path to container's working directory, which all the processes
 	// will default to.
 	WorkingDir string
-	// Unordered list of mounts which are expected to be present when the container
-	// starts
-	WaitMountPoints []string
 	// A list of constraints for determining if a given mount is allowed.
 	Mounts        []mountInternal
 	AllowElevated bool
@@ -235,11 +227,6 @@ func (c Container) toInternal() (securityPolicyContainer, error) {
 		return securityPolicyContainer{}, err
 	}
 
-	waitMounts, err := c.WaitMountPoints.toInternal()
-	if err != nil {
-		return securityPolicyContainer{}, err
-	}
-
 	mounts, err := c.Mounts.toInternal()
 	if err != nil {
 		return securityPolicyContainer{}, err
@@ -250,10 +237,9 @@ func (c Container) toInternal() (securityPolicyContainer, error) {
 		Layers:   layers,
 		// No need to have toInternal(), because WorkingDir is a string both
 		// internally and in the policy.
-		WorkingDir:      c.WorkingDir,
-		WaitMountPoints: waitMounts,
-		Mounts:          mounts,
-		AllowElevated:   c.AllowElevated,
+		WorkingDir:    c.WorkingDir,
+		Mounts:        mounts,
+		AllowElevated: c.AllowElevated,
 	}, nil
 }
 
@@ -294,14 +280,6 @@ func (l Layers) toInternal() ([]string, error) {
 	}
 
 	return stringMapToStringArray(l.Elements)
-}
-
-func (wm WaitMountPoints) toInternal() ([]string, error) {
-	if wm.Length != len(wm.Elements) {
-		return nil, fmt.Errorf("expectedMounts numbers don't match in policy. expected: %d, actual: %d", wm.Length, len(wm.Elements))
-	}
-
-	return stringMapToStringArray(wm.Elements)
 }
 
 func (o Options) toInternal() ([]string, error) {
@@ -785,94 +763,6 @@ func stringSlicesEqual(slice1, slice2 []string) bool {
 	return true
 }
 
-// EnforceWaitMountPointsPolicy for StandardSecurityPolicyEnforcer injects a
-// hooks.CreateRuntime hook into container spec and the hook ensures that
-// the expected mounts appear prior container start. At the moment enforcement
-// is expected to take place inside LCOW UVM.
-//
-// Expected mount is provided as a path under a sandbox mount path inside
-// container, e.g., sandbox mount is at path "/path/in/container" and wait path
-// is "/path/in/container/wait/path", which corresponds to
-// "/run/gcs/c/<podID>/sandboxMounts/path/on/the/host/wait/path"
-//
-// Iterates through container mounts to identify the correct sandbox
-// mount where the wait path is nested under. The mount spec will
-// be something like:
-//
-//	{
-//	   "source": "/run/gcs/c/<podID>/sandboxMounts/path/on/host",
-//	   "destination": "/path/in/container"
-//	}
-//
-// The wait path will be "/path/in/container/wait/path". To find the corresponding
-// sandbox mount do a prefix match on wait path against all container mounts
-// Destination and resolve the full path inside UVM. For example above it becomes
-// "/run/gcs/c/<podID>/sandboxMounts/path/on/host/wait/path"
-func (pe *StandardSecurityPolicyEnforcer) EnforceWaitMountPointsPolicy(containerID string, spec *oci.Spec) error {
-	pe.mutex.Lock()
-	defer pe.mutex.Unlock()
-
-	if len(pe.Containers) < 1 {
-		return errors.New("policy doesn't allow mounting containers")
-	}
-
-	sandboxID := spec.Annotations[annotations.KubernetesSandboxID]
-	if sandboxID == "" {
-		return errors.New("no sandbox ID present in spec annotations")
-	}
-
-	var wMounts []string
-	pIndices := pe.possibleIndicesForID(containerID)
-	if len(pIndices) == 0 {
-		return errors.New("no valid container indices found")
-	}
-
-	// Unlike environment variable and command line enforcement, there isn't anything
-	// to validate here, since we're essentially just injecting hooks when necessary
-	// for all containers.
-	matchFound := false
-	for _, index := range pIndices {
-		if !matchFound {
-			matchFound = true
-			wMounts = pe.Containers[index].WaitMountPoints
-		} else {
-			pe.narrowMatchesForContainerIndex(index, containerID)
-		}
-	}
-
-	if len(wMounts) == 0 {
-		return nil
-	}
-
-	var wPaths []string
-	for _, mount := range wMounts {
-		var wp string
-		for _, m := range spec.Mounts {
-			// prefix matching to find correct sandbox mount
-			if strings.HasPrefix(mount, m.Destination) {
-				wp = filepath.Join(m.Source, strings.TrimPrefix(mount, m.Destination))
-				break
-			}
-		}
-		if wp == "" {
-			return fmt.Errorf("invalid mount path: %q", mount)
-		}
-		wPaths = append(wPaths, filepath.Clean(wp))
-	}
-
-	pathsArg := strings.Join(wPaths, ",")
-	waitPathsBinary := "/bin/wait-paths"
-	args := []string{
-		waitPathsBinary,
-		"--paths",
-		pathsArg,
-		"--timeout",
-		"60",
-	}
-	hook := hooks.NewOCIHook(waitPathsBinary, args, os.Environ())
-	return hooks.AddOCIHook(spec, hooks.CreateRuntime, hook)
-}
-
 func (pe *StandardSecurityPolicyEnforcer) EncodedSecurityPolicy() string {
 	return pe.encodedSecurityPolicy
 }
@@ -900,10 +790,6 @@ func (OpenDoorSecurityPolicyEnforcer) EnforceCreateContainerPolicy(_ string, _ [
 }
 
 func (OpenDoorSecurityPolicyEnforcer) EnforceMountPolicy(_, _ string, _ *oci.Spec) error {
-	return nil
-}
-
-func (OpenDoorSecurityPolicyEnforcer) EnforceWaitMountPointsPolicy(_ string, _ *oci.Spec) error {
 	return nil
 }
 
@@ -935,10 +821,6 @@ func (ClosedDoorSecurityPolicyEnforcer) EnforceOverlayMountPolicy(_ string, _ []
 
 func (ClosedDoorSecurityPolicyEnforcer) EnforceCreateContainerPolicy(_ string, _ []string, _ []string, _ string) error {
 	return errors.New("running commands is denied by policy")
-}
-
-func (ClosedDoorSecurityPolicyEnforcer) EnforceWaitMountPointsPolicy(_ string, _ *oci.Spec) error {
-	return errors.New("enforcing wait mount points is denied by policy")
 }
 
 func (ClosedDoorSecurityPolicyEnforcer) EnforceMountPolicy(_, _ string, _ *oci.Spec) error {


### PR DESCRIPTION
Wait mounts was originally added as a synchronization mechanic that
allows to build dependencies between containers via security policy.

Some issues:

- Only available via policy so, you can't use in a non-confidential scenario
- Mixes configuration into policy enforcement
- Completely bespoke

With our moving to a rego based policy engine, we've decided to stop doing
anything that is "include configuration in policy" and instead switch to
"policy controls if a bit of configuration is allowed to be changed". This
approach eliminates wait mounts as a possibility to move over even if we
decided that the issues listed above weren't problematic.

We expect that any customer using wait mounts functionality via policy
will switch to handling dependencies amongst containers as they usually
would. Allow the container that is missing a dependency to fail in a fashion 
that will get the orchestrator to restart it until such time as the dependency
is available. For wait mounts, this means exiting if the mounted drive is
missing a known good file that is expected to exist thereby indicating that
the drive in question wasn't available at the time the container started and
instead, an empty directory was mounted.

These changes are a prerequisite for the soon to arrive change to switch from
the bespoke JSON based policy language I wrote to using Rego.

Signed-off-by: Sean T. Allen <seanallen@microsoft.com>