### PR TITLE
Properly assign logrus entry for fallback queries

### DIFF
--- a/internal/hcs/system.go
+++ b/internal/hcs/system.go
@@ -497,7 +497,7 @@ func (computeSystem *System) PropertiesV2(ctx context.Context, types ...hcsschem
 	if err == nil && len(fallbackTypes) == 0 {
 		return properties, nil
 	} else if err != nil {
-		logEntry.WithError(fmt.Errorf("failed to query compute system properties in-proc: %w", err))
+		logEntry = logEntry.WithError(fmt.Errorf("failed to query compute system properties in-proc: %w", err))
 		fallbackTypes = types
 	}
 


### PR DESCRIPTION
I didn't reassign the logEntry that contained the error reason if
querying for stats in the shim failed