### PR TITLE
Fix golangci-lint issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: "windows-2019"
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v3
         with:
           go-version: ${{ env.GO_VERSION }}
 
@@ -20,13 +20,11 @@ jobs:
         with:
           version: v1.48.0
           args: -v
-          skip-go-installation: true
-          only-new-issues: true
 
   protos:
     runs-on: "windows-2019"
     steps:
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v3
         with:
           go-version: ${{ env.GO_VERSION }}
       - uses: actions/checkout@v2
@@ -75,7 +73,7 @@ jobs:
       GOPROXY: "https://proxy.golang.org,direct"
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v3
         with:
           go-version: ${{ env.GO_VERSION }}
       - name: Validate main modules
@@ -96,7 +94,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ env.GO_VERSION }}
 
@@ -111,7 +109,7 @@ jobs:
         os: [windows-2019, windows-2022]
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v3
         with:
           go-version: ${{ env.GO_VERSION }}
 
@@ -149,7 +147,7 @@ jobs:
         os: [windows-2019, windows-2022]
 
     steps:
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v3
         with:
           go-version: ${{ env.GO_VERSION }}
           check-latest: true
@@ -279,7 +277,7 @@ jobs:
     runs-on: "windows-2019"
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v3
         with:
           go-version: ${{ env.GO_VERSION }}
 
@@ -322,7 +320,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ env.GO_VERSION }}
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -42,7 +42,7 @@ issues:
     - path: internal\\hcs\\schema2\\
       linters:
         - stylecheck
-      Text: "ST1003:"
+        - gofmt
 
     - path: internal\\wclayer\\
       linters:

--- a/cmd/containerd-shim-runhcs-v1/exec_hcs.go
+++ b/cmd/containerd-shim-runhcs-v1/exec_hcs.go
@@ -366,7 +366,7 @@ func (he *hcsExec) ForceExit(ctx context.Context, status int) {
 // To transition for a created state the following must be done:
 //
 // 1. Issue `he.processDoneCancel` to unblock the goroutine
-// `he.waitForContainerExit()``.
+// `he.waitForContainerExit()`.
 //
 // 2. Set `he.state`, `he.exitStatus` and `he.exitedAt` to the exited values.
 //

--- a/cmd/containerd-shim-runhcs-v1/serve.go
+++ b/cmd/containerd-shim-runhcs-v1/serve.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"os"
 	"strings"
@@ -157,7 +156,7 @@ var serveCommand = cli.Command{
 			panic("file log output mode is not supported")
 		case runhcsopts.Options_ETW:
 			logrus.SetFormatter(nopFormatter{})
-			logrus.SetOutput(ioutil.Discard)
+			logrus.SetOutput(io.Discard)
 		}
 
 		os.Stdin.Close()
@@ -274,7 +273,7 @@ func trapClosedConnErr(err error) error {
 // readOptions reads in bytes from the reader and converts it to a shim options
 // struct. If no data is available from the reader, returns (nil, nil).
 func readOptions(r io.Reader) (*runhcsopts.Options, error) {
-	d, err := ioutil.ReadAll(r)
+	d, err := io.ReadAll(r)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to read input")
 	}

--- a/cmd/containerd-shim-runhcs-v1/service_internal.go
+++ b/cmd/containerd-shim-runhcs-v1/service_internal.go
@@ -30,7 +30,6 @@ var empty = &google_protobuf1.Empty{}
 // callers responsibility to verify that `s.isSandbox == true` before calling
 // this method.
 //
-//
 // If `pod==nil` returns `errdefs.ErrFailedPrecondition`.
 func (s *service) getPod() (shimPod, error) {
 	raw := s.taskOrPod.Load()

--- a/cmd/containerd-shim-runhcs-v1/start.go
+++ b/cmd/containerd-shim-runhcs-v1/start.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -37,7 +36,7 @@ The start command can either start a new shim or return an address to an existin
 	SkipArgReorder: true,
 	Action: func(context *cli.Context) (err error) {
 		// We cant write anything to stdout/stderr for this cmd.
-		logrus.SetOutput(ioutil.Discard)
+		logrus.SetOutput(io.Discard)
 
 		// On Windows there are two scenarios that will launch a shim.
 		//

--- a/cmd/containerd-shim-runhcs-v1/task_hcs.go
+++ b/cmd/containerd-shim-runhcs-v1/task_hcs.go
@@ -117,7 +117,7 @@ func newHcsStandaloneTask(ctx context.Context, events publisher, req *task.Creat
 }
 
 // createContainer is a generic call to return either a process/hypervisor isolated container, or a job container
-//  based on what is set in the OCI spec.
+// based on what is set in the OCI spec.
 func createContainer(ctx context.Context, id, owner, netNS string, s *specs.Spec, parent *uvm.UtilityVM, shimOpts *runhcsopts.Options) (cow.Container, *resources.Resources, error) {
 	var (
 		err       error

--- a/cmd/gcs/main.go
+++ b/cmd/gcs/main.go
@@ -7,7 +7,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -135,7 +134,7 @@ func startTimeSyncService() error {
 	expectedClockName := "hyperv\n"
 	for _, ptpDirPath = range ptpDirList {
 		clockNameFilePath := filepath.Join(ptpClassDir.Name(), ptpDirPath, "clock_name")
-		buf, err := ioutil.ReadFile(clockNameFilePath)
+		buf, err := os.ReadFile(clockNameFilePath)
 		if err != nil && !os.IsNotExist(err) {
 			return errors.Wrapf(err, "failed to read clock name file at %s", clockNameFilePath)
 		}
@@ -155,7 +154,7 @@ func startTimeSyncService() error {
 	// chronyd config file take from: https://docs.microsoft.com/en-us/azure/virtual-machines/linux/time-sync
 	chronydConfigString := fmt.Sprintf("refclock PHC %s poll 3 dpoll -2 offset 0 stratum 2\nmakestep 0.1 -1\n", ptpDevPath)
 	chronydConfPath := "/tmp/chronyd.conf"
-	err = ioutil.WriteFile(chronydConfPath, []byte(chronydConfigString), 0644)
+	err = os.WriteFile(chronydConfPath, []byte(chronydConfigString), 0644)
 	if err != nil {
 		return errors.Wrapf(err, "failed to create chronyd conf file %s", chronydConfPath)
 	}
@@ -241,7 +240,7 @@ func main() {
 	// If no path is specified core dumps will just be placed in the working directory of wherever the process
 	// was invoked to a file named "core".
 	if *coreDumpLoc != "" {
-		if err := ioutil.WriteFile(
+		if err := os.WriteFile(
 			"/proc/sys/kernel/core_pattern",
 			[]byte(*coreDumpLoc),
 			0644,
@@ -292,7 +291,7 @@ func main() {
 	// Write 1 to memory.use_hierarchy on the root cgroup to enable hierarchy
 	// support. This needs to be set before we create any cgroups as the write
 	// will fail otherwise.
-	if err := ioutil.WriteFile("/sys/fs/cgroup/memory/memory.use_hierarchy", []byte("1"), 0644); err != nil {
+	if err := os.WriteFile("/sys/fs/cgroup/memory/memory.use_hierarchy", []byte("1"), 0644); err != nil {
 		logrus.WithError(err).Fatal("failed to enable hierarchy support for root cgroup")
 	}
 

--- a/cmd/gcstools/generichook.go
+++ b/cmd/gcstools/generichook.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"text/template"
@@ -51,7 +50,7 @@ func runGenericHook() error {
 }
 
 func logDebugFile(debugFilePath string) {
-	contents, err := ioutil.ReadFile(debugFilePath)
+	contents, err := os.ReadFile(debugFilePath)
 	if err != nil {
 		logrus.Errorf("failed to read debug file at %s: %v", debugFilePath, err)
 		return

--- a/cmd/ncproxy/config.go
+++ b/cmd/ncproxy/config.go
@@ -5,7 +5,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -41,7 +40,7 @@ var configCommand = cli.Command{
 							return errors.Wrap(err, "failed to make path to config file")
 						}
 					}
-					if err := ioutil.WriteFile(
+					if err := os.WriteFile(
 						file,
 						[]byte(configData),
 						0700,
@@ -95,7 +94,7 @@ func loadConfig(path string) (*config, error) {
 // Reads config from path and returns config struct if path is valid and marshaling
 // succeeds
 func readConfig(path string) (*config, error) {
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to read config file")
 	}

--- a/cmd/ncproxy/run.go
+++ b/cmd/ncproxy/run.go
@@ -5,7 +5,7 @@ package main
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -168,7 +168,7 @@ func run(clicontext *cli.Context) error {
 		if err := initPanicFile(panicLog); err != nil {
 			return err
 		}
-		logrus.SetOutput(ioutil.Discard)
+		logrus.SetOutput(io.Discard)
 		if err := launchService(serviceDone); err != nil {
 			return err
 		}

--- a/cmd/ncproxy/server.go
+++ b/cmd/ncproxy/server.go
@@ -146,12 +146,12 @@ func (s *server) serve(ctx context.Context, ttrpcListener net.Listener, grpcList
 //
 // There are a few failure modes for reconnect:
 //
-// 1. If a compute agent entry is stale, connecting to the compute agent client will fail
-//    and we will remove the entry from the database.
+//  1. If a compute agent entry is stale, connecting to the compute agent client will fail
+//     and we will remove the entry from the database.
 //
-// 2. If an active compute agent exists but we fail to connect to it, we will again remove
-//    the entry from the database. In this case, it is the node network service's
-//    responsibility to cleanup host network resources that are no longer being used.
+//  2. If an active compute agent exists but we fail to connect to it, we will again remove
+//     the entry from the database. In this case, it is the node network service's
+//     responsibility to cleanup host network resources that are no longer being used.
 //
 // Other failure modes are possible but not expected. In all failure cases we log the failures
 // but allow the service start to proceed. We chose this approach vs just failing service

--- a/cmd/ncproxy/utilities_test.go
+++ b/cmd/ncproxy/utilities_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -54,7 +53,7 @@ func endpointExists(targetName string, endpoints []*ncproxygrpc.GetEndpointRespo
 }
 
 func createTestNetworkingStore() (store *ncproxystore.NetworkingStore, closer func(), err error) {
-	tempDir, err := ioutil.TempDir("", "")
+	tempDir, err := os.MkdirTemp("", "")
 	if err != nil {
 		return nil, nil, err
 	}

--- a/cmd/runhcs/shim.go
+++ b/cmd/runhcs/shim.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"os"
 	"time"
@@ -85,7 +84,7 @@ var shimCommand = cli.Command{
 
 		if exec {
 			// Read the process spec from stdin.
-			specj, err := ioutil.ReadAll(os.Stdin)
+			specj, err := io.ReadAll(os.Stdin)
 			if err != nil {
 				return err
 			}
@@ -111,7 +110,7 @@ var shimCommand = cli.Command{
 			// successfully.
 			_, _ = errorOut.Write(runhcs.ShimSuccess)
 			errorOut.Close()
-			fatalWriter.Writer = ioutil.Discard
+			fatalWriter.Writer = io.Discard
 
 			// When this process exits, clear this process's pid in the registry.
 			defer func() {
@@ -203,7 +202,7 @@ var shimCommand = cli.Command{
 		// successfully.
 		_, _ = errorOut.Write(runhcs.ShimSuccess)
 		errorOut.Close()
-		fatalWriter.Writer = ioutil.Discard
+		fatalWriter.Writer = io.Discard
 
 		_ = cmd.Wait()
 		code := cmd.ExitState.ExitCode()

--- a/cmd/runhcs/vm.go
+++ b/cmd/runhcs/vm.go
@@ -6,7 +6,7 @@ import (
 	gcontext "context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"os"
 	"syscall"
@@ -50,7 +50,7 @@ var vmshimCommand = cli.Command{
 
 		pipePath := context.Args().First()
 
-		optsj, err := ioutil.ReadAll(os.Stdin)
+		optsj, err := io.ReadAll(os.Stdin)
 		if err != nil {
 			return err
 		}
@@ -101,7 +101,7 @@ var vmshimCommand = cli.Command{
 		// successfully.
 		os.Stdout.Write(runhcs.ShimSuccess)
 		os.Stdout.Close()
-		fatalWriter.Writer = ioutil.Discard
+		fatalWriter.Writer = io.Discard
 
 		pipeCh := make(chan net.Conn)
 		go func() {
@@ -130,7 +130,7 @@ var vmshimCommand = cli.Command{
 						err = closeWritePipe(pipe)
 					}
 					if err == nil {
-						_, _ = ioutil.ReadAll(pipe)
+						_, _ = io.ReadAll(pipe)
 					}
 				} else {
 					logrus.WithError(err).

--- a/cmd/tar2ext4/tar2ext4.go
+++ b/cmd/tar2ext4/tar2ext4.go
@@ -4,7 +4,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 
 	"github.com/Microsoft/hcsshim/ext4/tar2ext4"
@@ -54,7 +53,7 @@ func main() {
 		}
 
 		// Exhaust the tar stream.
-		_, _ = io.Copy(ioutil.Discard, in)
+		_, _ = io.Copy(io.Discard, in)
 		return nil
 	}()
 	if err != nil {

--- a/ext4/dmverity/dmverity_test.go
+++ b/ext4/dmverity/dmverity_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/binary"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"strings"
@@ -14,7 +13,7 @@ import (
 )
 
 func tempFileWithContentLength(t *testing.T, length int) *os.File {
-	tmpFile, err := ioutil.TempFile("", "")
+	tmpFile, err := os.CreateTemp("", "")
 	if err != nil {
 		t.Fatalf("failed to create temp file")
 	}

--- a/ext4/tar2ext4/tar2ext4.go
+++ b/ext4/tar2ext4/tar2ext4.go
@@ -5,9 +5,7 @@ import (
 	"bufio"
 	"encoding/binary"
 	"fmt"
-	"github.com/pkg/errors"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"strings"
@@ -15,6 +13,7 @@ import (
 	"github.com/Microsoft/hcsshim/ext4/dmverity"
 	"github.com/Microsoft/hcsshim/ext4/internal/compactext4"
 	"github.com/Microsoft/hcsshim/ext4/internal/format"
+	"github.com/pkg/errors"
 )
 
 type params struct {
@@ -243,7 +242,7 @@ func ReadExt4SuperBlock(vhdPath string) (*format.SuperBlock, error) {
 // merkle tree root digest. Convert is called with minimal options: ConvertWhiteout and MaximumDiskSize
 // set to dmverity.RecommendedVHDSizeGB.
 func ConvertAndComputeRootDigest(r io.Reader) (string, error) {
-	out, err := ioutil.TempFile("", "")
+	out, err := os.CreateTemp("", "")
 	if err != nil {
 		return "", fmt.Errorf("failed to create temporary file: %s", err)
 	}

--- a/hcn/hcn.go
+++ b/hcn/hcn.go
@@ -228,7 +228,7 @@ func IPv6DualStackSupported() error {
 	return platformDoesNotSupportError("IPv6 DualStack")
 }
 
-//L4proxySupported returns an error if the HCN version does not support L4Proxy
+// L4proxySupported returns an error if the HCN version does not support L4Proxy
 func L4proxyPolicySupported() error {
 	supported, err := GetCachedSupportedFeatures()
 	if err != nil {

--- a/hcn/hcnloadbalancer.go
+++ b/hcn/hcnloadbalancer.go
@@ -30,7 +30,7 @@ type HostComputeLoadBalancer struct {
 	Flags                LoadBalancerFlags         `json:",omitempty"` // 0: None, 1: EnableDirectServerReturn
 }
 
-//LoadBalancerFlags modify settings for a loadbalancer.
+// LoadBalancerFlags modify settings for a loadbalancer.
 type LoadBalancerFlags uint32
 
 var (

--- a/hcn/hcnpolicy.go
+++ b/hcn/hcnpolicy.go
@@ -315,7 +315,7 @@ const (
 	ProtocolTypeICMPv6  ProtocolType = 58
 )
 
-//L4ProxyPolicySetting applies proxy policy on network/endpoint
+// L4ProxyPolicySetting applies proxy policy on network/endpoint
 type L4ProxyPolicySetting struct {
 	IP          string       `json:",omitempty"`
 	Port        string       `json:",omitempty"`

--- a/hnsendpoint.go
+++ b/hnsendpoint.go
@@ -15,7 +15,7 @@ type HNSEndpointStats = hns.EndpointStats
 // Namespace represents a Compartment.
 type Namespace = hns.Namespace
 
-//SystemType represents the type of the system on which actions are done
+// SystemType represents the type of the system on which actions are done
 type SystemType string
 
 // SystemType const

--- a/internal/copyfile/copyfile.go
+++ b/internal/copyfile/copyfile.go
@@ -6,15 +6,10 @@ import (
 	"context"
 	"fmt"
 	"syscall"
-	"unsafe"
 
 	"github.com/Microsoft/hcsshim/internal/oc"
+	"github.com/Microsoft/hcsshim/internal/winapi"
 	"go.opencensus.io/trace"
-)
-
-var (
-	modkernel32   = syscall.NewLazyDLL("kernel32.dll")
-	procCopyFileW = modkernel32.NewProc("CopyFileW")
 )
 
 // CopyFile is a utility for copying a file using CopyFileW win32 API for
@@ -28,7 +23,7 @@ func CopyFile(ctx context.Context, srcFile, destFile string, overwrite bool) (er
 		trace.StringAttribute("destFile", destFile),
 		trace.BoolAttribute("overwrite", overwrite))
 
-	var bFailIfExists uint32 = 1
+	var bFailIfExists int32 = 1
 	if overwrite {
 		bFailIfExists = 0
 	}
@@ -41,13 +36,7 @@ func CopyFile(ctx context.Context, srcFile, destFile string, overwrite bool) (er
 	if err != nil {
 		return err
 	}
-	r1, _, err := syscall.Syscall(
-		procCopyFileW.Addr(),
-		3,
-		uintptr(unsafe.Pointer(lpExistingFileName)),
-		uintptr(unsafe.Pointer(lpNewFileName)),
-		uintptr(bFailIfExists))
-	if r1 == 0 {
+	if err := winapi.CopyFileW(lpExistingFileName, lpNewFileName, bFailIfExists); err != nil {
 		return fmt.Errorf("failed CopyFileW Win32 call from '%s' to '%s': %s", srcFile, destFile, err)
 	}
 	return nil

--- a/internal/devices/pnp.go
+++ b/internal/devices/pnp.go
@@ -6,7 +6,7 @@ package devices
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"strings"
 
@@ -79,7 +79,7 @@ func readCsPipeOutput(l net.Listener, errChan chan<- error, result *[]string) {
 		errChan <- errors.Wrapf(err, "failed to accept named pipe")
 		return
 	}
-	bytes, err := ioutil.ReadAll(c)
+	bytes, err := io.ReadAll(c)
 	if err != nil {
 		errChan <- err
 		return
@@ -108,7 +108,7 @@ func readAllPipeOutput(l net.Listener, errChan chan<- error, result *string) {
 		errChan <- errors.Wrapf(err, "failed to accept named pipe")
 		return
 	}
-	bytes, err := ioutil.ReadAll(c)
+	bytes, err := io.ReadAll(c)
 	if err != nil {
 		errChan <- err
 		return

--- a/internal/gcs/guestconnection_test.go
+++ b/internal/gcs/guestconnection_test.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"strings"
 	"testing"
@@ -233,7 +232,7 @@ func TestGcsCreateProcess(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	b, err := ioutil.ReadAll(stdout)
+	b, err := io.ReadAll(stdout)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/gcs/iochannel_test.go
+++ b/internal/gcs/iochannel_test.go
@@ -3,7 +3,7 @@
 package gcs
 
 import (
-	"io/ioutil"
+	"io"
 	"strings"
 	"testing"
 	"time"
@@ -22,7 +22,7 @@ func TestIoChannelClose(t *testing.T) {
 	defer ioc.Close()
 	ch := make(chan error, 1)
 	go func() {
-		_, err := ioutil.ReadAll(ioc)
+		_, err := io.ReadAll(ioc)
 		ch <- err
 	}()
 	time.Sleep(100 * time.Millisecond)
@@ -43,7 +43,7 @@ func TestIoChannelRead(t *testing.T) {
 	ch := make(chan error, 1)
 	go func() {
 		var err error
-		b, err = ioutil.ReadAll(ioc)
+		b, err = io.ReadAll(ioc)
 		ch <- err
 	}()
 	time.Sleep(100 * time.Millisecond)
@@ -84,7 +84,7 @@ func TestIoChannelWrite(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer c.Close()
-	b, err := ioutil.ReadAll(c)
+	b, err := io.ReadAll(c)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/guest/bridge/bridge.go
+++ b/internal/guest/bridge/bridge.go
@@ -164,14 +164,14 @@ type bridgeResponse struct {
 //
 // It has two fundamentally different dispatch options:
 //
-// 1. Request/Response where using the `Handler` a request
-//    of a given type will be dispatched to the appropriate handler
-//    and an appropriate response will respond to exactly that request that
-//    caused the dispatch.
+//  1. Request/Response where using the `Handler` a request
+//     of a given type will be dispatched to the appropriate handler
+//     and an appropriate response will respond to exactly that request that
+//     caused the dispatch.
 //
-// 2. `PublishNotification` where a notification that was not initiated
-//    by a request from any client can be written to the bridge at any time
-//    in any order.
+//  2. `PublishNotification` where a notification that was not initiated
+//     by a request from any client can be written to the bridge at any time
+//     in any order.
 type Bridge struct {
 	// Handler to invoke when messages are received.
 	Handler Handler

--- a/internal/guest/bridge/bridge_unit_test.go
+++ b/internal/guest/bridge/bridge_unit_test.go
@@ -7,7 +7,6 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"os"
 	"strings"
 	"sync"
@@ -455,7 +454,7 @@ func newLoopbackConnection() *loopbackConnection {
 
 func Test_Bridge_ListenAndServe_UnknownMessageHandler_Success(t *testing.T) {
 	// Turn off logging so as not to spam output.
-	logrus.SetOutput(ioutil.Discard)
+	logrus.SetOutput(io.Discard)
 
 	lc := newLoopbackConnection()
 	defer lc.close()
@@ -509,7 +508,7 @@ func Test_Bridge_ListenAndServe_UnknownMessageHandler_Success(t *testing.T) {
 
 func Test_Bridge_ListenAndServe_CorrectHandler_Success(t *testing.T) {
 	// Turn off logging so as not to spam output.
-	logrus.SetOutput(ioutil.Discard)
+	logrus.SetOutput(io.Discard)
 
 	lc := newLoopbackConnection()
 	defer lc.close()
@@ -590,7 +589,7 @@ func Test_Bridge_ListenAndServe_CorrectHandler_Success(t *testing.T) {
 
 func Test_Bridge_ListenAndServe_HandlersAreAsync_Success(t *testing.T) {
 	// Turn off logging so as not to spam output.
-	logrus.SetOutput(ioutil.Discard)
+	logrus.SetOutput(io.Discard)
 
 	lc := newLoopbackConnection()
 	defer lc.close()

--- a/internal/guest/network/network.go
+++ b/internal/guest/network/network.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -27,7 +26,7 @@ var (
 	pciFindDeviceFullPath             = pci.FindDeviceFullPath
 	storageWaitForFileMatchingPattern = storage.WaitForFileMatchingPattern
 	vmbusWaitForDevicePath            = vmbus.WaitForDevicePath
-	ioutilReadDir                     = ioutil.ReadDir
+	ioReadDir                         = os.ReadDir
 )
 
 // maxDNSSearches is limited to 6 in `man 5 resolv.conf`
@@ -139,9 +138,9 @@ func InstanceIDToName(ctx context.Context, id string, vpciAssigned bool) (_ stri
 		return "", errors.Wrapf(err, "failed to find adapter %v sysfs path", vmBusID)
 	}
 
-	var deviceDirs []os.FileInfo
+	var deviceDirs []os.DirEntry
 	for {
-		deviceDirs, err = ioutilReadDir(netDevicePath)
+		deviceDirs, err = ioReadDir(netDevicePath)
 		if err != nil {
 			if os.IsNotExist(err) {
 				select {

--- a/internal/guest/prot/protocol.go
+++ b/internal/guest/prot/protocol.go
@@ -721,9 +721,9 @@ type SchemaVersion struct {
 
 // Cmp compares s and v and returns:
 //
-// -1 if s <  v
-//  0 if s == v
-//  1 if s >  v
+//	-1 if s <  v
+//	0 if s == v
+//	1 if s >  v
 func (s *SchemaVersion) Cmp(v SchemaVersion) int {
 	if s.Major == v.Major {
 		if s.Minor == v.Minor {

--- a/internal/guest/runtime/hcsv2/sandbox_container.go
+++ b/internal/guest/runtime/hcsv2/sandbox_container.go
@@ -5,7 +5,6 @@ package hcsv2
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -60,14 +59,14 @@ func setupSandboxContainerSpec(ctx context.Context, id string, spec *oci.Spec) (
 	}
 
 	sandboxHostnamePath := getSandboxHostnamePath(id)
-	if err := ioutil.WriteFile(sandboxHostnamePath, []byte(hostname+"\n"), 0644); err != nil {
+	if err := os.WriteFile(sandboxHostnamePath, []byte(hostname+"\n"), 0644); err != nil {
 		return errors.Wrapf(err, "failed to write hostname to %q", sandboxHostnamePath)
 	}
 
 	// Write the hosts
 	sandboxHostsContent := network.GenerateEtcHostsContent(ctx, hostname)
 	sandboxHostsPath := getSandboxHostsPath(id)
-	if err := ioutil.WriteFile(sandboxHostsPath, []byte(sandboxHostsContent), 0644); err != nil {
+	if err := os.WriteFile(sandboxHostsPath, []byte(sandboxHostsContent), 0644); err != nil {
 		return errors.Wrapf(err, "failed to write sandbox hosts to %q", sandboxHostsPath)
 	}
 
@@ -90,7 +89,7 @@ func setupSandboxContainerSpec(ctx context.Context, id string, spec *oci.Spec) (
 		return errors.Wrap(err, "failed to generate sandbox resolv.conf content")
 	}
 	sandboxResolvPath := getSandboxResolvPath(id)
-	if err := ioutil.WriteFile(sandboxResolvPath, []byte(resolvContent), 0644); err != nil {
+	if err := os.WriteFile(sandboxResolvPath, []byte(resolvContent), 0644); err != nil {
 		return errors.Wrap(err, "failed to write sandbox resolv.conf")
 	}
 

--- a/internal/guest/runtime/hcsv2/spec_devices.go
+++ b/internal/guest/runtime/hcsv2/spec_devices.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package hcsv2

--- a/internal/guest/runtime/hcsv2/standalone_container.go
+++ b/internal/guest/runtime/hcsv2/standalone_container.go
@@ -5,7 +5,6 @@ package hcsv2
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -65,7 +64,7 @@ func setupStandaloneContainerSpec(ctx context.Context, id string, spec *oci.Spec
 	// Write the hostname
 	if !specInternal.MountPresent("/etc/hostname", spec.Mounts) {
 		standaloneHostnamePath := getStandaloneHostnamePath(id)
-		if err := ioutil.WriteFile(standaloneHostnamePath, []byte(hostname+"\n"), 0644); err != nil {
+		if err := os.WriteFile(standaloneHostnamePath, []byte(hostname+"\n"), 0644); err != nil {
 			return errors.Wrapf(err, "failed to write hostname to %q", standaloneHostnamePath)
 		}
 
@@ -85,7 +84,7 @@ func setupStandaloneContainerSpec(ctx context.Context, id string, spec *oci.Spec
 	if !specInternal.MountPresent("/etc/hosts", spec.Mounts) {
 		standaloneHostsContent := network.GenerateEtcHostsContent(ctx, hostname)
 		standaloneHostsPath := getStandaloneHostsPath(id)
-		if err := ioutil.WriteFile(standaloneHostsPath, []byte(standaloneHostsContent), 0644); err != nil {
+		if err := os.WriteFile(standaloneHostsPath, []byte(standaloneHostsContent), 0644); err != nil {
 			return errors.Wrapf(err, "failed to write standalone hosts to %q", standaloneHostsPath)
 		}
 
@@ -118,7 +117,7 @@ func setupStandaloneContainerSpec(ctx context.Context, id string, spec *oci.Spec
 			return errors.Wrap(err, "failed to generate standalone resolv.conf content")
 		}
 		standaloneResolvPath := getStandaloneResolvPath(id)
-		if err := ioutil.WriteFile(standaloneResolvPath, []byte(resolvContent), 0644); err != nil {
+		if err := os.WriteFile(standaloneResolvPath, []byte(resolvContent), 0644); err != nil {
 			return errors.Wrap(err, "failed to write standalone resolv.conf")
 		}
 

--- a/internal/guest/runtime/runc/container.go
+++ b/internal/guest/runtime/runc/container.go
@@ -5,7 +5,6 @@ package runc
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
@@ -192,7 +191,7 @@ func (c *container) GetRunningProcesses() ([]runtime.ContainerProcessState, erro
 
 	// For each process state directory which corresponds to a running pid, set
 	// that the process was created by the Runtime.
-	processDirs, err := ioutil.ReadDir(filepath.Join(containerFilesDir, c.id))
+	processDirs, err := os.ReadDir(filepath.Join(containerFilesDir, c.id))
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to read the contents of container directory %s", filepath.Join(containerFilesDir, c.id))
 	}
@@ -239,7 +238,7 @@ func (c *container) GetAllProcesses() ([]runtime.ContainerProcessState, error) {
 		pidMap[pid] = &runtime.ContainerProcessState{Pid: pid, Command: command, CreatedByRuntime: false, IsZombie: false}
 	}
 
-	processDirs, err := ioutil.ReadDir(filepath.Join(containerFilesDir, c.id))
+	processDirs, err := os.ReadDir(filepath.Join(containerFilesDir, c.id))
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to read the contents of container directory %s", filepath.Join(containerFilesDir, c.id))
 	}
@@ -315,7 +314,7 @@ func (c *container) Wait() (int, error) {
 // runExecCommand sets up the arguments for calling runc exec.
 func (c *container) runExecCommand(processDef *oci.Process, stdioSet *stdio.ConnectionSet) (p runtime.Process, err error) {
 	// Create a temporary random directory to store the process's files.
-	tempProcessDir, err := ioutil.TempDir(containerFilesDir, c.id)
+	tempProcessDir, err := os.MkdirTemp(containerFilesDir, c.id)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/guest/runtime/runc/runc.go
+++ b/internal/guest/runtime/runc/runc.go
@@ -5,7 +5,6 @@ package runc
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -116,7 +115,7 @@ func (r *runcRuntime) getRunningPids(id string) ([]int, error) {
 func (r *runcRuntime) getProcessCommand(pid int) ([]string, error) {
 	// Get the contents of the process's cmdline file. This file is formatted
 	// with a null character after every argument. e.g. "ping google.com "
-	data, err := ioutil.ReadFile(filepath.Join("/proc", strconv.Itoa(pid), "cmdline"))
+	data, err := os.ReadFile(filepath.Join("/proc", strconv.Itoa(pid), "cmdline"))
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to read cmdline file for process %d", pid)
 	}
@@ -162,7 +161,7 @@ func (r *runcRuntime) runCreateCommand(id string, bundlePath string, stdioSet *s
 		return nil, err
 	}
 	// Create a temporary random directory to store the process's files.
-	tempProcessDir, err := ioutil.TempDir(containerFilesDir, id)
+	tempProcessDir, err := os.MkdirTemp(containerFilesDir, id)
 	if err != nil {
 		return nil, err
 	}
@@ -202,7 +201,7 @@ func (r *runcRuntime) runCreateCommand(id string, bundlePath string, stdioSet *s
 
 	// Write pid to initpid file for container.
 	containerDir := r.getContainerDir(id)
-	if err := ioutil.WriteFile(filepath.Join(containerDir, initPidFilename), []byte(strconv.Itoa(p.pid)), 0777); err != nil {
+	if err := os.WriteFile(filepath.Join(containerDir, initPidFilename), []byte(strconv.Itoa(p.pid)), 0777); err != nil {
 		return nil, err
 	}
 

--- a/internal/guest/runtime/runc/utils.go
+++ b/internal/guest/runtime/runc/utils.go
@@ -5,7 +5,6 @@ package runc
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -21,7 +20,7 @@ import (
 
 // readPidFile reads the integer pid stored in the given file.
 func (r *runcRuntime) readPidFile(pidFile string) (pid int, err error) {
-	data, err := ioutil.ReadFile(pidFile)
+	data, err := os.ReadFile(pidFile)
 	if err != nil {
 		return -1, errors.Wrap(err, "failed reading from pid file")
 	}

--- a/internal/guest/storage/crypt/crypt.go
+++ b/internal/guest/storage/crypt/crypt.go
@@ -108,15 +108,15 @@ func mkfsExt4Command(args []string) error {
 //
 // In order to mount a block device as an encrypted device:
 //
-//  1. Generate a random key. It doesn't matter which key it is, the aim is to
+//	1. Generate a random key. It doesn't matter which key it is, the aim is to
 //     protect the contents of the scratch disk from the host OS. It can be
 //     deleted after mounting the encrypted device.
 //
-//  2. The original block device has to be formatted with cryptsetup with the
+//	2. The original block device has to be formatted with cryptsetup with the
 //     generated key. This results in that block device becoming an encrypted
 //     block device that can't be mounted directly.
 //
-//  3. Open the block device with cryptsetup. It is needed to assign it a device
+//	3. Open the block device with cryptsetup. It is needed to assign it a device
 //     name. We are using names that follow `cryptDeviceTemplate`, where "%s" is
 //     a unique name generated from the path of the original block device. In
 //     this case, it's just the path of the block device with all
@@ -126,7 +126,7 @@ func mkfsExt4Command(args []string) error {
 //     /dev/mapper/`cryptDeviceTemplate`. This can be mounted directly, but it
 //     doesn't have any format yet.
 //
-// 4. Format the unencrypted block device as ext4:
+//	4. Format the unencrypted block device as ext4:
 //
 //	A normal invocation of luksFormat wipes the target device. This takes
 //	a really long time, which isn't acceptable in our use-case. Passing the

--- a/internal/guest/storage/crypt/crypt.go
+++ b/internal/guest/storage/crypt/crypt.go
@@ -6,7 +6,6 @@ package crypt
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -24,7 +23,7 @@ var (
 	_cryptsetupOpen            = cryptsetupOpen
 	_generateKeyFile           = generateKeyFile
 	_getBlockDeviceSize        = getBlockDeviceSize
-	_ioutilTempDir             = ioutil.TempDir
+	_osMkdirTemp               = os.MkdirTemp
 	_mkfsExt4Command           = mkfsExt4Command
 	_osRemoveAll               = os.RemoveAll
 )
@@ -109,61 +108,61 @@ func mkfsExt4Command(args []string) error {
 //
 // In order to mount a block device as an encrypted device:
 //
-// 1. Generate a random key. It doesn't matter which key it is, the aim is to
-//    protect the contents of the scratch disk from the host OS. It can be
-//    deleted after mounting the encrypted device.
+//  1. Generate a random key. It doesn't matter which key it is, the aim is to
+//     protect the contents of the scratch disk from the host OS. It can be
+//     deleted after mounting the encrypted device.
 //
-// 2. The original block device has to be formatted with cryptsetup with the
-//    generated key. This results in that block device becoming an encrypted
-//    block device that can't be mounted directly.
+//  2. The original block device has to be formatted with cryptsetup with the
+//     generated key. This results in that block device becoming an encrypted
+//     block device that can't be mounted directly.
 //
-// 3. Open the block device with cryptsetup. It is needed to assign it a device
-//    name. We are using names that follow `cryptDeviceTemplate`, where "%s" is
-//    a unique name generated from the path of the original block device. In
-//    this case, it's just the path of the block device with all
-//    non-alphanumeric characters replaced by a '-'.
+//  3. Open the block device with cryptsetup. It is needed to assign it a device
+//     name. We are using names that follow `cryptDeviceTemplate`, where "%s" is
+//     a unique name generated from the path of the original block device. In
+//     this case, it's just the path of the block device with all
+//     non-alphanumeric characters replaced by a '-'.
 //
-//    The kernel exposes the unencrypted block device at the path
-//    /dev/mapper/`cryptDeviceTemplate`. This can be mounted directly, but it
-//    doesn't have any format yet.
+//     The kernel exposes the unencrypted block device at the path
+//     /dev/mapper/`cryptDeviceTemplate`. This can be mounted directly, but it
+//     doesn't have any format yet.
 //
 // 4. Format the unencrypted block device as ext4:
 //
-//    A normal invocation of luksFormat wipes the target device. This takes
-//    a really long time, which isn't acceptable in our use-case. Passing the
-//    option --integrity-no-wipe prevents this from happening so that the
-//    command ends in an instant.
+//	A normal invocation of luksFormat wipes the target device. This takes
+//	a really long time, which isn't acceptable in our use-case. Passing the
+//	option --integrity-no-wipe prevents this from happening so that the
+//	command ends in an instant.
 //
-//    Because of using --integrity-no-wipe, the resulting device isn't wiped and
-//    all the integrity tags are incorrect. This means that any attempt to read
-//    from it will cause an I/O error, which programs aren't prepared to handle.
-//    For example, mkfs.ext4 tries to read blocks before writing to them, and
-//    there is no way around it. When it gets an I/O error, it just exits.
+//	Because of using --integrity-no-wipe, the resulting device isn't wiped and
+//	all the integrity tags are incorrect. This means that any attempt to read
+//	from it will cause an I/O error, which programs aren't prepared to handle.
+//	For example, mkfs.ext4 tries to read blocks before writing to them, and
+//	there is no way around it. When it gets an I/O error, it just exits.
 //
-//    The solution is to create a file with the same size as the resulting
-//    device, format it as ext4, then use dd to copy the format to the device
-//    (dd won't try to read anything).
+//	The solution is to create a file with the same size as the resulting
+//	device, format it as ext4, then use dd to copy the format to the device
+//	(dd won't try to read anything).
 //
-//    However, creating a file that is several GB in size isn't a good solution
-//    either because doing dd of the whole file would take as long as letting
-//    luksFormat wipe the disk.
+//	However, creating a file that is several GB in size isn't a good solution
+//	either because doing dd of the whole file would take as long as letting
+//	luksFormat wipe the disk.
 //
-//    The solution is to create a sparse file and format it. Then, it is
-//    possible to copy the format to the block device by doing a sparse copy
-//    (only copy the data parts of the file, not the holes). This makes
-//    formatting the device almost instantaneous.
+//	The solution is to create a sparse file and format it. Then, it is
+//	possible to copy the format to the block device by doing a sparse copy
+//	(only copy the data parts of the file, not the holes). This makes
+//	formatting the device almost instantaneous.
 //
-//    4.1. Get size of scratch disk.
+//	4.1. Get size of scratch disk.
 //
-//    4.2. Create sparse filesystem image with the same size as the scratch
-//         device. It can be removed afterwards.
+//	4.2. Create sparse filesystem image with the same size as the scratch
+//	     device. It can be removed afterwards.
 //
-//    4.3. Format it as ext4. This way the file is only as big as the few blocks
-//         of the image that have the filesystem information, the ones modified
-//         by mkfs.ext4.
+//	4.3. Format it as ext4. This way the file is only as big as the few blocks
+//	     of the image that have the filesystem information, the ones modified
+//	     by mkfs.ext4.
 //
-//    4.4. Do a sparse copy of the filesystem into the unencrypted block device.
-//         This updates the integrity tags.
+//	4.4. Do a sparse copy of the filesystem into the unencrypted block device.
+//	     This updates the integrity tags.
 func EncryptDevice(ctx context.Context, source string) (path string, err error) {
 
 	uniqueName, err := getUniqueName(source)
@@ -172,7 +171,7 @@ func EncryptDevice(ctx context.Context, source string) (path string, err error) 
 	}
 
 	// Create temporary directory to store the keyfile and EXT4 image
-	tempDir, err := _ioutilTempDir("", "dm-crypt")
+	tempDir, err := _osMkdirTemp("", "dm-crypt")
 	if err != nil {
 		return "", errors.Wrapf(err, "failed to create temporary folder: %s", source)
 	}

--- a/internal/guest/storage/crypt/crypt_test.go
+++ b/internal/guest/storage/crypt/crypt_test.go
@@ -14,7 +14,7 @@ import (
 
 const tempDir = "/tmp/dir/"
 
-func ioutilTempDirTest(dir string, pattern string) (string, error) {
+func osMkdirTempTest(dir string, pattern string) (string, error) {
 	return tempDir, nil
 }
 
@@ -27,7 +27,7 @@ func clearCryptTestDependencies() {
 	_generateKeyFile = nil
 	_getBlockDeviceSize = nil
 	_mkfsExt4Command = nil
-	_ioutilTempDir = ioutilTempDirTest
+	_osMkdirTemp = osMkdirTempTest
 	_osRemoveAll = nil
 }
 

--- a/internal/guest/storage/crypt/utilities.go
+++ b/internal/guest/storage/crypt/utilities.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"crypto/rand"
 	"io"
-	"io/ioutil"
 	"os"
 	"regexp"
 
@@ -165,7 +164,7 @@ func generateKeyFile(path string, size int64) error {
 		return errors.Wrap(err, "failed to generate key array")
 	}
 
-	if err := ioutil.WriteFile(path, keyArray[:], 0644); err != nil {
+	if err := os.WriteFile(path, keyArray[:], 0644); err != nil {
 		return errors.Wrap(err, "failed to save key to file")
 	}
 

--- a/internal/guest/storage/devicemapper/devicemapper.go
+++ b/internal/guest/storage/devicemapper/devicemapper.go
@@ -166,11 +166,11 @@ func (t *Target) sizeof() int {
 // LinearTarget constructs a device-mapper target that maps a portion of a block
 // device at the specified offset.
 //
-// Example linear target table:
-// 0 20971520 linear /dev/hda 384
-// |     |      |        |     |
-// start |   target   data_dev |
-//     size                 offset
+//	Example linear target table:
+//	0 20971520 linear /dev/hda 384
+//	|     |      |        |     |
+//	start |   target   data_dev |
+//	     size                 offset
 func LinearTarget(sectorStart, lengthBlocks int64, path string, deviceStart int64) Target {
 	return Target{
 		Type:           "linear",

--- a/internal/guest/storage/devicemapper/devicemapper_test.go
+++ b/internal/guest/storage/devicemapper/devicemapper_test.go
@@ -5,7 +5,6 @@ package devicemapper
 
 import (
 	"flag"
-	"io/ioutil"
 	"os"
 	"syscall"
 	"testing"
@@ -162,7 +161,7 @@ func TestRemoveDeviceRetriesOnSyscallEBUSY(t *testing.T) {
 	retryDone := false
 	// Overrides openMapper to return temp file handle
 	openMapperWrapper = func() (*os.File, error) {
-		return ioutil.TempFile("", "")
+		return os.CreateTemp("", "")
 	}
 	removeDeviceWrapper = func(_ *os.File, _ string) error {
 		if !rmDeviceCalled {
@@ -200,7 +199,7 @@ func TestRemoveDeviceFailsOnNonSyscallEBUSY(t *testing.T) {
 	rmDeviceCalled := false
 	retryDone := false
 	openMapperWrapper = func() (*os.File, error) {
-		return ioutil.TempFile("", "")
+		return os.CreateTemp("", "")
 	}
 	removeDeviceWrapper = func(_ *os.File, _ string) error {
 		if !rmDeviceCalled {

--- a/internal/guest/storage/devicemapper/targets.go
+++ b/internal/guest/storage/devicemapper/targets.go
@@ -43,11 +43,16 @@ func CreateZeroSectorLinearTarget(ctx context.Context, devPath, devName string, 
 // CreateVerityTarget creates a dm-verity target for a given device and returns created virtual block device path.
 //
 // Example verity target table:
-// 0 417792 verity 1 /dev/sdb /dev/sdc 4096 4096 52224 1 sha256 2aa4f7b7b6...f4952060e8 762307f4bc8...d2a6b7595d8..
-// |    |     |    |     |     |        |    |    |    |    |              |                        |
-// start|     |    |  data_dev |  data_block | #blocks | hash_alg      root_digest                salt
-//     size   |  version    hash_dev         |     hash_offset
-//          target                       hash_block
+//
+//	  0 417792 verity 1 /dev/sdb /dev/sdc 4096 4096 52224 1 sha256 2aa4f7b7b6...f4952060e8 762307f4bc8...d2a6b7595d8..
+//	  |   |      |    |     |        |    |     |     |   |    |              |                        |
+//	start |      |    | data_dev     |    |     | #blocks | hash_alg      root_digest                salt
+//	     size    |  version      hash_dev | hash_block_sz |
+//	           target              data_block_sz      hash_offset
+//
+// See [dm-verity] for more information
+//
+// [dm-verity]: https://www.kernel.org/doc/html/latest/admin-guide/device-mapper/verity.html#construction-parameters
 func CreateVerityTarget(ctx context.Context, devPath, devName string, verityInfo *guestresource.DeviceVerityInfo) (_ string, err error) {
 	_, span := oc.StartSpan(ctx, "devicemapper::CreateVerityTarget")
 	defer span.End()

--- a/internal/guest/storage/scsi/scsi.go
+++ b/internal/guest/storage/scsi/scsi.go
@@ -6,7 +6,6 @@ package scsi
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -61,7 +60,7 @@ func fetchActualControllerNumber(ctx context.Context, passedController uint8) (u
 	// `N` is the controller number.
 	// Full file path would be /sys/bus/vmbus/devices/<controller-guid>/host<N>.
 	controllerDirPath := path.Join(vmbusDevicesPath, guestrequest.ScsiControllerGuids[passedController])
-	entries, err := ioutil.ReadDir(controllerDirPath)
+	entries, err := os.ReadDir(controllerDirPath)
 	if err != nil {
 		return 0, err
 	}
@@ -297,9 +296,9 @@ func ControllerLunToName(ctx context.Context, controller, lun uint8) (_ string, 
 	// Devices matching the given SCSI code should each have a subdirectory
 	// under /sys/bus/scsi/devices/<scsiID>/block.
 	blockPath := filepath.Join(scsiDevicesPath, scsiID, "block")
-	var deviceNames []os.FileInfo
+	var deviceNames []os.DirEntry
 	for {
-		deviceNames, err = ioutil.ReadDir(blockPath)
+		deviceNames, err = os.ReadDir(blockPath)
 		if err != nil && !os.IsNotExist(err) {
 			return "", err
 		}

--- a/internal/guest/transport/transport.go
+++ b/internal/guest/transport/transport.go
@@ -8,9 +8,10 @@ import (
 // Transport is the interface defining a method of transporting data in a
 // connection-like way.
 // Examples of a Transport implementation could be:
-//   Hyper-V socket transport
-//   TCP/IP socket transport
-//   Mocked-out local transport
+//
+//	-Hyper-V socket transport
+//	-TCP/IP socket transport
+//	-Mocked-out local transport
 type Transport interface {
 	// Dial takes a port number and returns a connected connection.
 	Dial(port uint32) (Connection, error)

--- a/internal/hcs/errors.go
+++ b/internal/hcs/errors.go
@@ -159,7 +159,7 @@ func (e *HcsError) Error() string {
 
 func (e *HcsError) Temporary() bool {
 	err, ok := e.Err.(net.Error)
-	return ok && err.Temporary()
+	return ok && err.Temporary() //nolint:staticcheck
 }
 
 func (e *HcsError) Timeout() bool {
@@ -198,7 +198,7 @@ func (e *SystemError) Error() string {
 
 func (e *SystemError) Temporary() bool {
 	err, ok := e.Err.(net.Error)
-	return ok && err.Temporary()
+	return ok && err.Temporary() //nolint:staticcheck
 }
 
 func (e *SystemError) Timeout() bool {
@@ -229,7 +229,7 @@ func (e *ProcessError) Error() string {
 
 func (e *ProcessError) Temporary() bool {
 	err, ok := e.Err.(net.Error)
-	return ok && err.Temporary()
+	return ok && err.Temporary() //nolint:staticcheck
 }
 
 func (e *ProcessError) Timeout() bool {

--- a/internal/hcsoci/devices.go
+++ b/internal/hcsoci/devices.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -95,7 +94,7 @@ func getDeviceExtensions(annotations map[string]string) (*hcsschema.ContainerDef
 		DeviceExtension: []hcsschema.DeviceExtension{},
 	}
 	for _, extensionPath := range extensionPaths {
-		data, err := ioutil.ReadFile(extensionPath)
+		data, err := os.ReadFile(extensionPath)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to read extension file at %s", extensionPath)
 		}

--- a/internal/hns/hnsendpoint.go
+++ b/internal/hns/hnsendpoint.go
@@ -36,7 +36,7 @@ type HNSEndpoint struct {
 	SharedContainers   []string          `json:",omitempty"`
 }
 
-//SystemType represents the type of the system on which actions are done
+// SystemType represents the type of the system on which actions are done
 type SystemType string
 
 // SystemType const

--- a/internal/layers/layers.go
+++ b/internal/layers/layers.go
@@ -156,13 +156,14 @@ func MountLCOWLayers(ctx context.Context, containerID string, layerFolders []str
 // MountWCOWLayers is a helper for clients to hide all the complexity of layer mounting for WCOW.
 // Layer folder are in order: base, [rolayer1..rolayern,] scratch
 //
-// v1/v2: Argon WCOW: Returns the mount path on the host as a volume GUID.
-// v1:    Xenon WCOW: Done internally in HCS, so no point calling doing anything here.
-// v2:    Xenon WCOW: Returns a CombinedLayersV2 structure where ContainerRootPath is a folder
-//                    inside the utility VM which is a GUID mapping of the scratch folder. Each
-//                    of the layers are the VSMB locations where the read-only layers are mounted.
-// Job container:     Returns the mount path on the host as a volume guid, with the volume mounted on
-// 					  the host at `volumeMountPath`.
+//	v1/v2: Argon WCOW: Returns the mount path on the host as a volume GUID.
+//	v1:    Xenon WCOW: Done internally in HCS, so no point calling doing anything here.
+//	v2:    Xenon WCOW: Returns a CombinedLayersV2 structure where ContainerRootPath is a folder
+//	inside the utility VM which is a GUID mapping of the scratch folder. Each of the layers are
+//	the VSMB locations where the read-only layers are mounted.
+//
+//	Job container: Returns the mount path on the host as a volume guid, with the volume mounted on
+//	the host at `volumeMountPath`.
 func MountWCOWLayers(ctx context.Context, containerID string, layerFolders []string, guestRoot, volumeMountPath string, vm *uvm.UtilityVM) (_ string, err error) {
 	if vm == nil {
 		if len(layerFolders) < 2 {

--- a/internal/log/context.go
+++ b/internal/log/context.go
@@ -48,9 +48,10 @@ func GetEntry(ctx context.Context) *logrus.Entry {
 }
 
 // SetEntry updates the log entry in the context with the provided fields, and
-// returns both. It is equivlent to:
-//   entry := GetEntry(ctx).WithFields(fields)
-//   ctx = WithContext(ctx, entry)
+// returns both. It is equivalent to:
+//
+//	entry := GetEntry(ctx).WithFields(fields)
+//	ctx = WithContext(ctx, entry)
 //
 // See WithContext for more information.
 func SetEntry(ctx context.Context, fields logrus.Fields) (context.Context, *logrus.Entry) {
@@ -63,9 +64,10 @@ func SetEntry(ctx context.Context, fields logrus.Fields) (context.Context, *logr
 
 // UpdateContext extracts the log entry from the context, and, if the entry's
 // context points to a parent's of the current context, ands the entry
-// to the most recent context. It is equivlent to:
-//   entry :=GetEntry(ctx)
-//   ctx = WithContext(ctx, entry)
+// to the most recent context. It is equivalent to:
+//
+//	entry := GetEntry(ctx)
+//	ctx = WithContext(ctx, entry)
 //
 // This allows the entry to reference the most recent context and any new
 // values (such as span contexts) added to it.

--- a/internal/runhcs/container.go
+++ b/internal/runhcs/container.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"syscall"
 	"time"
@@ -42,7 +41,7 @@ type ContainerState struct {
 // returned success or error. If error converts that to an error and returns. If
 // `p` is not nill will issue a `Kill` and `Wait` for exit.
 func GetErrorFromPipe(pipe io.Reader, p *os.Process) error {
-	serr, err := ioutil.ReadAll(pipe)
+	serr, err := io.ReadAll(pipe)
 	if err != nil {
 		return err
 	}

--- a/internal/tools/networkagent/defs.go
+++ b/internal/tools/networkagent/defs.go
@@ -4,7 +4,7 @@ package main
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 
 	ncproxygrpc "github.com/Microsoft/hcsshim/pkg/ncproxy/ncproxygrpc/v1"
 	"github.com/pkg/errors"
@@ -46,7 +46,7 @@ type config struct {
 // Reads config from path and returns config struct if path is valid and marshaling
 // succeeds
 func readConfig(path string) (*config, error) {
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to read config file")
 	}

--- a/internal/tools/networkagent/main.go
+++ b/internal/tools/networkagent/main.go
@@ -435,7 +435,8 @@ func (s *service) ConfigureNetworking(ctx context.Context, req *nodenetsvc.Confi
 	return s.teardownHelper(ctx, req, containerNamespaceID)
 }
 
-// GetHostLocalIpAddress is defined in the nodenetworksvc proto while is owned by the azure vnetagent team
+// GetHostLocalIpAddress is defined in the nodenetworksvc proto which is owned by the azure vnetagent team
+//
 //nolint:stylecheck
 func (s *service) GetHostLocalIpAddress(ctx context.Context, req *nodenetsvc.GetHostLocalIpAddressRequest) (*nodenetsvc.GetHostLocalIpAddressResponse, error) {
 	return &nodenetsvc.GetHostLocalIpAddressResponse{IpAddr: ""}, nil

--- a/internal/tools/securitypolicy/main.go
+++ b/internal/tools/securitypolicy/main.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/BurntSushi/toml"
@@ -27,7 +26,7 @@ func main() {
 	}
 
 	err := func() (err error) {
-		configData, err := ioutil.ReadFile(*configFile)
+		configData, err := os.ReadFile(*configFile)
 		if err != nil {
 			return err
 		}

--- a/internal/tools/uvmboot/wcow.go
+++ b/internal/tools/uvmboot/wcow.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -72,7 +71,7 @@ var wcowCommand = cli.Command{
 					return err
 				}
 			}
-			tempDir, err := ioutil.TempDir("", "uvmboot")
+			tempDir, err := os.MkdirTemp("", "uvmboot")
 			if err != nil {
 				return err
 			}
@@ -137,7 +136,7 @@ func getLayers(imageName string) ([]string, error) {
 
 func getLayerChain(layerFolder string) ([]string, error) {
 	jPath := filepath.Join(layerFolder, "layerchain.json")
-	content, err := ioutil.ReadFile(jPath)
+	content, err := os.ReadFile(jPath)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/uvm/create_wcow.go
+++ b/internal/uvm/create_wcow.go
@@ -231,7 +231,6 @@ func prepareConfigDoc(ctx context.Context, uvm *UtilityVM, opts *OptionsWCOW, uv
 //
 // WCOW Notes:
 //   - The scratch is always attached to SCSI 0:0
-//
 func CreateWCOW(ctx context.Context, opts *OptionsWCOW) (_ *UtilityVM, err error) {
 	ctx, span := oc.StartSpan(ctx, "uvm::CreateWCOW")
 	defer span.End()

--- a/internal/uvm/network.go
+++ b/internal/uvm/network.go
@@ -507,7 +507,7 @@ func (uvm *UtilityVM) RemoveEndpointsFromNS(ctx context.Context, id string, endp
 	return nil
 }
 
-// RemoveEndpointFromNS removes ``endpoint` in the network
+// RemoveEndpointFromNS removes `endpoint` in the network
 // namespace matching `id`. If no endpoint matching `endpoint.Id` is found in
 // the network namespace this command returns `ErrNICNotFound`.
 //

--- a/internal/uvm/scsi.go
+++ b/internal/uvm/scsi.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"encoding/gob"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -657,7 +656,7 @@ func (sm *SCSIMount) Clone(ctx context.Context, vm *UtilityVM, cd *cloneData) er
 		// clone it in the scratch folder
 		dir = cd.scratchFolder
 		if sm.Controller != 0 || sm.LUN != 0 {
-			dir, err = ioutil.TempDir(cd.scratchFolder, fmt.Sprintf("clone-mount-%d-%d", sm.Controller, sm.LUN))
+			dir, err = os.MkdirTemp(cd.scratchFolder, fmt.Sprintf("clone-mount-%d-%d", sm.Controller, sm.LUN))
 			if err != nil {
 				return fmt.Errorf("error while creating directory for scsi mounts of clone vm: %s", err)
 			}

--- a/internal/uvm/start.go
+++ b/internal/uvm/start.go
@@ -47,8 +47,7 @@ type gcsLogEntry struct {
 }
 
 // FUTURE-jstarks: Change the GCS log format to include type information
-//
-//	(e.g. by using a different encoding such as protobuf).
+// (e.g. by using a different encoding such as protobuf).
 func (e *gcsLogEntry) UnmarshalJSON(b []byte) error {
 	// Default the log level to info.
 	e.Level = logrus.InfoLevel

--- a/internal/uvm/start.go
+++ b/internal/uvm/start.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"os"
 	"syscall"
@@ -48,7 +47,8 @@ type gcsLogEntry struct {
 }
 
 // FUTURE-jstarks: Change the GCS log format to include type information
-//                 (e.g. by using a different encoding such as protobuf).
+//
+//	(e.g. by using a different encoding such as protobuf).
 func (e *gcsLogEntry) UnmarshalJSON(b []byte) error {
 	// Default the log level to info.
 	e.Level = logrus.InfoLevel
@@ -104,7 +104,7 @@ func parseLogrus(vmid string) func(r io.Reader) {
 						logrus.ErrorKey: err,
 					}).Error("gcs log read")
 				}
-				rest, _ := ioutil.ReadAll(io.MultiReader(j.Buffered(), r))
+				rest, _ := io.ReadAll(io.MultiReader(j.Buffered(), r))
 				rest = bytes.TrimSpace(rest)
 				if len(rest) != 0 {
 					logrus.WithFields(logrus.Fields{

--- a/internal/uvm/vsmb.go
+++ b/internal/uvm/vsmb.go
@@ -100,9 +100,11 @@ func (uvm *UtilityVM) findVSMBShare(ctx context.Context, m map[string]*VSMBShare
 // function is intended to return a handle suitable for use with GetFileInformationByHandleEx.
 //
 // We are not able to use builtin Go functionality for opening a directory path:
-// - os.Open on a directory returns a os.File where Fd() is a search handle from FindFirstFile.
-// - syscall.Open does not provide a way to specify FILE_FLAG_BACKUP_SEMANTICS, which is needed to
-//   open a directory.
+//
+//   - os.Open on a directory returns a os.File where Fd() is a search handle from FindFirstFile.
+//   - syscall.Open does not provide a way to specify FILE_FLAG_BACKUP_SEMANTICS, which is needed to
+//     open a directory.
+//
 // We could use os.Open if the path is a file, but it's easier to just use the same code for both.
 // Therefore, we call windows.CreateFile directly.
 func openHostPath(path string) (windows.Handle, error) {

--- a/internal/vm/remotevm/builder.go
+++ b/internal/vm/remotevm/builder.go
@@ -5,7 +5,6 @@ package remotevm
 import (
 	"context"
 	"io"
-	"io/ioutil"
 	"net"
 	"os/exec"
 
@@ -64,7 +63,7 @@ func NewUVMBuilder(ctx context.Context, id, owner, binPath, addr string, guestOS
 		}
 
 		// Wait for stdout to close. This is our signal that the server is successfully up and running.
-		_, _ = io.Copy(ioutil.Discard, p)
+		_, _ = io.Copy(io.Discard, p)
 	}
 
 	conn, err := net.Dial("unix", addr)

--- a/internal/vm/remotevm/vmsocket.go
+++ b/internal/vm/remotevm/vmsocket.go
@@ -4,7 +4,6 @@ package remotevm
 
 import (
 	"context"
-	"io/ioutil"
 	"net"
 	"os"
 
@@ -16,7 +15,7 @@ import (
 
 func (uvm *utilityVM) VMSocketListen(ctx context.Context, listenType vm.VMSocketType, connID interface{}) (_ net.Listener, err error) {
 	// Make a temp file and delete to "reserve" a unique name for the unix socket
-	f, err := ioutil.TempFile("", "")
+	f, err := os.CreateTemp("", "")
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create temp file for unix socket")
 	}

--- a/internal/wclayer/exportlayer.go
+++ b/internal/wclayer/exportlayer.go
@@ -4,7 +4,6 @@ package wclayer
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -68,7 +67,7 @@ func NewLayerReader(ctx context.Context, path string, parentLayerPaths []string)
 		trace.StringAttribute("path", path),
 		trace.StringAttribute("parentLayerPaths", strings.Join(parentLayerPaths, ", ")))
 
-	exportPath, err := ioutil.TempDir("", "hcs")
+	exportPath, err := os.MkdirTemp("", "hcs")
 	if err != nil {
 		return nil, err
 	}

--- a/internal/wclayer/importlayer.go
+++ b/internal/wclayer/importlayer.go
@@ -4,7 +4,6 @@ package wclayer
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -150,7 +149,7 @@ func NewLayerWriter(ctx context.Context, path string, parentLayerPaths []string)
 		}, nil
 	}
 
-	importPath, err := ioutil.TempDir("", "hcs")
+	importPath, err := os.MkdirTemp("", "hcs")
 	if err != nil {
 		return nil, err
 	}

--- a/internal/wclayer/layerutils.go
+++ b/internal/wclayer/layerutils.go
@@ -13,7 +13,9 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-/* To pass into syscall, we need a struct matching the following:
+/*
+To pass into syscall, we need a struct matching the following:
+
 enum GraphDriverType
 {
     DiffDriver,
@@ -36,32 +38,34 @@ var (
 	stdDriverInfo    = driverInfo{1, &utf16EmptyString}
 )
 
-/* To pass into syscall, we need a struct matching the following:
+/*
+To pass into syscall, we need a struct matching the following:
+
 typedef struct _WC_LAYER_DESCRIPTOR {
 
-    //
-    // The ID of the layer
-    //
+	//
+	// The ID of the layer
+	//
 
-    GUID LayerId;
+	GUID LayerId;
 
-    //
-    // Additional flags
-    //
+	//
+	// Additional flags
+	//
 
-    union {
-        struct {
-            ULONG Reserved : 31;
-            ULONG Dirty : 1;    // Created from sandbox as a result of snapshot
-        };
-        ULONG Value;
-    } Flags;
+	union {
+	    struct {
+	        ULONG Reserved : 31;
+	        ULONG Dirty : 1;    // Created from sandbox as a result of snapshot
+	    };
+	    ULONG Value;
+	} Flags;
 
-    //
-    // Path to the layer root directory, null-terminated
-    //
+	//
+	// Path to the layer root directory, null-terminated
+	//
 
-    PCWSTR Path;
+	PCWSTR Path;
 
 } WC_LAYER_DESCRIPTOR, *PWC_LAYER_DESCRIPTOR;
 */

--- a/internal/wclayer/legacy.go
+++ b/internal/wclayer/legacy.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -377,7 +376,7 @@ func newLegacyLayerWriter(root string, parentRoots []string, destRoot string) (w
 		}
 		w.parentRoots = append(w.parentRoots, f)
 	}
-	w.bufWriter = bufio.NewWriterSize(ioutil.Discard, 65536)
+	w.bufWriter = bufio.NewWriterSize(io.Discard, 65536)
 	return
 }
 
@@ -420,7 +419,7 @@ func (w *legacyLayerWriter) reset() error {
 	if err != nil {
 		return err
 	}
-	w.bufWriter.Reset(ioutil.Discard)
+	w.bufWriter.Reset(io.Discard)
 	if w.currentIsDir {
 		r := w.currentFile
 		br := winio.NewBackupStreamReader(r)
@@ -696,7 +695,7 @@ func (w *legacyLayerWriter) Add(name string, fileInfo *winio.FileBasicInfo) erro
 		// The file attributes are written before the stream.
 		err = binary.Write(w.bufWriter, binary.LittleEndian, uint32(fileInfo.FileAttributes))
 		if err != nil {
-			w.bufWriter.Reset(ioutil.Discard)
+			w.bufWriter.Reset(io.Discard)
 			return err
 		}
 	}

--- a/internal/winapi/filesystem.go
+++ b/internal/winapi/filesystem.go
@@ -104,8 +104,8 @@ type FileLinkInformation struct {
 // C declaration:
 //
 //	typedef struct _FILE_ID_INFO {
-//	    ULONGLONG   VolumeSerialNumber;
-//	    FILE_ID_128 FileId;
+//		ULONGLONG   VolumeSerialNumber;
+//		FILE_ID_128 FileId;
 //	} FILE_ID_INFO, *PFILE_ID_INFO;
 //
 // Documentation: https://docs.microsoft.com/en-us/windows/win32/api/winbase/ns-winbase-file_id_info

--- a/internal/winapi/filesystem.go
+++ b/internal/winapi/filesystem.go
@@ -2,6 +2,7 @@
 
 package winapi
 
+//sys CopyFileW(existingFileName *uint16, newFileName *uint16, failIfExists int32) (err error) = kernel32.CopyFileW
 //sys NtCreateFile(handle *uintptr, accessMask uint32, oa *ObjectAttributes, iosb *IOStatusBlock, allocationSize *uint64, fileAttributes uint32, shareAccess uint32, createDisposition uint32, createOptions uint32, eaBuffer *byte, eaLength uint32) (status uint32) = ntdll.NtCreateFile
 //sys NtSetInformationFile(handle uintptr, iosb *IOStatusBlock, information uintptr, length uint32, class uint32) (status uint32) = ntdll.NtSetInformationFile
 
@@ -36,34 +37,35 @@ const (
 // Select entries from FILE_INFO_BY_HANDLE_CLASS.
 //
 // C declaration:
-//   typedef enum _FILE_INFO_BY_HANDLE_CLASS {
-//       FileBasicInfo,
-//       FileStandardInfo,
-//       FileNameInfo,
-//       FileRenameInfo,
-//       FileDispositionInfo,
-//       FileAllocationInfo,
-//       FileEndOfFileInfo,
-//       FileStreamInfo,
-//       FileCompressionInfo,
-//       FileAttributeTagInfo,
-//       FileIdBothDirectoryInfo,
-//       FileIdBothDirectoryRestartInfo,
-//       FileIoPriorityHintInfo,
-//       FileRemoteProtocolInfo,
-//       FileFullDirectoryInfo,
-//       FileFullDirectoryRestartInfo,
-//       FileStorageInfo,
-//       FileAlignmentInfo,
-//       FileIdInfo,
-//       FileIdExtdDirectoryInfo,
-//       FileIdExtdDirectoryRestartInfo,
-//       FileDispositionInfoEx,
-//       FileRenameInfoEx,
-//       FileCaseSensitiveInfo,
-//       FileNormalizedNameInfo,
-//       MaximumFileInfoByHandleClass
-//   } FILE_INFO_BY_HANDLE_CLASS, *PFILE_INFO_BY_HANDLE_CLASS;
+//
+//	typedef enum _FILE_INFO_BY_HANDLE_CLASS {
+//	    FileBasicInfo,
+//	    FileStandardInfo,
+//	    FileNameInfo,
+//	    FileRenameInfo,
+//	    FileDispositionInfo,
+//	    FileAllocationInfo,
+//	    FileEndOfFileInfo,
+//	    FileStreamInfo,
+//	    FileCompressionInfo,
+//	    FileAttributeTagInfo,
+//	    FileIdBothDirectoryInfo,
+//	    FileIdBothDirectoryRestartInfo,
+//	    FileIoPriorityHintInfo,
+//	    FileRemoteProtocolInfo,
+//	    FileFullDirectoryInfo,
+//	    FileFullDirectoryRestartInfo,
+//	    FileStorageInfo,
+//	    FileAlignmentInfo,
+//	    FileIdInfo,
+//	    FileIdExtdDirectoryInfo,
+//	    FileIdExtdDirectoryRestartInfo,
+//	    FileDispositionInfoEx,
+//	    FileRenameInfoEx,
+//	    FileCaseSensitiveInfo,
+//	    FileNormalizedNameInfo,
+//	    MaximumFileInfoByHandleClass
+//	} FILE_INFO_BY_HANDLE_CLASS, *PFILE_INFO_BY_HANDLE_CLASS;
 //
 // Documentation: https://docs.microsoft.com/en-us/windows/win32/api/minwinbase/ne-minwinbase-file_info_by_handle_class
 const (
@@ -100,10 +102,11 @@ type FileLinkInformation struct {
 }
 
 // C declaration:
-//   typedef struct _FILE_ID_INFO {
-//       ULONGLONG   VolumeSerialNumber;
-//       FILE_ID_128 FileId;
-//   } FILE_ID_INFO, *PFILE_ID_INFO;
+//
+//	typedef struct _FILE_ID_INFO {
+//	    ULONGLONG   VolumeSerialNumber;
+//	    FILE_ID_128 FileId;
+//	} FILE_ID_INFO, *PFILE_ID_INFO;
 //
 // Documentation: https://docs.microsoft.com/en-us/windows/win32/api/winbase/ns-winbase-file_id_info
 type FILE_ID_INFO struct {

--- a/internal/winapi/jobobject.go
+++ b/internal/winapi/jobobject.go
@@ -122,8 +122,8 @@ type JOBOBJECT_BASIC_AND_IO_ACCOUNTING_INFORMATION struct {
 }
 
 //	typedef struct _JOBOBJECT_MEMORY_USAGE_INFORMATION {
-//	    ULONG64 JobMemory;
-//	    ULONG64 PeakJobMemoryUsed;
+//		ULONG64 JobMemory;
+//		ULONG64 PeakJobMemoryUsed;
 //	} JOBOBJECT_MEMORY_USAGE_INFORMATION, *PJOBOBJECT_MEMORY_USAGE_INFORMATION;
 type JOBOBJECT_MEMORY_USAGE_INFORMATION struct {
 	JobMemory         uint64
@@ -131,10 +131,10 @@ type JOBOBJECT_MEMORY_USAGE_INFORMATION struct {
 }
 
 //	typedef struct _JOBOBJECT_IO_ATTRIBUTION_STATS {
-//	    ULONG_PTR IoCount;
-//	    ULONGLONG TotalNonOverlappedQueueTime;
-//	    ULONGLONG TotalNonOverlappedServiceTime;
-//	    ULONGLONG TotalSize;
+//		ULONG_PTR IoCount;
+//		ULONGLONG TotalNonOverlappedQueueTime;
+//		ULONGLONG TotalNonOverlappedServiceTime;
+//		ULONGLONG TotalSize;
 //	} JOBOBJECT_IO_ATTRIBUTION_STATS, *PJOBOBJECT_IO_ATTRIBUTION_STATS;
 type JOBOBJECT_IO_ATTRIBUTION_STATS struct {
 	IoCount                       uintptr

--- a/internal/winapi/process.go
+++ b/internal/winapi/process.go
@@ -20,22 +20,20 @@ const ProcessVmCounters = 3
 //
 //sys NtQueryInformationProcess(processHandle windows.Handle, processInfoClass uint32, processInfo unsafe.Pointer, processInfoLength uint32, returnLength *uint32) (status uint32) = ntdll.NtQueryInformationProcess
 
-// typedef struct _VM_COUNTERS_EX
-// {
-//    SIZE_T PeakVirtualSize;
-//    SIZE_T VirtualSize;
-//    ULONG PageFaultCount;
-//    SIZE_T PeakWorkingSetSize;
-//    SIZE_T WorkingSetSize;
-//    SIZE_T QuotaPeakPagedPoolUsage;
-//    SIZE_T QuotaPagedPoolUsage;
-//    SIZE_T QuotaPeakNonPagedPoolUsage;
-//    SIZE_T QuotaNonPagedPoolUsage;
-//    SIZE_T PagefileUsage;
-//    SIZE_T PeakPagefileUsage;
-//    SIZE_T PrivateUsage;
-// } VM_COUNTERS_EX, *PVM_COUNTERS_EX;
-//
+//	typedef struct _VM_COUNTERS_EX {
+//		   SIZE_T PeakVirtualSize;
+//		   SIZE_T VirtualSize;
+//		   ULONG PageFaultCount;
+//		   SIZE_T PeakWorkingSetSize;
+//		   SIZE_T WorkingSetSize;
+//		   SIZE_T QuotaPeakPagedPoolUsage;
+//		   SIZE_T QuotaPagedPoolUsage;
+//		   SIZE_T QuotaPeakNonPagedPoolUsage;
+//		   SIZE_T QuotaNonPagedPoolUsage;
+//		   SIZE_T PagefileUsage;
+//		   SIZE_T PeakPagefileUsage;
+//		   SIZE_T PrivateUsage;
+//	} VM_COUNTERS_EX, *PVM_COUNTERS_EX;
 type VM_COUNTERS_EX struct {
 	PeakVirtualSize            uintptr
 	VirtualSize                uintptr
@@ -51,13 +49,11 @@ type VM_COUNTERS_EX struct {
 	PrivateUsage               uintptr
 }
 
-// typedef struct _VM_COUNTERS_EX2
-// {
-//    VM_COUNTERS_EX CountersEx;
-//    SIZE_T PrivateWorkingSetSize;
-//    SIZE_T SharedCommitUsage;
-// } VM_COUNTERS_EX2, *PVM_COUNTERS_EX2;
-//
+//	typedef struct _VM_COUNTERS_EX2 {
+//		   VM_COUNTERS_EX CountersEx;
+//		   SIZE_T PrivateWorkingSetSize;
+//		   SIZE_T SharedCommitUsage;
+//	} VM_COUNTERS_EX2, *PVM_COUNTERS_EX2;
 type VM_COUNTERS_EX2 struct {
 	CountersEx            VM_COUNTERS_EX
 	PrivateWorkingSetSize uintptr

--- a/internal/winapi/user.go
+++ b/internal/winapi/user.go
@@ -23,32 +23,32 @@ const (
 
 const NERR_UserNotFound = syscall.Errno(0x8AD)
 
-// typedef struct _LOCALGROUP_MEMBERS_INFO_0 {
-// 	PSID lgrmi0_sid;
-// } LOCALGROUP_MEMBERS_INFO_0, *PLOCALGROUP_MEMBERS_INFO_0, *LPLOCALGROUP_MEMBERS_INFO_0;
+//	typedef struct _LOCALGROUP_MEMBERS_INFO_0 {
+//		PSID lgrmi0_sid;
+//	} LOCALGROUP_MEMBERS_INFO_0, *PLOCALGROUP_MEMBERS_INFO_0, *LPLOCALGROUP_MEMBERS_INFO_0;
 type LocalGroupMembersInfo0 struct {
 	Sid *windows.SID
 }
 
-// typedef struct _LOCALGROUP_INFO_1 {
-// 	LPWSTR lgrpi1_name;
-// 	LPWSTR lgrpi1_comment;
-// } LOCALGROUP_INFO_1, *PLOCALGROUP_INFO_1, *LPLOCALGROUP_INFO_1;
+//	typedef struct _LOCALGROUP_INFO_1 {
+//		LPWSTR lgrpi1_name;
+//		LPWSTR lgrpi1_comment;
+//	} LOCALGROUP_INFO_1, *PLOCALGROUP_INFO_1, *LPLOCALGROUP_INFO_1;
 type LocalGroupInfo1 struct {
 	Name    *uint16
 	Comment *uint16
 }
 
-// typedef struct _USER_INFO_1 {
-// 	LPWSTR usri1_name;
-// 	LPWSTR usri1_password;
-// 	DWORD  usri1_password_age;
-// 	DWORD  usri1_priv;
-// 	LPWSTR usri1_home_dir;
-// 	LPWSTR usri1_comment;
-// 	DWORD  usri1_flags;
-// 	LPWSTR usri1_script_path;
-// } USER_INFO_1, *PUSER_INFO_1, *LPUSER_INFO_1;
+//	typedef struct _USER_INFO_1 {
+//		LPWSTR usri1_name;
+//		LPWSTR usri1_password;
+//		DWORD  usri1_password_age;
+//		DWORD  usri1_priv;
+//		LPWSTR usri1_home_dir;
+//		LPWSTR usri1_comment;
+//		DWORD  usri1_flags;
+//		LPWSTR usri1_script_path;
+//	} USER_INFO_1, *PUSER_INFO_1, *LPUSER_INFO_1;
 type UserInfo1 struct {
 	Name        *uint16
 	Password    *uint16

--- a/internal/winapi/utils.go
+++ b/internal/winapi/utils.go
@@ -34,7 +34,7 @@ type UnicodeString struct {
 // denotes the maximum number of wide chars a path can have.
 const NTSTRSAFE_UNICODE_STRING_MAX_CCH = 32767
 
-//String converts a UnicodeString to a golang string
+// String converts a UnicodeString to a golang string
 func (uni UnicodeString) String() string {
 	// UnicodeString is not guaranteed to be null terminated, therefore
 	// use the UnicodeString's Length field

--- a/internal/winapi/zsyscall_windows.go
+++ b/internal/winapi/zsyscall_windows.go
@@ -73,6 +73,7 @@ var (
 	procCM_Get_Device_ID_ListA                 = modcfgmgr32.NewProc("CM_Get_Device_ID_ListA")
 	procCM_Locate_DevNodeW                     = modcfgmgr32.NewProc("CM_Locate_DevNodeW")
 	procCM_Get_DevNode_PropertyW               = modcfgmgr32.NewProc("CM_Get_DevNode_PropertyW")
+	procCopyFileW                              = modkernel32.NewProc("CopyFileW")
 	procNtCreateFile                           = modntdll.NewProc("NtCreateFile")
 	procNtSetInformationFile                   = modntdll.NewProc("NtSetInformationFile")
 	procNtOpenDirectoryObject                  = modntdll.NewProc("NtOpenDirectoryObject")
@@ -352,6 +353,18 @@ func CMGetDevNodeProperty(dnDevInst uint32, propertyKey *DevPropKey, propertyTyp
 			r0 &= 0xffff
 		}
 		hr = syscall.Errno(r0)
+	}
+	return
+}
+
+func CopyFileW(existingFileName *uint16, newFileName *uint16, failIfExists int32) (err error) {
+	r1, _, e1 := syscall.Syscall(procCopyFileW.Addr(), 3, uintptr(unsafe.Pointer(existingFileName)), uintptr(unsafe.Pointer(newFileName)), uintptr(failIfExists))
+	if r1 == 0 {
+		if e1 != 0 {
+			err = errnoErr(e1)
+		} else {
+			err = syscall.EINVAL
+		}
 	}
 	return
 }

--- a/mksyscall_windows.go
+++ b/mksyscall_windows.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build ignore
 // +build ignore
 
 /*
@@ -14,29 +15,31 @@ to standard output.
 The prototypes are marked by lines beginning with "//sys" and read
 like func declarations if //sys is replaced by func, but:
 
-* The parameter lists must give a name for each argument. This
-  includes return parameters.
+  - The parameter lists must give a name for each argument. This
+    includes return parameters.
 
-* The parameter lists must give a type for each argument:
-  the (x, y, z int) shorthand is not allowed.
+  - The parameter lists must give a type for each argument:
+    the (x, y, z int) shorthand is not allowed.
 
 * If the return parameter is an error number, it must be named err.
 
-* If go func name needs to be different from it's winapi dll name,
-  the winapi name could be specified at the end, after "=" sign, like
-  //sys LoadLibrary(libname string) (handle uint32, err error) = LoadLibraryA
+  - If go func name needs to be different from it's winapi dll name,
+    the winapi name could be specified at the end, after "=" sign, like
+    //sys LoadLibrary(libname string) (handle uint32, err error) = LoadLibraryA
 
-* Each function that returns err needs to supply a condition, that
-  return value of winapi will be tested against to detect failure.
-  This would set err to windows "last-error", otherwise it will be nil.
-  The value can be provided at end of //sys declaration, like
-  //sys LoadLibrary(libname string) (handle uint32, err error) [failretval==-1] = LoadLibraryA
-  and is [failretval==0] by default.
+  - Each function that returns err needs to supply a condition, that
+    return value of winapi will be tested against to detect failure.
+    This would set err to windows "last-error", otherwise it will be nil.
+    The value can be provided at end of //sys declaration, like
+    //sys LoadLibrary(libname string) (handle uint32, err error) [failretval==-1] = LoadLibraryA
+    and is [failretval==0] by default.
 
 Usage:
+
 	mksyscall_windows [flags] [path ...]
 
 The flags are:
+
 	-output
 		Specify output file name (outputs to console if blank).
 	-trace
@@ -54,7 +57,6 @@ import (
 	"go/parser"
 	"go/token"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -842,7 +844,7 @@ func main() {
 	if *filename == "" {
 		_, err = os.Stdout.Write(data)
 	} else {
-		err = ioutil.WriteFile(*filename, data, 0644)
+		err = os.WriteFile(*filename, data, 0644)
 	}
 	if err != nil {
 		log.Fatal(err)

--- a/pkg/securitypolicy/securitypolicy.go
+++ b/pkg/securitypolicy/securitypolicy.go
@@ -327,10 +327,13 @@ func newMountOptions(opts []string) Options {
 // newOptionsFromConfig applies the same logic as CRI plugin to generate
 // mount options given readonly and propagation config.
 // TODO: (anmaxvl) update when support for other mount types is added,
-//   e.g., vhd:// or evd://
+//
+// e.g., vhd:// or evd://
+//
 // TODO: (anmaxvl) Do we need to set/validate Linux rootfs propagation?
-//   In case we do, update securityPolicyContainer and Container structs
-//   as well as mount enforcement logic.
+//
+// In case we do, update securityPolicyContainer and Container structs
+// as well as mount enforcement logic.
 func newOptionsFromConfig(mCfg *MountConfig) []string {
 	mountOpts := []string{"rbind"}
 

--- a/pkg/securitypolicy/securitypolicyenforcer.go
+++ b/pkg/securitypolicy/securitypolicyenforcer.go
@@ -798,10 +798,12 @@ func stringSlicesEqual(slice1, slice2 []string) bool {
 // Iterates through container mounts to identify the correct sandbox
 // mount where the wait path is nested under. The mount spec will
 // be something like:
-// {
-//    "source": "/run/gcs/c/<podID>/sandboxMounts/path/on/host",
-//    "destination": "/path/in/container"
-// }
+//
+//	{
+//	   "source": "/run/gcs/c/<podID>/sandboxMounts/path/on/host",
+//	   "destination": "/path/in/container"
+//	}
+//
 // The wait path will be "/path/in/container/wait/path". To find the corresponding
 // sandbox mount do a prefix match on wait path against all container mounts
 // Destination and resolve the full path inside UVM. For example above it becomes

--- a/test/cri-containerd/container_fileshare_test.go
+++ b/test/cri-containerd/container_fileshare_test.go
@@ -6,7 +6,7 @@ package cri_containerd
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -40,7 +40,7 @@ func Test_Container_File_Share_Writable_WCOW(t *testing.T) {
 		testContent   = "hello world"
 	)
 
-	if err := ioutil.WriteFile(
+	if err := os.WriteFile(
 		filepath.Join(tempDir, testFile),
 		[]byte(testContent),
 		0644); err != nil {
@@ -133,7 +133,7 @@ func Test_Container_File_Share_Writable_LCOW(t *testing.T) {
 		testContent   = "hello world"
 	)
 
-	if err := ioutil.WriteFile(
+	if err := os.WriteFile(
 		filepath.Join(tempDir, testFile),
 		[]byte(testContent),
 		0644,

--- a/test/cri-containerd/createcontainer_test.go
+++ b/test/cri-containerd/createcontainer_test.go
@@ -6,7 +6,6 @@ package cri_containerd
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -849,7 +848,7 @@ func Test_CreateContainer_Mount_File_LCOW(t *testing.T) {
 
 	pullRequiredLCOWImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
 
-	tempFile, err := ioutil.TempFile("", "test")
+	tempFile, err := os.CreateTemp("", "test")
 
 	if err != nil {
 		t.Fatalf("Failed to create temp file: %s", err)
@@ -894,7 +893,7 @@ func Test_CreateContainer_Mount_ReadOnlyFile_LCOW(t *testing.T) {
 
 	pullRequiredLCOWImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
 
-	tempFile, err := ioutil.TempFile("", "test")
+	tempFile, err := os.CreateTemp("", "test")
 
 	if err != nil {
 		t.Fatalf("Failed to create temp file: %s", err)
@@ -1003,7 +1002,7 @@ func Test_CreateContainer_Mount_File_WCOW(t *testing.T) {
 	requireFeatures(t, featureWCOWHypervisor)
 	pullRequiredImages(t, []string{imageWindowsNanoserver})
 
-	tempFile, err := ioutil.TempFile("", "test")
+	tempFile, err := os.CreateTemp("", "test")
 
 	if err != nil {
 		t.Fatalf("Failed to create temp file: %s", err)
@@ -1048,7 +1047,7 @@ func Test_CreateContainer_Mount_ReadOnlyFile_WCOW(t *testing.T) {
 
 	pullRequiredImages(t, []string{imageWindowsNanoserver})
 
-	tempFile, err := ioutil.TempFile("", "test")
+	tempFile, err := os.CreateTemp("", "test")
 
 	if err != nil {
 		t.Fatalf("Failed to create temp file: %s", err)

--- a/test/cri-containerd/helper_gmsa_test.go
+++ b/test/cri-containerd/helper_gmsa_test.go
@@ -5,7 +5,6 @@ package cri_containerd
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -32,16 +31,11 @@ func generateCredSpec(path string) error {
 // Tries to generate a cred spec to use for gmsa test cases. Returns the cred
 // spec and an error if any.
 func gmsaSetup(t *testing.T) string {
-	csDir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatalf("failed to create temp directory: %s", err)
-	}
-	defer os.RemoveAll(csDir)
-	csPath := filepath.Join(csDir, "credspec.json")
+	csPath := filepath.Join(t.TempDir(), "credspec.json")
 	if err := generateCredSpec(csPath); err != nil {
 		t.Fatal(err)
 	}
-	credSpec, err := ioutil.ReadFile(csPath)
+	credSpec, err := os.ReadFile(csPath)
 	if err != nil {
 		t.Fatalf("failed to read credential spec: %s", err)
 	}

--- a/test/cri-containerd/jobcontainer_test.go
+++ b/test/cri-containerd/jobcontainer_test.go
@@ -6,7 +6,6 @@ package cri_containerd
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -423,7 +422,7 @@ func Test_RunContainer_JobContainer_VolumeMount(t *testing.T) {
 	dir := t.TempDir()
 
 	tmpfn := filepath.Join(dir, "tmpfile")
-	if err := ioutil.WriteFile(tmpfn, []byte("test"), 0777); err != nil {
+	if err := os.WriteFile(tmpfn, []byte("test"), 0777); err != nil {
 		t.Fatal(err)
 	}
 

--- a/test/cri-containerd/logging_binary_test.go
+++ b/test/cri-containerd/logging_binary_test.go
@@ -6,7 +6,6 @@ package cri_containerd
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -162,7 +161,7 @@ func createAndRunContainer(t *testing.T, client runtime.RuntimeServiceClient, ct
 }
 
 func assertFileContent(path string, content string) (bool, error) {
-	fileContent, err := ioutil.ReadFile(path)
+	fileContent, err := os.ReadFile(path)
 	if err != nil {
 		return false, err
 	}

--- a/test/cri-containerd/test-images/unordered_tar/main.go
+++ b/test/cri-containerd/test-images/unordered_tar/main.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -18,7 +17,7 @@ import (
 )
 
 func createBlob(blobsDirPath string, blobContents io.Reader) (int64, digest.Digest, error) {
-	tempFile, err := ioutil.TempFile(blobsDirPath, "")
+	tempFile, err := os.CreateTemp(blobsDirPath, "")
 	if err != nil {
 		return 0, "", errors.Wrapf(err, "failed to create file")
 	}
@@ -126,7 +125,7 @@ func createImageFromLayerTars(layerTars []string) error {
 
 	// create a directory under which all image files are stored. This directory will be
 	// converted into the image tar at the end.
-	tempDirPath, err := ioutil.TempDir("", "imagecreator-imagedir")
+	tempDirPath, err := os.MkdirTemp("", "imagecreator-imagedir")
 	if err != nil {
 		return errors.Wrap(err, "failed to create temporary directory")
 	}
@@ -207,7 +206,7 @@ func createImageFromLayerTars(layerTars []string) error {
 }
 
 func main() {
-	tempDir, err := ioutil.TempDir("", "imagecreator-layerdir")
+	tempDir, err := os.MkdirTemp("", "imagecreator-layerdir")
 	if err != nil {
 		log.Fatalf("failed to create temp dir: %s\n", err)
 	}

--- a/test/functional/lcow_test.go
+++ b/test/functional/lcow_test.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -118,23 +117,19 @@ func TestLCOWSimplePodScenario(t *testing.T) {
 	testutilities.RequiresBuild(t, osversion.RS5)
 	alpineLayers := testutilities.LayerFolders(t, "alpine")
 
-	cacheDir := testutilities.CreateTempDir(t)
-	defer os.RemoveAll(cacheDir)
+	cacheDir := t.TempDir()
 	cacheFile := filepath.Join(cacheDir, "cache.vhdx")
 
 	// This is what gets mounted into /tmp/scratch
-	uvmScratchDir := testutilities.CreateTempDir(t)
-	defer os.RemoveAll(uvmScratchDir)
+	uvmScratchDir := t.TempDir()
 	uvmScratchFile := filepath.Join(uvmScratchDir, "uvmscratch.vhdx")
 
 	// Scratch for the first container
-	c1ScratchDir := testutilities.CreateTempDir(t)
-	defer os.RemoveAll(c1ScratchDir)
+	c1ScratchDir := t.TempDir()
 	c1ScratchFile := filepath.Join(c1ScratchDir, "sandbox.vhdx")
 
 	// Scratch for the second container
-	c2ScratchDir := testutilities.CreateTempDir(t)
-	defer os.RemoveAll(c2ScratchDir)
+	c2ScratchDir := t.TempDir()
 	c2ScratchFile := filepath.Join(c2ScratchDir, "sandbox.vhdx")
 
 	lcowUVM := testutilities.CreateLCOWUVM(context.Background(), t, "uvm")

--- a/test/functional/utilities/defaultlinuxspec.go
+++ b/test/functional/utilities/defaultlinuxspec.go
@@ -2,14 +2,14 @@ package testutilities
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 )
 
 func GetDefaultLinuxSpec(t *testing.T) *specs.Spec {
-	content, err := ioutil.ReadFile(`assets\defaultlinuxspec.json`)
+	content, err := os.ReadFile(`assets\defaultlinuxspec.json`)
 	if err != nil {
 		t.Fatalf("failed to read defaultlinuxspec.json: %s", err.Error())
 	}

--- a/test/functional/utilities/defaultwindowsspec.go
+++ b/test/functional/utilities/defaultwindowsspec.go
@@ -2,14 +2,14 @@ package testutilities
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 )
 
 func GetDefaultWindowsSpec(t *testing.T) *specs.Spec {
-	content, err := ioutil.ReadFile(`assets\defaultwindowsspec.json`)
+	content, err := os.ReadFile(`assets\defaultwindowsspec.json`)
 	if err != nil {
 		t.Fatalf("failed to read defaultwindowsspec.json: %s", err.Error())
 	}

--- a/test/functional/utilities/layerfolders.go
+++ b/test/functional/utilities/layerfolders.go
@@ -3,7 +3,6 @@ package testutilities
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -38,7 +37,7 @@ func getLayers(t *testing.T, imageName string) []string {
 
 func getLayerChain(t *testing.T, layerFolder string) []string {
 	jPath := filepath.Join(layerFolder, "layerchain.json")
-	content, err := ioutil.ReadFile(jPath)
+	content, err := os.ReadFile(jPath)
 	if os.IsNotExist(err) {
 		t.Fatalf("layerchain not found")
 	} else if err != nil {

--- a/test/functional/utilities/scratch.go
+++ b/test/functional/utilities/scratch.go
@@ -35,7 +35,7 @@ func CreateWCOWBlankRWLayer(t *testing.T, imageLayers []string) string {
 	//		t.Fatalf("failed to locate UVM folder from %+v: %s", imageLayers, err)
 	//	}
 
-	tempDir := CreateTempDir(t)
+	tempDir := t.TempDir()
 	if err := wclayer.CreateScratchLayer(context.Background(), tempDir, imageLayers); err != nil {
 		t.Fatalf("Failed CreateScratchLayer: %s", err)
 	}
@@ -48,9 +48,9 @@ func CreateWCOWBlankRWLayer(t *testing.T, imageLayers []string) string {
 func CreateLCOWBlankRWLayer(ctx context.Context, t *testing.T) string {
 	if lcowGlobalSVM == nil {
 		lcowGlobalSVM = CreateLCOWUVM(ctx, t, lcowGlobalSVMID)
-		lcowCacheScratchFile = filepath.Join(CreateTempDir(t), "sandbox.vhdx")
+		lcowCacheScratchFile = filepath.Join(t.TempDir(), "sandbox.vhdx")
 	}
-	tempDir := CreateTempDir(t)
+	tempDir := t.TempDir()
 
 	if err := lcow.CreateScratch(ctx, lcowGlobalSVM, filepath.Join(tempDir, "sandbox.vhdx"), lcow.DefaultScratchSizeGB, lcowCacheScratchFile); err != nil {
 		t.Fatalf("failed to create EXT4 scratch for LCOW test cases: %s", err)

--- a/test/functional/utilities/tempdir.go
+++ b/test/functional/utilities/tempdir.go
@@ -1,13 +1,13 @@
 package testutilities
 
 import (
-	"io/ioutil"
+	"os"
 	"testing"
 )
 
 // CreateTempDir creates a temporary directory
 func CreateTempDir(t *testing.T) string {
-	tempDir, err := ioutil.TempDir("", "test")
+	tempDir, err := os.MkdirTemp("", "test")
 	if err != nil {
 		t.Fatalf("failed to create temporary directory: %s", err)
 	}

--- a/test/functional/uvm_mem_backingtype_test.go
+++ b/test/functional/uvm_mem_backingtype_test.go
@@ -5,7 +5,7 @@ package functional
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"os"
 	"testing"
 
@@ -89,21 +89,21 @@ func runBenchMemStartLcowTest(b *testing.B, allowOvercommit bool, enableDeferred
 
 func BenchmarkMemBackingTypeVirtualLCOW(b *testing.B) {
 	//testutilities.RequiresBuild(t, osversion.RS5)
-	logrus.SetOutput(ioutil.Discard)
+	logrus.SetOutput(io.Discard)
 
 	runBenchMemStartLcowTest(b, true, false)
 }
 
 func BenchmarkMemBackingTypeVirtualDeferredLCOW(b *testing.B) {
 	//testutilities.RequiresBuild(t, osversion.RS5)
-	logrus.SetOutput(ioutil.Discard)
+	logrus.SetOutput(io.Discard)
 
 	runBenchMemStartLcowTest(b, true, true)
 }
 
 func BenchmarkMemBackingTypePhyscialLCOW(b *testing.B) {
 	//testutilities.RequiresBuild(t, osversion.RS5)
-	logrus.SetOutput(ioutil.Discard)
+	logrus.SetOutput(io.Discard)
 
 	runBenchMemStartLcowTest(b, false, false)
 }

--- a/test/functional/uvm_plannine_test.go
+++ b/test/functional/uvm_plannine_test.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -27,8 +26,7 @@ func TestPlan9(t *testing.T) {
 	vm := testutilities.CreateLCOWUVM(context.Background(), t, t.Name())
 	defer vm.Close()
 
-	dir := testutilities.CreateTempDir(t)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	var iterations uint32 = 64
 	var shares []*uvm.Plan9Share
 	for i := 0; i < int(iterations); i++ {
@@ -55,8 +53,7 @@ func TestPlan9_Writable(t *testing.T) {
 	vm := testutilities.CreateLCOWUVMFromOpts(context.Background(), t, opts)
 	defer vm.Close()
 
-	dir := testutilities.CreateTempDir(t)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	// mount as writable should fail
 	share, err := vm.AddPlan9(context.Background(), dir, fmt.Sprintf("/tmp/%s", filepath.Base(dir)), false, false, nil)

--- a/test/functional/uvm_scratch_test.go
+++ b/test/functional/uvm_scratch_test.go
@@ -17,8 +17,7 @@ import (
 
 func TestScratchCreateLCOW(t *testing.T) {
 	testutilities.RequiresBuild(t, osversion.RS5)
-	tempDir := testutilities.CreateTempDir(t)
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 
 	firstUVM := testutilities.CreateLCOWUVM(context.Background(), t, "TestCreateLCOWScratch")
 	defer firstUVM.Close()

--- a/test/functional/uvm_vpmem_test.go
+++ b/test/functional/uvm_vpmem_test.go
@@ -5,7 +5,6 @@ package functional
 
 import (
 	"context"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -27,11 +26,10 @@ func TestVPMEM(t *testing.T) {
 	var iterations uint32 = uvm.MaxVPMEMCount
 
 	// Use layer.vhd from the alpine image as something to add
-	tempDir := testutilities.CreateTempDir(t)
+	tempDir := t.TempDir()
 	if err := copyfile.CopyFile(ctx, filepath.Join(alpineLayers[0], "layer.vhd"), filepath.Join(tempDir, "layer.vhd"), true); err != nil {
 		t.Fatal(err)
 	}
-	defer os.RemoveAll(tempDir)
 
 	for i := 0; i < int(iterations); i++ {
 		uvmPath, err := u.AddVPMem(ctx, filepath.Join(tempDir, "layer.vhd"))

--- a/test/functional/uvm_vsmb_test.go
+++ b/test/functional/uvm_vsmb_test.go
@@ -22,8 +22,7 @@ func TestVSMB(t *testing.T) {
 	defer os.RemoveAll(uvmScratchDir)
 	defer uvm.Close()
 
-	dir := testutilities.CreateTempDir(t)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	var iterations uint32 = 64
 	options := uvm.DefaultVSMBOptions(true)
 	options.TakeBackupPrivilege = true
@@ -52,8 +51,7 @@ func TestVSMB_Writable(t *testing.T) {
 	defer os.RemoveAll(uvmScratchDir)
 	defer vm.Close()
 
-	dir := testutilities.CreateTempDir(t)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	options := vm.DefaultVSMBOptions(true)
 	options.TakeBackupPrivilege = true
 	options.ReadOnly = false

--- a/test/functional/wcow_test.go
+++ b/test/functional/wcow_test.go
@@ -342,8 +342,8 @@ const imageName = "busyboxw"
 // Creates two temp folders used for the mounts/mapped directories
 func createTestMounts(t *testing.T) (string, string) {
 	// Create two temp folders for mapped directories.
-	hostRWSharedDirectory := testutilities.CreateTempDir(t)
-	hostROSharedDirectory := testutilities.CreateTempDir(t)
+	hostRWSharedDirectory := t.TempDir()
+	hostROSharedDirectory := t.TempDir()
 	fRW, _ := os.OpenFile(filepath.Join(hostRWSharedDirectory, "readwrite"), os.O_RDWR|os.O_CREATE, 0755)
 	fRO, _ := os.OpenFile(filepath.Join(hostROSharedDirectory, "readonly"), os.O_RDWR|os.O_CREATE, 0755)
 	fRW.Close()
@@ -366,8 +366,7 @@ func TestWCOWArgonShim(t *testing.T) {
 	imageLayers := testutilities.LayerFolders(t, imageName)
 	argonShimMounted := false
 
-	argonShimScratchDir := testutilities.CreateTempDir(t)
-	defer os.RemoveAll(argonShimScratchDir)
+	argonShimScratchDir := t.TempDir()
 	if err := wclayer.CreateScratchLayer(context.Background(), argonShimScratchDir, imageLayers); err != nil {
 		t.Fatalf("failed to create argon scratch layer: %s", err)
 	}
@@ -431,8 +430,7 @@ func TestWCOWArgonShim(t *testing.T) {
 func TestWCOWXenonShim(t *testing.T) {
 	imageLayers := testutilities.LayerFolders(t, imageName)
 
-	xenonShimScratchDir := testutilities.CreateTempDir(t)
-	defer os.RemoveAll(xenonShimScratchDir)
+	xenonShimScratchDir := t.TempDir()
 	if err := wclayer.CreateScratchLayer(context.Background(), xenonShimScratchDir, imageLayers); err != nil {
 		t.Fatalf("failed to create xenon scratch layer: %s", err)
 	}
@@ -501,8 +499,7 @@ func generateWCOWOciTestSpec(t *testing.T, imageLayers []string, scratchPath, ho
 func TestWCOWArgonOciV1(t *testing.T) {
 	imageLayers := testutilities.LayerFolders(t, imageName)
 	argonOci1Mounted := false
-	argonOci1ScratchDir := testutilities.CreateTempDir(t)
-	defer os.RemoveAll(argonOci1ScratchDir)
+	argonOci1ScratchDir := t.TempDir()
 	if err := wclayer.CreateScratchLayer(context.Background(), argonOci1ScratchDir, imageLayers); err != nil {
 		t.Fatalf("failed to create argon scratch layer: %s", err)
 	}
@@ -550,8 +547,7 @@ func TestWCOWXenonOciV1(t *testing.T) {
 	imageLayers := testutilities.LayerFolders(t, imageName)
 	xenonOci1Mounted := false
 
-	xenonOci1ScratchDir := testutilities.CreateTempDir(t)
-	defer os.RemoveAll(xenonOci1ScratchDir)
+	xenonOci1ScratchDir := t.TempDir()
 	if err := wclayer.CreateScratchLayer(context.Background(), xenonOci1ScratchDir, imageLayers); err != nil {
 		t.Fatalf("failed to create xenon scratch layer: %s", err)
 	}
@@ -607,8 +603,7 @@ func TestWCOWArgonOciV2(t *testing.T) {
 	imageLayers := testutilities.LayerFolders(t, imageName)
 	argonOci2Mounted := false
 
-	argonOci2ScratchDir := testutilities.CreateTempDir(t)
-	defer os.RemoveAll(argonOci2ScratchDir)
+	argonOci2ScratchDir := t.TempDir()
 	if err := wclayer.CreateScratchLayer(context.Background(), argonOci2ScratchDir, imageLayers); err != nil {
 		t.Fatalf("failed to create argon scratch layer: %s", err)
 	}
@@ -659,8 +654,7 @@ func TestWCOWXenonOciV2(t *testing.T) {
 	xenonOci2Mounted := false
 	xenonOci2UVMCreated := false
 
-	xenonOci2ScratchDir := testutilities.CreateTempDir(t)
-	defer os.RemoveAll(xenonOci2ScratchDir)
+	xenonOci2ScratchDir := t.TempDir()
 	if err := wclayer.CreateScratchLayer(context.Background(), xenonOci2ScratchDir, imageLayers); err != nil {
 		t.Fatalf("failed to create xenon scratch layer: %s", err)
 	}
@@ -688,7 +682,7 @@ func TestWCOWXenonOciV2(t *testing.T) {
 
 	// Create the utility VM.
 	xenonOci2UVMId := "xenonOci2UVM"
-	xenonOci2UVMScratchDir := testutilities.CreateTempDir(t)
+	xenonOci2UVMScratchDir := t.TempDir()
 	if err := wcow.CreateUVMScratch(context.Background(), uvmImagePath, xenonOci2UVMScratchDir, xenonOci2UVMId); err != nil {
 		t.Fatalf("failed to create scratch: %s", err)
 	}

--- a/test/internal/schemaversion_test.go
+++ b/test/internal/schemaversion_test.go
@@ -3,7 +3,7 @@
 package internal
 
 import (
-	"io/ioutil"
+	"io"
 	"testing"
 
 	hcsschema "github.com/Microsoft/hcsshim/internal/hcs/schema2"
@@ -14,7 +14,7 @@ import (
 )
 
 func init() {
-	logrus.SetOutput(ioutil.Discard)
+	logrus.SetOutput(io.Discard)
 }
 
 func TestDetermineSchemaVersion(t *testing.T) {

--- a/test/runhcs/e2e_matrix_test.go
+++ b/test/runhcs/e2e_matrix_test.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -152,7 +151,7 @@ func getWindowsImageNameByVersion(t *testing.T, bv int) string {
 }
 
 func readPidFile(path string) (int, error) {
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return -1, errors.Wrap(err, "failed to read pidfile")
 	}


### PR DESCRIPTION
With an upgrade to our linter comes a lot of new yelling at us. This does quite a bit:

- Removes all usage of io/ioutil as it's been deprecated since 1.16. This additionally moves some tests to use `t.TempDir()` which was a nice side effect.
- Move CopyFileW usage in /internal/copyfile to winapi so it can be generated
and not call `syscall.Syscall` directly.
- gofmt -s everything our linter is not happy about. 
- Skip linting `net.Error.Temporary` usage for now. `net.Error`'s temporary method is deprecated since 1.18 but we make sure `HcsError`, `ProcessError` and `SystemError` all adhere to `net.Error`'s interface which contains the `Temporary` method. We're reworking the hcs errors package shortly and I'm not sure of the history or significance behind that choice. This seems sane for now.
- Don't whine about gofmt issues for the generated schema files
- Remove the skip-go-installation flag from our golanci-lint action as it no longer exists. 
- Swap to setup-go v3 action