### PR TITLE
Add new `ctrdtaskapi` package for shim task API support.

### DIFF
--- a/cmd/containerd-shim-runhcs-v1/task.go
+++ b/cmd/containerd-shim-runhcs-v1/task.go
@@ -12,9 +12,10 @@ import (
 	"github.com/Microsoft/hcsshim/internal/gcs"
 	"github.com/Microsoft/hcsshim/internal/hcs"
 	"github.com/Microsoft/hcsshim/internal/shimdiag"
+	"github.com/Microsoft/hcsshim/pkg/ctrdtaskapi"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/runtime/v2/task"
-	specs "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
 var (
@@ -109,6 +110,7 @@ func verifyTaskUpdateResourcesType(data interface{}) error {
 	switch data.(type) {
 	case *specs.WindowsResources:
 	case *specs.LinuxResources:
+	case *ctrdtaskapi.PolicyFragment:
 	default:
 		return errNotSupportedResourcesRequest
 	}

--- a/cmd/containerd-shim-runhcs-v1/task_hcs.go
+++ b/cmd/containerd-shim-runhcs-v1/task_hcs.go
@@ -15,7 +15,7 @@ import (
 	"github.com/containerd/containerd/runtime"
 	"github.com/containerd/containerd/runtime/v2/task"
 	"github.com/containerd/typeurl"
-	specs "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"go.opencensus.io/trace"
@@ -983,7 +983,7 @@ func (ht *hcsTask) Update(ctx context.Context, req *task.UpdateTaskRequest) erro
 	}
 
 	if ht.ownsHost && ht.host != nil {
-		return ht.host.UpdateConstraints(ctx, resources, req.Annotations)
+		return ht.host.Update(ctx, resources, req.Annotations)
 	}
 
 	return ht.updateTaskContainerResources(ctx, resources, req.Annotations)

--- a/cmd/containerd-shim-runhcs-v1/task_wcow_podsandbox.go
+++ b/cmd/containerd-shim-runhcs-v1/task_wcow_podsandbox.go
@@ -287,7 +287,7 @@ func (wpst *wcowPodSandboxTask) Update(ctx context.Context, req *task.UpdateTask
 		return err
 	}
 
-	return wpst.host.UpdateConstraints(ctx, resources, req.Annotations)
+	return wpst.host.Update(ctx, resources, req.Annotations)
 }
 
 func (wpst *wcowPodSandboxTask) Share(ctx context.Context, req *shimdiag.ShareRequest) error {

--- a/internal/guest/prot/protocol.go
+++ b/internal/guest/prot/protocol.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"strconv"
 
+	"github.com/Microsoft/hcsshim/pkg/ctrdtaskapi"
 	v1 "github.com/containerd/cgroups/stats/v1"
 	oci "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
@@ -583,6 +584,12 @@ func UnmarshalContainerModifySettings(b []byte) (*ContainerModifySettings, error
 			return &request, errors.Wrap(err, "failed to unmarshal settings as LCOWConfidentialOptions")
 		}
 		msr.Settings = enforcer
+	case guestresource.ResourceTypePolicyFragment:
+		fragment := &ctrdtaskapi.PolicyFragment{}
+		if err := commonutils.UnmarshalJSONWithHresult(msrRawSettings, fragment); err != nil {
+			return &request, errors.Wrap(err, "failed to unmarshal settings as PolicyFragment")
+		}
+		msr.Settings = fragment
 	default:
 		return &request, errors.Errorf("invalid ResourceType '%s'", msr.ResourceType)
 	}

--- a/internal/guest/prot/protocol.go
+++ b/internal/guest/prot/protocol.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"strconv"
 
-	"github.com/Microsoft/hcsshim/pkg/ctrdtaskapi"
 	v1 "github.com/containerd/cgroups/stats/v1"
 	oci "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
@@ -585,9 +584,9 @@ func UnmarshalContainerModifySettings(b []byte) (*ContainerModifySettings, error
 		}
 		msr.Settings = enforcer
 	case guestresource.ResourceTypePolicyFragment:
-		fragment := &ctrdtaskapi.PolicyFragment{}
+		fragment := &guestresource.LCOWSecurityPolicyFragment{}
 		if err := commonutils.UnmarshalJSONWithHresult(msrRawSettings, fragment); err != nil {
-			return &request, errors.Wrap(err, "failed to unmarshal settings as PolicyFragment")
+			return &request, errors.Wrap(err, "failed to unmarshal settings as LCOWSecurityPolicyFragment")
 		}
 		msr.Settings = fragment
 	default:

--- a/internal/guest/runtime/hcsv2/uvm.go
+++ b/internal/guest/runtime/hcsv2/uvm.go
@@ -34,7 +34,6 @@ import (
 	"github.com/Microsoft/hcsshim/internal/protocol/guestrequest"
 	"github.com/Microsoft/hcsshim/internal/protocol/guestresource"
 	"github.com/Microsoft/hcsshim/pkg/annotations"
-	"github.com/Microsoft/hcsshim/pkg/ctrdtaskapi"
 	"github.com/Microsoft/hcsshim/pkg/securitypolicy"
 	"github.com/mattn/go-shellwords"
 	"github.com/pkg/errors"
@@ -120,7 +119,10 @@ func (h *Host) SetConfidentialUVMOptions(enforcerType string, base64EncodedPolic
 
 // InjectFragment extends current security policy with additional constraints
 // from the incoming fragment.
-func (*Host) InjectFragment(ctx context.Context, frag *ctrdtaskapi.PolicyFragment) error {
+//
+// TODO (maksiman): add fragment validation and injection logic
+func (*Host) InjectFragment(ctx context.Context, fragment *guestresource.LCOWSecurityPolicyFragment) (err error) {
+	log.G(ctx).WithField("fragment", fragment).Debug("fragment received in guest")
 	return nil
 }
 
@@ -396,11 +398,10 @@ func (h *Host) modifyHostSettings(ctx context.Context, containerID string, req *
 		}
 		return h.SetConfidentialUVMOptions(r.EnforcerType, r.EncodedSecurityPolicy, r.EncodedUVMReference)
 	case guestresource.ResourceTypePolicyFragment:
-		r, ok := req.Settings.(*ctrdtaskapi.PolicyFragment)
+		r, ok := req.Settings.(*guestresource.LCOWSecurityPolicyFragment)
 		if !ok {
-			return errors.New("the request settings are not of type PolicyFragment")
+			return errors.New("the request settings are not of type LCOWSecurityPolicyFragment")
 		}
-		log.G(ctx).WithField("settings", r).Debug("policy fragment received in guest")
 		return h.InjectFragment(ctx, r)
 	default:
 		return errors.Errorf("the ResourceType \"%s\" is not supported for UVM", req.ResourceType)

--- a/internal/guest/runtime/hcsv2/uvm.go
+++ b/internal/guest/runtime/hcsv2/uvm.go
@@ -29,10 +29,12 @@ import (
 	"github.com/Microsoft/hcsshim/internal/guest/storage/pmem"
 	"github.com/Microsoft/hcsshim/internal/guest/storage/scsi"
 	"github.com/Microsoft/hcsshim/internal/guest/transport"
+	"github.com/Microsoft/hcsshim/internal/log"
 	"github.com/Microsoft/hcsshim/internal/oci"
 	"github.com/Microsoft/hcsshim/internal/protocol/guestrequest"
 	"github.com/Microsoft/hcsshim/internal/protocol/guestresource"
 	"github.com/Microsoft/hcsshim/pkg/annotations"
+	"github.com/Microsoft/hcsshim/pkg/ctrdtaskapi"
 	"github.com/Microsoft/hcsshim/pkg/securitypolicy"
 	"github.com/mattn/go-shellwords"
 	"github.com/pkg/errors"
@@ -113,6 +115,12 @@ func (h *Host) SetConfidentialUVMOptions(enforcerType string, base64EncodedPolic
 	h.securityPolicyEnforcerSet = true
 	h.uvmReferenceInfo = base64UVMReference
 
+	return nil
+}
+
+// InjectFragment extends current security policy with additional constraints
+// from the incoming fragment.
+func (*Host) InjectFragment(ctx context.Context, frag *ctrdtaskapi.PolicyFragment) error {
 	return nil
 }
 
@@ -387,6 +395,13 @@ func (h *Host) modifyHostSettings(ctx context.Context, containerID string, req *
 			return errors.New("the request's settings are not of type LCOWConfidentialOptions")
 		}
 		return h.SetConfidentialUVMOptions(r.EnforcerType, r.EncodedSecurityPolicy, r.EncodedUVMReference)
+	case guestresource.ResourceTypePolicyFragment:
+		r, ok := req.Settings.(*ctrdtaskapi.PolicyFragment)
+		if !ok {
+			return errors.New("the request settings are not of type PolicyFragment")
+		}
+		log.G(ctx).WithField("settings", r).Debug("policy fragment received in guest")
+		return h.InjectFragment(ctx, r)
 	default:
 		return errors.Errorf("the ResourceType \"%s\" is not supported for UVM", req.ResourceType)
 	}

--- a/internal/protocol/guestresource/resources.go
+++ b/internal/protocol/guestresource/resources.go
@@ -14,6 +14,7 @@ import (
 
 const (
 	// These are constants for v2 schema modify guest requests.
+
 	// ResourceTypeMappedDirectory is the modify resource type for mapped
 	// directories
 	ResourceTypeMappedDirectory guestrequest.ResourceType = "MappedDirectory"
@@ -38,6 +39,8 @@ const (
 	// ResourceTypeSecurityPolicy is the modify resource type for updating the security
 	// policy
 	ResourceTypeSecurityPolicy guestrequest.ResourceType = "SecurityPolicy"
+	// ResourceTypePolicyFragment is the modify resource type for injecting policy fragments.
+	ResourceTypePolicyFragment guestrequest.ResourceType = "PolicyFragment"
 )
 
 // This class is used by a modify request to add or remove a combined layers

--- a/internal/protocol/guestresource/resources.go
+++ b/internal/protocol/guestresource/resources.go
@@ -40,7 +40,7 @@ const (
 	// policy
 	ResourceTypeSecurityPolicy guestrequest.ResourceType = "SecurityPolicy"
 	// ResourceTypePolicyFragment is the modify resource type for injecting policy fragments.
-	ResourceTypePolicyFragment guestrequest.ResourceType = "PolicyFragment"
+	ResourceTypePolicyFragment guestrequest.ResourceType = "SecurityPolicyFragment"
 )
 
 // This class is used by a modify request to add or remove a combined layers
@@ -166,4 +166,8 @@ type LCOWConfidentialOptions struct {
 	EnforcerType          string `json:"EnforcerType,omitempty"`
 	EncodedSecurityPolicy string `json:"EncodedSecurityPolicy,omitempty"`
 	EncodedUVMReference   string `json:"EncodedUVMReference,omitempty"`
+}
+
+type LCOWSecurityPolicyFragment struct {
+	Fragment string `json:"Fragment,omitempty"`
 }

--- a/internal/uvm/security_policy.go
+++ b/internal/uvm/security_policy.go
@@ -95,8 +95,8 @@ func (uvm *UtilityVM) SetConfidentialUVMOptions(ctx context.Context, opts ...Con
 	return nil
 }
 
-// InjectPolicyFragment does something.
-func (uvm *UtilityVM) InjectPolicyFragment(ctx context.Context, frag *ctrdtaskapi.PolicyFragment) error {
+// InjectPolicyFragment sends policy fragment to GCS.
+func (uvm *UtilityVM) InjectPolicyFragment(ctx context.Context, fragment *ctrdtaskapi.PolicyFragment) error {
 	if uvm.operatingSystem != "linux" {
 		return errNotSupported
 	}
@@ -105,7 +105,9 @@ func (uvm *UtilityVM) InjectPolicyFragment(ctx context.Context, frag *ctrdtaskap
 		GuestRequest: guestrequest.ModificationRequest{
 			ResourceType: guestresource.ResourceTypePolicyFragment,
 			RequestType:  guestrequest.RequestTypeAdd,
-			Settings:     frag,
+			Settings: guestresource.LCOWSecurityPolicyFragment{
+				Fragment: fragment.Fragment,
+			},
 		},
 	}
 	return uvm.modify(ctx, mod)

--- a/internal/uvm/security_policy.go
+++ b/internal/uvm/security_policy.go
@@ -12,6 +12,7 @@ import (
 	hcsschema "github.com/Microsoft/hcsshim/internal/hcs/schema2"
 	"github.com/Microsoft/hcsshim/internal/protocol/guestrequest"
 	"github.com/Microsoft/hcsshim/internal/protocol/guestresource"
+	"github.com/Microsoft/hcsshim/pkg/ctrdtaskapi"
 	"github.com/Microsoft/hcsshim/pkg/securitypolicy"
 )
 
@@ -92,4 +93,20 @@ func (uvm *UtilityVM) SetConfidentialUVMOptions(ctx context.Context, opts ...Con
 	}
 
 	return nil
+}
+
+// InjectPolicyFragment does something.
+func (uvm *UtilityVM) InjectPolicyFragment(ctx context.Context, frag *ctrdtaskapi.PolicyFragment) error {
+	if uvm.operatingSystem != "linux" {
+		return errNotSupported
+	}
+	mod := &hcsschema.ModifySettingRequest{
+		RequestType: guestrequest.RequestTypeUpdate,
+		GuestRequest: guestrequest.ModificationRequest{
+			ResourceType: guestresource.ResourceTypePolicyFragment,
+			RequestType:  guestrequest.RequestTypeAdd,
+			Settings:     frag,
+		},
+	}
+	return uvm.modify(ctx, mod)
 }

--- a/internal/uvm/update_uvm.go
+++ b/internal/uvm/update_uvm.go
@@ -12,7 +12,7 @@ import (
 	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
-func (uvm *UtilityVM) UpdateConstraints(ctx context.Context, data interface{}, annots map[string]string) error {
+func (uvm *UtilityVM) Update(ctx context.Context, data interface{}, annots map[string]string) error {
 	var memoryLimitInBytes *uint64
 	var processorLimits *hcsschema.ProcessorLimits
 
@@ -47,7 +47,7 @@ func (uvm *UtilityVM) UpdateConstraints(ctx context.Context, data interface{}, a
 	case *ctrdtaskapi.PolicyFragment:
 		return uvm.InjectPolicyFragment(ctx, resources)
 	default:
-		return fmt.Errorf("invalid resource: %v", resources)
+		return fmt.Errorf("invalid resource: %+v", resources)
 	}
 
 	if memoryLimitInBytes != nil {

--- a/internal/uvm/update_uvm.go
+++ b/internal/uvm/update_uvm.go
@@ -4,10 +4,12 @@ package uvm
 
 import (
 	"context"
+	"fmt"
 
 	hcsschema "github.com/Microsoft/hcsshim/internal/hcs/schema2"
 	"github.com/Microsoft/hcsshim/pkg/annotations"
-	specs "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/Microsoft/hcsshim/pkg/ctrdtaskapi"
+	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
 func (uvm *UtilityVM) UpdateConstraints(ctx context.Context, data interface{}, annots map[string]string) error {
@@ -42,6 +44,10 @@ func (uvm *UtilityVM) UpdateConstraints(ctx context.Context, data interface{}, a
 				processorLimits.Weight = uint64(*resources.CPU.Shares)
 			}
 		}
+	case *ctrdtaskapi.PolicyFragment:
+		return uvm.InjectPolicyFragment(ctx, resources)
+	default:
+		return fmt.Errorf("invalid resource: %v", resources)
 	}
 
 	if memoryLimitInBytes != nil {

--- a/pkg/ctrdtaskapi/update.go
+++ b/pkg/ctrdtaskapi/update.go
@@ -11,5 +11,7 @@ func init() {
 type PolicyFragment struct {
 	// Fragment is used by containerd to pass additional security policy
 	// constraint fragments as part of shim task Update request.
+	// The value is a base64 encoded COSE_Sign1 document that contains the
+	// fragment and any additional information required for validation.
 	Fragment string `json:"fragment,omitempty"`
 }

--- a/pkg/ctrdtaskapi/update.go
+++ b/pkg/ctrdtaskapi/update.go
@@ -12,7 +12,4 @@ type PolicyFragment struct {
 	// Fragment is used by containerd to pass additional security policy
 	// constraint fragments as part of shim task Update request.
 	Fragment string `json:"fragment,omitempty"`
-	// Annotations hold arbitrary additional information that can be used to
-	// (e.g.) provide more context about Fragment.
-	Annotations map[string]string `json:"annotations,omitempty"`
 }

--- a/pkg/ctrdtaskapi/update.go
+++ b/pkg/ctrdtaskapi/update.go
@@ -1,0 +1,18 @@
+package ctrdtaskapi
+
+import (
+	"github.com/containerd/typeurl"
+)
+
+func init() {
+	typeurl.Register(&PolicyFragment{}, "github.com/Microsoft/hcsshim/pkg/ctrdtaskapi", "PolicyFragment")
+}
+
+type PolicyFragment struct {
+	// Fragment is used by containerd to pass additional security policy
+	// constraint fragments as part of shim task Update request.
+	Fragment string `json:"fragment,omitempty"`
+	// Annotations hold arbitrary additional information that can be used to
+	// (e.g.) provide more context about Fragment.
+	Annotations map[string]string `json:"annotations,omitempty"`
+}

--- a/test/functional/uvm_update_test.go
+++ b/test/functional/uvm_update_test.go
@@ -1,0 +1,74 @@
+//go:build functional
+// +build functional
+
+package functional
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Microsoft/hcsshim/internal/protocol/guestrequest"
+	"github.com/Microsoft/hcsshim/internal/uvm"
+	"github.com/Microsoft/hcsshim/pkg/ctrdtaskapi"
+	"github.com/opencontainers/runtime-spec/specs-go"
+)
+
+func Test_LCOW_Update_Resources(t *testing.T) {
+	for _, config := range []struct {
+		name     string
+		resource interface{}
+		valid    bool
+	}{
+		{
+			name:     "Valid_PolicyFragment",
+			resource: &ctrdtaskapi.PolicyFragment{},
+			valid:    true,
+		},
+		{
+			name:     "Valid_LinuxResources",
+			resource: &specs.LinuxResources{},
+			valid:    true,
+		},
+		{
+			name:     "Valid_WindowsResources",
+			resource: &specs.WindowsResources{},
+			valid:    true,
+		},
+		{
+			name:     "Invalid_Mount",
+			resource: &specs.Mount{},
+			valid:    false,
+		},
+		{
+			name:     "Invalid_LCOWNetwork",
+			resource: &guestrequest.NetworkModifyRequest{},
+			valid:    false,
+		},
+	} {
+		t.Run(config.name, func(t *testing.T) {
+			ctx := context.Background()
+			opts := uvm.NewDefaultOptionsLCOW(t.Name(), t.Name())
+			vm, err := uvm.CreateLCOW(ctx, opts)
+			if err != nil {
+				t.Fatalf("failed to create LCOW UVM: %s", err)
+			}
+			if err := vm.Start(ctx); err != nil {
+				t.Fatalf("failed to start LCOW UVM: %s", err)
+			}
+			t.Cleanup(func() {
+				if err := vm.Close(); err != nil {
+					t.Log(err)
+				}
+			})
+			if err := vm.UpdateConstraints(ctx, config.resource, nil); err != nil {
+				if config.valid {
+					t.Fatalf("failed to update LCOW UVM constraints: %s", err)
+				}
+			} else {
+				if !config.valid {
+					t.Fatal("expected error updating LCOW UVM constraints")
+				}
+			}
+		})
+	}
+}

--- a/test/functional/uvm_update_test.go
+++ b/test/functional/uvm_update_test.go
@@ -1,5 +1,5 @@
-//go:build functional
-// +build functional
+//go:build windows && functional
+// +build windows,functional
 
 package functional
 
@@ -20,11 +20,6 @@ func Test_LCOW_Update_Resources(t *testing.T) {
 		valid    bool
 	}{
 		{
-			name:     "Valid_PolicyFragment",
-			resource: &ctrdtaskapi.PolicyFragment{},
-			valid:    true,
-		},
-		{
 			name:     "Valid_LinuxResources",
 			resource: &specs.LinuxResources{},
 			valid:    true,
@@ -32,6 +27,11 @@ func Test_LCOW_Update_Resources(t *testing.T) {
 		{
 			name:     "Valid_WindowsResources",
 			resource: &specs.WindowsResources{},
+			valid:    true,
+		},
+		{
+			name:     "Valid_PolicyFragment",
+			resource: &ctrdtaskapi.PolicyFragment{},
 			valid:    true,
 		},
 		{
@@ -60,7 +60,7 @@ func Test_LCOW_Update_Resources(t *testing.T) {
 					t.Log(err)
 				}
 			})
-			if err := vm.UpdateConstraints(ctx, config.resource, nil); err != nil {
+			if err := vm.Update(ctx, config.resource, nil); err != nil {
 				if config.valid {
 					t.Fatalf("failed to update LCOW UVM constraints: %s", err)
 				}


### PR DESCRIPTION
Add new typeurl registered data structure to represent
additional security policy constraint fragments, which
can be passed as part of shim's task Update request.

Change behavior of UpdateContainerConstraints to return
an error when an invalid resource is passed.

Make sure hcsshim can consume the new resource as part
of task Update request handling and new GCS protocol
message can be properly accepted by the guest.

Signed-off-by: Maksim An <maksiman@microsoft.com>