### PR TITLE
Add Tasks command to shimdiag

### DIFF
--- a/cmd/containerd-shim-runhcs-v1/pod.go
+++ b/cmd/containerd-shim-runhcs-v1/pod.go
@@ -42,7 +42,7 @@ type shimPod interface {
 	// GetTasks returns every task in the pod.
 	//
 	// If a shim cannot be loaded, this will return an error.
-	GetTasks() ([]shimTask, error)
+	ListTasks() ([]shimTask, error)
 	// KillTask sends `signal` to task that matches `tid`.
 	//
 	// If `tid` is not found, this pod MUST return `errdefs.ErrNotFound`.
@@ -390,7 +390,7 @@ func (p *pod) GetTask(tid string) (shimTask, error) {
 	return raw.(shimTask), nil
 }
 
-func (p *pod) GetTasks() (_ []shimTask, err error) {
+func (p *pod) ListTasks() (_ []shimTask, err error) {
 	tasks := []shimTask{p.sandboxTask}
 	p.workloadTasks.Range(func(key, value interface{}) bool {
 		wt, loaded := value.(shimTask)

--- a/cmd/containerd-shim-runhcs-v1/pod_test.go
+++ b/cmd/containerd-shim-runhcs-v1/pod_test.go
@@ -39,17 +39,15 @@ func (tsp *testShimPod) GetTask(tid string) (shimTask, error) {
 	return nil, errdefs.ErrNotFound
 }
 
-func (tsp *testShimPod) GetTasks() (_ []shimTask, err error) {
-	tasks := []shimTask{}
+func (tsp *testShimPod) ListTasks() (_ []shimTask, err error) {
+	var tasks []shimTask
 	tsp.tasks.Range(func(key, value interface{}) bool {
-		wt, loaded := value.(shimTask)
-		if !loaded {
+		wt, ok := value.(shimTask)
+		if !ok {
 			err = fmt.Errorf("failed to load tasks %s", key)
 			return false
 		}
 		tasks = append(tasks, wt)
-		// Iterate all. Returning false stops the iteration. See:
-		// https://pkg.go.dev/sync#Map.Range
 		return true
 	})
 	if err != nil {

--- a/cmd/containerd-shim-runhcs-v1/pod_test.go
+++ b/cmd/containerd-shim-runhcs-v1/pod_test.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"math/rand"
 	"strconv"
 	"sync"
@@ -36,6 +37,25 @@ func (tsp *testShimPod) GetTask(tid string) (shimTask, error) {
 		return v.(shimTask), nil
 	}
 	return nil, errdefs.ErrNotFound
+}
+
+func (tsp *testShimPod) GetTasks() (_ []shimTask, err error) {
+	tasks := []shimTask{}
+	tsp.tasks.Range(func(key, value interface{}) bool {
+		wt, loaded := value.(shimTask)
+		if !loaded {
+			err = fmt.Errorf("failed to load tasks %s", key)
+			return false
+		}
+		tasks = append(tasks, wt)
+		// Iterate all. Returning false stops the iteration. See:
+		// https://pkg.go.dev/sync#Map.Range
+		return true
+	})
+	if err != nil {
+		return nil, err
+	}
+	return tasks, nil
 }
 
 func (tsp *testShimPod) KillTask(ctx context.Context, tid, eid string, signal uint32, all bool) error {

--- a/cmd/containerd-shim-runhcs-v1/service.go
+++ b/cmd/containerd-shim-runhcs-v1/service.go
@@ -340,6 +340,22 @@ func (s *service) DiagShare(ctx context.Context, req *shimdiag.ShareRequest) (_ 
 	return r, errdefs.ToGRPC(e)
 }
 
+func (s *service) DiagTasks(ctx context.Context, req *shimdiag.TasksRequest) (_ *shimdiag.TasksResponse, err error) {
+	ctx, span := oc.StartSpan(ctx, "DiagTasks")
+	defer span.End()
+	defer func() { oc.SetSpanStatus(span, err) }()
+
+	span.AddAttributes(
+		trace.BoolAttribute("execs", req.Execs))
+
+	if s.isSandbox {
+		span.AddAttributes(trace.StringAttribute("pod-id", s.tid))
+	}
+
+	r, e := s.diagTasksInternal(ctx, req)
+	return r, errdefs.ToGRPC(e)
+}
+
 func (s *service) ResizePty(ctx context.Context, req *task.ResizePtyRequest) (_ *google_protobuf1.Empty, err error) {
 	ctx, span := oc.StartSpan(ctx, "ResizePty")
 	defer span.End()

--- a/cmd/containerd-shim-runhcs-v1/task.go
+++ b/cmd/containerd-shim-runhcs-v1/task.go
@@ -38,6 +38,10 @@ type shimTask interface {
 	//
 	// If `eid` is not found this task MUST return `errdefs.ErrNotFound`.
 	GetExec(eid string) (shimExec, error)
+	// GetExecs returns all execs in the task.
+	//
+	// If an exec fails to load, this will return an error.
+	GetExecs() ([]shimExec, error)
 	// KillExec sends `signal` to the exec that matches `eid`. If `all==true`
 	// `eid` MUST be empty and this task will send `signal` to all exec's in the
 	// task and lastly send `signal` to the init exec.

--- a/cmd/containerd-shim-runhcs-v1/task.go
+++ b/cmd/containerd-shim-runhcs-v1/task.go
@@ -41,7 +41,7 @@ type shimTask interface {
 	// GetExecs returns all execs in the task.
 	//
 	// If an exec fails to load, this will return an error.
-	GetExecs() ([]shimExec, error)
+	ListExecs() ([]shimExec, error)
 	// KillExec sends `signal` to the exec that matches `eid`. If `all==true`
 	// `eid` MUST be empty and this task will send `signal` to all exec's in the
 	// task and lastly send `signal` to the init exec.

--- a/cmd/containerd-shim-runhcs-v1/task_hcs.go
+++ b/cmd/containerd-shim-runhcs-v1/task_hcs.go
@@ -519,23 +519,20 @@ func (ht *hcsTask) GetExec(eid string) (shimExec, error) {
 	return raw.(shimExec), nil
 }
 
-func (ht *hcsTask) GetExecs() (_ []shimExec, err error) {
+func (ht *hcsTask) ListExecs() (_ []shimExec, err error) {
 	var execs []shimExec
 	ht.execs.Range(func(key, value interface{}) bool {
-		wt, loaded := value.(shimExec)
-		if !loaded {
+		wt, ok := value.(shimExec)
+		if !ok {
 			err = fmt.Errorf("failed to load exec %q", key)
 			return false
 		}
 		execs = append(execs, wt)
-		// Iterate all. Returning false stops the iteration. See:
-		// https://pkg.go.dev/sync#Map.Range
 		return true
 	})
 	if err != nil {
 		return nil, err
 	}
-
 	return execs, nil
 }
 

--- a/cmd/containerd-shim-runhcs-v1/task_hcs.go
+++ b/cmd/containerd-shim-runhcs-v1/task_hcs.go
@@ -519,6 +519,26 @@ func (ht *hcsTask) GetExec(eid string) (shimExec, error) {
 	return raw.(shimExec), nil
 }
 
+func (ht *hcsTask) GetExecs() (_ []shimExec, err error) {
+	var execs []shimExec
+	ht.execs.Range(func(key, value interface{}) bool {
+		wt, loaded := value.(shimExec)
+		if !loaded {
+			err = fmt.Errorf("failed to load exec %q", key)
+			return false
+		}
+		execs = append(execs, wt)
+		// Iterate all. Returning false stops the iteration. See:
+		// https://pkg.go.dev/sync#Map.Range
+		return true
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return execs, nil
+}
+
 func (ht *hcsTask) KillExec(ctx context.Context, eid string, signal uint32, all bool) error {
 	e, err := ht.GetExec(eid)
 	if err != nil {

--- a/cmd/containerd-shim-runhcs-v1/task_test.go
+++ b/cmd/containerd-shim-runhcs-v1/task_test.go
@@ -46,6 +46,14 @@ func (tst *testShimTask) GetExec(eid string) (shimExec, error) {
 	return nil, errdefs.ErrNotFound
 }
 
+func (tst *testShimTask) GetExecs() ([]shimExec, error) {
+	var execs []shimExec
+	for _, v := range tst.execs {
+		execs = append(execs, v)
+	}
+	return execs, nil
+}
+
 func (tst *testShimTask) KillExec(ctx context.Context, eid string, signal uint32, all bool) error {
 	e, err := tst.GetExec(eid)
 	if err != nil {

--- a/cmd/containerd-shim-runhcs-v1/task_test.go
+++ b/cmd/containerd-shim-runhcs-v1/task_test.go
@@ -46,7 +46,7 @@ func (tst *testShimTask) GetExec(eid string) (shimExec, error) {
 	return nil, errdefs.ErrNotFound
 }
 
-func (tst *testShimTask) GetExecs() ([]shimExec, error) {
+func (tst *testShimTask) ListExecs() ([]shimExec, error) {
 	var execs []shimExec
 	for _, v := range tst.execs {
 		execs = append(execs, v)

--- a/cmd/containerd-shim-runhcs-v1/task_wcow_podsandbox.go
+++ b/cmd/containerd-shim-runhcs-v1/task_wcow_podsandbox.go
@@ -111,7 +111,7 @@ func (wpst *wcowPodSandboxTask) GetExec(eid string) (shimExec, error) {
 	return nil, errors.Wrapf(errdefs.ErrNotFound, "exec: '%s' in task: '%s' not found", eid, wpst.id)
 }
 
-func (wpst *wcowPodSandboxTask) GetExecs() ([]shimExec, error) {
+func (wpst *wcowPodSandboxTask) ListExecs() ([]shimExec, error) {
 	return []shimExec{wpst.init}, nil
 }
 

--- a/cmd/containerd-shim-runhcs-v1/task_wcow_podsandbox.go
+++ b/cmd/containerd-shim-runhcs-v1/task_wcow_podsandbox.go
@@ -111,6 +111,10 @@ func (wpst *wcowPodSandboxTask) GetExec(eid string) (shimExec, error) {
 	return nil, errors.Wrapf(errdefs.ErrNotFound, "exec: '%s' in task: '%s' not found", eid, wpst.id)
 }
 
+func (wpst *wcowPodSandboxTask) GetExecs() ([]shimExec, error) {
+	return []shimExec{wpst.init}, nil
+}
+
 func (wpst *wcowPodSandboxTask) KillExec(ctx context.Context, eid string, signal uint32, all bool) error {
 	e, err := wpst.GetExec(eid)
 	if err != nil {

--- a/cmd/shimdiag/shimdiag.go
+++ b/cmd/shimdiag/shimdiag.go
@@ -19,6 +19,7 @@ func main() {
 		listCommand,
 		execCommand,
 		stacksCommand,
+		tasksCommand,
 		shareCommand,
 	}
 	if err := app.Run(os.Args); err != nil {

--- a/cmd/shimdiag/tasks.go
+++ b/cmd/shimdiag/tasks.go
@@ -1,0 +1,49 @@
+//go:build windows
+
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Microsoft/hcsshim/internal/appargs"
+	"github.com/Microsoft/hcsshim/internal/shimdiag"
+	"github.com/urfave/cli"
+)
+
+var tasksCommand = cli.Command{
+	Name:      "tasks",
+	Usage:     "Dump the shims current tasks",
+	ArgsUsage: "[flags] <shim name>",
+	Before:    appargs.Validate(appargs.String),
+	Flags: []cli.Flag{
+		cli.BoolFlag{
+			Name:  "execs",
+			Usage: "Shows the execs in each task",
+		},
+	},
+	Action: func(c *cli.Context) error {
+		shim, err := shimdiag.GetShim(c.Args()[0])
+		if err != nil {
+			return err
+		}
+		svc := shimdiag.NewShimDiagClient(shim)
+		resp, err := svc.DiagTasks(context.Background(), &shimdiag.TasksRequest{Execs: c.Bool("execs")})
+		if err != nil {
+			return err
+		}
+
+		for _, task := range resp.Tasks {
+			fmt.Println(task.ID)
+			if len(task.Execs) != 0 {
+				fmt.Printf("|\n|----> ")
+				for _, exec := range task.Execs {
+					fmt.Printf("\t%s: %s\n", exec.State, exec.ID)
+				}
+				fmt.Printf("\n")
+			}
+		}
+
+		return nil
+	},
+}

--- a/internal/shimdiag/shimdiag.pb.go
+++ b/internal/shimdiag/shimdiag.pb.go
@@ -343,6 +343,164 @@ func (m *PidResponse) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_PidResponse proto.InternalMessageInfo
 
+type TasksRequest struct {
+	Execs                bool     `protobuf:"varint,1,opt,name=execs,proto3" json:"execs,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
+}
+
+func (m *TasksRequest) Reset()      { *m = TasksRequest{} }
+func (*TasksRequest) ProtoMessage() {}
+func (*TasksRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_c7933dc6ffbb8784, []int{8}
+}
+func (m *TasksRequest) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *TasksRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_TasksRequest.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *TasksRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_TasksRequest.Merge(m, src)
+}
+func (m *TasksRequest) XXX_Size() int {
+	return m.Size()
+}
+func (m *TasksRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_TasksRequest.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_TasksRequest proto.InternalMessageInfo
+
+type Task struct {
+	ID                   string   `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	Execs                []*Exec  `protobuf:"bytes,2,rep,name=execs,proto3" json:"execs,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
+}
+
+func (m *Task) Reset()      { *m = Task{} }
+func (*Task) ProtoMessage() {}
+func (*Task) Descriptor() ([]byte, []int) {
+	return fileDescriptor_c7933dc6ffbb8784, []int{9}
+}
+func (m *Task) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *Task) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_Task.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *Task) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Task.Merge(m, src)
+}
+func (m *Task) XXX_Size() int {
+	return m.Size()
+}
+func (m *Task) XXX_DiscardUnknown() {
+	xxx_messageInfo_Task.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_Task proto.InternalMessageInfo
+
+type Exec struct {
+	ID                   string   `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	State                string   `protobuf:"bytes,2,opt,name=state,proto3" json:"state,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
+}
+
+func (m *Exec) Reset()      { *m = Exec{} }
+func (*Exec) ProtoMessage() {}
+func (*Exec) Descriptor() ([]byte, []int) {
+	return fileDescriptor_c7933dc6ffbb8784, []int{10}
+}
+func (m *Exec) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *Exec) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_Exec.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *Exec) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Exec.Merge(m, src)
+}
+func (m *Exec) XXX_Size() int {
+	return m.Size()
+}
+func (m *Exec) XXX_DiscardUnknown() {
+	xxx_messageInfo_Exec.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_Exec proto.InternalMessageInfo
+
+type TasksResponse struct {
+	Tasks                []*Task  `protobuf:"bytes,1,rep,name=tasks,proto3" json:"tasks,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
+}
+
+func (m *TasksResponse) Reset()      { *m = TasksResponse{} }
+func (*TasksResponse) ProtoMessage() {}
+func (*TasksResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_c7933dc6ffbb8784, []int{11}
+}
+func (m *TasksResponse) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *TasksResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_TasksResponse.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *TasksResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_TasksResponse.Merge(m, src)
+}
+func (m *TasksResponse) XXX_Size() int {
+	return m.Size()
+}
+func (m *TasksResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_TasksResponse.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_TasksResponse proto.InternalMessageInfo
+
 func init() {
 	proto.RegisterType((*ExecProcessRequest)(nil), "containerd.runhcs.v1.diag.ExecProcessRequest")
 	proto.RegisterType((*ExecProcessResponse)(nil), "containerd.runhcs.v1.diag.ExecProcessResponse")
@@ -352,6 +510,10 @@ func init() {
 	proto.RegisterType((*ShareResponse)(nil), "containerd.runhcs.v1.diag.ShareResponse")
 	proto.RegisterType((*PidRequest)(nil), "containerd.runhcs.v1.diag.PidRequest")
 	proto.RegisterType((*PidResponse)(nil), "containerd.runhcs.v1.diag.PidResponse")
+	proto.RegisterType((*TasksRequest)(nil), "containerd.runhcs.v1.diag.TasksRequest")
+	proto.RegisterType((*Task)(nil), "containerd.runhcs.v1.diag.Task")
+	proto.RegisterType((*Exec)(nil), "containerd.runhcs.v1.diag.Exec")
+	proto.RegisterType((*TasksResponse)(nil), "containerd.runhcs.v1.diag.TasksResponse")
 }
 
 func init() {
@@ -359,41 +521,46 @@ func init() {
 }
 
 var fileDescriptor_c7933dc6ffbb8784 = []byte{
-	// 534 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x94, 0x54, 0xcd, 0x6e, 0xd3, 0x40,
-	0x10, 0x8e, 0x49, 0x93, 0xda, 0xd3, 0x50, 0xd0, 0x52, 0x21, 0xd7, 0x91, 0x4c, 0xb0, 0x04, 0x98,
-	0x03, 0x8e, 0x28, 0x07, 0x0e, 0x88, 0x0b, 0x3f, 0x12, 0x08, 0x21, 0x42, 0x72, 0xa9, 0x38, 0x10,
-	0x6d, 0xed, 0xc5, 0x5e, 0x35, 0xde, 0x0d, 0xbb, 0xeb, 0xd0, 0xde, 0x78, 0x0c, 0x1e, 0x80, 0x87,
-	0xe9, 0x91, 0x23, 0x47, 0x9a, 0x27, 0x41, 0xbb, 0x5e, 0x07, 0x2a, 0x44, 0xda, 0x9e, 0x32, 0xdf,
-	0xb7, 0xf3, 0xcd, 0xec, 0x7c, 0xb3, 0x31, 0x3c, 0xcd, 0xa9, 0x2a, 0xaa, 0x83, 0x24, 0xe5, 0xe5,
-	0xf0, 0x2d, 0x4d, 0x05, 0x97, 0xfc, 0x93, 0x1a, 0x16, 0xa9, 0x94, 0x05, 0x2d, 0x87, 0x94, 0x29,
-	0x22, 0x18, 0x9e, 0x0d, 0x35, 0xca, 0x28, 0xce, 0x57, 0x41, 0x32, 0x17, 0x5c, 0x71, 0xb4, 0x9b,
-	0x72, 0xa6, 0x30, 0x65, 0x44, 0x64, 0x89, 0xa8, 0x58, 0x91, 0xca, 0x64, 0xf1, 0x30, 0xd1, 0x09,
-	0xc1, 0x4e, 0xce, 0x73, 0x6e, 0xb2, 0x86, 0x3a, 0xaa, 0x05, 0xd1, 0x77, 0x07, 0xd0, 0xcb, 0x23,
-	0x92, 0x8e, 0x04, 0x4f, 0x89, 0x94, 0x63, 0xf2, 0xb9, 0x22, 0x52, 0x21, 0x04, 0x1b, 0x58, 0xe4,
-	0xd2, 0x77, 0x06, 0xed, 0xd8, 0x1b, 0x9b, 0x18, 0xf9, 0xb0, 0xf9, 0x85, 0x8b, 0xc3, 0x8c, 0x0a,
-	0xff, 0xca, 0xc0, 0x89, 0xbd, 0x71, 0x03, 0x51, 0x00, 0xae, 0x22, 0xa2, 0xa4, 0x0c, 0xcf, 0xfc,
-	0xf6, 0xc0, 0x89, 0xdd, 0xf1, 0x0a, 0xa3, 0x1d, 0xe8, 0x48, 0x95, 0x51, 0xe6, 0x6f, 0x18, 0x4d,
-	0x0d, 0xd0, 0x4d, 0xe8, 0x4a, 0x95, 0xf1, 0x4a, 0xf9, 0x1d, 0x43, 0x5b, 0x64, 0x79, 0x22, 0x84,
-	0xdf, 0x5d, 0xf1, 0x44, 0x88, 0x68, 0x0f, 0x6e, 0x9c, 0xb9, 0xa5, 0x9c, 0x73, 0x26, 0x09, 0xea,
-	0x83, 0x47, 0x8e, 0xa8, 0x9a, 0xa6, 0x3c, 0x23, 0xbe, 0x33, 0x70, 0xe2, 0xce, 0xd8, 0xd5, 0xc4,
-	0x73, 0x9e, 0x91, 0xe8, 0x1a, 0x5c, 0x9d, 0x28, 0x9c, 0x1e, 0x36, 0x43, 0x45, 0x6f, 0x60, 0xbb,
-	0x21, 0xac, 0xde, 0xb4, 0xd3, 0x8c, 0x11, 0x9b, 0x76, 0x1a, 0xa1, 0xdb, 0xd0, 0xcb, 0xb5, 0x64,
-	0x6a, 0x4f, 0xeb, 0x79, 0xb7, 0x0c, 0x57, 0x97, 0x88, 0x52, 0xe8, 0x4d, 0x0a, 0x2c, 0x48, 0xe3,
-	0x58, 0x1f, 0xbc, 0x82, 0x4b, 0x35, 0x9d, 0x63, 0x55, 0xd8, 0x6a, 0xae, 0x26, 0x46, 0x58, 0x15,
-	0x68, 0x17, 0xdc, 0x6a, 0x51, 0xd6, 0x67, 0xd6, 0xbb, 0x6a, 0x51, 0x9a, 0xa3, 0x3e, 0x78, 0x82,
-	0xe0, 0x6c, 0xca, 0xd9, 0xec, 0xb8, 0x31, 0x4f, 0x13, 0xef, 0xd8, 0xec, 0xd8, 0x8c, 0x50, 0x37,
-	0xa9, 0x2f, 0x1c, 0xf5, 0x00, 0x46, 0x34, 0x6b, 0x06, 0xba, 0x05, 0x5b, 0x06, 0xd9, 0x69, 0xae,
-	0x43, 0x7b, 0x4e, 0x33, 0xeb, 0x83, 0x0e, 0xf7, 0xbe, 0xb5, 0xc1, 0x9d, 0x14, 0xb4, 0x7c, 0x41,
-	0x71, 0x8e, 0x38, 0x6c, 0xeb, 0x5f, 0xed, 0xe3, 0x6b, 0xf6, 0x8a, 0x4b, 0x85, 0x1e, 0x24, 0xff,
-	0x7d, 0x2e, 0xc9, 0xbf, 0x8f, 0x22, 0x48, 0x2e, 0x9a, 0x6e, 0xef, 0x83, 0x01, 0x74, 0xc3, 0xda,
-	0x30, 0x14, 0xaf, 0x51, 0x9f, 0xd9, 0x53, 0x70, 0xff, 0x02, 0x99, 0xb6, 0xc5, 0x47, 0xf0, 0x4c,
-	0x0b, 0x6d, 0x12, 0xba, 0xb7, 0x4e, 0xf7, 0xd7, 0xae, 0x82, 0xf8, 0xfc, 0x44, 0x5b, 0x7f, 0x1f,
-	0x36, 0x75, 0xfd, 0x11, 0xcd, 0xd0, 0x9d, 0x35, 0xa2, 0x3f, 0x3b, 0x09, 0xee, 0x9e, 0x97, 0x56,
-	0x57, 0x7e, 0xf6, 0xfe, 0xe4, 0x34, 0x6c, 0xfd, 0x3c, 0x0d, 0x5b, 0x5f, 0x97, 0xa1, 0x73, 0xb2,
-	0x0c, 0x9d, 0x1f, 0xcb, 0xd0, 0xf9, 0xb5, 0x0c, 0x9d, 0x0f, 0x8f, 0x2f, 0xf7, 0x09, 0x78, 0xd2,
-	0x04, 0xfb, 0xad, 0x83, 0xae, 0xf9, 0x53, 0x3f, 0xfa, 0x1d, 0x00, 0x00, 0xff, 0xff, 0x3e, 0xb1,
-	0xa6, 0x27, 0x46, 0x04, 0x00, 0x00,
+	// 623 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x94, 0x54, 0xcb, 0x6e, 0xd3, 0x40,
+	0x14, 0xad, 0xf3, 0xaa, 0x7d, 0x9b, 0x16, 0x34, 0xa0, 0xca, 0x4d, 0xa5, 0x34, 0x58, 0x3c, 0xcc,
+	0x02, 0x47, 0x14, 0x2a, 0x16, 0x88, 0x4d, 0x29, 0x88, 0x0a, 0x21, 0x82, 0x0b, 0x12, 0x62, 0x41,
+	0x34, 0xb5, 0x87, 0x78, 0xd4, 0xc4, 0x13, 0x66, 0xc6, 0xa5, 0xdd, 0xf1, 0x31, 0x7c, 0x4c, 0x97,
+	0x2c, 0x59, 0x21, 0x9a, 0xaf, 0x60, 0x89, 0xe6, 0xe1, 0x40, 0x16, 0x4d, 0xca, 0xca, 0x73, 0xce,
+	0xdc, 0x73, 0xee, 0xc3, 0xd7, 0x86, 0x27, 0x03, 0x2a, 0xb3, 0xe2, 0x30, 0x4a, 0xd8, 0xa8, 0xfb,
+	0x8a, 0x26, 0x9c, 0x09, 0xf6, 0x49, 0x76, 0xb3, 0x44, 0x88, 0x8c, 0x8e, 0xba, 0x34, 0x97, 0x84,
+	0xe7, 0x78, 0xd8, 0x55, 0x28, 0xa5, 0x78, 0x30, 0x3d, 0x44, 0x63, 0xce, 0x24, 0x43, 0x1b, 0x09,
+	0xcb, 0x25, 0xa6, 0x39, 0xe1, 0x69, 0xc4, 0x8b, 0x3c, 0x4b, 0x44, 0x74, 0x7c, 0x3f, 0x52, 0x01,
+	0xc1, 0x37, 0x07, 0xd0, 0xb3, 0x13, 0x92, 0xf4, 0x38, 0x4b, 0x88, 0x10, 0x31, 0xf9, 0x5c, 0x10,
+	0x21, 0x11, 0x82, 0x1a, 0xe6, 0x03, 0xe1, 0x3b, 0x9d, 0x6a, 0xe8, 0xc5, 0xfa, 0x8c, 0x7c, 0x58,
+	0xfe, 0xc2, 0xf8, 0x51, 0x4a, 0xb9, 0x5f, 0xe9, 0x38, 0xa1, 0x17, 0x97, 0x10, 0xb5, 0xc0, 0x95,
+	0x84, 0x8f, 0x68, 0x8e, 0x87, 0x7e, 0xb5, 0xe3, 0x84, 0x6e, 0x3c, 0xc5, 0xe8, 0x3a, 0xd4, 0x85,
+	0x4c, 0x69, 0xee, 0xd7, 0xb4, 0xc6, 0x00, 0xb4, 0x0e, 0x0d, 0x21, 0x53, 0x56, 0x48, 0xbf, 0xae,
+	0x69, 0x8b, 0x2c, 0x4f, 0x38, 0xf7, 0x1b, 0x53, 0x9e, 0x70, 0x1e, 0x6c, 0xc3, 0xb5, 0x99, 0x2a,
+	0xc5, 0x98, 0xe5, 0x82, 0xa0, 0x4d, 0xf0, 0xc8, 0x09, 0x95, 0xfd, 0x84, 0xa5, 0xc4, 0x77, 0x3a,
+	0x4e, 0x58, 0x8f, 0x5d, 0x45, 0x3c, 0x65, 0x29, 0x09, 0xae, 0xc0, 0xea, 0x81, 0xc4, 0xc9, 0x51,
+	0xd9, 0x54, 0xf0, 0x12, 0xd6, 0x4a, 0xc2, 0xea, 0x75, 0x3a, 0xc5, 0x68, 0xb1, 0x4e, 0xa7, 0x10,
+	0xba, 0x01, 0xcd, 0x81, 0x92, 0xf4, 0xed, 0xad, 0xe9, 0x77, 0x45, 0x73, 0xc6, 0x22, 0x48, 0xa0,
+	0x79, 0x90, 0x61, 0x4e, 0xca, 0x89, 0x6d, 0x82, 0x97, 0x31, 0x21, 0xfb, 0x63, 0x2c, 0x33, 0xeb,
+	0xe6, 0x2a, 0xa2, 0x87, 0x65, 0x86, 0x36, 0xc0, 0x2d, 0x8e, 0x47, 0xe6, 0xce, 0xce, 0xae, 0x38,
+	0x1e, 0xe9, 0xab, 0x4d, 0xf0, 0x38, 0xc1, 0x69, 0x9f, 0xe5, 0xc3, 0xd3, 0x72, 0x78, 0x8a, 0x78,
+	0x9d, 0x0f, 0x4f, 0x75, 0x0b, 0x26, 0x89, 0x29, 0x38, 0x68, 0x02, 0xf4, 0x68, 0x5a, 0x36, 0xb4,
+	0x05, 0x2b, 0x1a, 0xd9, 0x6e, 0xae, 0x42, 0x75, 0x4c, 0x53, 0x3b, 0x07, 0x75, 0x0c, 0x6e, 0x42,
+	0xf3, 0x2d, 0x16, 0xd3, 0x09, 0xa8, 0x97, 0x41, 0x4e, 0x48, 0x62, 0xda, 0x75, 0x63, 0x03, 0x82,
+	0x77, 0x50, 0x53, 0x51, 0x68, 0x1d, 0x2a, 0x56, 0xee, 0xed, 0x36, 0x26, 0x3f, 0xb7, 0x2a, 0xfb,
+	0x7b, 0x71, 0x85, 0xa6, 0x68, 0xa7, 0x54, 0x55, 0x3a, 0xd5, 0x70, 0x65, 0x7b, 0x2b, 0xba, 0x70,
+	0x9d, 0x22, 0xf5, 0x92, 0x4a, 0xdb, 0x87, 0x50, 0x53, 0xf0, 0x42, 0x5b, 0xbd, 0x19, 0x58, 0x12,
+	0x3b, 0x11, 0x03, 0x82, 0xe7, 0xb0, 0x6a, 0x4b, 0xb6, 0x5d, 0xed, 0x40, 0x5d, 0x2a, 0x42, 0xef,
+	0xe2, 0xfc, 0xec, 0x4a, 0x18, 0x9b, 0xe8, 0xed, 0xdf, 0x55, 0x70, 0x0f, 0x32, 0x3a, 0xda, 0xa3,
+	0x78, 0x80, 0x18, 0xac, 0xa9, 0xa7, 0x2a, 0x67, 0x3f, 0x7f, 0xc1, 0x84, 0x44, 0xf7, 0x16, 0x34,
+	0x31, 0xfb, 0x3d, 0xb4, 0xa2, 0xcb, 0x86, 0xdb, 0xa2, 0x31, 0x80, 0x4a, 0x68, 0x76, 0x05, 0x85,
+	0x73, 0xd4, 0x33, 0x2b, 0xda, 0xba, 0x7b, 0x89, 0x48, 0x9b, 0xe2, 0x23, 0x78, 0x2a, 0x85, 0x1e,
+	0x16, 0xba, 0xb3, 0x60, 0x2a, 0xd3, 0x04, 0xe1, 0xe2, 0xc0, 0x59, 0x7f, 0xbd, 0x7f, 0x73, 0xfd,
+	0xff, 0xfd, 0x0c, 0xe6, 0xfa, 0xcf, 0xac, 0x32, 0x7a, 0x0f, 0xcb, 0xca, 0xbf, 0x47, 0x53, 0x74,
+	0x6b, 0x8e, 0xe8, 0xef, 0xba, 0xb7, 0x6e, 0x2f, 0x0a, 0x33, 0xce, 0xbb, 0x6f, 0xce, 0xce, 0xdb,
+	0x4b, 0x3f, 0xce, 0xdb, 0x4b, 0x5f, 0x27, 0x6d, 0xe7, 0x6c, 0xd2, 0x76, 0xbe, 0x4f, 0xda, 0xce,
+	0xaf, 0x49, 0xdb, 0xf9, 0xf0, 0xe8, 0xff, 0xfe, 0xa3, 0x8f, 0xcb, 0xc3, 0x61, 0x43, 0xff, 0x48,
+	0x1f, 0xfc, 0x09, 0x00, 0x00, 0xff, 0xff, 0x40, 0x66, 0xf4, 0x09, 0x89, 0x05, 0x00, 0x00,
 }
 
 func (m *ExecProcessRequest) Marshal() (dAtA []byte, err error) {
@@ -707,6 +874,173 @@ func (m *PidResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+func (m *TasksRequest) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *TasksRequest) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *TasksRequest) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.XXX_unrecognized != nil {
+		i -= len(m.XXX_unrecognized)
+		copy(dAtA[i:], m.XXX_unrecognized)
+	}
+	if m.Execs {
+		i--
+		if m.Execs {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *Task) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *Task) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *Task) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.XXX_unrecognized != nil {
+		i -= len(m.XXX_unrecognized)
+		copy(dAtA[i:], m.XXX_unrecognized)
+	}
+	if len(m.Execs) > 0 {
+		for iNdEx := len(m.Execs) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.Execs[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintShimdiag(dAtA, i, uint64(size))
+			}
+			i--
+			dAtA[i] = 0x12
+		}
+	}
+	if len(m.ID) > 0 {
+		i -= len(m.ID)
+		copy(dAtA[i:], m.ID)
+		i = encodeVarintShimdiag(dAtA, i, uint64(len(m.ID)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *Exec) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *Exec) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *Exec) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.XXX_unrecognized != nil {
+		i -= len(m.XXX_unrecognized)
+		copy(dAtA[i:], m.XXX_unrecognized)
+	}
+	if len(m.State) > 0 {
+		i -= len(m.State)
+		copy(dAtA[i:], m.State)
+		i = encodeVarintShimdiag(dAtA, i, uint64(len(m.State)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if len(m.ID) > 0 {
+		i -= len(m.ID)
+		copy(dAtA[i:], m.ID)
+		i = encodeVarintShimdiag(dAtA, i, uint64(len(m.ID)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *TasksResponse) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *TasksResponse) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *TasksResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.XXX_unrecognized != nil {
+		i -= len(m.XXX_unrecognized)
+		copy(dAtA[i:], m.XXX_unrecognized)
+	}
+	if len(m.Tasks) > 0 {
+		for iNdEx := len(m.Tasks) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.Tasks[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintShimdiag(dAtA, i, uint64(size))
+			}
+			i--
+			dAtA[i] = 0xa
+		}
+	}
+	return len(dAtA) - i, nil
+}
+
 func encodeVarintShimdiag(dAtA []byte, offset int, v uint64) int {
 	offset -= sovShimdiag(v)
 	base := offset
@@ -864,6 +1198,81 @@ func (m *PidResponse) Size() (n int) {
 	return n
 }
 
+func (m *TasksRequest) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.Execs {
+		n += 2
+	}
+	if m.XXX_unrecognized != nil {
+		n += len(m.XXX_unrecognized)
+	}
+	return n
+}
+
+func (m *Task) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.ID)
+	if l > 0 {
+		n += 1 + l + sovShimdiag(uint64(l))
+	}
+	if len(m.Execs) > 0 {
+		for _, e := range m.Execs {
+			l = e.Size()
+			n += 1 + l + sovShimdiag(uint64(l))
+		}
+	}
+	if m.XXX_unrecognized != nil {
+		n += len(m.XXX_unrecognized)
+	}
+	return n
+}
+
+func (m *Exec) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.ID)
+	if l > 0 {
+		n += 1 + l + sovShimdiag(uint64(l))
+	}
+	l = len(m.State)
+	if l > 0 {
+		n += 1 + l + sovShimdiag(uint64(l))
+	}
+	if m.XXX_unrecognized != nil {
+		n += len(m.XXX_unrecognized)
+	}
+	return n
+}
+
+func (m *TasksResponse) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if len(m.Tasks) > 0 {
+		for _, e := range m.Tasks {
+			l = e.Size()
+			n += 1 + l + sovShimdiag(uint64(l))
+		}
+	}
+	if m.XXX_unrecognized != nil {
+		n += len(m.XXX_unrecognized)
+	}
+	return n
+}
+
 func sovShimdiag(x uint64) (n int) {
 	return (math_bits.Len64(x|1) + 6) / 7
 }
@@ -963,6 +1372,62 @@ func (this *PidResponse) String() string {
 	}, "")
 	return s
 }
+func (this *TasksRequest) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&TasksRequest{`,
+		`Execs:` + fmt.Sprintf("%v", this.Execs) + `,`,
+		`XXX_unrecognized:` + fmt.Sprintf("%v", this.XXX_unrecognized) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *Task) String() string {
+	if this == nil {
+		return "nil"
+	}
+	repeatedStringForExecs := "[]*Exec{"
+	for _, f := range this.Execs {
+		repeatedStringForExecs += strings.Replace(f.String(), "Exec", "Exec", 1) + ","
+	}
+	repeatedStringForExecs += "}"
+	s := strings.Join([]string{`&Task{`,
+		`ID:` + fmt.Sprintf("%v", this.ID) + `,`,
+		`Execs:` + repeatedStringForExecs + `,`,
+		`XXX_unrecognized:` + fmt.Sprintf("%v", this.XXX_unrecognized) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *Exec) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&Exec{`,
+		`ID:` + fmt.Sprintf("%v", this.ID) + `,`,
+		`State:` + fmt.Sprintf("%v", this.State) + `,`,
+		`XXX_unrecognized:` + fmt.Sprintf("%v", this.XXX_unrecognized) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *TasksResponse) String() string {
+	if this == nil {
+		return "nil"
+	}
+	repeatedStringForTasks := "[]*Task{"
+	for _, f := range this.Tasks {
+		repeatedStringForTasks += strings.Replace(f.String(), "Task", "Task", 1) + ","
+	}
+	repeatedStringForTasks += "}"
+	s := strings.Join([]string{`&TasksResponse{`,
+		`Tasks:` + repeatedStringForTasks + `,`,
+		`XXX_unrecognized:` + fmt.Sprintf("%v", this.XXX_unrecognized) + `,`,
+		`}`,
+	}, "")
+	return s
+}
 func valueToStringShimdiag(v interface{}) string {
 	rv := reflect.ValueOf(v)
 	if rv.IsNil() {
@@ -975,6 +1440,7 @@ func valueToStringShimdiag(v interface{}) string {
 type ShimDiagService interface {
 	DiagExecInHost(ctx context.Context, req *ExecProcessRequest) (*ExecProcessResponse, error)
 	DiagStacks(ctx context.Context, req *StacksRequest) (*StacksResponse, error)
+	DiagTasks(ctx context.Context, req *TasksRequest) (*TasksResponse, error)
 	DiagShare(ctx context.Context, req *ShareRequest) (*ShareResponse, error)
 	DiagPid(ctx context.Context, req *PidRequest) (*PidResponse, error)
 }
@@ -994,6 +1460,13 @@ func RegisterShimDiagService(srv *github_com_containerd_ttrpc.Server, svc ShimDi
 				return nil, err
 			}
 			return svc.DiagStacks(ctx, &req)
+		},
+		"DiagTasks": func(ctx context.Context, unmarshal func(interface{}) error) (interface{}, error) {
+			var req TasksRequest
+			if err := unmarshal(&req); err != nil {
+				return nil, err
+			}
+			return svc.DiagTasks(ctx, &req)
 		},
 		"DiagShare": func(ctx context.Context, unmarshal func(interface{}) error) (interface{}, error) {
 			var req ShareRequest
@@ -1033,6 +1506,14 @@ func (c *shimDiagClient) DiagExecInHost(ctx context.Context, req *ExecProcessReq
 func (c *shimDiagClient) DiagStacks(ctx context.Context, req *StacksRequest) (*StacksResponse, error) {
 	var resp StacksResponse
 	if err := c.client.Call(ctx, "containerd.runhcs.v1.diag.ShimDiag", "DiagStacks", req, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+func (c *shimDiagClient) DiagTasks(ctx context.Context, req *TasksRequest) (*TasksResponse, error) {
+	var resp TasksResponse
+	if err := c.client.Call(ctx, "containerd.runhcs.v1.diag.ShimDiag", "DiagTasks", req, &resp); err != nil {
 		return nil, err
 	}
 	return &resp, nil
@@ -1805,6 +2286,394 @@ func (m *PidResponse) Unmarshal(dAtA []byte) error {
 					break
 				}
 			}
+		default:
+			iNdEx = preIndex
+			skippy, err := skipShimdiag(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthShimdiag
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.XXX_unrecognized = append(m.XXX_unrecognized, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *TasksRequest) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowShimdiag
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: TasksRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: TasksRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Execs", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowShimdiag
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.Execs = bool(v != 0)
+		default:
+			iNdEx = preIndex
+			skippy, err := skipShimdiag(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthShimdiag
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.XXX_unrecognized = append(m.XXX_unrecognized, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *Task) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowShimdiag
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: Task: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: Task: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ID", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowShimdiag
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthShimdiag
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthShimdiag
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.ID = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Execs", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowShimdiag
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthShimdiag
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthShimdiag
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Execs = append(m.Execs, &Exec{})
+			if err := m.Execs[len(m.Execs)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipShimdiag(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthShimdiag
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.XXX_unrecognized = append(m.XXX_unrecognized, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *Exec) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowShimdiag
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: Exec: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: Exec: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ID", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowShimdiag
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthShimdiag
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthShimdiag
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.ID = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field State", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowShimdiag
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthShimdiag
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthShimdiag
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.State = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipShimdiag(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthShimdiag
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.XXX_unrecognized = append(m.XXX_unrecognized, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *TasksResponse) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowShimdiag
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: TasksResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: TasksResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Tasks", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowShimdiag
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthShimdiag
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthShimdiag
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Tasks = append(m.Tasks, &Task{})
+			if err := m.Tasks[len(m.Tasks)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := skipShimdiag(dAtA[iNdEx:])

--- a/internal/shimdiag/shimdiag.proto
+++ b/internal/shimdiag/shimdiag.proto
@@ -3,11 +3,10 @@ syntax = "proto3";
 package containerd.runhcs.v1.diag;
 option go_package = "github.com/Microsoft/hcsshim/internal/shimdiag;shimdiag";
 
-import weak "gogoproto/gogo.proto";
-
 service ShimDiag {
     rpc DiagExecInHost(ExecProcessRequest) returns (ExecProcessResponse);
     rpc DiagStacks(StacksRequest) returns (StacksResponse);
+    rpc DiagTasks(TasksRequest) returns (TasksResponse);
     rpc DiagShare(ShareRequest) returns (ShareResponse);
     rpc DiagPid(PidRequest) returns (PidResponse);
 }
@@ -30,7 +29,7 @@ message StacksRequest {
 
 message StacksResponse {
     string stacks = 1;
-    string guest_stacks =2; 
+    string guest_stacks =2;
 }
 
 message ShareRequest {
@@ -48,3 +47,22 @@ message PidRequest{
 message PidResponse{
     int32 pid = 1;
 }
+
+message TasksRequest {
+    bool execs = 1;
+}
+
+message Task {
+    string id = 1;
+    repeated Exec execs = 2;
+}
+
+message Exec {
+    string id = 1;
+    string state = 2;
+}
+
+message TasksResponse {
+    repeated Task tasks = 1;
+}
+


### PR DESCRIPTION
This command prints the tasks that are currently being managed
by a given shim instance, and optionally the execs in each task.

There've been a couple times where our shim and containerd have
seemingly disagreed on what tasks are still running.. This should
make it easy to see the state of the world from our shims point
of view.

Example output:
```
PS C:\cplat> .\shimdiag.exe tasks -execs k8s
07f437749e5cd32534b8eef2eeb8eb3bf9fdfaacb9085b5b8ff4a281c48b87ab
|
|---->  running: 07f437749e5cd32534b8eef2eeb8eb3bf9fdfaacb9085b5b8ff4a281c48b87ab

3307379237a87b9a1243f83ea3ba933d1f48dffc4186dd697f5ab73589f7cda4
|
|---->  running: 9bbb5a3bd36ef4e8db0531f5bdbef9def01b782f5ac916f5d5737632834e32af
        running: 7492e558a89d4f5ff10442112d93e92f26593671497878f7d431fdf0988144a0
```