### PR TITLE
fix unmarshaling of LCOWSecurityPolicyEnforcer

### DIFF
--- a/internal/guest/prot/protocol.go
+++ b/internal/guest/prot/protocol.go
@@ -15,7 +15,6 @@ import (
 	hcsschema "github.com/Microsoft/hcsshim/internal/hcs/schema2"
 	"github.com/Microsoft/hcsshim/internal/protocol/guestrequest"
 	"github.com/Microsoft/hcsshim/internal/protocol/guestresource"
-	"github.com/Microsoft/hcsshim/pkg/securitypolicy"
 )
 
 //////////// Code for the Message Header ////////////
@@ -579,11 +578,11 @@ func UnmarshalContainerModifySettings(b []byte) (*ContainerModifySettings, error
 		}
 		msr.Settings = cc
 	case guestresource.ResourceTypeSecurityPolicy:
-		policy := &securitypolicy.EncodedSecurityPolicy{}
-		if err := commonutils.UnmarshalJSONWithHresult(msrRawSettings, policy); err != nil {
-			return &request, errors.Wrap(err, "failed to unmarshal settings as EncodedSecurityPolicy")
+		enforcer := &guestresource.LCOWSecurityPolicyEnforcer{}
+		if err := commonutils.UnmarshalJSONWithHresult(msrRawSettings, enforcer); err != nil {
+			return &request, errors.Wrap(err, "failed to unmarshal settings as LCOWSecurityPolicyEnforcer")
 		}
-		msr.Settings = policy
+		msr.Settings = enforcer
 	default:
 		return &request, errors.Errorf("invalid ResourceType '%s'", msr.ResourceType)
 	}

--- a/internal/guest/runtime/hcsv2/uvm.go
+++ b/internal/guest/runtime/hcsv2/uvm.go
@@ -375,9 +375,8 @@ func (h *Host) modifyHostSettings(ctx context.Context, containerID string, req *
 	case guestresource.ResourceTypeSecurityPolicy:
 		r, ok := req.Settings.(*guestresource.LCOWSecurityPolicyEnforcer)
 		if !ok {
-			return errors.New("the request's settings are not of type EncodedSecurityPolicy")
+			return errors.New("the request's settings are not of type LCOWSecurityPolicyEnforcer")
 		}
-
 		return h.SetSecurityPolicy(r.EnforcerType, r.EncodedSecurityPolicy)
 	default:
 		return errors.Errorf("the ResourceType \"%s\" is not supported for UVM", req.ResourceType)


### PR DESCRIPTION
When adding multiple enforcer support in https://github.com/microsoft/hcsshim/pull/1476
I forgot to update the unmarshal code accordingly.

Signed-off-by: Maksim An <maksiman@microsoft.com>