### PR TITLE
Call container.Terminate() on shutdown timeouts

### DIFF
--- a/cmd/containerd-shim-runhcs-v1/task_hcs.go
+++ b/cmd/containerd-shim-runhcs-v1/task_hcs.go
@@ -788,7 +788,8 @@ func (ht *hcsTask) close(ctx context.Context) {
 						log.G(ctx).WithError(err).Error("failed to wait for container shutdown")
 					}
 				case <-t.C:
-					log.G(ctx).WithError(hcs.ErrTimeout).Error("failed to wait for container shutdown")
+					err = hcs.ErrTimeout
+					log.G(ctx).WithError(err).Error("failed to wait for container shutdown")
 				}
 			}
 


### PR DESCRIPTION
We were logging if HcsShutdownComputeSystem failed, but we weren't
trying to force kill the container via Terminate after if we timed
out waiting for it to complete. Shutdown is async and we wait for
a notification for success, so most of the time the call itself will
return nil, but it doesn't indicate indicate success until we can
see that the system exited. So now we will fallback to Terminate for:

1. Shutdown returning an error that doesn't indicate the result is
to be waited on.
2. The async result of shutdown was non-nil
3. Waiting for the result passed the timeout we set.