### PR TITLE
Linux/LCOW bugs

### DIFF
--- a/internal/guest/runtime/runc/container.go
+++ b/internal/guest/runtime/runc/container.go
@@ -101,16 +101,12 @@ func (c *container) Delete() error {
 		runcErr := parseRuncError(string(out))
 		return errors.Wrapf(runcErr, "runc delete failed with %v: %s", err, string(out))
 	}
-	if err := c.r.cleanupContainer(c.id); err != nil {
-		return err
-	}
-
-	return nil
+	return c.r.cleanupContainer(c.id)
 }
 
 // Pause suspends all processes running in the container.
 func (c *container) Pause() error {
-	cmd := runcCommandLog("pause", c.id)
+	cmd := runcCommand("pause", c.id)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		runcErr := parseRuncError(string(out))
@@ -153,7 +149,7 @@ func (c *container) GetState() (*runtime.ContainerState, error) {
 // deleted are still considered to exist.
 func (c *container) Exists() (bool, error) {
 	// use global path because container may not exist
-	cmd := runcCommandLog("state", c.id)
+	cmd := runcCommand("state", c.id)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		runcErr := parseRuncError(string(out))

--- a/internal/guest/runtime/runc/utils.go
+++ b/internal/guest/runtime/runc/utils.go
@@ -57,7 +57,7 @@ func (r *runcRuntime) getProcessDir(id string, pid int) string {
 
 // getContainerDir returns the path to the state directory of the given
 // container.
-func (r *runcRuntime) getContainerDir(id string) string {
+func (*runcRuntime) getContainerDir(id string) string {
 	return filepath.Join(containerFilesDir, id)
 }
 

--- a/internal/tools/uvmboot/lcow.go
+++ b/internal/tools/uvmboot/lcow.go
@@ -246,7 +246,7 @@ func createLCOWOptions(_ context.Context, c *cli.Context, id string) (*uvm.Optio
 	}
 	options.SecurityPolicy = openPolicy
 	if c.IsSet(securityPolicyArgName) {
-		options.SecurityPolicy = c.String(options.SecurityPolicy)
+		options.SecurityPolicy = c.String(securityPolicyArgName)
 	}
 	if c.IsSet(securityHardwareFlag) {
 		options.GuestStateFile = uvm.GuestStateFile

--- a/test/cri-containerd/helper_cri_plugins_test.go
+++ b/test/cri-containerd/helper_cri_plugins_test.go
@@ -1,4 +1,5 @@
-//go:build functional
+//go:build windows && functional
+// +build windows,functional
 
 package cri_containerd
 


### PR DESCRIPTION
Container/runc commands used `runcCommandLog` instead of `runcCommand`,
which fails to run properly.
Since they do not need to use a log file, the latter call is correct.

Bug with how `uvmboot` sets security policy arg.

Missing windows build tag.

Linting/style changes:
 - unnecessary `if err != nil { return err }` statement
 - simplified nested if statments
 - unused method receivers

Signed-off-by: Hamza El-Saawy <hamzaelsaawy@microsoft.com>