### PR TITLE
Enable linting on test directory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,22 +4,42 @@ on:
   - pull_request
 
 env:
-  GO_VERSION: '1.18.x'
+  GO_VERSION: "1.18.x"
 
 jobs:
   lint:
     runs-on: "windows-2019"
+    strategy:
+      fail-fast: false
+      matrix:
+        goos: [windows, linux]
+        root: ["", test] # cannot specify "./... ./test/..." unless in go workspace
+        include:
+          - goos: linux
+            root: ""
+            dirs: >-
+              ./cmd/gcs/...
+              ./cmd/gcstools/...
+              ./internal/guest...
+              ./internal/tools/...
+              ./pkg/...
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
           go-version: ${{ env.GO_VERSION }}
-
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+      - uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.48.0
-          args: -v
+          version: v1.48
+          args: >-
+            --verbose
+            --max-issues-per-linter=0
+            --max-same-issues=0
+            --modules-download-mode=readonly
+            ${{ matrix.dirs }}
+          working-directory: ${{ matrix.root }}
+        env:
+          GOOS: ${{ matrix.goos }}
 
   protos:
     runs-on: "windows-2019"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,9 +1,20 @@
 run:
   timeout: 8m
+  tests: true
+  build-tags:
+    - admin
+    - functional
+    - integration
+    - rego
+  skip-dirs:
+    # paths are relative to module root
+    - cri-containerd/test-images
 
 linters:
   enable:
     - gofmt
+    - misspell
+    - nolintlint
     - stylecheck
 
 linters-settings:
@@ -11,14 +22,22 @@ linters-settings:
     # https://staticcheck.io/docs/checks
     checks: ["all"]
 
-
 issues:
-  # This repo has a LOT of generated schema files, operating system bindings, and other things that ST1003 from stylecheck won't like
-  # (screaming case Windows api constants for example). There's also some structs that we *could* change the initialisms to be Go
-  # friendly (Id -> ID) but they're exported and it would be a breaking change. This makes it so that most new code, code that isn't
-  # supposed to be a pretty faithful mapping to an OS call/constants, or non-generated code still checks if we're following idioms,
-  # while ignoring the things that are just noise or would be more of a hassle than it'd be worth to change.
   exclude-rules:
+    # path is relative to module root, which is ./test/
+    - path: cri-containerd
+      linters:
+        - stylecheck
+      text: "^ST1003: should not use underscores in package names$"
+      source: "^package cri_containerd$"
+
+    # This repo has a LOT of generated schema files, operating system bindings, and other
+    # things that ST1003 from stylecheck won't like (screaming case Windows api constants for example).
+    # There's also some structs that we *could* change the initialisms to be Go friendly
+    # (Id -> ID) but they're exported and it would be a breaking change.
+    # This makes it so that most new code, code that isn't supposed to be a pretty faithful
+    # mapping to an OS call/constants, or non-generated code still checks if we're following idioms,
+    # while ignoring the things that are just noise or would be more of a hassle than it'd be worth to change.
     - path: layer.go
       linters:
         - stylecheck

--- a/cmd/containerd-shim-runhcs-v1/service.go
+++ b/cmd/containerd-shim-runhcs-v1/service.go
@@ -532,7 +532,7 @@ func (s *service) DiagPid(ctx context.Context, req *shimdiag.PidRequest) (*shimd
 }
 
 func (s *service) ComputeProcessorInfo(ctx context.Context, req *extendedtask.ComputeProcessorInfoRequest) (*extendedtask.ComputeProcessorInfoResponse, error) {
-	ctx, span := oc.StartSpan(ctx, "ComputeProcessorInfo") //nolint:ineffassign,staticcheck
+	ctx, span := oc.StartSpan(ctx, "ComputeProcessorInfo")
 	defer span.End()
 
 	span.AddAttributes(trace.StringAttribute("tid", s.tid))

--- a/cmd/ncproxy/ncproxy.go
+++ b/cmd/ncproxy/ncproxy.go
@@ -307,7 +307,7 @@ func (s *grpcService) DeleteNIC(ctx context.Context, req *ncproxygrpc.DeleteNICR
 }
 
 func (s *grpcService) CreateNetwork(ctx context.Context, req *ncproxygrpc.CreateNetworkRequest) (_ *ncproxygrpc.CreateNetworkResponse, err error) {
-	ctx, span := oc.StartSpan(ctx, "CreateNetwork") //nolint:ineffassign,staticcheck
+	ctx, span := oc.StartSpan(ctx, "CreateNetwork")
 	defer span.End()
 	defer func() { oc.SetSpanStatus(span, err) }()
 
@@ -357,7 +357,7 @@ func (s *grpcService) CreateNetwork(ctx context.Context, req *ncproxygrpc.Create
 }
 
 func (s *grpcService) CreateEndpoint(ctx context.Context, req *ncproxygrpc.CreateEndpointRequest) (_ *ncproxygrpc.CreateEndpointResponse, err error) {
-	ctx, span := oc.StartSpan(ctx, "CreateEndpoint") //nolint:ineffassign,staticcheck
+	ctx, span := oc.StartSpan(ctx, "CreateEndpoint")
 	defer span.End()
 	defer func() { oc.SetSpanStatus(span, err) }()
 
@@ -434,7 +434,7 @@ func (s *grpcService) CreateEndpoint(ctx context.Context, req *ncproxygrpc.Creat
 }
 
 func (s *grpcService) AddEndpoint(ctx context.Context, req *ncproxygrpc.AddEndpointRequest) (_ *ncproxygrpc.AddEndpointResponse, err error) {
-	ctx, span := oc.StartSpan(ctx, "AddEndpoint") //nolint:ineffassign,staticcheck
+	ctx, span := oc.StartSpan(ctx, "AddEndpoint")
 	defer span.End()
 	defer func() { oc.SetSpanStatus(span, err) }()
 
@@ -472,7 +472,7 @@ func (s *grpcService) AddEndpoint(ctx context.Context, req *ncproxygrpc.AddEndpo
 }
 
 func (s *grpcService) DeleteEndpoint(ctx context.Context, req *ncproxygrpc.DeleteEndpointRequest) (_ *ncproxygrpc.DeleteEndpointResponse, err error) {
-	ctx, span := oc.StartSpan(ctx, "DeleteEndpoint") //nolint:ineffassign,staticcheck
+	ctx, span := oc.StartSpan(ctx, "DeleteEndpoint")
 	defer span.End()
 	defer func() { oc.SetSpanStatus(span, err) }()
 
@@ -508,7 +508,7 @@ func (s *grpcService) DeleteEndpoint(ctx context.Context, req *ncproxygrpc.Delet
 }
 
 func (s *grpcService) DeleteNetwork(ctx context.Context, req *ncproxygrpc.DeleteNetworkRequest) (_ *ncproxygrpc.DeleteNetworkResponse, err error) {
-	ctx, span := oc.StartSpan(ctx, "DeleteNetwork") //nolint:ineffassign,staticcheck
+	ctx, span := oc.StartSpan(ctx, "DeleteNetwork")
 	defer span.End()
 	defer func() { oc.SetSpanStatus(span, err) }()
 
@@ -577,7 +577,7 @@ func ncpNetworkingEndpointToEndpointResponse(ep *ncproxynetworking.Endpoint) (_ 
 }
 
 func (s *grpcService) GetEndpoint(ctx context.Context, req *ncproxygrpc.GetEndpointRequest) (_ *ncproxygrpc.GetEndpointResponse, err error) {
-	ctx, span := oc.StartSpan(ctx, "GetEndpoint") //nolint:ineffassign,staticcheck
+	ctx, span := oc.StartSpan(ctx, "GetEndpoint")
 	defer span.End()
 	defer func() { oc.SetSpanStatus(span, err) }()
 
@@ -605,7 +605,7 @@ func (s *grpcService) GetEndpoint(ctx context.Context, req *ncproxygrpc.GetEndpo
 }
 
 func (s *grpcService) GetEndpoints(ctx context.Context, req *ncproxygrpc.GetEndpointsRequest) (_ *ncproxygrpc.GetEndpointsResponse, err error) {
-	ctx, span := oc.StartSpan(ctx, "GetEndpoints") //nolint:ineffassign,staticcheck
+	ctx, span := oc.StartSpan(ctx, "GetEndpoints")
 	defer span.End()
 	defer func() { oc.SetSpanStatus(span, err) }()
 
@@ -656,7 +656,7 @@ func ncpNetworkingNetworkToNetworkResponse(network *ncproxynetworking.Network) (
 }
 
 func (s *grpcService) GetNetwork(ctx context.Context, req *ncproxygrpc.GetNetworkRequest) (_ *ncproxygrpc.GetNetworkResponse, err error) {
-	ctx, span := oc.StartSpan(ctx, "GetNetwork") //nolint:ineffassign,staticcheck
+	ctx, span := oc.StartSpan(ctx, "GetNetwork")
 	defer span.End()
 	defer func() { oc.SetSpanStatus(span, err) }()
 
@@ -685,7 +685,7 @@ func (s *grpcService) GetNetwork(ctx context.Context, req *ncproxygrpc.GetNetwor
 }
 
 func (s *grpcService) GetNetworks(ctx context.Context, req *ncproxygrpc.GetNetworksRequest) (_ *ncproxygrpc.GetNetworksResponse, err error) {
-	ctx, span := oc.StartSpan(ctx, "GetNetworks") //nolint:ineffassign,staticcheck
+	ctx, span := oc.StartSpan(ctx, "GetNetworks")
 	defer span.End()
 	defer func() { oc.SetSpanStatus(span, err) }()
 
@@ -755,7 +755,7 @@ func getComputeAgentClient(agentAddr string) (*computeAgentClient, error) {
 }
 
 func (s *ttrpcService) RegisterComputeAgent(ctx context.Context, req *ncproxyttrpc.RegisterComputeAgentRequest) (_ *ncproxyttrpc.RegisterComputeAgentResponse, err error) {
-	ctx, span := oc.StartSpan(ctx, "RegisterComputeAgent") //nolint:ineffassign,staticcheck
+	ctx, span := oc.StartSpan(ctx, "RegisterComputeAgent")
 	defer span.End()
 	defer func() { oc.SetSpanStatus(span, err) }()
 
@@ -782,7 +782,7 @@ func (s *ttrpcService) RegisterComputeAgent(ctx context.Context, req *ncproxyttr
 }
 
 func (s *ttrpcService) UnregisterComputeAgent(ctx context.Context, req *ncproxyttrpc.UnregisterComputeAgentRequest) (_ *ncproxyttrpc.UnregisterComputeAgentResponse, err error) {
-	ctx, span := oc.StartSpan(ctx, "UnregisterComputeAgent") //nolint:ineffassign,staticcheck
+	ctx, span := oc.StartSpan(ctx, "UnregisterComputeAgent")
 	defer span.End()
 	defer func() { oc.SetSpanStatus(span, err) }()
 
@@ -809,7 +809,7 @@ func (s *ttrpcService) UnregisterComputeAgent(ctx context.Context, req *ncproxyt
 }
 
 func (s *ttrpcService) ConfigureNetworking(ctx context.Context, req *ncproxyttrpc.ConfigureNetworkingInternalRequest) (_ *ncproxyttrpc.ConfigureNetworkingInternalResponse, err error) {
-	ctx, span := oc.StartSpan(ctx, "ConfigureNetworking") //nolint:ineffassign,staticcheck
+	ctx, span := oc.StartSpan(ctx, "ConfigureNetworking")
 	defer span.End()
 	defer func() { oc.SetSpanStatus(span, err) }()
 

--- a/cmd/ncproxy/service.go
+++ b/cmd/ncproxy/service.go
@@ -172,7 +172,7 @@ func launchService(done chan struct{}) error {
 		done:    done,
 	}
 
-	interactive, err := svc.IsAnInteractiveSession() // nolint:staticcheck
+	interactive, err := svc.IsAnInteractiveSession() //nolint:staticcheck
 	if err != nil {
 		return err
 	}

--- a/hcn/hcnendpoint.go
+++ b/hcn/hcnendpoint.go
@@ -72,14 +72,14 @@ type PolicyEndpointRequest struct {
 	Policies []EndpointPolicy `json:",omitempty"`
 }
 
-func getEndpoint(endpointGuid guid.GUID, query string) (*HostComputeEndpoint, error) {
+func getEndpoint(endpointGUID guid.GUID, query string) (*HostComputeEndpoint, error) {
 	// Open endpoint.
 	var (
 		endpointHandle   hcnEndpoint
 		resultBuffer     *uint16
 		propertiesBuffer *uint16
 	)
-	hr := hcnOpenEndpoint(&endpointGuid, &endpointHandle, &resultBuffer)
+	hr := hcnOpenEndpoint(&endpointGUID, &endpointHandle, &resultBuffer)
 	if err := checkForErrors("hcnOpenEndpoint", hr, resultBuffer); err != nil {
 		return nil, err
 	}
@@ -121,8 +121,8 @@ func enumerateEndpoints(query string) ([]HostComputeEndpoint, error) {
 	}
 
 	var outputEndpoints []HostComputeEndpoint
-	for _, endpointGuid := range endpointIds {
-		endpoint, err := getEndpoint(endpointGuid, query)
+	for _, endpointGUID := range endpointIds {
+		endpoint, err := getEndpoint(endpointGUID, query)
 		if err != nil {
 			return nil, err
 		}
@@ -131,22 +131,22 @@ func enumerateEndpoints(query string) ([]HostComputeEndpoint, error) {
 	return outputEndpoints, nil
 }
 
-func createEndpoint(networkId string, endpointSettings string) (*HostComputeEndpoint, error) {
-	networkGuid, err := guid.FromString(networkId)
+func createEndpoint(networkID string, endpointSettings string) (*HostComputeEndpoint, error) {
+	networkGUID, err := guid.FromString(networkID)
 	if err != nil {
 		return nil, errInvalidNetworkID
 	}
 	// Open network.
 	var networkHandle hcnNetwork
 	var resultBuffer *uint16
-	hr := hcnOpenNetwork(&networkGuid, &networkHandle, &resultBuffer)
+	hr := hcnOpenNetwork(&networkGUID, &networkHandle, &resultBuffer)
 	if err := checkForErrors("hcnOpenNetwork", hr, resultBuffer); err != nil {
 		return nil, err
 	}
 	// Create endpoint.
-	endpointId := guid.GUID{}
+	endpointID := guid.GUID{}
 	var endpointHandle hcnEndpoint
-	hr = hcnCreateEndpoint(networkHandle, &endpointId, endpointSettings, &endpointHandle, &resultBuffer)
+	hr = hcnCreateEndpoint(networkHandle, &endpointID, endpointSettings, &endpointHandle, &resultBuffer)
 	if err := checkForErrors("hcnCreateEndpoint", hr, resultBuffer); err != nil {
 		return nil, err
 	}
@@ -180,8 +180,8 @@ func createEndpoint(networkId string, endpointSettings string) (*HostComputeEndp
 	return &outputEndpoint, nil
 }
 
-func modifyEndpoint(endpointId string, settings string) (*HostComputeEndpoint, error) {
-	endpointGuid, err := guid.FromString(endpointId)
+func modifyEndpoint(endpointID string, settings string) (*HostComputeEndpoint, error) {
+	endpointGUID, err := guid.FromString(endpointID)
 	if err != nil {
 		return nil, errInvalidEndpointID
 	}
@@ -191,7 +191,7 @@ func modifyEndpoint(endpointId string, settings string) (*HostComputeEndpoint, e
 		resultBuffer     *uint16
 		propertiesBuffer *uint16
 	)
-	hr := hcnOpenEndpoint(&endpointGuid, &endpointHandle, &resultBuffer)
+	hr := hcnOpenEndpoint(&endpointGUID, &endpointHandle, &resultBuffer)
 	if err := checkForErrors("hcnOpenEndpoint", hr, resultBuffer); err != nil {
 		return nil, err
 	}
@@ -224,13 +224,13 @@ func modifyEndpoint(endpointId string, settings string) (*HostComputeEndpoint, e
 	return &outputEndpoint, nil
 }
 
-func deleteEndpoint(endpointId string) error {
-	endpointGuid, err := guid.FromString(endpointId)
+func deleteEndpoint(endpointID string) error {
+	endpointGUID, err := guid.FromString(endpointID)
 	if err != nil {
 		return errInvalidEndpointID
 	}
 	var resultBuffer *uint16
-	hr := hcnDeleteEndpoint(&endpointGuid, &resultBuffer)
+	hr := hcnDeleteEndpoint(&endpointGUID, &resultBuffer)
 	if err := checkForErrors("hcnDeleteEndpoint", hr, resultBuffer); err != nil {
 		return err
 	}
@@ -249,12 +249,12 @@ func ListEndpoints() ([]HostComputeEndpoint, error) {
 
 // ListEndpointsQuery makes a call to query the list of available endpoints.
 func ListEndpointsQuery(query HostComputeQuery) ([]HostComputeEndpoint, error) {
-	queryJson, err := json.Marshal(query)
+	queryJSON, err := json.Marshal(query)
 	if err != nil {
 		return nil, err
 	}
 
-	endpoints, err := enumerateEndpoints(string(queryJson))
+	endpoints, err := enumerateEndpoints(string(queryJSON))
 	if err != nil {
 		return nil, err
 	}
@@ -262,10 +262,10 @@ func ListEndpointsQuery(query HostComputeQuery) ([]HostComputeEndpoint, error) {
 }
 
 // ListEndpointsOfNetwork queries the list of endpoints on a network.
-func ListEndpointsOfNetwork(networkId string) ([]HostComputeEndpoint, error) {
+func ListEndpointsOfNetwork(networkID string) ([]HostComputeEndpoint, error) {
 	hcnQuery := defaultQuery()
 	// TODO: Once query can convert schema, change to {HostComputeNetwork:networkId}
-	mapA := map[string]string{"VirtualNetwork": networkId}
+	mapA := map[string]string{"VirtualNetwork": networkID}
 	filter, err := json.Marshal(mapA)
 	if err != nil {
 		return nil, err
@@ -276,9 +276,9 @@ func ListEndpointsOfNetwork(networkId string) ([]HostComputeEndpoint, error) {
 }
 
 // GetEndpointByID returns an endpoint specified by Id
-func GetEndpointByID(endpointId string) (*HostComputeEndpoint, error) {
+func GetEndpointByID(endpointID string) (*HostComputeEndpoint, error) {
 	hcnQuery := defaultQuery()
-	mapA := map[string]string{"ID": endpointId}
+	mapA := map[string]string{"ID": endpointID}
 	filter, err := json.Marshal(mapA)
 	if err != nil {
 		return nil, err
@@ -290,7 +290,7 @@ func GetEndpointByID(endpointId string) (*HostComputeEndpoint, error) {
 		return nil, err
 	}
 	if len(endpoints) == 0 {
-		return nil, EndpointNotFoundError{EndpointID: endpointId}
+		return nil, EndpointNotFoundError{EndpointID: endpointID}
 	}
 	return &endpoints[0], err
 }
@@ -347,15 +347,15 @@ func (endpoint *HostComputeEndpoint) Delete() error {
 }
 
 // ModifyEndpointSettings updates the Port/Policy of an Endpoint.
-func ModifyEndpointSettings(endpointId string, request *ModifyEndpointSettingRequest) error {
-	logrus.Debugf("hcn::HostComputeEndpoint::ModifyEndpointSettings id=%s", endpointId)
+func ModifyEndpointSettings(endpointID string, request *ModifyEndpointSettingRequest) error {
+	logrus.Debugf("hcn::HostComputeEndpoint::ModifyEndpointSettings id=%s", endpointID)
 
 	endpointSettingsRequest, err := json.Marshal(request)
 	if err != nil {
 		return err
 	}
 
-	_, err = modifyEndpoint(endpointId, string(endpointSettingsRequest))
+	_, err = modifyEndpoint(endpointID, string(endpointSettingsRequest))
 	if err != nil {
 		return err
 	}
@@ -366,25 +366,25 @@ func ModifyEndpointSettings(endpointId string, request *ModifyEndpointSettingReq
 func (endpoint *HostComputeEndpoint) ApplyPolicy(requestType RequestType, endpointPolicy PolicyEndpointRequest) error {
 	logrus.Debugf("hcn::HostComputeEndpoint::ApplyPolicy id=%s", endpoint.Id)
 
-	settingsJson, err := json.Marshal(endpointPolicy)
+	settingsJSON, err := json.Marshal(endpointPolicy)
 	if err != nil {
 		return err
 	}
 	requestMessage := &ModifyEndpointSettingRequest{
 		ResourceType: EndpointResourceTypePolicy,
 		RequestType:  requestType,
-		Settings:     settingsJson,
+		Settings:     settingsJSON,
 	}
 
 	return ModifyEndpointSettings(endpoint.Id, requestMessage)
 }
 
 // NamespaceAttach modifies a Namespace to add an endpoint.
-func (endpoint *HostComputeEndpoint) NamespaceAttach(namespaceId string) error {
-	return AddNamespaceEndpoint(namespaceId, endpoint.Id)
+func (endpoint *HostComputeEndpoint) NamespaceAttach(namespaceID string) error {
+	return AddNamespaceEndpoint(namespaceID, endpoint.Id)
 }
 
 // NamespaceDetach modifies a Namespace to remove an endpoint.
-func (endpoint *HostComputeEndpoint) NamespaceDetach(namespaceId string) error {
-	return RemoveNamespaceEndpoint(namespaceId, endpoint.Id)
+func (endpoint *HostComputeEndpoint) NamespaceDetach(namespaceID string) error {
+	return RemoveNamespaceEndpoint(namespaceID, endpoint.Id)
 }

--- a/hcn/hcnerrors.go
+++ b/hcn/hcnerrors.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Microsoft/hcsshim/internal/hcserror"
 	"github.com/Microsoft/hcsshim/internal/interop"
 	"github.com/sirupsen/logrus"
+	"golang.org/x/sys/windows"
 )
 
 var (
@@ -48,8 +49,8 @@ type ErrorCode uint32
 
 // For common errors, define the error as it is in windows, so we can quickly determine it later
 const (
-	ERROR_NOT_FOUND                     = 0x490
-	HCN_E_PORT_ALREADY_EXISTS ErrorCode = 0x803b0013
+	ERROR_NOT_FOUND                     = ErrorCode(windows.ERROR_NOT_FOUND)
+	HCN_E_PORT_ALREADY_EXISTS ErrorCode = ErrorCode(windows.HCN_E_PORT_ALREADY_EXISTS)
 )
 
 type HcnError struct {

--- a/hcn/hcnerrors_test.go
+++ b/hcn/hcnerrors_test.go
@@ -5,8 +5,9 @@ package hcn
 
 import (
 	"encoding/json"
-	"github.com/Microsoft/go-winio/pkg/guid"
 	"testing"
+
+	"github.com/Microsoft/go-winio/pkg/guid"
 )
 
 func TestMissingNetworkByName(t *testing.T) {
@@ -65,7 +66,7 @@ func TestEndpointAlreadyExistsError(t *testing.T) {
 	if err != nil {
 		t.Fatal("Failed to create overlay network for setup.", err)
 	}
-	defer testNetwork.Delete()
+	defer testNetwork.Delete() //nolint:errcheck
 	portMappingSetting := PortMappingPolicySetting{
 		Protocol:     17,
 		InternalPort: 45678,
@@ -81,12 +82,12 @@ func TestEndpointAlreadyExistsError(t *testing.T) {
 	if err != nil {
 		t.Fatal("Failed to create endpoint for setup.", err)
 	}
-	defer endpoint.Delete()
+	defer endpoint.Delete() //nolint:errcheck
 
 	endpoint2, err := HcnCreateTestEndpointWithPolicies(testNetwork, []EndpointPolicy{portMappingPolicy})
 	if err == nil {
+		_ = endpoint2.Delete()
 		t.Fatal("Endpoint should have failed with duplicate port mapping.", err)
-		defer endpoint2.Delete()
 	}
 
 	if !IsPortAlreadyExistsError(err) {

--- a/hcn/hcnloadbalancer.go
+++ b/hcn/hcnloadbalancer.go
@@ -69,14 +69,14 @@ var (
 	LoadBalancerDistributionSourceIP LoadBalancerDistribution = 2
 )
 
-func getLoadBalancer(loadBalancerGuid guid.GUID, query string) (*HostComputeLoadBalancer, error) {
+func getLoadBalancer(loadBalancerGUID guid.GUID, query string) (*HostComputeLoadBalancer, error) {
 	// Open loadBalancer.
 	var (
 		loadBalancerHandle hcnLoadBalancer
 		resultBuffer       *uint16
 		propertiesBuffer   *uint16
 	)
-	hr := hcnOpenLoadBalancer(&loadBalancerGuid, &loadBalancerHandle, &resultBuffer)
+	hr := hcnOpenLoadBalancer(&loadBalancerGUID, &loadBalancerHandle, &resultBuffer)
 	if err := checkForErrors("hcnOpenLoadBalancer", hr, resultBuffer); err != nil {
 		return nil, err
 	}
@@ -117,8 +117,8 @@ func enumerateLoadBalancers(query string) ([]HostComputeLoadBalancer, error) {
 	}
 
 	var outputLoadBalancers []HostComputeLoadBalancer
-	for _, loadBalancerGuid := range loadBalancerIds {
-		loadBalancer, err := getLoadBalancer(loadBalancerGuid, query)
+	for _, loadBalancerGUID := range loadBalancerIds {
+		loadBalancer, err := getLoadBalancer(loadBalancerGUID, query)
 		if err != nil {
 			return nil, err
 		}
@@ -134,8 +134,8 @@ func createLoadBalancer(settings string) (*HostComputeLoadBalancer, error) {
 		resultBuffer       *uint16
 		propertiesBuffer   *uint16
 	)
-	loadBalancerGuid := guid.GUID{}
-	hr := hcnCreateLoadBalancer(&loadBalancerGuid, settings, &loadBalancerHandle, &resultBuffer)
+	loadBalancerGUID := guid.GUID{}
+	hr := hcnCreateLoadBalancer(&loadBalancerGUID, settings, &loadBalancerHandle, &resultBuffer)
 	if err := checkForErrors("hcnCreateLoadBalancer", hr, resultBuffer); err != nil {
 		return nil, err
 	}
@@ -163,13 +163,13 @@ func createLoadBalancer(settings string) (*HostComputeLoadBalancer, error) {
 	return &outputLoadBalancer, nil
 }
 
-func deleteLoadBalancer(loadBalancerId string) error {
-	loadBalancerGuid, err := guid.FromString(loadBalancerId)
+func deleteLoadBalancer(loadBalancerID string) error {
+	loadBalancerGUID, err := guid.FromString(loadBalancerID)
 	if err != nil {
 		return errInvalidLoadBalancerID
 	}
 	var resultBuffer *uint16
-	hr := hcnDeleteLoadBalancer(&loadBalancerGuid, &resultBuffer)
+	hr := hcnDeleteLoadBalancer(&loadBalancerGUID, &resultBuffer)
 	if err := checkForErrors("hcnDeleteLoadBalancer", hr, resultBuffer); err != nil {
 		return err
 	}
@@ -188,12 +188,12 @@ func ListLoadBalancers() ([]HostComputeLoadBalancer, error) {
 
 // ListLoadBalancersQuery makes a call to query the list of available loadBalancers.
 func ListLoadBalancersQuery(query HostComputeQuery) ([]HostComputeLoadBalancer, error) {
-	queryJson, err := json.Marshal(query)
+	queryJSON, err := json.Marshal(query)
 	if err != nil {
 		return nil, err
 	}
 
-	loadBalancers, err := enumerateLoadBalancers(string(queryJson))
+	loadBalancers, err := enumerateLoadBalancers(string(queryJSON))
 	if err != nil {
 		return nil, err
 	}
@@ -201,9 +201,9 @@ func ListLoadBalancersQuery(query HostComputeQuery) ([]HostComputeLoadBalancer, 
 }
 
 // GetLoadBalancerByID returns the LoadBalancer specified by Id.
-func GetLoadBalancerByID(loadBalancerId string) (*HostComputeLoadBalancer, error) {
+func GetLoadBalancerByID(loadBalancerID string) (*HostComputeLoadBalancer, error) {
 	hcnQuery := defaultQuery()
-	mapA := map[string]string{"ID": loadBalancerId}
+	mapA := map[string]string{"ID": loadBalancerID}
 	filter, err := json.Marshal(mapA)
 	if err != nil {
 		return nil, err
@@ -215,7 +215,7 @@ func GetLoadBalancerByID(loadBalancerId string) (*HostComputeLoadBalancer, error
 		return nil, err
 	}
 	if len(loadBalancers) == 0 {
-		return nil, LoadBalancerNotFoundError{LoadBalancerId: loadBalancerId}
+		return nil, LoadBalancerNotFoundError{LoadBalancerId: loadBalancerID}
 	}
 	return &loadBalancers[0], err
 }

--- a/hcn/hcnnamespace.go
+++ b/hcn/hcnnamespace.go
@@ -72,14 +72,14 @@ type ModifyNamespaceSettingRequest struct {
 	Settings     json.RawMessage       `json:",omitempty"`
 }
 
-func getNamespace(namespaceGuid guid.GUID, query string) (*HostComputeNamespace, error) {
+func getNamespace(namespaceGUID guid.GUID, query string) (*HostComputeNamespace, error) {
 	// Open namespace.
 	var (
 		namespaceHandle  hcnNamespace
 		resultBuffer     *uint16
 		propertiesBuffer *uint16
 	)
-	hr := hcnOpenNamespace(&namespaceGuid, &namespaceHandle, &resultBuffer)
+	hr := hcnOpenNamespace(&namespaceGUID, &namespaceHandle, &resultBuffer)
 	if err := checkForErrors("hcnOpenNamespace", hr, resultBuffer); err != nil {
 		return nil, err
 	}
@@ -120,8 +120,8 @@ func enumerateNamespaces(query string) ([]HostComputeNamespace, error) {
 	}
 
 	var outputNamespaces []HostComputeNamespace
-	for _, namespaceGuid := range namespaceIds {
-		namespace, err := getNamespace(namespaceGuid, query)
+	for _, namespaceGUID := range namespaceIds {
+		namespace, err := getNamespace(namespaceGUID, query)
 		if err != nil {
 			return nil, err
 		}
@@ -137,8 +137,8 @@ func createNamespace(settings string) (*HostComputeNamespace, error) {
 		resultBuffer     *uint16
 		propertiesBuffer *uint16
 	)
-	namespaceGuid := guid.GUID{}
-	hr := hcnCreateNamespace(&namespaceGuid, settings, &namespaceHandle, &resultBuffer)
+	namespaceGUID := guid.GUID{}
+	hr := hcnCreateNamespace(&namespaceGUID, settings, &namespaceHandle, &resultBuffer)
 	if err := checkForErrors("hcnCreateNamespace", hr, resultBuffer); err != nil {
 		return nil, err
 	}
@@ -166,8 +166,8 @@ func createNamespace(settings string) (*HostComputeNamespace, error) {
 	return &outputNamespace, nil
 }
 
-func modifyNamespace(namespaceId string, settings string) (*HostComputeNamespace, error) {
-	namespaceGuid, err := guid.FromString(namespaceId)
+func modifyNamespace(namespaceID string, settings string) (*HostComputeNamespace, error) {
+	namespaceGUID, err := guid.FromString(namespaceID)
 	if err != nil {
 		return nil, errInvalidNamespaceID
 	}
@@ -177,7 +177,7 @@ func modifyNamespace(namespaceId string, settings string) (*HostComputeNamespace
 		resultBuffer     *uint16
 		propertiesBuffer *uint16
 	)
-	hr := hcnOpenNamespace(&namespaceGuid, &namespaceHandle, &resultBuffer)
+	hr := hcnOpenNamespace(&namespaceGUID, &namespaceHandle, &resultBuffer)
 	if err := checkForErrors("hcnOpenNamespace", hr, resultBuffer); err != nil {
 		return nil, err
 	}
@@ -210,13 +210,13 @@ func modifyNamespace(namespaceId string, settings string) (*HostComputeNamespace
 	return &outputNamespace, nil
 }
 
-func deleteNamespace(namespaceId string) error {
-	namespaceGuid, err := guid.FromString(namespaceId)
+func deleteNamespace(namespaceID string) error {
+	namespaceGUID, err := guid.FromString(namespaceID)
 	if err != nil {
 		return errInvalidNamespaceID
 	}
 	var resultBuffer *uint16
-	hr := hcnDeleteNamespace(&namespaceGuid, &resultBuffer)
+	hr := hcnDeleteNamespace(&namespaceGUID, &resultBuffer)
 	if err := checkForErrors("hcnDeleteNamespace", hr, resultBuffer); err != nil {
 		return err
 	}
@@ -235,12 +235,12 @@ func ListNamespaces() ([]HostComputeNamespace, error) {
 
 // ListNamespacesQuery makes a call to query the list of available namespaces.
 func ListNamespacesQuery(query HostComputeQuery) ([]HostComputeNamespace, error) {
-	queryJson, err := json.Marshal(query)
+	queryJSON, err := json.Marshal(query)
 	if err != nil {
 		return nil, err
 	}
 
-	namespaces, err := enumerateNamespaces(string(queryJson))
+	namespaces, err := enumerateNamespaces(string(queryJSON))
 	if err != nil {
 		return nil, err
 	}
@@ -248,9 +248,9 @@ func ListNamespacesQuery(query HostComputeQuery) ([]HostComputeNamespace, error)
 }
 
 // GetNamespaceByID returns the Namespace specified by Id.
-func GetNamespaceByID(namespaceId string) (*HostComputeNamespace, error) {
+func GetNamespaceByID(namespaceID string) (*HostComputeNamespace, error) {
 	hcnQuery := defaultQuery()
-	mapA := map[string]string{"ID": namespaceId}
+	mapA := map[string]string{"ID": namespaceID}
 	filter, err := json.Marshal(mapA)
 	if err != nil {
 		return nil, err
@@ -262,15 +262,15 @@ func GetNamespaceByID(namespaceId string) (*HostComputeNamespace, error) {
 		return nil, err
 	}
 	if len(namespaces) == 0 {
-		return nil, NamespaceNotFoundError{NamespaceID: namespaceId}
+		return nil, NamespaceNotFoundError{NamespaceID: namespaceID}
 	}
 
 	return &namespaces[0], err
 }
 
 // GetNamespaceEndpointIds returns the endpoints of the Namespace specified by Id.
-func GetNamespaceEndpointIds(namespaceId string) ([]string, error) {
-	namespace, err := GetNamespaceByID(namespaceId)
+func GetNamespaceEndpointIds(namespaceID string) ([]string, error) {
+	namespace, err := GetNamespaceByID(namespaceID)
 	if err != nil {
 		return nil, err
 	}
@@ -288,8 +288,8 @@ func GetNamespaceEndpointIds(namespaceId string) ([]string, error) {
 }
 
 // GetNamespaceContainerIds returns the containers of the Namespace specified by Id.
-func GetNamespaceContainerIds(namespaceId string) ([]string, error) {
-	namespace, err := GetNamespaceByID(namespaceId)
+func GetNamespaceContainerIds(namespaceID string) ([]string, error) {
+	namespace, err := GetNamespaceByID(namespaceID)
 	if err != nil {
 		return nil, err
 	}
@@ -396,15 +396,15 @@ func (namespace *HostComputeNamespace) Sync() error {
 }
 
 // ModifyNamespaceSettings updates the Endpoints/Containers of a Namespace.
-func ModifyNamespaceSettings(namespaceId string, request *ModifyNamespaceSettingRequest) error {
-	logrus.Debugf("hcn::HostComputeNamespace::ModifyNamespaceSettings id=%s", namespaceId)
+func ModifyNamespaceSettings(namespaceID string, request *ModifyNamespaceSettingRequest) error {
+	logrus.Debugf("hcn::HostComputeNamespace::ModifyNamespaceSettings id=%s", namespaceID)
 
 	namespaceSettings, err := json.Marshal(request)
 	if err != nil {
 		return err
 	}
 
-	_, err = modifyNamespace(namespaceId, string(namespaceSettings))
+	_, err = modifyNamespace(namespaceID, string(namespaceSettings))
 	if err != nil {
 		return err
 	}
@@ -412,37 +412,37 @@ func ModifyNamespaceSettings(namespaceId string, request *ModifyNamespaceSetting
 }
 
 // AddNamespaceEndpoint adds an endpoint to a Namespace.
-func AddNamespaceEndpoint(namespaceId string, endpointId string) error {
-	logrus.Debugf("hcn::HostComputeEndpoint::AddNamespaceEndpoint id=%s", endpointId)
+func AddNamespaceEndpoint(namespaceID string, endpointID string) error {
+	logrus.Debugf("hcn::HostComputeEndpoint::AddNamespaceEndpoint id=%s", endpointID)
 
-	mapA := map[string]string{"EndpointId": endpointId}
-	settingsJson, err := json.Marshal(mapA)
+	mapA := map[string]string{"EndpointId": endpointID}
+	settingsJSON, err := json.Marshal(mapA)
 	if err != nil {
 		return err
 	}
 	requestMessage := &ModifyNamespaceSettingRequest{
 		ResourceType: NamespaceResourceTypeEndpoint,
 		RequestType:  RequestTypeAdd,
-		Settings:     settingsJson,
+		Settings:     settingsJSON,
 	}
 
-	return ModifyNamespaceSettings(namespaceId, requestMessage)
+	return ModifyNamespaceSettings(namespaceID, requestMessage)
 }
 
 // RemoveNamespaceEndpoint removes an endpoint from a Namespace.
-func RemoveNamespaceEndpoint(namespaceId string, endpointId string) error {
-	logrus.Debugf("hcn::HostComputeNamespace::RemoveNamespaceEndpoint id=%s", endpointId)
+func RemoveNamespaceEndpoint(namespaceID string, endpointID string) error {
+	logrus.Debugf("hcn::HostComputeNamespace::RemoveNamespaceEndpoint id=%s", endpointID)
 
-	mapA := map[string]string{"EndpointId": endpointId}
-	settingsJson, err := json.Marshal(mapA)
+	mapA := map[string]string{"EndpointId": endpointID}
+	settingsJSON, err := json.Marshal(mapA)
 	if err != nil {
 		return err
 	}
 	requestMessage := &ModifyNamespaceSettingRequest{
 		ResourceType: NamespaceResourceTypeEndpoint,
 		RequestType:  RequestTypeRemove,
-		Settings:     settingsJson,
+		Settings:     settingsJSON,
 	}
 
-	return ModifyNamespaceSettings(namespaceId, requestMessage)
+	return ModifyNamespaceSettings(namespaceID, requestMessage)
 }

--- a/hcn/hcnnamespace_test.go
+++ b/hcn/hcnnamespace_test.go
@@ -398,7 +398,7 @@ func TestSyncNamespaceGuest(t *testing.T) {
 	pnc := cni.NewPersistedNamespaceConfig(t.Name(), "test-container", newGUID(t))
 	err = pnc.Store()
 	if err != nil {
-		pnc.Remove()
+		_ = pnc.Remove()
 		t.Fatal(err)
 	}
 
@@ -438,7 +438,7 @@ func TestSyncNamespaceGuestDefault(t *testing.T) {
 	pnc := cni.NewPersistedNamespaceConfig(t.Name(), "test-container", newGUID(t))
 	err = pnc.Store()
 	if err != nil {
-		pnc.Remove()
+		_ = pnc.Remove()
 		t.Fatal(err)
 	}
 

--- a/hcn/hcnnetwork.go
+++ b/hcn/hcnnetwork.go
@@ -112,14 +112,14 @@ type PolicyNetworkRequest struct {
 	Policies []NetworkPolicy `json:",omitempty"`
 }
 
-func getNetwork(networkGuid guid.GUID, query string) (*HostComputeNetwork, error) {
+func getNetwork(networkGUID guid.GUID, query string) (*HostComputeNetwork, error) {
 	// Open network.
 	var (
 		networkHandle    hcnNetwork
 		resultBuffer     *uint16
 		propertiesBuffer *uint16
 	)
-	hr := hcnOpenNetwork(&networkGuid, &networkHandle, &resultBuffer)
+	hr := hcnOpenNetwork(&networkGUID, &networkHandle, &resultBuffer)
 	if err := checkForErrors("hcnOpenNetwork", hr, resultBuffer); err != nil {
 		return nil, err
 	}
@@ -166,8 +166,8 @@ func enumerateNetworks(query string) ([]HostComputeNetwork, error) {
 	}
 
 	var outputNetworks []HostComputeNetwork
-	for _, networkGuid := range networkIds {
-		network, err := getNetwork(networkGuid, query)
+	for _, networkGUID := range networkIds {
+		network, err := getNetwork(networkGUID, query)
 		if err != nil {
 			return nil, err
 		}
@@ -183,8 +183,8 @@ func createNetwork(settings string) (*HostComputeNetwork, error) {
 		resultBuffer     *uint16
 		propertiesBuffer *uint16
 	)
-	networkGuid := guid.GUID{}
-	hr := hcnCreateNetwork(&networkGuid, settings, &networkHandle, &resultBuffer)
+	networkGUID := guid.GUID{}
+	hr := hcnCreateNetwork(&networkGUID, settings, &networkHandle, &resultBuffer)
 	if err := checkForErrors("hcnCreateNetwork", hr, resultBuffer); err != nil {
 		return nil, err
 	}
@@ -218,8 +218,8 @@ func createNetwork(settings string) (*HostComputeNetwork, error) {
 	return &outputNetwork, nil
 }
 
-func modifyNetwork(networkId string, settings string) (*HostComputeNetwork, error) {
-	networkGuid, err := guid.FromString(networkId)
+func modifyNetwork(networkID string, settings string) (*HostComputeNetwork, error) {
+	networkGUID, err := guid.FromString(networkID)
 	if err != nil {
 		return nil, errInvalidNetworkID
 	}
@@ -229,7 +229,7 @@ func modifyNetwork(networkId string, settings string) (*HostComputeNetwork, erro
 		resultBuffer     *uint16
 		propertiesBuffer *uint16
 	)
-	hr := hcnOpenNetwork(&networkGuid, &networkHandle, &resultBuffer)
+	hr := hcnOpenNetwork(&networkGUID, &networkHandle, &resultBuffer)
 	if err := checkForErrors("hcnOpenNetwork", hr, resultBuffer); err != nil {
 		return nil, err
 	}
@@ -268,13 +268,13 @@ func modifyNetwork(networkId string, settings string) (*HostComputeNetwork, erro
 	return &outputNetwork, nil
 }
 
-func deleteNetwork(networkId string) error {
-	networkGuid, err := guid.FromString(networkId)
+func deleteNetwork(networkID string) error {
+	networkGUID, err := guid.FromString(networkID)
 	if err != nil {
 		return errInvalidNetworkID
 	}
 	var resultBuffer *uint16
-	hr := hcnDeleteNetwork(&networkGuid, &resultBuffer)
+	hr := hcnDeleteNetwork(&networkGUID, &resultBuffer)
 	if err := checkForErrors("hcnDeleteNetwork", hr, resultBuffer); err != nil {
 		return err
 	}
@@ -293,12 +293,12 @@ func ListNetworks() ([]HostComputeNetwork, error) {
 
 // ListNetworksQuery makes a call to query the list of available networks.
 func ListNetworksQuery(query HostComputeQuery) ([]HostComputeNetwork, error) {
-	queryJson, err := json.Marshal(query)
+	queryJSON, err := json.Marshal(query)
 	if err != nil {
 		return nil, err
 	}
 
-	networks, err := enumerateNetworks(string(queryJson))
+	networks, err := enumerateNetworks(string(queryJSON))
 	if err != nil {
 		return nil, err
 	}
@@ -410,14 +410,14 @@ func (network *HostComputeNetwork) ModifyNetworkSettings(request *ModifyNetworkS
 func (network *HostComputeNetwork) AddPolicy(networkPolicy PolicyNetworkRequest) error {
 	logrus.Debugf("hcn::HostComputeNetwork::AddPolicy id=%s", network.Id)
 
-	settingsJson, err := json.Marshal(networkPolicy)
+	settingsJSON, err := json.Marshal(networkPolicy)
 	if err != nil {
 		return err
 	}
 	requestMessage := &ModifyNetworkSettingRequest{
 		ResourceType: NetworkResourceTypePolicy,
 		RequestType:  RequestTypeAdd,
-		Settings:     settingsJson,
+		Settings:     settingsJSON,
 	}
 
 	return network.ModifyNetworkSettings(requestMessage)
@@ -427,14 +427,14 @@ func (network *HostComputeNetwork) AddPolicy(networkPolicy PolicyNetworkRequest)
 func (network *HostComputeNetwork) RemovePolicy(networkPolicy PolicyNetworkRequest) error {
 	logrus.Debugf("hcn::HostComputeNetwork::RemovePolicy id=%s", network.Id)
 
-	settingsJson, err := json.Marshal(networkPolicy)
+	settingsJSON, err := json.Marshal(networkPolicy)
 	if err != nil {
 		return err
 	}
 	requestMessage := &ModifyNetworkSettingRequest{
 		ResourceType: NetworkResourceTypePolicy,
 		RequestType:  RequestTypeRemove,
-		Settings:     settingsJson,
+		Settings:     settingsJSON,
 	}
 
 	return network.ModifyNetworkSettings(requestMessage)

--- a/hcn/hcnnetwork_test.go
+++ b/hcn/hcnnetwork_test.go
@@ -13,8 +13,7 @@ import (
 type HcnNetworkMakerFunc func() (*HostComputeNetwork, error)
 
 func TestCreateDeleteNetworks(t *testing.T) {
-	var netMaker HcnNetworkMakerFunc
-	netMaker = HcnCreateTestNATNetwork
+	var netMaker HcnNetworkMakerFunc = HcnCreateTestNATNetwork
 	err := CreateDeleteNetworksHelper(t, netMaker)
 	if err != nil {
 		t.Fatal(err)
@@ -102,7 +101,7 @@ func testNetworkPolicy(t *testing.T, policiesToTest *PolicyNetworkRequest) {
 		t.Fatal(err)
 	}
 
-	network.AddPolicy(*policiesToTest)
+	_ = network.AddPolicy(*policiesToTest)
 
 	//Reload the network object from HNS.
 	network, err = GetNetworkByID(network.Id)
@@ -123,7 +122,7 @@ func testNetworkPolicy(t *testing.T, policiesToTest *PolicyNetworkRequest) {
 		}
 	}
 
-	network.RemovePolicy(*policiesToTest)
+	_ = network.RemovePolicy(*policiesToTest)
 
 	//Reload the network object from HNS.
 	network, err = GetNetworkByID(network.Id)

--- a/hcn/hcnutils_test.go
+++ b/hcn/hcnutils_test.go
@@ -131,9 +131,6 @@ func CreateTestOverlayNetwork() (*HostComputeNetwork, error) {
 }
 
 func HcnCreateTestEndpoint(network *HostComputeNetwork) (*HostComputeEndpoint, error) {
-	if network == nil {
-
-	}
 	Endpoint := &HostComputeEndpoint{
 		Name: NatTestEndpointName,
 		SchemaVersion: SchemaVersion{

--- a/hcn/hnsv1_test.go
+++ b/hcn/hnsv1_test.go
@@ -90,7 +90,7 @@ func TestEndpointStatsAll(t *testing.T) {
 		Name: NatTestEndpointName,
 	}
 
-	Endpoint, err = network.CreateEndpoint(Endpoint)
+	_, err = network.CreateEndpoint(Endpoint)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/guest/bridge/bridge.go
+++ b/internal/guest/bridge/bridge.go
@@ -261,12 +261,11 @@ func (b *Bridge) ListenAndServe(bridgeIn io.ReadCloser, bridgeOut io.WriteCloser
 				}
 
 				base := prot.MessageBase{}
-				if err := json.Unmarshal(message, &base); err != nil {
-					// TODO: JTERRY75 - This should fail the request but right
-					// now we still forward to the method and let them return
-					// this error. Unify the JSON part previous to invoking a
-					// request.
-				}
+				// TODO: JTERRY75 - This should fail the request but right
+				// now we still forward to the method and let them return
+				// this error. Unify the JSON part previous to invoking a
+				// request.
+				_ = json.Unmarshal(message, &base)
 
 				var ctx context.Context
 				var span *trace.Span

--- a/internal/guest/bridge/bridge_unit_test.go
+++ b/internal/guest/bridge/bridge_unit_test.go
@@ -39,7 +39,7 @@ type thandler struct {
 	err  error
 }
 
-func (h *thandler) ServeMsg(r *Request) (RequestResponse, error) {
+func (h *thandler) ServeMsg(_ *Request) (RequestResponse, error) {
 	h.set = true
 	return h.resp, h.err
 }
@@ -84,7 +84,7 @@ func Test_Bridge_Mux_Handle_Succeeds(t *testing.T) {
 	}
 
 	// Is it the correct handler?
-	hOut.ServeMsg(nil)
+	_, _ = hOut.ServeMsg(nil)
 
 	if !th.set {
 		t.Error("The handler added was not the same handler.")
@@ -139,7 +139,7 @@ func Test_Bridge_Mux_HandleFunc_Succeeds(t *testing.T) {
 	}
 
 	// Is it the correct handler?
-	hOut.ServeMsg(nil)
+	_, _ = hOut.ServeMsg(nil)
 
 	if !set {
 		t.Error("The handler added was not the same handler.")
@@ -368,10 +368,12 @@ func Test_Bridge_Mux_ServeMsg_Success(t *testing.T) {
 	}
 }
 
+//nolint:unused // may be used in future tests
 type errorTransport struct {
 	e error
 }
 
+//nolint:unused // may be used in future tests
 func (e *errorTransport) Dial(_ uint32) (transport.Connection, error) {
 	return nil, e.e
 }
@@ -382,7 +384,7 @@ func serverSend(conn io.Writer, messageType prot.MessageIdentifier, messageID pr
 		var err error
 		body, err = json.Marshal(i)
 		if err != nil {
-			return errors.Wrap(err, "Failed to json marshal to server.")
+			return errors.Wrap(err, "failed to json marshal to server.")
 		}
 	}
 

--- a/internal/guest/bridge/bridge_v2.go
+++ b/internal/guest/bridge/bridge_v2.go
@@ -368,13 +368,9 @@ func (b *Bridge) getPropertiesV2(r *Request) (_ RequestResponse, err error) {
 		}
 	}
 
-	propertyJSON := []byte("{}")
-	if properties != nil {
-		var err error
-		propertyJSON, err = json.Marshal(properties)
-		if err != nil {
-			return nil, errors.Wrapf(err, "failed to unmarshal JSON in message \"%+v\"", properties)
-		}
+	propertyJSON, err := json.Marshal(properties)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to unmarshal JSON in message \"%+v\"", properties)
 	}
 
 	return &prot.ContainerGetPropertiesResponse{

--- a/internal/guest/network/network.go
+++ b/internal/guest/network/network.go
@@ -122,9 +122,10 @@ func InstanceIDToName(ctx context.Context, id string, vpciAssigned bool) (_ stri
 	vmBusID := strings.ToLower(id)
 	span.AddAttributes(trace.StringAttribute("adapterInstanceID", vmBusID))
 
-	netDevicePath := ""
+	var netDevicePath string
 	if vpciAssigned {
-		pciDevicePath, err := pciFindDeviceFullPath(ctx, vmBusID)
+		var pciDevicePath string
+		pciDevicePath, err = pciFindDeviceFullPath(ctx, vmBusID)
 		if err != nil {
 			return "", err
 		}

--- a/internal/guest/runtime/hcsv2/hostdata.go
+++ b/internal/guest/runtime/hcsv2/hostdata.go
@@ -23,7 +23,7 @@ func validateHostData(hostData []byte) error {
 		return err
 	}
 
-	if bytes.Compare(hostData, report.HostData) != 0 {
+	if !bytes.Equal(hostData, report.HostData) {
 		return fmt.Errorf(
 			"security policy digest %q doesn't match HostData provided at launch %q",
 			hostData,

--- a/internal/guest/runtime/hcsv2/process.go
+++ b/internal/guest/runtime/hcsv2/process.go
@@ -133,9 +133,9 @@ func newProcess(c *Container, spec *oci.Process, process runtime.Process, pid ui
 // Kill sends 'signal' to the process.
 //
 // If the process has already exited returns `gcserr.HrErrNotFound` by contract.
-func (p *containerProcess) Kill(ctx context.Context, signal syscall.Signal) error {
+func (p *containerProcess) Kill(_ context.Context, signal syscall.Signal) error {
 	if err := syscall.Kill(int(p.pid), signal); err != nil {
-		if err == syscall.ESRCH {
+		if errors.Is(err, syscall.ESRCH) {
 			return gcserr.NewHresultError(gcserr.HrErrNotFound)
 		}
 		return err
@@ -153,7 +153,7 @@ func (p *containerProcess) Pid() int {
 }
 
 // ResizeConsole resizes the tty to `height`x`width` for the process.
-func (p *containerProcess) ResizeConsole(ctx context.Context, height, width uint16) error {
+func (p *containerProcess) ResizeConsole(_ context.Context, height, width uint16) error {
 	tty := p.process.Tty()
 	if tty == nil {
 		return fmt.Errorf("pid: %d, is not a tty and cannot be resized", p.pid)
@@ -192,25 +192,23 @@ func (p *containerProcess) Wait() (<-chan int, chan<- bool) {
 
 			// The caller got the exit code. Wait for them to tell us they have
 			// issued the write
-			select {
-			case <-doneChan:
-				p.writersSyncRoot.Lock()
-				// Decrement this waiter
-				log.G(ctx).Debug("wait completed, releasing wait count")
+			<-doneChan
+			p.writersSyncRoot.Lock()
+			// Decrement this waiter
+			log.G(ctx).Debug("wait completed, releasing wait count")
 
+			p.writersWg.Done()
+			if !p.writersCalled {
+				// We have at least 1 response for the exit code for this
+				// process. Decrement the release waiter that will free the
+				// process resources when the writersWg hits 0
+				log.G(ctx).Debug("first wait completed, releasing first wait count")
+
+				p.writersCalled = true
 				p.writersWg.Done()
-				if !p.writersCalled {
-					// We have at least 1 response for the exit code for this
-					// process. Decrement the release waiter that will free the
-					// process resources when the writersWg hits 0
-					log.G(ctx).Debug("first wait completed, releasing first wait count")
-
-					p.writersCalled = true
-					p.writersWg.Done()
-				}
-				p.writersSyncRoot.Unlock()
-				span.End()
 			}
+			p.writersSyncRoot.Unlock()
+			span.End()
 
 		case <-doneChan:
 			// In this case the caller timed out before the process exited. Just
@@ -241,7 +239,7 @@ func newExternalProcess(ctx context.Context, cmd *exec.Cmd, tty *stdio.TtyRelay,
 		tty.Start()
 	}
 	go func() {
-		cmd.Wait()
+		_ = cmd.Wait()
 		ep.exitCode = cmd.ProcessState.ExitCode()
 		log.G(ctx).WithFields(logrus.Fields{
 			"pid":      cmd.Process.Pid,
@@ -268,9 +266,9 @@ type externalProcess struct {
 
 var _ Process = &externalProcess{}
 
-func (ep *externalProcess) Kill(ctx context.Context, signal syscall.Signal) error {
-	if err := syscall.Kill(int(ep.cmd.Process.Pid), signal); err != nil {
-		if err == syscall.ESRCH {
+func (ep *externalProcess) Kill(_ context.Context, signal syscall.Signal) error {
+	if err := syscall.Kill(ep.cmd.Process.Pid, signal); err != nil {
+		if errors.Is(err, syscall.ESRCH) {
 			return gcserr.NewHresultError(gcserr.HrErrNotFound)
 		}
 		return err
@@ -282,7 +280,7 @@ func (ep *externalProcess) Pid() int {
 	return ep.cmd.Process.Pid
 }
 
-func (ep *externalProcess) ResizeConsole(ctx context.Context, height, width uint16) error {
+func (ep *externalProcess) ResizeConsole(_ context.Context, height, width uint16) error {
 	if ep.tty == nil {
 		return fmt.Errorf("pid: %d, is not a tty and cannot be resized", ep.cmd.Process.Pid)
 	}

--- a/internal/guest/runtime/runc/ioutils.go
+++ b/internal/guest/runtime/runc/ioutils.go
@@ -15,7 +15,7 @@ import (
 // createConsoleSocket creates a unix socket in the given process directory and
 // returns its path and a listener to it. This socket can then be used to
 // receive the container's terminal master file descriptor.
-func (r *runcRuntime) createConsoleSocket(processDir string) (listener *net.UnixListener, socketPath string, err error) {
+func (*runcRuntime) createConsoleSocket(processDir string) (listener *net.UnixListener, socketPath string, err error) {
 	socketPath = filepath.Join(processDir, "master.sock")
 	addr, err := net.ResolveUnixAddr("unix", socketPath)
 	if err != nil {
@@ -31,7 +31,7 @@ func (r *runcRuntime) createConsoleSocket(processDir string) (listener *net.Unix
 // getMasterFromSocket blocks on the given listener's socket until a message is
 // sent, then parses the file descriptor representing the terminal master out
 // of the message and returns it as a file.
-func (r *runcRuntime) getMasterFromSocket(listener *net.UnixListener) (master *os.File, err error) {
+func (*runcRuntime) getMasterFromSocket(listener *net.UnixListener) (master *os.File, err error) {
 	// Accept the listener's connection.
 	conn, err := listener.Accept()
 	if err != nil {
@@ -93,7 +93,9 @@ func (r *runcRuntime) getMasterFromSocket(listener *net.UnixListener) (master *o
 }
 
 // pathExists returns true if the given path exists, false if not.
-func (r *runcRuntime) pathExists(pathToCheck string) (bool, error) {
+//
+//nolint:unused
+func (*runcRuntime) pathExists(pathToCheck string) (bool, error) {
 	_, err := os.Stat(pathToCheck)
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/internal/guest/runtime/runc/utils.go
+++ b/internal/guest/runtime/runc/utils.go
@@ -90,6 +90,8 @@ func (r *runcRuntime) getLogPath(id string) string {
 }
 
 // getLogPath returns the path to the log file used by the runC wrapper.
+//
+//nolint:unused
 func (r *runcRuntime) getGlobalLogPath() string {
 	// runcLogBasePath should be created by r.initialize
 	return filepath.Join(r.runcLogBasePath, "global-runc.log")
@@ -99,7 +101,7 @@ func (r *runcRuntime) getGlobalLogPath() string {
 // not.
 // It should be noted that processes which have exited, but have not yet been
 // waited on (i.e. zombies) are still considered to exist by this function.
-func (r *runcRuntime) processExists(pid int) bool {
+func (*runcRuntime) processExists(pid int) bool {
 	_, err := os.Stat(filepath.Join("/proc", strconv.Itoa(pid)))
 	return !os.IsNotExist(err)
 }

--- a/internal/guest/stdio/stdio.go
+++ b/internal/guest/stdio/stdio.go
@@ -24,7 +24,7 @@ type ConnectionSet struct {
 func (s *ConnectionSet) Close() error {
 	var err error
 	if s.In != nil {
-		if cerr := s.In.Close(); cerr != nil && err == nil {
+		if cerr := s.In.Close(); cerr != nil {
 			err = errors.Wrap(cerr, "failed Close on stdin")
 		}
 		s.In = nil
@@ -54,7 +54,7 @@ type FileSet struct {
 func (fs *FileSet) Close() error {
 	var err error
 	if fs.In != nil {
-		if cerr := fs.In.Close(); cerr != nil && err == nil {
+		if cerr := fs.In.Close(); cerr != nil {
 			err = errors.Wrap(cerr, "failed Close on stdin")
 		}
 		fs.In = nil
@@ -183,7 +183,7 @@ func copyAndCleanClose(c transport.Connection, r io.Reader, name string) {
 		if err == nil {
 			err = errors.New("unexpected data in socket")
 		}
-		if err != io.EOF {
+		if err != io.EOF { //nolint:errorlint
 			logrus.WithFields(logrus.Fields{
 				logrus.ErrorKey: err,
 				"file":          name,
@@ -248,7 +248,7 @@ func (pr *PipeRelay) Wait() {
 	// exit back to the client, and the client expects the process notification before
 	// it will close its side of stdin (which io.Copy is waiting on in the copying goroutine).
 	if pr.s != nil && pr.s.In != nil {
-		pr.s.In.CloseRead()
+		_ = pr.s.In.CloseRead()
 	}
 
 	pr.wg.Wait()
@@ -259,7 +259,7 @@ func (pr *PipeRelay) Wait() {
 }
 
 // CloseUnusedPipes gives the caller the ability to close any pipes that do not
-// have a cooresponding entry on the ConnectionSet. This is to be used in
+// have a corresponding entry on the ConnectionSet. This is to be used in
 // conjunction with NewPipeRelay where s is nil which wil open all pipes and
 // later calling ReplaceConnectionSet with the actual connections.
 func (pr *PipeRelay) CloseUnusedPipes() {
@@ -316,7 +316,7 @@ func (r *TtyRelay) ReplaceConnectionSet(s *ConnectionSet) {
 	r.s = s
 }
 
-// ResizeConsole sends the appropriate resize to a pTTY FD
+// ResizeConsole sends the appropriate resize to a pTTY FD.
 func (r *TtyRelay) ResizeConsole(height, width uint16) error {
 	r.m.Lock()
 	defer r.m.Unlock()
@@ -362,7 +362,7 @@ func (r *TtyRelay) Wait() {
 	// exit back to the client, and the client expects the process notification before
 	// it will close its side of stdin (which io.Copy is waiting on in the copying goroutine).
 	if r.s != nil && r.s.In != nil {
-		r.s.In.CloseRead()
+		_ = r.s.In.CloseRead()
 	}
 
 	// Wait for all users of stdioSet and master to finish before closing them.

--- a/internal/guest/storage/crypt/crypt.go
+++ b/internal/guest/storage/crypt/crypt.go
@@ -108,15 +108,15 @@ func mkfsExt4Command(args []string) error {
 //
 // In order to mount a block device as an encrypted device:
 //
-//	1. Generate a random key. It doesn't matter which key it is, the aim is to
+//  1. Generate a random key. It doesn't matter which key it is, the aim is to
 //     protect the contents of the scratch disk from the host OS. It can be
 //     deleted after mounting the encrypted device.
 //
-//	2. The original block device has to be formatted with cryptsetup with the
+//  2. The original block device has to be formatted with cryptsetup with the
 //     generated key. This results in that block device becoming an encrypted
 //     block device that can't be mounted directly.
 //
-//	3. Open the block device with cryptsetup. It is needed to assign it a device
+//  3. Open the block device with cryptsetup. It is needed to assign it a device
 //     name. We are using names that follow `cryptDeviceTemplate`, where "%s" is
 //     a unique name generated from the path of the original block device. In
 //     this case, it's just the path of the block device with all
@@ -126,43 +126,43 @@ func mkfsExt4Command(args []string) error {
 //     /dev/mapper/`cryptDeviceTemplate`. This can be mounted directly, but it
 //     doesn't have any format yet.
 //
-//	4. Format the unencrypted block device as ext4:
+//  4. Format the unencrypted block device as ext4:
 //
-//	A normal invocation of luksFormat wipes the target device. This takes
-//	a really long time, which isn't acceptable in our use-case. Passing the
-//	option --integrity-no-wipe prevents this from happening so that the
-//	command ends in an instant.
+//     A normal invocation of luksFormat wipes the target device. This takes
+//     a really long time, which isn't acceptable in our use-case. Passing the
+//     option --integrity-no-wipe prevents this from happening so that the
+//     command ends in an instant.
 //
-//	Because of using --integrity-no-wipe, the resulting device isn't wiped and
-//	all the integrity tags are incorrect. This means that any attempt to read
-//	from it will cause an I/O error, which programs aren't prepared to handle.
-//	For example, mkfs.ext4 tries to read blocks before writing to them, and
-//	there is no way around it. When it gets an I/O error, it just exits.
+//     Because of using --integrity-no-wipe, the resulting device isn't wiped and
+//     all the integrity tags are incorrect. This means that any attempt to read
+//     from it will cause an I/O error, which programs aren't prepared to handle.
+//     For example, mkfs.ext4 tries to read blocks before writing to them, and
+//     there is no way around it. When it gets an I/O error, it just exits.
 //
-//	The solution is to create a file with the same size as the resulting
-//	device, format it as ext4, then use dd to copy the format to the device
-//	(dd won't try to read anything).
+//     The solution is to create a file with the same size as the resulting
+//     device, format it as ext4, then use dd to copy the format to the device
+//     (dd won't try to read anything).
 //
-//	However, creating a file that is several GB in size isn't a good solution
-//	either because doing dd of the whole file would take as long as letting
-//	luksFormat wipe the disk.
+//     However, creating a file that is several GB in size isn't a good solution
+//     either because doing dd of the whole file would take as long as letting
+//     luksFormat wipe the disk.
 //
-//	The solution is to create a sparse file and format it. Then, it is
-//	possible to copy the format to the block device by doing a sparse copy
-//	(only copy the data parts of the file, not the holes). This makes
-//	formatting the device almost instantaneous.
+//     The solution is to create a sparse file and format it. Then, it is
+//     possible to copy the format to the block device by doing a sparse copy
+//     (only copy the data parts of the file, not the holes). This makes
+//     formatting the device almost instantaneous.
 //
-//	4.1. Get size of scratch disk.
+//     4.1. Get size of scratch disk.
 //
-//	4.2. Create sparse filesystem image with the same size as the scratch
-//	     device. It can be removed afterwards.
+//     4.2. Create sparse filesystem image with the same size as the scratch
+//     device. It can be removed afterwards.
 //
-//	4.3. Format it as ext4. This way the file is only as big as the few blocks
-//	     of the image that have the filesystem information, the ones modified
-//	     by mkfs.ext4.
+//     4.3. Format it as ext4. This way the file is only as big as the few blocks
+//     of the image that have the filesystem information, the ones modified
+//     by mkfs.ext4.
 //
-//	4.4. Do a sparse copy of the filesystem into the unencrypted block device.
-//	     This updates the integrity tags.
+//     4.4. Do a sparse copy of the filesystem into the unencrypted block device.
+//     This updates the integrity tags.
 func EncryptDevice(ctx context.Context, source string) (path string, err error) {
 
 	uniqueName, err := getUniqueName(source)

--- a/internal/guest/storage/crypt/crypt_test.go
+++ b/internal/guest/storage/crypt/crypt_test.go
@@ -425,7 +425,7 @@ func Test_Cleanup_Dm_Crypt_Error(t *testing.T) {
 func Test_Cleanup_Dm_Crypt_Success(t *testing.T) {
 	clearCryptTestDependencies()
 
-	// Test what happens when cryptsetup succeedes to close an encrypted device.
+	// Test what happens when cryptsetup succeeds to close an encrypted device.
 
 	_cryptsetupClose = func(deviceName string) error {
 		return nil

--- a/internal/guest/storage/crypt/utilities.go
+++ b/internal/guest/storage/crypt/utilities.go
@@ -76,6 +76,8 @@ func createSparseEmptyFile(ctx context.Context, path string, size int64) (err er
 }
 
 // The following constants aren't defined in the io or os libraries.
+//
+//nolint:stylecheck // ST1003: ALL_CAPS
 const (
 	SEEK_DATA = 3
 	SEEK_HOLE = 4
@@ -127,6 +129,7 @@ func copyEmptySparseFilesystem(source string, destination string) error {
 		offset = chunkEnd
 
 		// Read contents of this data chunk
+		//nolint:staticcheck //TODO: SA1019: os.SEEK_SET has been deprecated since Go 1.7: Use io.SeekStart, io.SeekCurrent, and io.SeekEnd.
 		_, err = fin.Seek(chunkStart, os.SEEK_SET)
 		if err != nil {
 			return errors.Wrap(err, "failed to seek set in source file")
@@ -142,6 +145,7 @@ func copyEmptySparseFilesystem(source string, destination string) error {
 		}
 
 		// Write data to destination file
+		//nolint:staticcheck //TODO: SA1019: os.SEEK_SET has been deprecated since Go 1.7: Use io.SeekStart, io.SeekCurrent, and io.SeekEnd.
 		_, err = fout.Seek(chunkStart, os.SEEK_SET)
 		if err != nil {
 			return errors.Wrap(err, "failed to seek destination file")

--- a/internal/guest/storage/devicemapper/devicemapper.go
+++ b/internal/guest/storage/devicemapper/devicemapper.go
@@ -29,6 +29,7 @@ var (
 	openMapperWrapper   = openMapper
 )
 
+//nolint:deadcode,varcheck,stylecheck // ST1003: ALL_CAPS
 const (
 	_DM_IOCTL      = 0xfd
 	_DM_IOCTL_SIZE = 312
@@ -37,10 +38,11 @@ const (
 	_DM_READONLY_FLAG       = 1 << 0
 	_DM_SUSPEND_FLAG        = 1 << 1
 	_DM_PERSISTENT_DEV_FLAG = 1 << 3
-
-	blockSize = 512
 )
 
+const blockSize = 512
+
+//nolint:deadcode,varcheck,stylecheck // ST1003: ALL_CAPS
 const (
 	_DM_VERSION = iota
 	_DM_REMOVE_ALL
@@ -97,7 +99,7 @@ type targetSpec struct {
 }
 
 // initIoctl initializes a device-mapper ioctl input struct with the given size
-// and device name
+// and device name.
 func initIoctl(d *dmIoctl, size int, name string) {
 	*d = dmIoctl{
 		Version:  [3]uint32{4, 0, 0},
@@ -119,7 +121,7 @@ func (err *dmError) Error() string {
 	return "device-mapper " + op + ": " + err.Err.Error()
 }
 
-// devMapperIoctl issues the specified device-mapper ioctl
+// devMapperIoctl issues the specified device-mapper ioctl.
 func devMapperIoctl(f *os.File, code int, data *dmIoctl) error {
 	if err := linux.Ioctl(f, code|_DM_IOCTL_BASE, unsafe.Pointer(data)); err != nil {
 		return &dmError{Op: code, Err: err}
@@ -128,7 +130,7 @@ func devMapperIoctl(f *os.File, code int, data *dmIoctl) error {
 }
 
 // openMapper opens the device-mapper control device and validates that it
-// supports the required version
+// supports the required version.
 func openMapper() (f *os.File, err error) {
 	f, err = os.OpenFile("/dev/mapper/control", os.O_RDWR, 0)
 	if err != nil {
@@ -181,7 +183,7 @@ func LinearTarget(sectorStart, lengthBlocks int64, path string, deviceStart int6
 }
 
 // zeroSectorLinearTarget creates a Target for devices with 0 sector start and length/device start
-// expected to be in bytes rather than blocks
+// expected to be in bytes rather than blocks.
 func zeroSectorLinearTarget(lengthBytes int64, path string, deviceStartBytes int64) Target {
 	lengthInBlocks := lengthBytes / blockSize
 	startInBlocks := deviceStartBytes / blockSize
@@ -209,7 +211,7 @@ func makeTableIoctl(name string, targets []Target) *dmIoctl {
 		spec.Next = uint32(sn)
 		copy(spec.Type[:], t.Type)
 		copy(b[off+int(unsafe.Sizeof(*spec)):], t.Params)
-		off += int(sn)
+		off += sn
 	}
 	return d
 }
@@ -232,7 +234,7 @@ func CreateDevice(name string, flags CreateFlags, targets []Target) (_ string, e
 	}
 	defer func() {
 		if err != nil {
-			removeDeviceWrapper(f, name)
+			_ = removeDeviceWrapper(f, name)
 		}
 	}()
 
@@ -278,7 +280,7 @@ func RemoveDevice(name string) (err error) {
 	// target has been unmounted.
 	for i := 0; i < 10; i++ {
 		if err = rm(); err != nil {
-			if e, ok := err.(*dmError); !ok || e.Err != syscall.EBUSY {
+			if e, ok := err.(*dmError); !ok || e.Err != syscall.EBUSY { //nolint:errorlint
 				break
 			}
 			time.Sleep(10 * time.Millisecond)
@@ -286,7 +288,7 @@ func RemoveDevice(name string) (err error) {
 		}
 		break
 	}
-	return
+	return err
 }
 
 func removeDevice(f *os.File, name string) error {

--- a/internal/guest/storage/mount.go
+++ b/internal/guest/storage/mount.go
@@ -101,13 +101,13 @@ func ParseMountOptions(options []string) (flagOpts uintptr, pgFlags []uintptr, d
 // Expected that the filepath exists before calling this function
 func MountRShared(path string) error {
 	if path == "" {
-		return errors.New("Path must not be empty to mount as rshared")
+		return errors.New("path must not be empty to mount as rshared")
 	}
 	if err := unixMount(path, path, "", syscall.MS_BIND, ""); err != nil {
-		return fmt.Errorf("Failed to create bind mount for %v: %v", path, err)
+		return fmt.Errorf("failed to create bind mount for %v: %v", path, err)
 	}
 	if err := unixMount(path, path, "", syscall.MS_SHARED|syscall.MS_REC, ""); err != nil {
-		return fmt.Errorf("Failed to make %v rshared: %v", path, err)
+		return fmt.Errorf("failed to make %v rshared: %v", path, err)
 	}
 	return nil
 }

--- a/internal/guest/storage/mount_test.go
+++ b/internal/guest/storage/mount_test.go
@@ -91,7 +91,7 @@ func Test_Unmount_Valid_Flags(t *testing.T) {
 		return nil, nil
 	}
 	unixUnmount = func(target string, flags int) error {
-		if 0 != flags {
+		if flags != 0 {
 			t.Errorf("expected flags 0, got: %d", flags)
 			return errors.New("unexpected flags")
 		}

--- a/internal/guest/storage/overlay/overlay_test.go
+++ b/internal/guest/storage/overlay/overlay_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	fakeContainerId = "1"
+	fakeContainerID = "1"
 )
 
 type undo struct {
@@ -84,7 +84,7 @@ func Test_Mount_Success(t *testing.T) {
 		return nil
 	}
 
-	err := MountLayer(context.Background(), []string{"/layer1", "/layer2"}, "/upper", "/work", "/root", false, fakeContainerId, openDoorSecurityPolicyEnforcer())
+	err := MountLayer(context.Background(), []string{"/layer1", "/layer2"}, "/upper", "/work", "/root", false, fakeContainerID, openDoorSecurityPolicyEnforcer())
 	if err != nil {
 		t.Fatalf("expected no error got: %v", err)
 	}
@@ -128,7 +128,7 @@ func Test_Mount_Readonly_Success(t *testing.T) {
 		return nil
 	}
 
-	err := MountLayer(context.Background(), []string{"/layer1", "/layer2"}, "", "", "/root", false, fakeContainerId, openDoorSecurityPolicyEnforcer())
+	err := MountLayer(context.Background(), []string{"/layer1", "/layer2"}, "", "", "/root", false, fakeContainerID, openDoorSecurityPolicyEnforcer())
 	if err != nil {
 		t.Fatalf("expected no error got: %v", err)
 	}
@@ -179,7 +179,7 @@ func Test_Security_Policy_Enforcement(t *testing.T) {
 	}
 
 	enforcer := mountMonitoringSecurityPolicyEnforcer()
-	err := MountLayer(context.Background(), []string{"/layer1", "/layer2"}, "/upper", "/work", "/root", false, fakeContainerId, enforcer)
+	err := MountLayer(context.Background(), []string{"/layer1", "/layer2"}, "/upper", "/work", "/root", false, fakeContainerID, enforcer)
 	if err != nil {
 		t.Fatalf("expected no error got: %v", err)
 	}

--- a/internal/guest/storage/pci/pci_test.go
+++ b/internal/guest/storage/pci/pci_test.go
@@ -11,7 +11,8 @@ import (
 )
 
 func Test_WaitForPCIDeviceFromVMBusGUID_Success(t *testing.T) {
-	ctx, _ := context.WithTimeout(context.Background(), 2*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
 
 	vmBusGUID := "1111-2222-3333-4444"
 	pciDir := "pci1234:00"

--- a/internal/guest/storage/plan9/plan9.go
+++ b/internal/guest/storage/plan9/plan9.go
@@ -18,7 +18,7 @@ import (
 
 const packetPayloadBytes = 65536
 
-// Test dependencies
+// Test dependencies.
 var (
 	osMkdirAll  = os.MkdirAll
 	osRemoveAll = os.RemoveAll
@@ -45,7 +45,7 @@ func Mount(ctx context.Context, vsock transport.Transport, target, share string,
 	}
 	defer func() {
 		if err != nil {
-			osRemoveAll(target)
+			_ = osRemoveAll(target)
 		}
 	}()
 	conn, err := vsock.Dial(port)

--- a/internal/guest/storage/scsi/scsi.go
+++ b/internal/guest/storage/scsi/scsi.go
@@ -27,7 +27,7 @@ import (
 	"github.com/Microsoft/hcsshim/pkg/securitypolicy"
 )
 
-// Test dependencies
+// Test dependencies.
 var (
 	osMkdirAll  = os.MkdirAll
 	osRemoveAll = os.RemoveAll
@@ -35,9 +35,9 @@ var (
 
 	// controllerLunToName is stubbed to make testing `Mount` easier.
 	controllerLunToName = ControllerLunToName
-	// createVerityTarget is stubbed for unit testing `Mount`
+	// createVerityTarget is stubbed for unit testing `Mount`.
 	createVerityTarget = dm.CreateVerityTarget
-	// removeDevice is stubbed for unit testing `Mount`
+	// removeDevice is stubbed for unit testing `Mount`.
 	removeDevice = dm.RemoveDevice
 )
 
@@ -55,7 +55,7 @@ const (
 // inside the UVM. However, we can refer to the SCSI controllers with their GUIDs (that
 // are hardcoded) and then using that GUID find out the SCSI controller number inside the
 // guest. This function does exactly that.
-func fetchActualControllerNumber(ctx context.Context, passedController uint8) (uint8, error) {
+func fetchActualControllerNumber(_ context.Context, passedController uint8) (uint8, error) {
 	// find the controller number by looking for a file named host<N> (e.g host1, host3 etc.)
 	// `N` is the controller number.
 	// Full file path would be /sys/bus/vmbus/devices/<controller-guid>/host<N>.
@@ -144,7 +144,7 @@ func mount(
 	}
 	defer func() {
 		if err != nil {
-			osRemoveAll(target)
+			_ = osRemoveAll(target)
 		}
 	}()
 
@@ -169,7 +169,7 @@ func mount(
 			// The `source` found by controllerLunToName can take some time
 			// before its actually available under `/dev/sd*`. Retry while we
 			// wait for `source` to show up.
-			if err == unix.ENOENT {
+			if errors.Is(err, unix.ENOENT) {
 				select {
 				case <-ctx.Done():
 					return ctx.Err()

--- a/internal/guest/storage/scsi/scsi_test.go
+++ b/internal/guest/storage/scsi/scsi_test.go
@@ -47,7 +47,7 @@ func Test_Mount_Mkdir_Fails_Error(t *testing.T) {
 		nil,
 		nil,
 		openDoorSecurityPolicyEnforcer(),
-	); err != expectedErr {
+	); !errors.Is(err, expectedErr) {
 		t.Fatalf("expected err: %v, got: %v", expectedErr, err)
 	}
 }
@@ -235,7 +235,7 @@ func Test_Mount_Calls_RemoveAll_OnMountFailure(t *testing.T) {
 		nil,
 		nil,
 		openDoorSecurityPolicyEnforcer(),
-	); err != expectedErr {
+	); !errors.Is(err, expectedErr) {
 		t.Fatalf("expected err: %v, got: %v", expectedErr, err)
 	}
 	if !removeAllCalled {
@@ -426,7 +426,7 @@ func Test_Mount_Valid_Data(t *testing.T) {
 		return "", nil
 	}
 	unixMount = func(source string, target string, fstype string, flags uintptr, data string) error {
-		if "" != data {
+		if data != "" {
 			t.Errorf("expected empty data, got: %s", data)
 			return errors.New("unexpected data")
 		}
@@ -627,6 +627,7 @@ func mountMonitoringSecurityPolicyEnforcer() *policy.MountMonitoringSecurityPoli
 }
 
 // dm-verity tests
+
 func Test_CreateVerityTarget_And_Mount_Called_With_Correct_Parameters(t *testing.T) {
 	clearTestDependencies()
 

--- a/internal/guest/storage/utilities_test.go
+++ b/internal/guest/storage/utilities_test.go
@@ -12,7 +12,8 @@ import (
 )
 
 func Test_WaitForFileMatchingPattern_Success(t *testing.T) {
-	ctx, _ := context.WithTimeout(context.Background(), 2*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
 
 	testDir := t.TempDir()
 
@@ -36,7 +37,8 @@ func Test_WaitForFileMatchingPattern_Success(t *testing.T) {
 }
 
 func Test_WaitForFileMatchingPattern_Multiple_Matches(t *testing.T) {
-	ctx, _ := context.WithTimeout(context.Background(), 2*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
 
 	testDir := t.TempDir()
 
@@ -57,7 +59,8 @@ func Test_WaitForFileMatchingPattern_Multiple_Matches(t *testing.T) {
 }
 
 func Test_WaitForFileMatchingPattern_No_Matches(t *testing.T) {
-	ctx, _ := context.WithTimeout(context.Background(), 2*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
 
 	testDir := t.TempDir()
 

--- a/internal/guest/storage/vmbus/vmbus_test.go
+++ b/internal/guest/storage/vmbus/vmbus_test.go
@@ -11,7 +11,8 @@ import (
 )
 
 func Test_WaitForVMBusDevicePath_Success(t *testing.T) {
-	ctx, _ := context.WithTimeout(context.Background(), 2*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
 
 	vmBusGUID := "1111-2222-3333-4444"
 	pciDir := "pci1234:00"

--- a/internal/hcs/process.go
+++ b/internal/hcs/process.go
@@ -229,12 +229,12 @@ func (process *Process) waitBackground() {
 			propertiesJSON, resultJSON, err = vmcompute.HcsGetProcessProperties(ctx, process.handle)
 			events := processHcsResult(ctx, resultJSON)
 			if err != nil {
-				err = makeProcessError(process, operation, err, events) //nolint:ineffassign
+				err = makeProcessError(process, operation, err, events)
 			} else {
 				properties := &processStatus{}
 				err = json.Unmarshal([]byte(propertiesJSON), properties)
 				if err != nil {
-					err = makeProcessError(process, operation, err, nil) //nolint:ineffassign
+					err = makeProcessError(process, operation, err, nil)
 				} else {
 					if properties.LastWaitResult != 0 {
 						log.G(ctx).WithField("wait-result", properties.LastWaitResult).Warning("non-zero last wait result")

--- a/internal/hcs/resourcepaths/silo.go
+++ b/internal/hcs/resourcepaths/silo.go
@@ -1,6 +1,5 @@
 package resourcepaths
 
-//nolint:deadcode,varcheck
 const (
 	// silo container resources paths
 	SiloDeviceResourcePath          string = "Container/Devices/Generic"

--- a/internal/hcs/resourcepaths/virtualmachine.go
+++ b/internal/hcs/resourcepaths/virtualmachine.go
@@ -1,6 +1,5 @@
 package resourcepaths
 
-//nolint:deadcode,varcheck
 const (
 	GPUResourcePath                  string = "VirtualMachine/ComputeTopology/Gpu"
 	MemoryResourcePath               string = "VirtualMachine/ComputeTopology/Memory/SizeInMB"

--- a/internal/hcs/system.go
+++ b/internal/hcs/system.go
@@ -413,7 +413,7 @@ func (computeSystem *System) statisticsInProc(job *jobobject.JobObject) (*hcssch
 	// as well which isn't great and is wasted work to fetch.
 	//
 	// HCS only let's you grab statistics in an all or nothing fashion, so we can't just grab the private
-	// working set ourselves and ask for everything else seperately. The optimization we can make here is
+	// working set ourselves and ask for everything else separately. The optimization we can make here is
 	// to open the silo ourselves and do the same queries for the rest of the info, as well as calculating
 	// the private working set in a more efficient manner by:
 	//

--- a/internal/jobcontainers/jobcontainer.go
+++ b/internal/jobcontainers/jobcontainer.go
@@ -82,7 +82,7 @@ type JobContainer struct {
 	waitError        error
 }
 
-// Compile time checks for interface adherance.
+// Compile time checks for interface adherence.
 var (
 	_ cow.ProcessHost = &JobContainer{}
 	_ cow.Container   = &JobContainer{}
@@ -165,7 +165,7 @@ func Create(ctx context.Context, id string, s *specs.Spec) (_ cow.Container, _ *
 	// there being no way for us to have the path be unique in the face of multiple containers, or just
 	// the same file existing on the host. If two containers asked for two different paths to show up
 	// at C:\path\in\container, we can't symlink them both to that location. Another thing to note however
-	// is as a backwards compatability measure for machines that don't have file binding support
+	// is as a backwards compatibility measure for machines that don't have file binding support
 	// (ws2019 at the moment) we *also* bind the path under the containers rootfs location so checking
 	// for your mount in either the old or new location will work.
 	//
@@ -324,7 +324,7 @@ func (c *JobContainer) CreateProcess(ctx context.Context, config interface{}) (_
 		}
 	}
 
-	// Replace any occurences of the sandbox mount env variable in the commandline.
+	// Replace any occurrences of the sandbox mount env variable in the commandline.
 	// For example: %CONTAINER_SANDBOX_MOUNTPOINT%\mybinary.exe -> C:\<rootfslocation>\mybinary.exe.
 	commandLine, _ := c.replaceWithMountPoint(conf.CommandLine)
 

--- a/internal/safefile/safeopen_admin_test.go
+++ b/internal/safefile/safeopen_admin_test.go
@@ -126,6 +126,7 @@ func TestOpenRelative(t *testing.T) {
 	// Make sure it's not possible to escape with .. (NT doesn't support .. at the kernel level)
 	f, err = OpenRelative("..", root, syscall.GENERIC_READ, syscall.FILE_SHARE_READ, winapi.FILE_OPEN, 0)
 	if err == nil {
+		f.Close()
 		t.Fatal("escaped the directory")
 	}
 	t.Log(err)

--- a/pkg/amdsevsnp/report.go
+++ b/pkg/amdsevsnp/report.go
@@ -16,6 +16,7 @@ import (
 	"github.com/Microsoft/hcsshim/internal/guest/linux"
 )
 
+//nolint:deadcode,varcheck // enumerate all options
 const (
 	msgTypeInvalid = iota
 	msgCPUIDRequest
@@ -46,11 +47,11 @@ type guestRequest struct {
 	Error           uint32
 }
 
-// AMD SEV ioctl definitions
+// AMD SEV ioctl definitions.
 const (
-	// SEV-SNP IOCTL type
+	// SEV-SNP IOCTL type.
 	guestType = 'S'
-	// SEV-SNP IOCTL size, same as unsafe.Sizeof(SevSNPGuestRequest{})
+	// SEV-SNP IOCTL size, same as unsafe.Sizeof(SevSNPGuestRequest{}).
 	guestSize = 40
 	ioctlBase = linux.IocWRBase | guestType<<linux.IocTypeShift | guestSize<<linux.IocSizeShift
 
@@ -131,8 +132,9 @@ func (sr *report) report() Report {
 // https://www.amd.com/system/files/TechDocs/56860.pdf
 // MSG_REPORT_RSP Table 23.
 // NOTE: reportResponse.Report is a byte slice, to have the original
-//     response in bytes. The conversion to internal struct happens inside
-//     convertRawReport.
+// response in bytes. The conversion to internal struct happens inside
+// convertRawReport.
+//
 // NOTE: the additional 64 bytes are reserved, without them, the ioctl fails.
 type reportResponse struct {
 	Status     uint32

--- a/pkg/securitypolicy/regopolicy_test.go
+++ b/pkg/securitypolicy/regopolicy_test.go
@@ -648,7 +648,7 @@ func Test_Rego_ExtendDefaultMounts(t *testing.T) {
 		}
 
 		defaultMounts := generateMounts(testRand)
-		tc.policy.ExtendDefaultMounts(toOCIMounts(defaultMounts))
+		_ = tc.policy.ExtendDefaultMounts(toOCIMounts(defaultMounts))
 
 		additionalMounts := buildMountSpecFromMountArray(defaultMounts, tc.sandboxID, testRand)
 		tc.mounts = append(tc.mounts, additionalMounts.Mounts...)

--- a/pkg/securitypolicy/securitypolicy_test.go
+++ b/pkg/securitypolicy/securitypolicy_test.go
@@ -708,7 +708,7 @@ func Test_WorkingDirectoryPolicy_NoMatches(t *testing.T) {
 	}
 }
 
-// Consequent layers
+// Consequent layers.
 func Test_Overlay_Duplicate_Layers(t *testing.T) {
 	f := func(p *generatedContainers) bool {
 		c1 := generateContainersContainer(testRand, 5, 5)
@@ -818,26 +818,26 @@ func (*SecurityPolicy) Generate(r *rand.Rand, _ int) reflect.Value {
 
 		// command
 		numArgs := int(atLeastOneAtMost(r, maxGeneratedCommandArgs))
-		for i := 0; i < numArgs; i++ {
-			c.Command.Elements[strconv.Itoa(i)] = randVariableString(r, maxGeneratedCommandLength)
+		for j := 0; j < numArgs; j++ {
+			c.Command.Elements[strconv.Itoa(j)] = randVariableString(r, maxGeneratedCommandLength)
 		}
 		c.Command.Length = numArgs
 
 		// layers
 		numLayers := int(atLeastOneAtMost(r, maxLayersInGeneratedContainer))
-		for i := 0; i < numLayers; i++ {
-			c.Layers.Elements[strconv.Itoa(i)] = generateRootHash(r)
+		for j := 0; j < numLayers; j++ {
+			c.Layers.Elements[strconv.Itoa(j)] = generateRootHash(r)
 		}
 		c.Layers.Length = numLayers
 
 		// env variable rules
 		numEnvRules := int(atMost(r, maxGeneratedEnvironmentVariableRules))
-		for i := 0; i < numEnvRules; i++ {
+		for j := 0; j < numEnvRules; j++ {
 			rule := EnvRuleConfig{
 				Strategy: "string",
 				Rule:     randVariableString(r, maxGeneratedEnvironmentVariableRuleLength),
 			}
-			c.EnvRules.Elements[strconv.Itoa(i)] = rule
+			c.EnvRules.Elements[strconv.Itoa(j)] = rule
 		}
 		c.EnvRules.Length = numEnvRules
 
@@ -1038,19 +1038,19 @@ func generateMounts(r *rand.Rand) []mountInternal {
 			options[j] = randVariableString(r, maxGeneratedMountOptionLength)
 		}
 
-		source_prefix := ""
+		sourcePrefix := ""
 		// select a "source type". our default is "no special prefix" ie a
 		// "standard source".
-		prefix_type := randMinMax(r, 1, 3)
-		if prefix_type == 2 {
+		prefixType := randMinMax(r, 1, 3)
+		if prefixType == 2 {
 			// sandbox mount, gets special handling
-			source_prefix = guestpath.SandboxMountPrefix
-		} else if prefix_type == 3 {
+			sourcePrefix = guestpath.SandboxMountPrefix
+		} else if prefixType == 3 {
 			// huge page mount, gets special handling
-			source_prefix = guestpath.HugePagesMountPrefix
+			sourcePrefix = guestpath.HugePagesMountPrefix
 		}
 
-		source := source_prefix + randVariableString(r, maxGeneratedMountSourceLength)
+		source := sourcePrefix + randVariableString(r, maxGeneratedMountSourceLength)
 		destination := randVariableString(r, maxGeneratedMountDestinationLength)
 
 		mounts[i] = mountInternal{
@@ -1161,7 +1161,10 @@ func (gen *dataGenerator) uniqueSandboxID() string {
 	}
 }
 
-func (gen *dataGenerator) createValidOverlayForContainer(enforcer SecurityPolicyEnforcer, container *securityPolicyContainer) ([]string, error) {
+func (gen *dataGenerator) createValidOverlayForContainer(
+	enforcer SecurityPolicyEnforcer,
+	container *securityPolicyContainer,
+) ([]string, error) {
 	// storage for our mount paths
 	overlay := make([]string, len(container.Layers))
 

--- a/test/cri-containerd/clone_test.go
+++ b/test/cri-containerd/clone_test.go
@@ -157,7 +157,14 @@ func createPodAndContainer(ctx context.Context, t *testing.T, client runtime.Run
 // actually saved.
 // It is the callers responsibility to clean the stop and remove the cloned
 // containers and pods.
-func createTemplateContainer(ctx context.Context, t *testing.T, client runtime.RuntimeServiceClient, templateSandboxRequest *runtime.RunPodSandboxRequest, templateContainerRequest *runtime.CreateContainerRequest, templatePodID, templateContainerID *string) {
+func createTemplateContainer(
+	ctx context.Context,
+	t *testing.T,
+	client runtime.RuntimeServiceClient,
+	templateSandboxRequest *runtime.RunPodSandboxRequest,
+	templateContainerRequest *runtime.CreateContainerRequest,
+	templatePodID, templateContainerID *string,
+) {
 	createPodAndContainer(ctx, t, client, templateSandboxRequest, templateContainerRequest, templatePodID, templateContainerID)
 
 	// Send a context with deadline for waitForTemplateSave function
@@ -165,17 +172,22 @@ func createTemplateContainer(ctx context.Context, t *testing.T, client runtime.R
 	ctx, cancel := context.WithDeadline(ctx, d)
 	defer cancel()
 	waitForTemplateSave(ctx, t, *templatePodID)
-	return
 }
 
 // Creates a clone from the given template pod and container.
 // It is the callers responsibility to clean the stop and remove the cloned
 // containers and pods.
-func createClonedContainer(ctx context.Context, t *testing.T, client runtime.RuntimeServiceClient, templatePodID, templateContainerID string, cloneNumber int, clonedPodID, clonedContainerID *string) {
+func createClonedContainer(
+	ctx context.Context,
+	t *testing.T,
+	client runtime.RuntimeServiceClient,
+	templatePodID, templateContainerID string,
+	cloneNumber int,
+	clonedPodID, clonedContainerID *string,
+) {
 	cloneSandboxRequest := getClonedPodConfig(cloneNumber, templatePodID)
 	cloneContainerRequest := getClonedContainerConfig(cloneNumber, templateContainerID)
 	createPodAndContainer(ctx, t, client, cloneSandboxRequest, cloneContainerRequest, clonedPodID, clonedContainerID)
-	return
 }
 
 // Runs a command inside given container and verifies if the command executes successfully.
@@ -405,7 +417,7 @@ func Test_ClonedContainerRunningAfterDeletingTemplate(t *testing.T) {
 	verifyContainerExec(ctx, t, client, clonedContainerID)
 }
 
-// A test to verify that multiple templats can be created and clones
+// A test to verify that multiple templates can be created and clones
 // can be made from each of them simultaneously.
 func Test_MultipleTemplateAndClones_WCOW(t *testing.T) {
 	requireFeatures(t, featureWCOWHypervisor)

--- a/test/cri-containerd/container_test.go
+++ b/test/cri-containerd/container_test.go
@@ -739,14 +739,14 @@ func Test_CreateContainer_HugePageMount_LCOW(t *testing.T) {
 	request.PodSandboxId = podID
 	request.SandboxConfig = sandboxRequest.Config
 
-	containerId := createContainer(t, client, ctx, request)
-	defer removeContainer(t, client, ctx, containerId)
-	startContainer(t, client, ctx, containerId)
-	defer stopContainer(t, client, ctx, containerId)
+	containerID := createContainer(t, client, ctx, request)
+	defer removeContainer(t, client, ctx, containerID)
+	startContainer(t, client, ctx, containerID)
+	defer stopContainer(t, client, ctx, containerID)
 
 	execCommand := []string{"grep", "-i", "/mnt/hugepage2M", "/proc/mounts"}
 
-	output, errorMsg, exitCode := execContainer(t, client, ctx, containerId, execCommand)
+	output, errorMsg, exitCode := execContainer(t, client, ctx, containerID, execCommand)
 	if exitCode != 0 || len(errorMsg) > 0 {
 		t.Fatalf("failed to exec in hugepage container errorMsg: %s, exitcode: %v\n", errorMsg, exitCode)
 	}

--- a/test/cri-containerd/container_update_test.go
+++ b/test/cri-containerd/container_update_test.go
@@ -24,6 +24,7 @@ func calculateJobCPUWeight(processorWeight uint32) uint32 {
 	return 1 + uint32((8*processorWeight)/processorWeightMax)
 }
 
+//nolint:deadcode,unused // may be used in future tests
 func calculateJobCPURate(hostProcs uint32, processorCount uint32) uint32 {
 	rate := (processorCount * 10000) / hostProcs
 	if rate == 0 {

--- a/test/cri-containerd/container_virtual_device_test.go
+++ b/test/cri-containerd/container_virtual_device_test.go
@@ -105,6 +105,8 @@ func findTestNvidiaGPULocationPath() (string, error) {
 }
 
 // findTestVirtualDeviceID returns the instance ID of the first generic pcip device on the host
+//
+//nolint:deadcode,unused // may be used in future tests
 func findTestVirtualDeviceID() (string, error) {
 	out, err := exec.Command(
 		"powershell",

--- a/test/cri-containerd/createcontainer_test.go
+++ b/test/cri-containerd/createcontainer_test.go
@@ -1235,29 +1235,29 @@ func Test_Mount_ReadOnlyDirReuse_WCOW(t *testing.T) {
 
 	request.Config.Metadata.Name = request.Config.Metadata.Name + "-ro"
 	request.Config.Mounts[0].Readonly = true
-	c_ro := createContainer(t, client, ctx, request)
-	defer removeContainer(t, client, ctx, c_ro)
-	startContainer(t, client, ctx, c_ro)
-	defer stopContainer(t, client, ctx, c_ro)
+	cRO := createContainer(t, client, ctx, request)
+	defer removeContainer(t, client, ctx, cRO)
+	startContainer(t, client, ctx, cRO)
+	defer stopContainer(t, client, ctx, cRO)
 
 	request.Config.Metadata.Name = request.Config.Metadata.Name + "-rw"
 	request.Config.Mounts[0].Readonly = false
-	c_rw := createContainer(t, client, ctx, request)
-	defer removeContainer(t, client, ctx, c_rw)
-	startContainer(t, client, ctx, c_rw)
-	defer stopContainer(t, client, ctx, c_rw)
+	cRW := createContainer(t, client, ctx, request)
+	defer removeContainer(t, client, ctx, cRW)
+	startContainer(t, client, ctx, cRW)
+	defer stopContainer(t, client, ctx, cRW)
 
 	filePath := containerPath + `\tmp.txt`
 	execCommand := []string{"cmd", "/c", "echo foo", ">", filePath}
 
-	_, errorMsg, exitCode := execContainer(t, client, ctx, c_rw, execCommand)
+	_, errorMsg, exitCode := execContainer(t, client, ctx, cRW, execCommand)
 
 	// Writing a file to the rw container mount should succeed.
 	if exitCode != 0 || len(errorMsg) > 0 {
 		t.Fatalf("Failed to write file to rw container mount: %s, exitcode: %v\n", errorMsg, exitCode)
 	}
 
-	_, errorMsg, exitCode = execContainer(t, client, ctx, c_ro, execCommand)
+	_, errorMsg, exitCode = execContainer(t, client, ctx, cRO, execCommand)
 
 	// Writing a file to the ro container mount should fail.
 	if exitCode == 0 && len(errorMsg) == 0 {

--- a/test/cri-containerd/disable_vpmem_test.go
+++ b/test/cri-containerd/disable_vpmem_test.go
@@ -22,7 +22,7 @@ func uniqueRef() string {
 	t := time.Now()
 	var b [3]byte
 	// Ignore read failures, just decreases uniqueness
-	rand.Read(b[:])
+	_, _ = rand.Read(b[:])
 	return fmt.Sprintf("%d-%s", t.UnixNano(), base64.URLEncoding.EncodeToString(b[:]))
 }
 

--- a/test/cri-containerd/jobcontainer_test.go
+++ b/test/cri-containerd/jobcontainer_test.go
@@ -313,7 +313,7 @@ func Test_RunContainer_VHD_JobContainer_WCOW(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer syscall.CloseHandle(vhdHandle)
+	defer syscall.CloseHandle(vhdHandle) //nolint:errcheck
 
 	if err := vhd.AttachVirtualDisk(syscall.Handle(vhdHandle), vhd.AttachVirtualDiskFlagNone, &vhd.AttachVirtualDiskParameters{Version: 1}); err != nil {
 		t.Fatalf("failed to attach vhd at %q: %s", vhdPath, err)
@@ -605,7 +605,7 @@ func Test_RunContainer_WorkingDirectory_JobContainer_WCOW(t *testing.T) {
 
 	type config struct {
 		name             string
-		containerName    string
+		containerName    string //nolint:unused // may be used in future tests
 		workDir          string
 		requiredFeatures []string
 		sandboxImage     string

--- a/test/cri-containerd/main_test.go
+++ b/test/cri-containerd/main_test.go
@@ -71,6 +71,8 @@ const (
 )
 
 // Image definitions
+//
+//nolint:deadcode,unused,varcheck // may be used in future tests
 var (
 	imageWindowsNanoserver      = getWindowsNanoserverImage(osversion.Build())
 	imageWindowsServercore      = getWindowsServerCoreImage(osversion.Build())
@@ -183,6 +185,7 @@ func createGRPCConn(ctx context.Context) (*grpc.ClientConn, error) {
 	if err != nil {
 		return nil, err
 	}
+	//nolint:staticcheck //TODO: SA1019: grpc.WithInsecure is deprecated: use WithTransportCredentials and insecure.NewCredentials()
 	return grpc.DialContext(ctx, addr, grpc.WithInsecure(), grpc.WithContextDialer(dialer))
 }
 

--- a/test/cri-containerd/pod_update_test.go
+++ b/test/cri-containerd/pod_update_test.go
@@ -257,6 +257,7 @@ func Test_Pod_UpdateResources_CPUGroup(t *testing.T) {
 		}
 	}()
 
+	//nolint:unused // false positive about config being unused
 	type config struct {
 		name             string
 		requiredFeatures []string

--- a/test/cri-containerd/policy_test.go
+++ b/test/cri-containerd/policy_test.go
@@ -19,9 +19,7 @@ import (
 	"github.com/Microsoft/hcsshim/pkg/securitypolicy"
 )
 
-var (
-	validPolicyAlpineCommand = []string{"ash", "-c", "echo 'Hello'"}
-)
+var validPolicyAlpineCommand = []string{"ash", "-c", "echo 'Hello'"}
 
 type configSideEffect func(*runtime.CreateContainerRequest) error
 

--- a/test/cri-containerd/pullimage_test.go
+++ b/test/cri-containerd/pullimage_test.go
@@ -67,13 +67,13 @@ func Test_PullImageTimestamps(t *testing.T) {
 		testDirPath,
 	}
 
-	containerId := createContainerInSandbox(t, client, ctx, podID, t.Name()+"-Container", imageWindowsNanoserverTestImage, command, nil, nil, sandboxRequest.Config)
-	defer removeContainer(t, client, ctx, containerId)
+	containerID := createContainerInSandbox(t, client, ctx, podID, t.Name()+"-Container", imageWindowsNanoserverTestImage, command, nil, nil, sandboxRequest.Config)
+	defer removeContainer(t, client, ctx, containerID)
 
-	startContainer(t, client, ctx, containerId)
-	defer stopContainer(t, client, ctx, containerId)
+	startContainer(t, client, ctx, containerID)
+	defer stopContainer(t, client, ctx, containerID)
 
-	output, errorMsg, exitCode := execContainer(t, client, ctx, containerId, execCommand)
+	output, errorMsg, exitCode := execContainer(t, client, ctx, containerID, execCommand)
 
 	if exitCode != 0 || len(errorMsg) > 0 {
 		t.Fatalf("Failed to exec inside container: %s, exitcode: %v\n",

--- a/test/cri-containerd/runpodsandbox_test.go
+++ b/test/cri-containerd/runpodsandbox_test.go
@@ -1116,17 +1116,17 @@ func Test_RunPodSandbox_MultipleContainersSameVhd_LCOW(t *testing.T) {
 	// create 2 containers with vhd mounts and verify both can mount vhd
 	for i := 1; i < 3; i++ {
 		containerName := t.Name() + "-Container-" + strconv.Itoa(i)
-		containerId := createContainerInSandbox(t, client, ctx, podID, containerName, imageLcowAlpine, command, annots, mounts, sbRequest.Config)
-		defer removeContainer(t, client, ctx, containerId)
+		containerID := createContainerInSandbox(t, client, ctx, podID, containerName, imageLcowAlpine, command, annots, mounts, sbRequest.Config)
+		defer removeContainer(t, client, ctx, containerID)
 
-		startContainer(t, client, ctx, containerId)
-		defer stopContainer(t, client, ctx, containerId)
+		startContainer(t, client, ctx, containerID)
+		defer stopContainer(t, client, ctx, containerID)
 
-		_, errorMsg, exitCode := execContainer(t, client, ctx, containerId, execCommand)
+		_, errorMsg, exitCode := execContainer(t, client, ctx, containerID, execCommand)
 
 		// For container 1 and 2 we should find the mounts
 		if exitCode != 0 {
-			t.Fatalf("Exec into container failed with: %v and exit code: %d, %s", errorMsg, exitCode, containerId)
+			t.Fatalf("Exec into container failed with: %v and exit code: %d, %s", errorMsg, exitCode, containerID)
 		}
 	}
 
@@ -1135,17 +1135,17 @@ func Test_RunPodSandbox_MultipleContainersSameVhd_LCOW(t *testing.T) {
 	// at the same time containers in a pod that don't have any mounts
 	mounts = []*runtime.Mount{}
 	containerName := t.Name() + "-Container-3"
-	containerId := createContainerInSandbox(t, client, ctx, podID, containerName, imageLcowAlpine, command, annots, mounts, sbRequest.Config)
-	defer removeContainer(t, client, ctx, containerId)
+	containerID := createContainerInSandbox(t, client, ctx, podID, containerName, imageLcowAlpine, command, annots, mounts, sbRequest.Config)
+	defer removeContainer(t, client, ctx, containerID)
 
-	startContainer(t, client, ctx, containerId)
-	defer stopContainer(t, client, ctx, containerId)
+	startContainer(t, client, ctx, containerID)
+	defer stopContainer(t, client, ctx, containerID)
 
-	output, errorMsg, exitCode := execContainer(t, client, ctx, containerId, execCommand)
+	output, errorMsg, exitCode := execContainer(t, client, ctx, containerID, execCommand)
 
 	// 3rd container should not have the mount and ls should fail
 	if exitCode == 0 {
-		t.Fatalf("Exec into container succeeded but we expected it to fail: %v and exit code: %s, %s", errorMsg, output, containerId)
+		t.Fatalf("Exec into container succeeded but we expected it to fail: %v and exit code: %s, %s", errorMsg, output, containerID)
 	}
 }
 
@@ -1205,26 +1205,26 @@ func Test_RunPodSandbox_MultipleContainersSameVhd_RShared_LCOW(t *testing.T) {
 
 	containerName := t.Name() + "-Container-0"
 	cRequest.Config.Metadata.Name = containerName
-	containerId0 := createContainer(t, client, ctx, cRequest)
-	defer removeContainer(t, client, ctx, containerId0)
-	startContainer(t, client, ctx, containerId0)
-	defer stopContainer(t, client, ctx, containerId0)
+	containerID0 := createContainer(t, client, ctx, cRequest)
+	defer removeContainer(t, client, ctx, containerID0)
+	startContainer(t, client, ctx, containerID0)
+	defer stopContainer(t, client, ctx, containerID0)
 
 	containerName1 := t.Name() + "-Container-1"
 	cRequest.Config.Metadata.Name = containerName1
-	containerId1 := createContainer(t, client, ctx, cRequest)
-	defer removeContainer(t, client, ctx, containerId1)
-	startContainer(t, client, ctx, containerId1)
-	defer stopContainer(t, client, ctx, containerId1)
+	containerID1 := createContainer(t, client, ctx, cRequest)
+	defer removeContainer(t, client, ctx, containerID1)
+	startContainer(t, client, ctx, containerID1)
+	defer stopContainer(t, client, ctx, containerID1)
 
 	// create a test directory that will be the new mountpoint's source
 	createTestDirCmd := []string{
 		"mkdir",
 		"/tmp/testdir",
 	}
-	_, errorMsg, exitCode := execContainer(t, client, ctx, containerId0, createTestDirCmd)
+	_, errorMsg, exitCode := execContainer(t, client, ctx, containerID0, createTestDirCmd)
 	if exitCode != 0 {
-		t.Fatalf("Exec into container failed with: %v and exit code: %d, %s", errorMsg, exitCode, containerId0)
+		t.Fatalf("Exec into container failed with: %v and exit code: %d, %s", errorMsg, exitCode, containerID0)
 	}
 
 	// create a file in the test directory
@@ -1232,9 +1232,9 @@ func Test_RunPodSandbox_MultipleContainersSameVhd_RShared_LCOW(t *testing.T) {
 		"touch",
 		"/tmp/testdir/test.txt",
 	}
-	_, errorMsg, exitCode = execContainer(t, client, ctx, containerId0, createTestDirContentCmd)
+	_, errorMsg, exitCode = execContainer(t, client, ctx, containerID0, createTestDirContentCmd)
 	if exitCode != 0 {
-		t.Fatalf("Exec into container failed with: %v and exit code: %d, %s", errorMsg, exitCode, containerId0)
+		t.Fatalf("Exec into container failed with: %v and exit code: %d, %s", errorMsg, exitCode, containerID0)
 	}
 
 	// create a test directory in the vhd that will be the new mountpoint's destination
@@ -1242,9 +1242,9 @@ func Test_RunPodSandbox_MultipleContainersSameVhd_RShared_LCOW(t *testing.T) {
 		"mkdir",
 		fmt.Sprintf("%s/testdir", vhdContainerPath),
 	}
-	_, errorMsg, exitCode = execContainer(t, client, ctx, containerId0, createTestDirVhdCmd)
+	_, errorMsg, exitCode = execContainer(t, client, ctx, containerID0, createTestDirVhdCmd)
 	if exitCode != 0 {
-		t.Fatalf("Exec into container failed with: %v and exit code: %d, %s", errorMsg, exitCode, containerId0)
+		t.Fatalf("Exec into container failed with: %v and exit code: %d, %s", errorMsg, exitCode, containerID0)
 	}
 
 	// perform rshared mount of test directory into the vhd
@@ -1255,9 +1255,9 @@ func Test_RunPodSandbox_MultipleContainersSameVhd_RShared_LCOW(t *testing.T) {
 		"/tmp/testdir",
 		fmt.Sprintf("%s/testdir", vhdContainerPath),
 	}
-	_, errorMsg, exitCode = execContainer(t, client, ctx, containerId0, mountTestDirToVhdCmd)
+	_, errorMsg, exitCode = execContainer(t, client, ctx, containerID0, mountTestDirToVhdCmd)
 	if exitCode != 0 {
-		t.Fatalf("Exec into container failed with: %v and exit code: %d, %s", errorMsg, exitCode, containerId0)
+		t.Fatalf("Exec into container failed with: %v and exit code: %d, %s", errorMsg, exitCode, containerID0)
 	}
 
 	// try to list the test file in the second container to verify it was propagated correctly
@@ -1265,9 +1265,9 @@ func Test_RunPodSandbox_MultipleContainersSameVhd_RShared_LCOW(t *testing.T) {
 		"ls",
 		fmt.Sprintf("%s/testdir/test.txt", vhdContainerPath),
 	}
-	_, errorMsg, exitCode = execContainer(t, client, ctx, containerId1, verifyTestMountCommand)
+	_, errorMsg, exitCode = execContainer(t, client, ctx, containerID1, verifyTestMountCommand)
 	if exitCode != 0 {
-		t.Fatalf("Exec into container failed with: %v and exit code: %d, %s", errorMsg, exitCode, containerId1)
+		t.Fatalf("Exec into container failed with: %v and exit code: %d, %s", errorMsg, exitCode, containerID1)
 	}
 }
 
@@ -1327,18 +1327,20 @@ func Test_RunPodSandbox_MultipleContainersSameVhd_WCOW(t *testing.T) {
 	// create 2 containers with vhd mounts and verify both can mount vhd
 	for i := 1; i < 3; i++ {
 		containerName := t.Name() + "-Container-" + strconv.Itoa(i)
-		containerId := createContainerInSandbox(t, client, ctx, podID, containerName, imageWindowsNanoserver, command, annots, mounts, sbRequest.Config)
-		defer removeContainer(t, client, ctx, containerId)
+		containerID := createContainerInSandbox(t, client,
+			ctx, podID, containerName, imageWindowsNanoserver,
+			command, annots, mounts, sbRequest.Config)
+		defer removeContainer(t, client, ctx, containerID)
 
-		startContainer(t, client, ctx, containerId)
-		defer stopContainer(t, client, ctx, containerId)
+		startContainer(t, client, ctx, containerID)
+		defer stopContainer(t, client, ctx, containerID)
 
-		_, errorMsg, exitCode := execContainer(t, client, ctx, containerId, execCommand)
+		_, errorMsg, exitCode := execContainer(t, client, ctx, containerID, execCommand)
 
 		// The dir command will return File Not Found error if the directory is empty.
 		// Don't fail the test if that happens. It is expected behaviour in this case.
 		if exitCode != 0 && !strings.Contains(errorMsg, "File Not Found") {
-			t.Fatalf("Exec into container failed with: %v and exit code: %d, %s", errorMsg, exitCode, containerId)
+			t.Fatalf("Exec into container failed with: %v and exit code: %d, %s", errorMsg, exitCode, containerID)
 		}
 	}
 
@@ -1347,17 +1349,19 @@ func Test_RunPodSandbox_MultipleContainersSameVhd_WCOW(t *testing.T) {
 	// at the same time containers in a pod that don't have any mounts
 	mounts = []*runtime.Mount{}
 	containerName := t.Name() + "-Container-3"
-	containerId := createContainerInSandbox(t, client, ctx, podID, containerName, imageWindowsNanoserver, command, annots, mounts, sbRequest.Config)
-	defer removeContainer(t, client, ctx, containerId)
+	containerID := createContainerInSandbox(t, client,
+		ctx, podID, containerName, imageWindowsNanoserver,
+		command, annots, mounts, sbRequest.Config)
+	defer removeContainer(t, client, ctx, containerID)
 
-	startContainer(t, client, ctx, containerId)
-	defer stopContainer(t, client, ctx, containerId)
+	startContainer(t, client, ctx, containerID)
+	defer stopContainer(t, client, ctx, containerID)
 
-	output, errorMsg, exitCode := execContainer(t, client, ctx, containerId, execCommand)
+	output, errorMsg, exitCode := execContainer(t, client, ctx, containerID, execCommand)
 
 	// 3rd container should not have the mount and ls should fail
 	if exitCode != 0 && !strings.Contains(errorMsg, "File Not Found") {
-		t.Fatalf("Exec into container failed: %v and exit code: %s, %s", errorMsg, output, containerId)
+		t.Fatalf("Exec into container failed: %v and exit code: %s, %s", errorMsg, output, containerID)
 	}
 }
 
@@ -1437,13 +1441,6 @@ func Test_RunPodSandbox_ProcessDump_LCOW(t *testing.T) {
 		},
 		PodSandboxId:  podID,
 		SandboxConfig: sbRequest.Config,
-	}
-
-	mounts = []*runtime.Mount{
-		{
-			HostPath:      "sandbox:///coredump",
-			ContainerPath: "/coredumps",
-		},
 	}
 
 	container2ID := createContainer(t, client, ctx, c2Request)
@@ -1566,13 +1563,6 @@ func Test_RunPodSandbox_ProcessDump_WCOW_Hypervisor(t *testing.T) {
 		},
 		PodSandboxId:  podID,
 		SandboxConfig: sbRequest.Config,
-	}
-
-	mounts = []*runtime.Mount{
-		{
-			HostPath:      "sandbox:///processdump",
-			ContainerPath: "C:\\processdump",
-		},
 	}
 
 	container2ID := createContainer(t, client, ctx, c2Request)
@@ -1770,10 +1760,17 @@ func createSandboxContainerAndExecForCustomScratch(t *testing.T, annots map[stri
 	return createSandboxContainerAndExec(t, annots, nil, cmd)
 }
 
-func createContainerInSandbox(t *testing.T, client runtime.RuntimeServiceClient, ctx context.Context, podId, containerName, imageName string, command []string,
-	annots map[string]string, mounts []*runtime.Mount, podConfig *runtime.PodSandboxConfig) string {
-
-	cRequest := getCreateContainerRequest(podId, containerName, imageName, command, podConfig)
+func createContainerInSandbox(
+	t *testing.T,
+	client runtime.RuntimeServiceClient,
+	ctx context.Context,
+	podID, containerName, imageName string,
+	command []string,
+	annots map[string]string,
+	mounts []*runtime.Mount,
+	podConfig *runtime.PodSandboxConfig,
+) string {
+	cRequest := getCreateContainerRequest(podID, containerName, imageName, command, podConfig)
 	cRequest.Config.Annotations = annots
 	cRequest.Config.Mounts = mounts
 
@@ -1782,9 +1779,15 @@ func createContainerInSandbox(t *testing.T, client runtime.RuntimeServiceClient,
 	return containerID
 }
 
-func execContainer(t *testing.T, client runtime.RuntimeServiceClient, ctx context.Context, containerId string, command []string) (string, string, int) {
+func execContainer(
+	t *testing.T,
+	client runtime.RuntimeServiceClient,
+	ctx context.Context,
+	containerID string,
+	command []string,
+) (string, string, int) {
 	execRequest := &runtime.ExecSyncRequest{
-		ContainerId: containerId,
+		ContainerId: containerID,
 		Cmd:         command,
 		Timeout:     20,
 	}

--- a/test/functional/lcow_test.go
+++ b/test/functional/lcow_test.go
@@ -161,6 +161,7 @@ func TestLCOWSimplePodScenario(t *testing.T) {
 	require.Build(t, osversion.RS5)
 	requireFeatures(t, featureLCOW, featureContainer)
 
+	//nolint:staticcheck // SA1019: TODO: replace `LayerFolders`
 	alpineLayers := layers.LayerFolders(t, "alpine")
 
 	cacheDir := t.TempDir()
@@ -235,12 +236,12 @@ func TestLCOWSimplePodScenario(t *testing.T) {
 	if err := c1hcsSystem.Start(context.Background()); err != nil {
 		t.Fatal(err)
 	}
-	defer resources.ReleaseResources(context.Background(), c1Resources, lcowUVM, true)
+	defer resources.ReleaseResources(context.Background(), c1Resources, lcowUVM, true) //nolint:errcheck
 
 	if err := c2hcsSystem.Start(context.Background()); err != nil {
 		t.Fatal(err)
 	}
-	defer resources.ReleaseResources(context.Background(), c2Resources, lcowUVM, true)
+	defer resources.ReleaseResources(context.Background(), c2Resources, lcowUVM, true) //nolint:errcheck
 
 	// Start the init process in each container and grab it's stdout comparing to expected
 	runInitProcess(t, c1hcsSystem, "hello lcow container one")
@@ -250,6 +251,8 @@ func TestLCOWSimplePodScenario(t *testing.T) {
 
 // Helper to run the init process in an LCOW container; verify it exits with exit
 // code 0; verify stderr is empty; check output is as expected.
+//
+//nolint:unused // unused since tests are skipped
 func runInitProcess(t *testing.T, s cow.Container, expected string) {
 	var errB bytes.Buffer
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)

--- a/test/functional/main_test.go
+++ b/test/functional/main_test.go
@@ -32,7 +32,7 @@ import (
 	"github.com/Microsoft/hcsshim/test/internal/require"
 )
 
-// owner field for uVMs
+// owner field for uVMs.
 const hcsOwner = "hcsshim-functional-tests"
 
 const (
@@ -67,14 +67,12 @@ var (
 	debug                                 bool
 	pauseDurationOnCreateContainerFailure time.Duration
 
-	// flags
 	flagFeatures            = testflag.NewFeatureFlag(allFeatures)
-	flagContainerdAddress   = flag.String("ctr-address", "tcp://127.0.0.1:2376", "Address for containerd's GRPC server")
-	flagContainerdNamespace = flag.String("ctr-namespace", "k8s.io", "Containerd namespace")
-	flagCtrExePath          = flag.String("ctr-path", `C:\ContainerPlat\ctr.exe`, "Path to ctr.exe")
+	flagContainerdAddress   = flag.String("ctr-address", "tcp://127.0.0.1:2376", "`address` for containerd's GRPC server")
+	flagContainerdNamespace = flag.String("ctr-namespace", "k8s.io", "containerd `namespace`")
 	flagLinuxBootFilesPath  = flag.String("linux-bootfiles",
 		`C:\\ContainerPlat\\LinuxBootFiles`,
-		"Path to LCOW UVM boot files (rootfs.vhd, initrd.img, kernel, vmlinux)")
+		"`path` to LCOW UVM boot files (rootfs.vhd, initrd.img, kernel, and vmlinux)")
 )
 
 func init() {
@@ -85,7 +83,7 @@ func init() {
 	if _, ok := os.LookupEnv("HCSSHIM_FUNCTIONAL_TESTS_DEBUG"); ok {
 		debug = true
 	}
-	flag.BoolVar(&debug, "debug", debug, "Set logging level to debug [%HCSSHIM_FUNCTIONAL_TESTS_DEBUG%]")
+	flag.BoolVar(&debug, "debug", debug, "set logging level to debug [%HCSSHIM_FUNCTIONAL_TESTS_DEBUG%]")
 
 	// This allows for debugging a utility VM.
 	if s := os.Getenv("HCSSHIM_FUNCTIONAL_TESTS_PAUSE_ON_CREATECONTAINER_FAIL_IN_MINUTES"); s != "" {
@@ -96,7 +94,7 @@ func init() {
 	flag.DurationVar(&pauseDurationOnCreateContainerFailure,
 		"container-creation-failure-pause",
 		pauseDurationOnCreateContainerFailure,
-		"The number of minutes to wait after a container creation failure to try again "+
+		"the number of minutes to wait after a container creation failure to try again "+
 			"[%HCSSHIM_FUNCTIONAL_TESTS_PAUSE_ON_CREATECONTAINER_FAIL_IN_MINUTES%]")
 }
 
@@ -114,7 +112,8 @@ func TestMain(m *testing.M) {
 	e := m.Run()
 
 	// close any uVMs that escaped
-	cmdStr := ` foreach ($vm in Get-ComputeProcess -Owner '` + hcsOwner + `') { Write-Output "uVM $($vm.Id) was left running" ; Stop-ComputeProcess -Force -Id $vm.Id } `
+	cmdStr := ` foreach ($vm in Get-ComputeProcess -Owner '` + hcsOwner +
+		`') { Write-Output "uVM $($vm.Id) was left running" ; Stop-ComputeProcess -Force -Id $vm.Id } `
 	cmd := exec.Command("powershell", "-NoLogo", " -NonInteractive", "-Command", cmdStr)
 	o, err := cmd.CombinedOutput()
 	if err != nil {
@@ -162,6 +161,7 @@ func defaultLCOWOptions(t testing.TB) *uvm.OptionsLCOW {
 	return opts
 }
 
+//nolint:deadcode,unused // will be used when WCOW tests are updated
 func defaultWCOWOptions(t testing.TB) *uvm.OptionsWCOW {
 	opts := uvm.NewDefaultOptionsWCOW(cleanName(t.Name()), "")
 

--- a/test/functional/uvm_mem_backingtype_test.go
+++ b/test/functional/uvm_mem_backingtype_test.go
@@ -17,16 +17,19 @@ import (
 	tuvm "github.com/Microsoft/hcsshim/test/internal/uvm"
 )
 
+//nolint:unused // unused since tests are skipped
 func runMemStartLCOWTest(t *testing.T, opts *uvm.OptionsLCOW) {
 	u := tuvm.CreateAndStartLCOWFromOpts(context.Background(), t, opts)
 	u.Close()
 }
 
+//nolint:unused // unused since tests are skipped
 func runMemStartWCOWTest(t *testing.T, opts *uvm.OptionsWCOW) {
 	u, _, _ := tuvm.CreateWCOWUVMFromOptsWithImage(context.Background(), t, opts, "microsoft/nanoserver")
 	u.Close()
 }
 
+//nolint:unused // unused since tests are skipped
 func runMemTests(t *testing.T, os string) {
 	type testCase struct {
 		allowOvercommit      bool
@@ -72,6 +75,7 @@ func TestMemBackingTypeLCOW(t *testing.T) {
 	runMemTests(t, "linux")
 }
 
+//nolint:unused // unused since tests are skipped
 func runBenchMemStartTest(b *testing.B, opts *uvm.OptionsLCOW) {
 	// Cant use testutilities here because its `testing.B` not `testing.T`
 	u, err := uvm.CreateLCOW(context.Background(), opts)
@@ -84,6 +88,7 @@ func runBenchMemStartTest(b *testing.B, opts *uvm.OptionsLCOW) {
 	}
 }
 
+//nolint:unused // unused since tests are skipped
 func runBenchMemStartLcowTest(b *testing.B, allowOvercommit bool, enableDeferredCommit bool) {
 	for i := 0; i < b.N; i++ {
 		opts := uvm.NewDefaultOptionsLCOW(b.Name(), "")

--- a/test/functional/uvm_scsi_test.go
+++ b/test/functional/uvm_scsi_test.go
@@ -55,6 +55,7 @@ func TestSCSIAddRemoveWCOW(t *testing.T) {
 	testSCSIAddRemoveSingle(t, u, `c:\`, "windows", layers)
 }
 
+//nolint:unused // unused since tests are skipped
 func testAddSCSI(u *uvm.UtilityVM, disks []string, pathPrefix string, usePath bool, reAdd bool) error {
 	for i := range disks {
 		uvmPath := ""
@@ -73,6 +74,7 @@ func testAddSCSI(u *uvm.UtilityVM, disks []string, pathPrefix string, usePath bo
 	return nil
 }
 
+//nolint:unused // unused since tests are skipped
 func testRemoveAllSCSI(u *uvm.UtilityVM, disks []string) error {
 	for i := range disks {
 		if err := u.RemoveSCSI(context.Background(), disks[i]); err != nil {
@@ -84,6 +86,8 @@ func testRemoveAllSCSI(u *uvm.UtilityVM, disks []string) error {
 
 // TODO this test is only needed until WCOW supports adding the same scsi device to
 // multiple containers
+//
+//nolint:unused // unused since tests are skipped
 func testSCSIAddRemoveSingle(t *testing.T, u *uvm.UtilityVM, pathPrefix string, operatingSystem string, wcowImageLayerFolders []string) {
 	numDisks := 63 // Windows: 63 as the UVM scratch is at 0:0
 	if operatingSystem == "linux" {
@@ -134,6 +138,7 @@ func testSCSIAddRemoveSingle(t *testing.T, u *uvm.UtilityVM, pathPrefix string, 
 	// TODO: Could extend to validate can't add a 64th disk (windows). 65th (linux).
 }
 
+//nolint:unused // unused since tests are skipped
 func testSCSIAddRemoveMultiple(t *testing.T, u *uvm.UtilityVM, pathPrefix string, operatingSystem string, wcowImageLayerFolders []string) {
 	numDisks := 63 // Windows: 63 as the UVM scratch is at 0:0
 	if operatingSystem == "linux" {

--- a/test/functional/uvm_virtualdevice_test.go
+++ b/test/functional/uvm_virtualdevice_test.go
@@ -19,6 +19,8 @@ import (
 const lcowGPUBootFilesPath = "C:\\ContainerPlat\\LinuxBootFiles\\nvidiagpu"
 
 // findTestDevices returns the first pcip device on the host
+//
+//nolint:unused // unused since tests are skipped
 func findTestVirtualDevice() (string, error) {
 	out, err := exec.Command(
 		"powershell",

--- a/test/functional/uvm_vpmem_test.go
+++ b/test/functional/uvm_vpmem_test.go
@@ -24,6 +24,7 @@ func TestVPMEM(t *testing.T) {
 	require.Build(t, osversion.RS5)
 	requireFeatures(t, featureLCOW, featureVPMEM)
 
+	//nolint:staticcheck // SA1019: TODO: replace `LayerFolders`
 	alpineLayers := layers.LayerFolders(t, "alpine")
 
 	ctx := context.Background()

--- a/test/functional/wcow_test.go
+++ b/test/functional/wcow_test.go
@@ -180,6 +180,8 @@ import (
 // Helper to stop a container.
 // Ones created through hcsoci methods will be of type cow.Container.
 // Ones created through hcsshim methods will be of type hcsshim.Container
+//
+//nolint:unused // unused since tests are skipped
 func stopContainer(t *testing.T, c interface{}) {
 	switch c := c.(type) {
 	case cow.Container:
@@ -190,7 +192,7 @@ func stopContainer(t *testing.T, c interface{}) {
 		} else {
 			t.Fatalf("Failed shutdown: %s", err)
 		}
-		c.Terminate(context.Background())
+		_ = c.Terminate(context.Background())
 
 	case hcsshim.Container:
 		if err := c.Shutdown(); err != nil {
@@ -202,7 +204,7 @@ func stopContainer(t *testing.T, c interface{}) {
 				t.Fatalf("Failed shutdown: %s", err)
 			}
 		}
-		c.Terminate()
+		_ = c.Terminate()
 	default:
 		t.Fatalf("unknown type")
 	}
@@ -210,12 +212,15 @@ func stopContainer(t *testing.T, c interface{}) {
 
 // Helper to launch a process in a container created through the hcsshim methods.
 // At the point of calling, the container must have been successfully created.
+//
+//nolint:unused // unused since tests are skipped
 func runShimCommand(t *testing.T,
 	c hcsshim.Container,
 	command string,
 	workdir string,
 	expectedExitCode int,
-	expectedOutput string) {
+	expectedOutput string,
+) {
 
 	if c == nil {
 		t.Fatalf("requested container to start is nil!")
@@ -247,7 +252,7 @@ func runShimCommand(t *testing.T,
 		t.Fatalf("Failed to get Stdio handles for process: %s", err)
 	}
 	buf := new(bytes.Buffer)
-	buf.ReadFrom(o)
+	_, _ = buf.ReadFrom(o)
 	out := strings.TrimSpace(buf.String())
 	if expectedOutput != "" {
 		if out != expectedOutput {
@@ -256,6 +261,7 @@ func runShimCommand(t *testing.T,
 	}
 }
 
+//nolint:unused // unused since tests are skipped
 func runShimCommands(t *testing.T, c hcsshim.Container) {
 	runShimCommand(t, c, `echo Hello`, `c:\`, 0, "Hello")
 
@@ -273,6 +279,7 @@ func runShimCommands(t *testing.T, c hcsshim.Container) {
 	runShimCommand(t, c, `ls`, `c:\mappedrw`, 0, `readwrite`)
 }
 
+//nolint:unused // unused since tests are skipped
 func runHcsCommands(t *testing.T, c cow.Container) {
 	runHcsCommand(t, c, `echo Hello`, `c:\`, 0, "Hello")
 
@@ -292,6 +299,8 @@ func runHcsCommands(t *testing.T, c cow.Container) {
 
 // Helper to launch a process in a container created through the hcsshim methods.
 // At the point of calling, the container must have been successfully created.
+//
+//nolint:unused // unused since tests are skipped
 func runHcsCommand(t *testing.T,
 	c cow.Container,
 	command string,
@@ -328,7 +337,7 @@ func runHcsCommand(t *testing.T,
 	}
 	_, o, _ := p.Stdio()
 	buf := new(bytes.Buffer)
-	buf.ReadFrom(o)
+	_, _ = buf.ReadFrom(o)
 	out := strings.TrimSpace(buf.String())
 	if expectedOutput != "" {
 		if out != expectedOutput {
@@ -342,6 +351,8 @@ func runHcsCommand(t *testing.T,
 const imageName = "busyboxw"
 
 // Creates two temp folders used for the mounts/mapped directories
+//
+//nolint:unused // unused since tests are skipped
 func createTestMounts(t *testing.T) (string, string) {
 	// Create two temp folders for mapped directories.
 	hostRWSharedDirectory := t.TempDir()
@@ -354,6 +365,8 @@ func createTestMounts(t *testing.T) (string, string) {
 }
 
 // For calling hcsshim interface, need hcsshim.Layer built from an images layer folders
+//
+//nolint:unused // unused since tests are skipped
 func generateShimLayersStruct(t *testing.T, imageLayers []string) []hcsshim.Layer {
 	var layers []hcsshim.Layer
 	for _, layerFolder := range imageLayers {
@@ -369,6 +382,7 @@ func TestWCOWArgonShim(t *testing.T) {
 
 	requireFeatures(t, featureWCOW)
 
+	//nolint:staticcheck // SA1019: TODO: replace `LayerFolders`
 	imageLayers := layers.LayerFolders(t, imageName)
 	argonShimMounted := false
 
@@ -383,7 +397,12 @@ func TestWCOWArgonShim(t *testing.T) {
 	// For cleanup on failure
 	defer func() {
 		if argonShimMounted {
-			layerspkg.UnmountContainerLayers(context.Background(), append(imageLayers, argonShimScratchDir), "", "", nil, layerspkg.UnmountOperationAll)
+			_ = layerspkg.UnmountContainerLayers(context.Background(),
+				append(imageLayers, argonShimScratchDir),
+				"",
+				"",
+				nil,
+				layerspkg.UnmountOperationAll)
 		}
 	}()
 
@@ -422,7 +441,14 @@ func TestWCOWArgonShim(t *testing.T) {
 	}
 	runShimCommands(t, argonShim)
 	stopContainer(t, argonShim)
-	if err := layerspkg.UnmountContainerLayers(context.Background(), append(imageLayers, argonShimScratchDir), "", "", nil, layerspkg.UnmountOperationAll); err != nil {
+	if err := layerspkg.UnmountContainerLayers(
+		context.Background(),
+		append(imageLayers, argonShimScratchDir),
+		"",
+		"",
+		nil,
+		layerspkg.UnmountOperationAll,
+	); err != nil {
 		t.Fatal(err)
 	}
 	argonShimMounted = false
@@ -435,6 +461,7 @@ func TestWCOWXenonShim(t *testing.T) {
 
 	requireFeatures(t, featureWCOW)
 
+	//nolint:staticcheck // SA1019: TODO: replace `LayerFolders`
 	imageLayers := layers.LayerFolders(t, imageName)
 
 	xenonShimScratchDir := t.TempDir()
@@ -480,6 +507,7 @@ func TestWCOWXenonShim(t *testing.T) {
 	stopContainer(t, xenonShim)
 }
 
+//nolint:unused // unused since tests are skipped
 func generateWCOWOciTestSpec(t *testing.T, imageLayers []string, scratchPath, hostRWSharedDirectory, hostROSharedDirectory string) *specs.Spec {
 	return &specs.Spec{
 		Windows: &specs.Windows{
@@ -505,6 +533,7 @@ func TestWCOWArgonOciV1(t *testing.T) {
 
 	requireFeatures(t, featureWCOW)
 
+	//nolint:staticcheck // SA1019: TODO: replace `LayerFolders`
 	imageLayers := layers.LayerFolders(t, imageName)
 	argonOci1Mounted := false
 	argonOci1ScratchDir := t.TempDir()
@@ -518,7 +547,7 @@ func TestWCOWArgonOciV1(t *testing.T) {
 	var argonOci1 cow.Container
 	defer func() {
 		if argonOci1Mounted {
-			resources.ReleaseResources(context.Background(), argonOci1Resources, nil, true)
+			_ = resources.ReleaseResources(context.Background(), argonOci1Resources, nil, true)
 		}
 	}()
 
@@ -553,6 +582,7 @@ func TestWCOWXenonOciV1(t *testing.T) {
 
 	requireFeatures(t, featureWCOW)
 
+	//nolint:staticcheck // SA1019: TODO: replace `LayerFolders`
 	imageLayers := layers.LayerFolders(t, imageName)
 	xenonOci1Mounted := false
 
@@ -573,7 +603,7 @@ func TestWCOWXenonOciV1(t *testing.T) {
 	var xenonOci1 cow.Container
 	defer func() {
 		if xenonOci1Mounted {
-			resources.ReleaseResources(context.Background(), xenonOci1Resources, nil, true)
+			_ = resources.ReleaseResources(context.Background(), xenonOci1Resources, nil, true)
 		}
 	}()
 
@@ -610,6 +640,7 @@ func TestWCOWArgonOciV2(t *testing.T) {
 	require.Build(t, osversion.RS5)
 	requireFeatures(t, featureWCOW)
 
+	//nolint:staticcheck // SA1019: TODO: replace `LayerFolders`
 	imageLayers := layers.LayerFolders(t, imageName)
 	argonOci2Mounted := false
 
@@ -624,7 +655,7 @@ func TestWCOWArgonOciV2(t *testing.T) {
 	var argonOci2 cow.Container
 	defer func() {
 		if argonOci2Mounted {
-			resources.ReleaseResources(context.Background(), argonOci2Resources, nil, true)
+			_ = resources.ReleaseResources(context.Background(), argonOci2Resources, nil, true)
 		}
 	}()
 
@@ -661,6 +692,7 @@ func TestWCOWXenonOciV2(t *testing.T) {
 	require.Build(t, osversion.RS5)
 	requireFeatures(t, featureWCOW)
 
+	//nolint:staticcheck // SA1019: TODO: replace `LayerFolders`
 	imageLayers := layers.LayerFolders(t, imageName)
 	xenonOci2Mounted := false
 	xenonOci2UVMCreated := false
@@ -681,7 +713,7 @@ func TestWCOWXenonOciV2(t *testing.T) {
 	var xenonOci2UVM *uvm.UtilityVM
 	defer func() {
 		if xenonOci2Mounted {
-			resources.ReleaseResources(context.Background(), xenonOci2Resources, xenonOci2UVM, true)
+			_ = resources.ReleaseResources(context.Background(), xenonOci2Resources, xenonOci2UVM, true)
 		}
 		if xenonOci2UVMCreated {
 			xenonOci2UVM.Close()

--- a/test/internal/containerd/containerd.go
+++ b/test/internal/containerd/containerd.go
@@ -34,7 +34,7 @@ func createGRPCConn(ctx context.Context, address string) (*grpc.ClientConn, erro
 	if err != nil {
 		return nil, err
 	}
-
+	//nolint:staticcheck //TODO: SA1019: grpc.WithInsecure is deprecated: use WithTransportCredentials and insecure.NewCredentials()
 	return grpc.DialContext(ctx, addr, grpc.WithInsecure(), grpc.WithContextDialer(dialer))
 }
 

--- a/test/internal/flag/flag.go
+++ b/test/internal/flag/flag.go
@@ -13,8 +13,8 @@ const FeatureFlagName = "feature"
 func NewFeatureFlag(all []string) *StringSlice {
 	ff := NewStringSlice()
 	flag.Var(ff, FeatureFlagName,
-		"The sets of functionality to test; can be set multiple times, or separated with commas."+
-			"Supported features: "+strings.Join(all, ","),
+		"the sets of functionality to test; can be set multiple times, or separated with commas. "+
+			"Supported features: "+strings.Join(all, ", "),
 	)
 
 	return ff

--- a/test/internal/uvm/wcow.go
+++ b/test/internal/uvm/wcow.go
@@ -12,7 +12,7 @@ import (
 )
 
 // CreateWCOWUVM creates a WCOW utility VM with all default options. Returns the
-// UtilityVM object; folder used as its scratch
+// UtilityVM object; folder used as its scratch.
 func CreateWCOWUVM(ctx context.Context, t testing.TB, id, image string) (*uvm.UtilityVM, []string, string) {
 	return CreateWCOWUVMFromOptsWithImage(ctx, t, uvm.NewDefaultOptionsWCOW(id, ""), image)
 }
@@ -25,28 +25,35 @@ func CreateWCOWUVMFromOpts(ctx context.Context, t testing.TB, opts *uvm.OptionsW
 		t.Fatalf("opts must bet set with LayerFolders")
 	}
 
-	uvm, err := uvm.CreateWCOW(ctx, opts)
+	vm, err := uvm.CreateWCOW(ctx, opts)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := uvm.Start(ctx); err != nil {
-		uvm.Close()
+	if err := vm.Start(ctx); err != nil {
+		vm.Close()
 		t.Fatal(err)
 	}
 
-	return uvm
+	return vm
 }
 
 // CreateWCOWUVMFromOptsWithImage creates a WCOW utility VM with the passed opts
 // builds the LayerFolders based on `image`. Returns the UtilityVM object;
-// folder used as its scratch
-func CreateWCOWUVMFromOptsWithImage(ctx context.Context, t testing.TB, opts *uvm.OptionsWCOW, image string) (*uvm.UtilityVM, []string, string) {
+// folder used as its scratch.
+//
+//nolint:staticcheck // SA5011: staticcheck thinks `opts` may be nil, even though we fail if it is
+func CreateWCOWUVMFromOptsWithImage(
+	ctx context.Context,
+	t testing.TB,
+	opts *uvm.OptionsWCOW,
+	image string,
+) (*uvm.UtilityVM, []string, string) {
 	t.Helper()
-
 	if opts == nil {
 		t.Fatal("opts must be set")
 	}
 
+	//nolint:staticcheck // SA1019: TODO: switch from LayerFolders
 	uvmLayers := layers.LayerFolders(t, image)
 	scratchDir := t.TempDir()
 	opts.LayerFolders = append(opts.LayerFolders, uvmLayers...)

--- a/test/runhcs/e2e_matrix_test.go
+++ b/test/runhcs/e2e_matrix_test.go
@@ -177,7 +177,7 @@ func testWindows(t *testing.T, version int, isolated bool) {
 	}()
 	scratch := t.TempDir()
 	defer func() {
-		vhd.DetachVhd(filepath.Join(scratch, "sandbox.vhdx"))
+		_ = vhd.DetachVhd(filepath.Join(scratch, "sandbox.vhdx"))
 		os.RemoveAll(scratch)
 	}()
 
@@ -195,6 +195,7 @@ func testWindows(t *testing.T, version int, isolated bool) {
 
 	// Get the LayerFolders
 	imageName := getWindowsImageNameByVersion(t, version)
+	//nolint:staticcheck // SA1019: TODO: replace `LayerFolders`
 	layers := layers.LayerFolders(t, imageName)
 	for _, layer := range layers {
 		g.AddWindowsLayerFolders(layer)
@@ -242,7 +243,7 @@ func testWindows(t *testing.T, version int, isolated bool) {
 		return
 	}
 	defer func() {
-		rhcs.Delete(ctx, t.Name(), &runhcs.DeleteOpts{Force: true})
+		_ = rhcs.Delete(ctx, t.Name(), &runhcs.DeleteOpts{Force: true})
 	}()
 
 	// Find the shim/vmshim process and begin exit wait
@@ -265,7 +266,7 @@ func testWindows(t *testing.T, version int, isolated bool) {
 	}
 	defer func() {
 		if err != nil {
-			rhcs.Kill(ctx, t.Name(), "CtrlC")
+			_ = rhcs.Kill(ctx, t.Name(), "CtrlC")
 		}
 	}()
 
@@ -286,7 +287,7 @@ func testWindows(t *testing.T, version int, isolated bool) {
 	}
 
 	// Wait for the relay to exit
-	tio.Wait()
+	_ = tio.Wait()
 	outString := tio.outBuff.String()
 	if outString != "Hello World!\r\n" {
 		t.Errorf("stdout expected: 'Hello World!', got: '%v'", outString)


### PR DESCRIPTION
Currently linting is not run on files with the `admin`, `functional`, or `integration` build constraints, which precludes test files within `hcn` and `./internal/safefiles`.
Additionally, `golanglint-ci` only processes a module, so it does not lint the `./test` directory.

This PR updates the CI to run both from the root and from within the `test` module.
Additionally, it updates the build tags used by the linters, excludes the files within `cri-containerd/test-images` (since they are just used for building docker images to test with), and ignores linting errors that the package name `cri-containerd` is invalid because of the `-`.

Finally, the second commit updates files to conform to the linter.