### PR TITLE
Add support for accepting Rego policy code.

### DIFF
--- a/internal/guest/runtime/hcsv2/uvm.go
+++ b/internal/guest/runtime/hcsv2/uvm.go
@@ -79,22 +79,16 @@ func NewHost(rtime runtime.Runtime, vsock transport.Transport) *Host {
 // so we first have to remove the base64 encoding that allows
 // the JSON based policy to be passed as a string. From there,
 // we decode the JSON and setup our security policy state
-func (h *Host) SetSecurityPolicy(enforcerType, base64Policy string) error {
+func (h *Host) SetSecurityPolicy(enforcerType, base64EncodedPolicy string) error {
 	h.policyMutex.Lock()
 	defer h.policyMutex.Unlock()
 	if h.securityPolicyEnforcerSet {
 		return errors.New("security policy has already been set")
 	}
 
-	// construct security policy state
-	securityPolicyState, err := securitypolicy.NewSecurityPolicyState(base64Policy)
-	if err != nil {
-		return err
-	}
-
 	p, err := securitypolicy.CreateSecurityPolicyEnforcer(
 		enforcerType,
-		*securityPolicyState,
+		base64EncodedPolicy,
 		policy.DefaultCRIMounts(),
 		policy.DefaultCRIPrivilegedMounts(),
 	)
@@ -102,7 +96,7 @@ func (h *Host) SetSecurityPolicy(enforcerType, base64Policy string) error {
 		return err
 	}
 
-	hostData, err := securitypolicy.NewSecurityPolicyDigest(base64Policy)
+	hostData, err := securitypolicy.NewSecurityPolicyDigest(base64EncodedPolicy)
 	if err != nil {
 		return err
 	}

--- a/pkg/securitypolicy/framework.rego
+++ b/pkg/securitypolicy/framework.rego
@@ -117,3 +117,55 @@ mountList_ok(container) {
         mount_ok(container, mount)
     }
 }
+
+# error messages
+
+default container_started := false
+container_started := true {
+    input.containerID in data.started
+}
+
+reason["container already started"] {
+    input.rule == "create_container"
+    container_started
+}
+
+default command_matches := false
+command_matches := true {
+    some container in data.policy.containers
+    data.framework.command_ok(container)
+}
+
+reason["invalid command"] {
+    not command_matches
+}
+
+default envList_matches := false
+envList_matches := true {
+    some container in data.policy.containers
+    data.framework.envList_ok(container)
+}
+
+reason["invalid env list"] {
+    not envList_matches
+}
+
+default workingDirectory_matches := false
+workingDirectory_matches := true {
+    some container in data.policy.containers
+    data.framework.workingDirectory_ok(container)
+}
+
+reason["invalid working directory"] {
+    not workingDirectory_matches
+}
+
+default mountList_matches := false
+mountList_matches := true {
+    some container in data.policy.containers
+    data.framework.mountList_ok(container)
+}
+
+reason["invalid mount list"] {
+    not mountList_matches
+}

--- a/pkg/securitypolicy/open_door.rego
+++ b/pkg/securitypolicy/open_door.rego
@@ -1,0 +1,5 @@
+package policy
+
+mount_device := true
+mount_overlay := true
+create_container := true 

--- a/pkg/securitypolicy/policy.rego
+++ b/pkg/securitypolicy/policy.rego
@@ -3,14 +3,11 @@ package policy
 import future.keywords.every
 import future.keywords.in
 
+##OBJECTS##
+
 default mount_device := false
 mount_device := true {
     data.framework.mount_device
-}
-
-mount_device := true {
-    count(data.policy.containers) == 0
-    data.policy.allow_all
 }
 
 default mount_overlay := false
@@ -18,80 +15,9 @@ mount_overlay := true {
     data.framework.mount_overlay
 }
 
-mount_overlay := true {
-    count(data.policy.containers) == 0
-    data.policy.allow_all
-}
-
-default container_started := false
-container_started := true {
-    input.containerID in data.started
-}
-
 default create_container := false
 create_container := true {
     data.framework.create_container
 }
 
-
-create_container := true {
-    count(data.policy.containers) == 0
-    data.policy.allow_all
-}
-
-default mount := false
-mount := true {
-    data.framework.mount
-}
-
-mount := true {
-    count(data.policy.containers) == 0
-    data.policy.allow_all
-}
-
-# error messages
-
-reason["container already started"] {
-    input.rule == "create_container"
-    container_started
-}
-
-default command_matches := false
-command_matches := true {
-    some container in data.policy.containers
-    data.framework.command_ok(container)
-}
-
-reason["invalid command"] {
-    not command_matches
-}
-
-default envList_matches := false
-envList_matches := true {
-    some container in data.policy.containers
-    data.framework.envList_ok(container)
-}
-
-reason["invalid env list"] {
-    not envList_matches
-}
-
-default workingDirectory_matches := false
-workingDirectory_matches := true {
-    some container in data.policy.containers
-    data.framework.workingDirectory_ok(container)
-}
-
-reason["invalid working directory"] {
-    not workingDirectory_matches
-}
-
-default mountList_matches := false
-mountList_matches := true {
-    some container in data.policy.containers
-    data.framework.mountList_ok(container)
-}
-
-reason["invalid mount list"] {
-    not mountList_matches
-}
+reason := data.framework.reason

--- a/pkg/securitypolicy/securitypolicy_internal.go
+++ b/pkg/securitypolicy/securitypolicy_internal.go
@@ -1,0 +1,140 @@
+package securitypolicy
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// Internal version of SecurityPolicy
+type securityPolicyInternal struct {
+	Containers []*securityPolicyContainer
+}
+
+// Internal version of Container
+type securityPolicyContainer struct {
+	// The command that we will allow the container to execute
+	Command []string
+	// The rules for determining if a given environment variable is allowed
+	EnvRules []EnvRuleConfig
+	// An ordered list of dm-verity root hashes for each layer that makes up
+	// "a container". Containers are constructed as an overlay file system. The
+	// order that the layers are overlayed is important and needs to be enforced
+	// as part of policy.
+	Layers []string
+	// WorkingDir is a path to container's working directory, which all the processes
+	// will default to.
+	WorkingDir string
+	// A list of constraints for determining if a given mount is allowed.
+	Mounts        []mountInternal
+	AllowElevated bool
+}
+
+// Internal version of Mount
+type mountInternal struct {
+	Source      string
+	Destination string
+	Type        string
+	Options     []string
+}
+
+func (c Container) toInternal() (securityPolicyContainer, error) {
+	command, err := c.Command.toInternal()
+	if err != nil {
+		return securityPolicyContainer{}, err
+	}
+
+	envRules, err := c.EnvRules.toInternal()
+	if err != nil {
+		return securityPolicyContainer{}, err
+	}
+
+	layers, err := c.Layers.toInternal()
+	if err != nil {
+		return securityPolicyContainer{}, err
+	}
+
+	mounts, err := c.Mounts.toInternal()
+	if err != nil {
+		return securityPolicyContainer{}, err
+	}
+	return securityPolicyContainer{
+		Command:  command,
+		EnvRules: envRules,
+		Layers:   layers,
+		// No need to have toInternal(), because WorkingDir is a string both
+		// internally and in the policy.
+		WorkingDir:    c.WorkingDir,
+		Mounts:        mounts,
+		AllowElevated: c.AllowElevated,
+	}, nil
+}
+
+func (c CommandArgs) toInternal() ([]string, error) {
+	return stringMapToStringArray(c.Elements)
+}
+
+func (e EnvRules) toInternal() ([]EnvRuleConfig, error) {
+	envRulesMapLength := len(e.Elements)
+	envRules := make([]EnvRuleConfig, envRulesMapLength)
+	for i := 0; i < envRulesMapLength; i++ {
+		eIndex := strconv.Itoa(i)
+		elem, ok := e.Elements[eIndex]
+		if !ok {
+			return nil, fmt.Errorf("env rule with index %q doesn't exist", eIndex)
+		}
+		rule := EnvRuleConfig{
+			Strategy: elem.Strategy,
+			Rule:     elem.Rule,
+		}
+		envRules[i] = rule
+	}
+
+	return envRules, nil
+}
+
+func (l Layers) toInternal() ([]string, error) {
+	return stringMapToStringArray(l.Elements)
+}
+
+func (o Options) toInternal() ([]string, error) {
+	return stringMapToStringArray(o.Elements)
+}
+
+func (m Mounts) toInternal() ([]mountInternal, error) {
+	mountLength := len(m.Elements)
+	mountConstraints := make([]mountInternal, mountLength)
+	for i := 0; i < mountLength; i++ {
+		mIndex := strconv.Itoa(i)
+		mount, ok := m.Elements[mIndex]
+		if !ok {
+			return nil, fmt.Errorf("mount constraint with index %q not found", mIndex)
+		}
+		opts, err := mount.Options.toInternal()
+		if err != nil {
+			return nil, err
+		}
+		mountConstraints[i] = mountInternal{
+			Source:      mount.Source,
+			Destination: mount.Destination,
+			Type:        mount.Type,
+			Options:     opts,
+		}
+	}
+	return mountConstraints, nil
+}
+
+func stringMapToStringArray(m map[string]string) ([]string, error) {
+	mapSize := len(m)
+	out := make([]string, mapSize)
+
+	for i := 0; i < mapSize; i++ {
+		index := strconv.Itoa(i)
+		value, ok := m[index]
+		if !ok {
+			return nil, fmt.Errorf("element with index %q not found", index)
+		}
+		out[i] = value
+	}
+
+	return out, nil
+}

--- a/pkg/securitypolicy/securitypolicy_marshal.go
+++ b/pkg/securitypolicy/securitypolicy_marshal.go
@@ -1,0 +1,242 @@
+package securitypolicy
+
+/** TODO
+ *  Once JSON output/input functionality is removed, this code should be
+ *  moved to the securitypolicy tool.
+ */
+
+import (
+	_ "embed"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+type marshalFunc func(allowAll bool, containers []*Container) (string, error)
+
+const (
+	jsonMarshaller = "json"
+	regoMarshaller = "rego"
+)
+
+var (
+	registeredMarshallers = map[string]marshalFunc{}
+	defaultMarshaller     = jsonMarshaller
+)
+
+func init() {
+	registeredMarshallers[jsonMarshaller] = marshalJSON
+	registeredMarshallers[regoMarshaller] = marshalRego
+}
+
+//go:embed policy.rego
+var policyRegoTemplate string
+
+//go:embed open_door.rego
+var openDoorRegoTemplate string
+
+func marshalJSON(allowAll bool, containers []*Container) (string, error) {
+	var policy *SecurityPolicy
+	if allowAll {
+		if len(containers) > 0 {
+			return "", ErrInvalidOpenDoorPolicy
+		}
+
+		policy = NewOpenDoorPolicy()
+	} else {
+		policy = NewSecurityPolicy(allowAll, containers)
+	}
+
+	policyCode, err := json.Marshal(policy)
+	if err != nil {
+		return "", err
+	}
+
+	return string(policyCode), nil
+}
+
+func marshalRego(allowAll bool, containers []*Container) (string, error) {
+	if allowAll {
+		if len(containers) > 0 {
+			return "", ErrInvalidOpenDoorPolicy
+		}
+
+		return openDoorRegoTemplate, nil
+	}
+
+	var policy securityPolicyInternal
+	policy.Containers = make([]*securityPolicyContainer, len(containers))
+	for i, cConf := range containers {
+		cInternal, err := cConf.toInternal()
+		if err != nil {
+			return "", err
+		}
+		policy.Containers[i] = &cInternal
+	}
+
+	return policy.marshalRego(), nil
+}
+
+func MarshalPolicy(marshaller string, allowAll bool, containers []*Container) (string, error) {
+	if marshaller == "" {
+		marshaller = defaultMarshaller
+	}
+
+	if marshal, ok := registeredMarshallers[marshaller]; !ok {
+		return "", fmt.Errorf("unknown marshaller: %q", marshaller)
+	} else {
+		return marshal(allowAll, containers)
+	}
+}
+
+// Custom JSON marshalling to add `length` field that matches the number of
+// elements present in the `elements` field.
+
+func (c Containers) MarshalJSON() ([]byte, error) {
+	type Alias Containers
+	return json.Marshal(&struct {
+		Length int `json:"length"`
+		*Alias
+	}{
+		Length: len(c.Elements),
+		Alias:  (*Alias)(&c),
+	})
+}
+
+func (e EnvRules) MarshalJSON() ([]byte, error) {
+	type Alias EnvRules
+	return json.Marshal(&struct {
+		Length int `json:"length"`
+		*Alias
+	}{
+		Length: len(e.Elements),
+		Alias:  (*Alias)(&e),
+	})
+}
+
+func (s StringArrayMap) MarshalJSON() ([]byte, error) {
+	type Alias StringArrayMap
+	return json.Marshal(&struct {
+		Length int `json:"length"`
+		*Alias
+	}{
+		Length: len(s.Elements),
+		Alias:  (*Alias)(&s),
+	})
+}
+
+func (c CommandArgs) MarshalJSON() ([]byte, error) {
+	return json.Marshal(StringArrayMap(c))
+}
+
+func (l Layers) MarshalJSON() ([]byte, error) {
+	return json.Marshal(StringArrayMap(l))
+}
+
+func (o Options) MarshalJSON() ([]byte, error) {
+	return json.Marshal(StringArrayMap(o))
+}
+
+func (m Mounts) MarshalJSON() ([]byte, error) {
+	type Alias Mounts
+	return json.Marshal(&struct {
+		Length int `json:"length"`
+		*Alias
+	}{
+		Length: len(m.Elements),
+		Alias:  (*Alias)(&m),
+	})
+}
+
+// Marshaling for creating Rego policy code
+
+var indentUsing string = "    "
+
+type stringArray []string
+
+func (array stringArray) marshalRego() string {
+	values := make([]string, len(array))
+	for i, value := range array {
+		values[i] = fmt.Sprintf(`"%s"`, value)
+	}
+
+	return fmt.Sprintf("[%s]", strings.Join(values, ","))
+}
+
+func writeLine(builder *strings.Builder, format string, args ...interface{}) {
+	builder.WriteString(fmt.Sprintf(format, args...) + "\n")
+}
+
+func writeCommand(builder *strings.Builder, command []string, indent string) {
+	array := (stringArray(command)).marshalRego()
+	writeLine(builder, `%s"command": %s,`, indent, array)
+}
+
+func (e EnvRuleConfig) marshalRego() string {
+	return fmt.Sprintf(`{"pattern": "%s", "strategy": "%s"}`, e.Rule, e.Strategy)
+}
+
+type envRuleArray []EnvRuleConfig
+
+func (array envRuleArray) marshalRego() string {
+	values := make([]string, len(array))
+	for i, env := range array {
+		values[i] = env.marshalRego()
+	}
+
+	return fmt.Sprintf("[%s]", strings.Join(values, ","))
+}
+
+func writeEnvRules(builder *strings.Builder, envRules []EnvRuleConfig, indent string) {
+	writeLine(builder, `%s"env_rules": %s,`, indent, envRuleArray(envRules).marshalRego())
+}
+
+func writeLayers(builder *strings.Builder, layers []string, indent string) {
+	writeLine(builder, `%s"layers": %s,`, indent, (stringArray(layers)).marshalRego())
+}
+
+func (m mountInternal) marshalRego() string {
+	options := stringArray(m.Options).marshalRego()
+	return fmt.Sprintf(`{"destination": "%s", "options": %s, "source": "%s", "type": "%s"}`, m.Destination, options, m.Source, m.Type)
+}
+
+func writeMounts(builder *strings.Builder, mounts []mountInternal, indent string) {
+	values := make([]string, len(mounts))
+	for i, mount := range mounts {
+		values[i] = mount.marshalRego()
+	}
+
+	writeLine(builder, `%s"mounts": [%s],`, indent, strings.Join(values, ","))
+}
+
+func writeContainer(builder *strings.Builder, container *securityPolicyContainer, indent string, end string) {
+	writeLine(builder, "%s{", indent)
+	writeCommand(builder, container.Command, indent+indentUsing)
+	writeEnvRules(builder, container.EnvRules, indent+indentUsing)
+	writeLayers(builder, container.Layers, indent+indentUsing)
+	writeMounts(builder, container.Mounts, indent+indentUsing)
+	writeLine(builder, `%s"allow_elevated": %v,`, indent+indentUsing, container.AllowElevated)
+	writeLine(builder, `%s"working_dir": "%s"`, indent+indentUsing, container.WorkingDir)
+	writeLine(builder, "%s}%s", indent, end)
+}
+
+func addContainers(builder *strings.Builder, containers []*securityPolicyContainer) {
+	writeLine(builder, "containers := [")
+
+	for i, container := range containers {
+		end := ","
+		if i == len(containers)-1 {
+			end = ""
+		}
+		writeContainer(builder, container, indentUsing, end)
+	}
+
+	writeLine(builder, "]")
+}
+
+func (p securityPolicyInternal) marshalRego() string {
+	builder := new(strings.Builder)
+	addContainers(builder, p.Containers)
+	objects := builder.String()
+	return strings.Replace(policyRegoTemplate, "##OBJECTS##", objects, 1)
+}

--- a/test/cri-containerd/policy_test.go
+++ b/test/cri-containerd/policy_test.go
@@ -5,6 +5,7 @@ package cri_containerd
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -24,29 +25,28 @@ var (
 
 type configSideEffect func(*runtime.CreateContainerRequest) error
 
-func securityPolicyFromContainers(containers []securitypolicy.ContainerConfig) (string, error) {
+func securityPolicyFromContainers(policyType string, containers []securitypolicy.ContainerConfig) (string, error) {
 	pc, err := helpers.PolicyContainersFromConfigs(containers)
 	if err != nil {
 		return "", err
 	}
-	p := securitypolicy.NewSecurityPolicy(false, pc)
-	pString, err := p.EncodeToString()
+	policyString, err := securitypolicy.MarshalPolicy(policyType, false, pc)
 	if err != nil {
 		return "", err
 	}
-	return pString, nil
+	return base64.StdEncoding.EncodeToString([]byte(policyString)), nil
 }
 
-func sandboxSecurityPolicy(t *testing.T) string {
+func sandboxSecurityPolicy(t *testing.T, policyType string) string {
 	defaultContainers := helpers.DefaultContainerConfigs()
-	policyString, err := securityPolicyFromContainers(defaultContainers)
+	policyString, err := securityPolicyFromContainers(policyType, defaultContainers)
 	if err != nil {
 		t.Fatalf("failed to create security policy string: %s", err)
 	}
 	return policyString
 }
 
-func alpineSecurityPolicy(t *testing.T, opts ...securitypolicy.ContainerConfigOpt) string {
+func alpineSecurityPolicy(t *testing.T, policyType string, opts ...securitypolicy.ContainerConfigOpt) string {
 	defaultContainers := helpers.DefaultContainerConfigs()
 
 	alpineContainer := securitypolicy.ContainerConfig{
@@ -61,7 +61,7 @@ func alpineSecurityPolicy(t *testing.T, opts ...securitypolicy.ContainerConfigOp
 	}
 
 	containers := append(defaultContainers, alpineContainer)
-	policyString, err := securityPolicyFromContainers(containers)
+	policyString, err := securityPolicyFromContainers(policyType, containers)
 	if err != nil {
 		t.Fatalf("failed to create security policy string: %s", err)
 	}
@@ -82,94 +82,83 @@ func sandboxRequestWithPolicy(t *testing.T, policy string) *runtime.RunPodSandbo
 	)
 }
 
+type policyConfig struct {
+	enforcer string
+	input    string
+}
+
+var policyTestMatrix = []policyConfig{
+	{
+		enforcer: "rego",
+		input:    "rego",
+	},
+	{
+		enforcer: "rego",
+		input:    "json",
+	},
+	{
+		enforcer: "standard",
+		input:    "json",
+	},
+}
+
 func Test_RunPodSandbox_WithPolicy_Allowed(t *testing.T) {
 	requireFeatures(t, featureLCOW, featureLCOWIntegrity)
 	pullRequiredLCOWImages(t, []string{imageLcowK8sPause})
-
-	sandboxPolicy := sandboxSecurityPolicy(t)
 
 	client := newTestRuntimeClient(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	sandboxRequest := sandboxRequestWithPolicy(t, sandboxPolicy)
+	for _, pc := range policyTestMatrix {
+		t.Run(t.Name()+fmt.Sprintf("_Enforcer_%s_Input_%s", pc.enforcer, pc.input), func(t *testing.T) {
+			sandboxPolicy := sandboxSecurityPolicy(t, pc.input)
+			sandboxRequest := sandboxRequestWithPolicy(t, sandboxPolicy)
+			sandboxRequest.Config.Annotations[annotations.SecurityPolicyEnforcer] = pc.enforcer
 
-	podID := runPodSandbox(t, client, ctx, sandboxRequest)
-	defer removePodSandbox(t, client, ctx, podID)
-	defer stopPodSandbox(t, client, ctx, podID)
+			podID := runPodSandbox(t, client, ctx, sandboxRequest)
+			defer removePodSandbox(t, client, ctx, podID)
+			defer stopPodSandbox(t, client, ctx, podID)
+		})
+	}
 }
 
 func Test_RunSimpleAlpineContainer_WithPolicy_Allowed(t *testing.T) {
 	requireFeatures(t, featureLCOW, featureLCOWIntegrity)
 	pullRequiredLCOWImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
 
-	alpinePolicy := alpineSecurityPolicy(t)
-
 	client := newTestRuntimeClient(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	sandboxRequest := sandboxRequestWithPolicy(t, alpinePolicy)
+	for _, pc := range policyTestMatrix {
+		t.Run(t.Name()+fmt.Sprintf("_Enforcer_%s_Input_%s", pc.enforcer, pc.input), func(t *testing.T) {
+			alpinePolicy := alpineSecurityPolicy(t, pc.input)
+			sandboxRequest := sandboxRequestWithPolicy(t, alpinePolicy)
+			sandboxRequest.Config.Annotations[annotations.SecurityPolicyEnforcer] = pc.enforcer
 
-	podID := runPodSandbox(t, client, ctx, sandboxRequest)
-	defer removePodSandbox(t, client, ctx, podID)
-	defer stopPodSandbox(t, client, ctx, podID)
+			podID := runPodSandbox(t, client, ctx, sandboxRequest)
+			defer removePodSandbox(t, client, ctx, podID)
+			defer stopPodSandbox(t, client, ctx, podID)
 
-	containerRequest := getCreateContainerRequest(
-		podID,
-		"alpine-with-policy",
-		"alpine:latest",
-		validPolicyAlpineCommand,
-		sandboxRequest.Config,
-	)
+			containerRequest := getCreateContainerRequest(
+				podID,
+				"alpine-with-policy",
+				"alpine:latest",
+				validPolicyAlpineCommand,
+				sandboxRequest.Config,
+			)
 
-	containerID := createContainer(t, client, ctx, containerRequest)
-	defer removeContainer(t, client, ctx, containerID)
+			containerID := createContainer(t, client, ctx, containerRequest)
+			defer removeContainer(t, client, ctx, containerID)
 
-	startContainer(t, client, ctx, containerID)
-	stopContainer(t, client, ctx, containerID)
+			startContainer(t, client, ctx, containerID)
+			stopContainer(t, client, ctx, containerID)
+		})
+	}
 }
 
-func syncContainerRequests(
-	writer, waiter *securitypolicy.ContainerConfig,
-	podID string,
-	podConfig *runtime.PodSandboxConfig,
-) (writerReq, waiterReq *runtime.CreateContainerRequest) {
-	writerReq = getCreateContainerRequest(
-		podID,
-		"alpine-writer",
-		"alpine:latest",
-		writer.Command,
-		podConfig,
-	)
-	writerReq.Config.Mounts = append(
-		writerReq.Config.Mounts, &runtime.Mount{
-			HostPath:      "sandbox://host/path",
-			ContainerPath: "/mnt/shared/container-A",
-			Propagation:   runtime.MountPropagation_PROPAGATION_BIDIRECTIONAL,
-		},
-	)
-
-	waiterReq = getCreateContainerRequest(
-		podID,
-		"alpine-waiter",
-		"alpine:latest",
-		waiter.Command,
-		podConfig,
-	)
-	waiterReq.Config.Mounts = append(
-		waiterReq.Config.Mounts, &runtime.Mount{
-			// The HostPath must be the same as for the "writer" container
-			HostPath:      "sandbox://host/path",
-			ContainerPath: "/mnt/shared/container-B",
-			Propagation:   runtime.MountPropagation_PROPAGATION_BIDIRECTIONAL,
-		},
-	)
-
-	return writerReq, waiterReq
-}
-
-func Test_RunContainer_ValidContainerConfigs_Allowed(t *testing.T) {
+func Test_RunContainer_WithPolicy_And_ValidConfigs(t *testing.T) {
 	type sideEffect func(*runtime.CreateContainerRequest)
 	type config struct {
 		name string
@@ -214,32 +203,36 @@ func Test_RunContainer_ValidContainerConfigs_Allowed(t *testing.T) {
 			},
 		},
 	} {
-		t.Run(testConfig.name, func(t *testing.T) {
-			alpinePolicy := alpineSecurityPolicy(t, testConfig.opts...)
-			sandboxRequest := sandboxRequestWithPolicy(t, alpinePolicy)
+		for _, pc := range policyTestMatrix {
+			t.Run(testConfig.name+fmt.Sprintf("_Enforcer_%s_Input_%s", pc.enforcer, pc.input), func(t *testing.T) {
+				alpinePolicy := alpineSecurityPolicy(t, pc.input, testConfig.opts...)
+				sandboxRequest := sandboxRequestWithPolicy(t, alpinePolicy)
+				sandboxRequest.Config.Annotations[annotations.SecurityPolicyEnforcer] = pc.enforcer
 
-			podID := runPodSandbox(t, client, ctx, sandboxRequest)
-			defer removePodSandbox(t, client, ctx, podID)
-			defer stopPodSandbox(t, client, ctx, podID)
+				podID := runPodSandbox(t, client, ctx, sandboxRequest)
+				defer removePodSandbox(t, client, ctx, podID)
+				defer stopPodSandbox(t, client, ctx, podID)
 
-			containerRequest := getCreateContainerRequest(
-				podID,
-				"alpine-with-policy",
-				"alpine:latest",
-				validPolicyAlpineCommand,
-				sandboxRequest.Config,
-			)
-			testConfig.sf(containerRequest)
+				containerRequest := getCreateContainerRequest(
+					podID,
+					"alpine-with-policy",
+					"alpine:latest",
+					validPolicyAlpineCommand,
+					sandboxRequest.Config,
+				)
+				testConfig.sf(containerRequest)
 
-			containerID := createContainer(t, client, ctx, containerRequest)
-			startContainer(t, client, ctx, containerID)
-			defer removeContainer(t, client, ctx, containerID)
-			defer stopContainer(t, client, ctx, containerID)
-		})
+				containerID := createContainer(t, client, ctx, containerRequest)
+				startContainer(t, client, ctx, containerID)
+				defer removeContainer(t, client, ctx, containerID)
+				defer stopContainer(t, client, ctx, containerID)
+			})
+		}
 	}
 }
 
-func Test_RunContainer_InvalidContainerConfigs_NotAllowed(t *testing.T) {
+// todo (maksiman): add coverage for rego enforcer
+func Test_RunContainer_WithPolicy_And_InvalidConfigs(t *testing.T) {
 	type config struct {
 		name          string
 		sf            configSideEffect
@@ -253,7 +246,6 @@ func Test_RunContainer_InvalidContainerConfigs_NotAllowed(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	alpinePolicy := alpineSecurityPolicy(t)
 	for _, testConfig := range []config{
 		{
 			name: "InvalidWorkingDir",
@@ -286,7 +278,9 @@ func Test_RunContainer_InvalidContainerConfigs_NotAllowed(t *testing.T) {
 		},
 	} {
 		t.Run(testConfig.name, func(t *testing.T) {
+			alpinePolicy := alpineSecurityPolicy(t, "json")
 			sandboxRequest := sandboxRequestWithPolicy(t, alpinePolicy)
+			sandboxRequest.Config.Annotations[annotations.SecurityPolicyEnforcer] = "standard"
 
 			podID := runPodSandbox(t, client, ctx, sandboxRequest)
 			defer removePodSandbox(t, client, ctx, podID)
@@ -320,7 +314,7 @@ func Test_RunContainer_InvalidContainerConfigs_NotAllowed(t *testing.T) {
 	}
 }
 
-func Test_RunContainer_WithMountConstraints_Allowed(t *testing.T) {
+func Test_RunContainer_WithPolicy_And_MountConstraints_Allowed(t *testing.T) {
 	requireFeatures(t, featureLCOW, featureLCOWIntegrity)
 	pullRequiredLCOWImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
 
@@ -411,35 +405,39 @@ func Test_RunContainer_WithMountConstraints_Allowed(t *testing.T) {
 				)},
 		},
 	} {
-		t.Run(testConfig.name, func(t *testing.T) {
-			alpinePolicy := alpineSecurityPolicy(t, testConfig.opts...)
-			sandboxRequest := sandboxRequestWithPolicy(t, alpinePolicy)
+		for _, pc := range policyTestMatrix {
+			t.Run(testConfig.name+fmt.Sprintf("_Enforcer_%s_Input_%s", pc.enforcer, pc.input), func(t *testing.T) {
+				alpinePolicy := alpineSecurityPolicy(t, pc.input, testConfig.opts...)
+				sandboxRequest := sandboxRequestWithPolicy(t, alpinePolicy)
+				sandboxRequest.Config.Annotations[annotations.SecurityPolicyEnforcer] = pc.enforcer
 
-			podID := runPodSandbox(t, client, ctx, sandboxRequest)
-			defer removePodSandbox(t, client, ctx, podID)
-			defer stopPodSandbox(t, client, ctx, podID)
+				podID := runPodSandbox(t, client, ctx, sandboxRequest)
+				defer removePodSandbox(t, client, ctx, podID)
+				defer stopPodSandbox(t, client, ctx, podID)
 
-			containerRequest := getCreateContainerRequest(
-				podID,
-				"alpine-with-policy",
-				"alpine:latest",
-				validPolicyAlpineCommand,
-				sandboxRequest.Config,
-			)
+				containerRequest := getCreateContainerRequest(
+					podID,
+					"alpine-with-policy",
+					"alpine:latest",
+					validPolicyAlpineCommand,
+					sandboxRequest.Config,
+				)
 
-			if err := testConfig.sideEffect(containerRequest); err != nil {
-				t.Fatalf("failed to apply containerRequest side effect: %s", err)
-			}
+				if err := testConfig.sideEffect(containerRequest); err != nil {
+					t.Fatalf("failed to apply containerRequest side effect: %s", err)
+				}
 
-			containerID := createContainer(t, client, ctx, containerRequest)
-			startContainer(t, client, ctx, containerID)
-			defer removeContainer(t, client, ctx, containerID)
-			defer stopContainer(t, client, ctx, containerID)
-		})
+				containerID := createContainer(t, client, ctx, containerRequest)
+				startContainer(t, client, ctx, containerID)
+				defer removeContainer(t, client, ctx, containerID)
+				defer stopContainer(t, client, ctx, containerID)
+			})
+		}
 	}
 }
 
-func Test_RunContainer_WithMountConstraints_NotAllowed(t *testing.T) {
+// todo (maksiman): add coverage for rego enforcer
+func Test_RunContainer_WithPolicy_And_MountConstraints_NotAllowed(t *testing.T) {
 	requireFeatures(t, featureLCOW, featureLCOWIntegrity)
 	pullRequiredLCOWImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
 
@@ -560,8 +558,9 @@ func Test_RunContainer_WithMountConstraints_NotAllowed(t *testing.T) {
 		},
 	} {
 		t.Run(testConfig.name, func(t *testing.T) {
-			alpinePolicy := alpineSecurityPolicy(t, testConfig.opts...)
+			alpinePolicy := alpineSecurityPolicy(t, "json", testConfig.opts...)
 			sandboxRequest := sandboxRequestWithPolicy(t, alpinePolicy)
+			sandboxRequest.Config.Annotations[annotations.SecurityPolicyEnforcer] = "standard"
 
 			podID := runPodSandbox(t, client, ctx, sandboxRequest)
 			defer removePodSandbox(t, client, ctx, podID)
@@ -595,7 +594,7 @@ func Test_RunContainer_WithMountConstraints_NotAllowed(t *testing.T) {
 	}
 }
 
-func Test_RunPrivilegedContainer_AllowElevated_Set(t *testing.T) {
+func Test_RunPrivilegedContainer_WithPolicy_And_AllowElevated_Set(t *testing.T) {
 	requireFeatures(t, featureLCOWIntegrity)
 	pullRequiredLCOWImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
 
@@ -603,36 +602,44 @@ func Test_RunPrivilegedContainer_AllowElevated_Set(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	alpinePolicy := alpineSecurityPolicy(t, securitypolicy.WithAllowElevated(true))
-	sandboxRequest := sandboxRequestWithPolicy(t, alpinePolicy)
-	sandboxRequest.Config.Linux = &runtime.LinuxPodSandboxConfig{
-		SecurityContext: &runtime.LinuxSandboxSecurityContext{
-			Privileged: true,
-		},
-	}
-	podID := runPodSandbox(t, client, ctx, sandboxRequest)
-	defer removePodSandbox(t, client, ctx, podID)
-	defer stopPodSandbox(t, client, ctx, podID)
+	for _, pc := range policyTestMatrix {
+		t.Run(t.Name()+fmt.Sprintf("_Enforcer_%s_Input_%s", pc.enforcer, pc.input), func(t *testing.T) {
+			alpinePolicy := alpineSecurityPolicy(t, pc.input, securitypolicy.WithAllowElevated(true))
+			sandboxRequest := sandboxRequestWithPolicy(t, alpinePolicy)
+			sandboxRequest.Config.Linux = &runtime.LinuxPodSandboxConfig{
+				SecurityContext: &runtime.LinuxSandboxSecurityContext{
+					Privileged: true,
+				},
+			}
+			sandboxRequest.Config.Annotations[annotations.SecurityPolicyEnforcer] = pc.enforcer
 
-	contRequest := getCreateContainerRequest(
-		podID,
-		"alpine-privileged",
-		"alpine:latest",
-		validPolicyAlpineCommand,
-		sandboxRequest.Config,
-	)
-	contRequest.Config.Linux = &runtime.LinuxContainerConfig{
-		SecurityContext: &runtime.LinuxContainerSecurityContext{
-			Privileged: true,
-		},
+			podID := runPodSandbox(t, client, ctx, sandboxRequest)
+			defer removePodSandbox(t, client, ctx, podID)
+			defer stopPodSandbox(t, client, ctx, podID)
+
+			contRequest := getCreateContainerRequest(
+				podID,
+				"alpine-privileged",
+				"alpine:latest",
+				validPolicyAlpineCommand,
+				sandboxRequest.Config,
+			)
+			contRequest.Config.Linux = &runtime.LinuxContainerConfig{
+				SecurityContext: &runtime.LinuxContainerSecurityContext{
+					Privileged: true,
+				},
+			}
+			containerID := createContainer(t, client, ctx, contRequest)
+			defer removeContainer(t, client, ctx, containerID)
+			startContainer(t, client, ctx, containerID)
+			defer stopContainer(t, client, ctx, containerID)
+		})
 	}
-	containerID := createContainer(t, client, ctx, contRequest)
-	defer removeContainer(t, client, ctx, containerID)
-	startContainer(t, client, ctx, containerID)
-	defer stopContainer(t, client, ctx, containerID)
+
 }
 
-func Test_RunPrivilegedContainer_AllowElevated_NotSet(t *testing.T) {
+// todo (maksiman): add coverage for rego enforcer
+func Test_RunPrivilegedContainer_WithPolicy_And_AllowElevated_NotSet(t *testing.T) {
 	requireFeatures(t, featureLCOWIntegrity)
 	pullRequiredLCOWImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
 
@@ -640,13 +647,15 @@ func Test_RunPrivilegedContainer_AllowElevated_NotSet(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	alpinePolicy := alpineSecurityPolicy(t)
+	alpinePolicy := alpineSecurityPolicy(t, "json")
 	sandboxRequest := sandboxRequestWithPolicy(t, alpinePolicy)
 	sandboxRequest.Config.Linux = &runtime.LinuxPodSandboxConfig{
 		SecurityContext: &runtime.LinuxSandboxSecurityContext{
 			Privileged: true,
 		},
 	}
+	sandboxRequest.Config.Annotations[annotations.SecurityPolicyEnforcer] = "standard"
+
 	podID := runPodSandbox(t, client, ctx, sandboxRequest)
 	defer removePodSandbox(t, client, ctx, podID)
 	defer stopPodSandbox(t, client, ctx, podID)
@@ -679,7 +688,8 @@ func Test_RunPrivilegedContainer_AllowElevated_NotSet(t *testing.T) {
 	}
 }
 
-func Test_CannotSet_AllowAll_And_Containers(t *testing.T) {
+// todo (maksiman): add coverage for rego enforcer
+func Test_RunContainer_WithPolicy_CannotSet_AllowAll_And_Containers(t *testing.T) {
 	requireFeatures(t, featureLCOW, featureLCOWIntegrity)
 	pullRequiredLCOWImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
 
@@ -708,7 +718,7 @@ func Test_CannotSet_AllowAll_And_Containers(t *testing.T) {
 	}
 }
 
-func Test_SecurityPolicyEnv_Annotation(t *testing.T) {
+func Test_RunContainer_WithPolicy_And_SecurityPolicyEnv_Annotation(t *testing.T) {
 	requireFeatures(t, featureLCOW, featureLCOWIntegrity)
 	pullRequiredLCOWImages(t, []string{imageLcowK8sPause, imageLcowAlpine})
 
@@ -717,17 +727,13 @@ func Test_SecurityPolicyEnv_Annotation(t *testing.T) {
 		t.Fatalf("failed to create open door policy string: %s", err)
 	}
 
-	// The command prints environment variables to stdout, which we can capture
-	// and validate later
-	alpineCmd := []string{"ash", "-c", "env"}
-	alpinePolicy := alpineSecurityPolicy(
-		t,
-		securitypolicy.WithCommand(alpineCmd),
-	)
-
 	client := newTestRuntimeClient(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+
+	// The command prints environment variables to stdout, which we can capture
+	// and validate later
+	alpineCmd := []string{"ash", "-c", "env"}
 
 	for _, config := range []struct {
 		name   string
@@ -739,7 +745,11 @@ func Test_SecurityPolicyEnv_Annotation(t *testing.T) {
 		},
 		{
 			name:   "StandardPolicy",
-			policy: alpinePolicy,
+			policy: alpineSecurityPolicy(t, "json", securitypolicy.WithCommand(alpineCmd)),
+		},
+		{
+			name:   "RegoPolicy",
+			policy: alpineSecurityPolicy(t, "rego", securitypolicy.WithCommand(alpineCmd)),
 		},
 	} {
 		for _, setPolicyEnv := range []bool{true, false} {


### PR DESCRIPTION
Refactors (due to build tags):
- Internal classes (needed for Rego marshaling) moved to `securitypolicy_internal.go`
- Marshal code (needed for Rego marshaling) moved to `securitypolicy_marshal.go`. Once the JSON input/output is removed, this code can safely be moved to the `securitypolicy` tool
- Rego error logic has been moved to `framework.rego`
- `open_door.rego` added as Rego alternative to OpenDoor, and the `allow_all` logic has been removed from `policy.rego`

New Features:
- `MarshalPolicy` method which supports turning a policy into either JSON or Rego
- `securitypolicy` now takes a `t` parameter that can be equal to either `rego` or `json` and a `r` parameter which indicates whether it should output the raw output in addition to the base64 encoded policy
- `createRegoEnforcer` can now handle either a JSON policy or a Rego policy as input