### PR TITLE
Add enforcement versioning to rego enforcer 

### DIFF
--- a/pkg/securitypolicy/api.rego
+++ b/pkg/securitypolicy/api.rego
@@ -1,0 +1,27 @@
+package api
+
+svn := "0.1.0"
+
+enforcement_points := {
+	"mount_device": {"introducedVersion": "0.1.0", "allowedByDefault": false},
+	"mount_overlay": {"introducedVersion": "0.1.0", "allowedByDefault": false},
+	"create_container": {"introducedVersion": "0.1.0", "allowedByDefault": false},
+    # the following rules are used for testing the default behavior logic. DO NOT REMOVE.
+    "__fixture_for_future_test__": {"introducedVersion": "100.0.0", "allowedByDefault": true},
+    "__fixture_for_allowed_test_true__": {"introducedVersion": "0.0.2", "allowedByDefault": true},
+    "__fixture_for_allowed_test_false__": {"introducedVersion": "0.0.2", "allowedByDefault": false},
+}
+
+default enforcement_point_info := {"available": false, "allowed": false, "unknown": true, "invalid": false}
+
+enforcement_point_info := {"available": available, "allowed": allowed, "unknown": false, "invalid": false} {
+	enforcement_point := enforcement_points[input.name]
+	semver.compare(svn, enforcement_point.introducedVersion) >= 0
+	available := semver.compare(data.policy.api_svn, enforcement_point.introducedVersion) >= 0
+	allowed := enforcement_point.allowedByDefault
+}
+
+enforcement_point_info := {"available": false, "allowed": false, "unknown": false, "invalid": true} {
+	enforcement_point := enforcement_points[input.name]
+	semver.compare(svn, enforcement_point.introducedVersion) < 0
+}

--- a/pkg/securitypolicy/policy.rego
+++ b/pkg/securitypolicy/policy.rego
@@ -1,5 +1,7 @@
 package policy
 
+api_svn := "0.1.0"
+
 import future.keywords.every
 import future.keywords.in
 

--- a/pkg/securitypolicy/securitypolicy_test.go
+++ b/pkg/securitypolicy/securitypolicy_test.go
@@ -38,6 +38,7 @@ const (
 	maxGeneratedMountDestinationLength        = 32
 	maxGeneratedMountOptions                  = 5
 	maxGeneratedMountOptionLength             = 32
+	maxGeneratedEnforcementPointLength        = 64
 	// additional consts
 	// the standard enforcer tests don't do anything with the encoded policy
 	// string. this const exists to make that explicit
@@ -1027,6 +1028,11 @@ func generateSandboxID(r *rand.Rand) string {
 	return randVariableString(r, maxGeneratedSandboxIDLength)
 }
 
+func generateEnforcementPoint(r *rand.Rand) string {
+	first := randChar(r)
+	return first + randString(r, atMost(r, maxGeneratedEnforcementPointLength))
+}
+
 func generateMounts(r *rand.Rand) []mountInternal {
 	numberOfMounts := atLeastOneAtMost(r, maxGeneratedMounts)
 	mounts := make([]mountInternal, numberOfMounts)
@@ -1116,10 +1122,11 @@ func selectContainerFromContainers(containers *generatedContainers, r *rand.Rand
 }
 
 type dataGenerator struct {
-	rng          *rand.Rand
-	mountTargets map[string]struct{}
-	containerIDs map[string]struct{}
-	sandboxIDs   map[string]struct{}
+	rng               *rand.Rand
+	mountTargets      map[string]struct{}
+	containerIDs      map[string]struct{}
+	sandboxIDs        map[string]struct{}
+	enforcementPoints map[string]struct{}
 }
 
 func newDataGenerator(rng *rand.Rand) *dataGenerator {
@@ -1128,6 +1135,11 @@ func newDataGenerator(rng *rand.Rand) *dataGenerator {
 		mountTargets: map[string]struct{}{},
 		containerIDs: map[string]struct{}{},
 		sandboxIDs:   map[string]struct{}{},
+		enforcementPoints: map[string]struct{}{
+			"mount_device":     {},
+			"mount_overlay":    {},
+			"create_container": {},
+		},
 	}
 }
 
@@ -1161,10 +1173,17 @@ func (gen *dataGenerator) uniqueSandboxID() string {
 	}
 }
 
-func (gen *dataGenerator) createValidOverlayForContainer(
-	enforcer SecurityPolicyEnforcer,
-	container *securityPolicyContainer,
-) ([]string, error) {
+func (gen *dataGenerator) uniqueEnforcementPoint() string {
+	for {
+		t := generateEnforcementPoint(gen.rng)
+		if _, ok := gen.enforcementPoints[t]; !ok {
+			gen.enforcementPoints[t] = struct{}{}
+			return t
+		}
+	}
+}
+
+func (gen *dataGenerator) createValidOverlayForContainer(enforcer SecurityPolicyEnforcer, container *securityPolicyContainer) ([]string, error) {
 	// storage for our mount paths
 	overlay := make([]string, len(container.Layers))
 
@@ -1256,6 +1275,11 @@ func (gen *dataGenerator) invalidOverlayRandomJunk(enforcer SecurityPolicyEnforc
 
 func randVariableString(r *rand.Rand, maxLen int32) string {
 	return randString(r, atLeastOneAtMost(r, maxLen))
+}
+
+func randChar(r *rand.Rand) string {
+	charset := "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+	return string(charset[r.Intn(len(charset))])
 }
 
 func randString(r *rand.Rand, length int32) string {


### PR DESCRIPTION
Adds versioning to the framework (and policies) to enable backwards compatibility and fine-tuned behavioral logic based upon version comparisons. Every enforcement point will now be explicitly linked to a minimum version and given a default behavior (allow/not allow) which should be applied automatically below that version. The logic looks like this:

```go
func (policy *regoEnforcer) allowed(enforcementPoint string, input map[string]interface{}) (bool, error) {
	results, err := policy.Query(enforcementPoint, input)
	if err != nil {
		// Rego execution error
		return false, err
	}

	if len(results) == 0 {
		// rule was undefined
		available, err := policy.enforcementPoints.isAvailableByVersion(enforcementPoint, policy.versionInfo)
		if err != nil {
			// unknown rule
			return false, err
		}

		if available {
			// policy should define this rule but it is missing
			return false, fmt.Errorf("rule for %s is missing from policy", enforcementPoint)
		} else {
			// rule added after policy was authored
			return policy.enforcementPoints.getDefaultBehavior(enforcementPoint)
		}
	}

	return results.Allowed(), nil
}
```

A Rego query for a rule that doesn't exist returns an empty result set. If we receive no results, we first check to see if the rule _should_ be there by checking whether it was introduced after the policy was authored. If the enforcement point should be defined (*i.e.* it was added before the policy was authored), we raise an error. If it is new, then we use the default behavior. If there are results, then the rule was present and we proceed as normal.

This logic allows us to add new enforcement points without breaking older policies.