### PR TITLE
Fix nil pointer dereference in addSCSI

### DIFF
--- a/internal/uvm/scsi.go
+++ b/internal/uvm/scsi.go
@@ -386,7 +386,7 @@ func (uvm *UtilityVM) AddSCSIExtensibleVirtualDisk(ctx context.Context, hostPath
 // so-on tracking what SCSI locations are available or used.
 //
 // Returns result from calling modify with the given scsi mount
-func (uvm *UtilityVM) addSCSIActual(ctx context.Context, addReq *addSCSIRequest) (sm *SCSIMount, err error) {
+func (uvm *UtilityVM) addSCSIActual(ctx context.Context, addReq *addSCSIRequest) (_ *SCSIMount, err error) {
 	sm, existed, err := uvm.allocateSCSIMount(
 		ctx,
 		addReq.readOnly,
@@ -421,10 +421,6 @@ func (uvm *UtilityVM) addSCSIActual(ctx context.Context, addReq *addSCSIRequest)
 		sm.waitErr = err
 		close(sm.waitCh)
 	}()
-
-	if uvm.scsiControllerCount == 0 {
-		return nil, ErrNoSCSIControllers
-	}
 
 	SCSIModification := &hcsschema.ModifySettingRequest{
 		RequestType: guestrequest.RequestTypeAdd,


### PR DESCRIPTION
The new change that we added to fix a race condition in addSCSI introduced a bug where the code ends up accessing a
nil pointer in certain situations. For example, the deferred function to unblock any waiters of the attach
SCSI operation accesses the scsi mount object to propagate any errors. However, this pointer is a named return
value of the function and is set to `nil` when returning an error. In those cases the deferred function panics
with the nil pointer dereference error. To fix this we don't use the named return value for the scsi mount
object anymore.
This change also removes the check for zero SCSI controllers since that check is done by the
`allocateSCSIMount` function.

Signed-off-by: Amit Barve <ambarve@microsoft.com>