### PR TITLE
Set HCSSHIM_UVM_REFERENCE_INFO env for workload containers

### DIFF
--- a/cmd/containerd-shim-runhcs-v1/pod.go
+++ b/cmd/containerd-shim-runhcs-v1/pod.go
@@ -153,7 +153,7 @@ func createPod(ctx context.Context, events publisher, req *task.CreateTaskReques
 				ctx,
 				uvm.WithSecurityPolicyEnforcer(lopts.SecurityPolicyEnforcer),
 				uvm.WithSecurityPolicy(lopts.SecurityPolicy),
-				uvm.WithSignedUVMMeasurement(filepath.Join(lopts.BootFilesPath, lopts.SignedUVMMeasurementFile)),
+				uvm.WithUVMReferenceInfo(lopts.BootFilesPath, lopts.UVMReferenceInfoFile),
 			); err != nil {
 				return nil, errors.Wrap(err, "unable to set security policy")
 			}

--- a/cmd/containerd-shim-runhcs-v1/pod.go
+++ b/cmd/containerd-shim-runhcs-v1/pod.go
@@ -149,8 +149,12 @@ func createPod(ctx context.Context, events publisher, req *task.CreateTaskReques
 		}
 
 		if lopts != nil {
-			err := parent.SetSecurityPolicy(ctx, lopts.SecurityPolicyEnforcer, lopts.SecurityPolicy)
-			if err != nil {
+			if err := parent.SetConfidentialUVMOptions(
+				ctx,
+				uvm.WithSecurityPolicyEnforcer(lopts.SecurityPolicyEnforcer),
+				uvm.WithSecurityPolicy(lopts.SecurityPolicy),
+				uvm.WithSignedUVMMeasurement(filepath.Join(lopts.BootFilesPath, lopts.SignedUVMMeasurementFile)),
+			); err != nil {
 				return nil, errors.Wrap(err, "unable to set security policy")
 			}
 		}

--- a/internal/guest/prot/protocol.go
+++ b/internal/guest/prot/protocol.go
@@ -578,9 +578,9 @@ func UnmarshalContainerModifySettings(b []byte) (*ContainerModifySettings, error
 		}
 		msr.Settings = cc
 	case guestresource.ResourceTypeSecurityPolicy:
-		enforcer := &guestresource.LCOWSecurityPolicyEnforcer{}
+		enforcer := &guestresource.LCOWConfidentialOptions{}
 		if err := commonutils.UnmarshalJSONWithHresult(msrRawSettings, enforcer); err != nil {
-			return &request, errors.Wrap(err, "failed to unmarshal settings as LCOWSecurityPolicyEnforcer")
+			return &request, errors.Wrap(err, "failed to unmarshal settings as LCOWConfidentialOptions")
 		}
 		msr.Settings = enforcer
 	default:

--- a/internal/guest/runtime/hcsv2/uvm.go
+++ b/internal/guest/runtime/hcsv2/uvm.go
@@ -59,6 +59,7 @@ type Host struct {
 	policyMutex               sync.Mutex
 	securityPolicyEnforcer    securitypolicy.SecurityPolicyEnforcer
 	securityPolicyEnforcerSet bool
+	signedUVMMeasurementInfo  string
 }
 
 func NewHost(rtime runtime.Runtime, vsock transport.Transport) *Host {
@@ -72,14 +73,17 @@ func NewHost(rtime runtime.Runtime, vsock transport.Transport) *Host {
 	}
 }
 
-// SetSecurityPolicy takes a base64 encoded security policy
-// and sets up our internal data structures we use to store
-// said policy.
+// SetConfidentialUVMOptions takes a security policy enforcer type, base64
+// encoded security policy and base64 encoded UVM reference information to set
+// up our internal data structures we use to store said policy. The signed
+// UVM measurement can be presented to the workload containers via an
+// environment variable if client requests so.
+//
 // The security policy is transmitted as json in an annotation,
 // so we first have to remove the base64 encoding that allows
 // the JSON based policy to be passed as a string. From there,
 // we decode the JSON and setup our security policy state
-func (h *Host) SetSecurityPolicy(enforcerType, base64EncodedPolicy string) error {
+func (h *Host) SetConfidentialUVMOptions(enforcerType string, base64EncodedPolicy string, base64SignedMeasurement string) error {
 	h.policyMutex.Lock()
 	defer h.policyMutex.Unlock()
 	if h.securityPolicyEnforcerSet {
@@ -107,6 +111,7 @@ func (h *Host) SetSecurityPolicy(enforcerType, base64EncodedPolicy string) error
 
 	h.securityPolicyEnforcer = p
 	h.securityPolicyEnforcerSet = true
+	h.signedUVMMeasurementInfo = base64SignedMeasurement
 
 	return nil
 }
@@ -289,16 +294,20 @@ func (h *Host) CreateContainer(ctx context.Context, id string, settings *prot.VM
 		return nil, errors.Wrapf(err, "container creation denied due to policy")
 	}
 
-	// Export security policy as one of the process's environment variables so that application and sidecar
-	// containers can have access to it. The security policy is required by containers which need to extract
-	// init-time claims found in the security policy.
+	// Export security policy and signed UVM reference info as one of the
+	// process's environment variables so that application and sidecar
+	// containers can have access to it. The security policy is required
+	// by containers which need to extract init-time claims found in the
+	// security policy.
 	//
-	// We append the variable after the security policy enforcing logic completes to bypass it; the
-	// security policy variable cannot be included in the security policy as its value is not available
-	// security policy construction time.
+	// We append the variable after the security policy enforcing logic
+	// completes to bypass it; the security policy variable cannot be included
+	// in the security policy as its value is not available security policy
+	// construction time.
 	if oci.ParseAnnotationsBool(ctx, settings.OCISpecification.Annotations, annotations.SecurityPolicyEnv, false) {
 		secPolicyEnv := fmt.Sprintf("SECURITY_POLICY=%s", h.securityPolicyEnforcer.EncodedSecurityPolicy())
-		settings.OCISpecification.Process.Env = append(settings.OCISpecification.Process.Env, secPolicyEnv)
+		uvmReferenceInfo := fmt.Sprintf("SIGNED_UVM_REFERENCE_INFO=%s", h.signedUVMMeasurementInfo)
+		settings.OCISpecification.Process.Env = append(settings.OCISpecification.Process.Env, secPolicyEnv, uvmReferenceInfo)
 	}
 
 	// Create the BundlePath
@@ -373,11 +382,11 @@ func (h *Host) modifyHostSettings(ctx context.Context, containerID string, req *
 		}
 		return c.modifyContainerConstraints(ctx, req.RequestType, req.Settings.(*guestresource.LCOWContainerConstraints))
 	case guestresource.ResourceTypeSecurityPolicy:
-		r, ok := req.Settings.(*guestresource.LCOWSecurityPolicyEnforcer)
+		r, ok := req.Settings.(*guestresource.LCOWConfidentialOptions)
 		if !ok {
-			return errors.New("the request's settings are not of type LCOWSecurityPolicyEnforcer")
+			return errors.New("the request's settings are not of type LCOWConfidentialOptions")
 		}
-		return h.SetSecurityPolicy(r.EnforcerType, r.EncodedSecurityPolicy)
+		return h.SetConfidentialUVMOptions(r.EnforcerType, r.EncodedSecurityPolicy, r.EncodedSignedMeasurement)
 	default:
 		return errors.Errorf("the ResourceType \"%s\" is not supported for UVM", req.ResourceType)
 	}

--- a/internal/oci/uvm.go
+++ b/internal/oci/uvm.go
@@ -278,7 +278,7 @@ func SpecToUVMCreateOpts(ctx context.Context, s *specs.Spec, id, owner string) (
 		lopts.EnableScratchEncryption = ParseAnnotationsBool(ctx, s.Annotations, annotations.EncryptedScratchDisk, lopts.EnableScratchEncryption)
 		lopts.SecurityPolicy = parseAnnotationsString(s.Annotations, annotations.SecurityPolicy, lopts.SecurityPolicy)
 		lopts.SecurityPolicyEnforcer = parseAnnotationsString(s.Annotations, annotations.SecurityPolicyEnforcer, lopts.SecurityPolicyEnforcer)
-		lopts.SignedUVMMeasurementFile = parseAnnotationsString(s.Annotations, annotations.SignedUVMReferenceFile, lopts.SignedUVMMeasurementFile)
+		lopts.UVMReferenceInfoFile = parseAnnotationsString(s.Annotations, annotations.UVMReferenceInfoFile, lopts.UVMReferenceInfoFile)
 		lopts.KernelBootOptions = parseAnnotationsString(s.Annotations, annotations.KernelBootOptions, lopts.KernelBootOptions)
 		lopts.DisableTimeSyncService = ParseAnnotationsBool(ctx, s.Annotations, annotations.DisableLCOWTimeSyncService, lopts.DisableTimeSyncService)
 		handleAnnotationPreferredRootFSType(ctx, s.Annotations, lopts)

--- a/internal/oci/uvm.go
+++ b/internal/oci/uvm.go
@@ -278,6 +278,7 @@ func SpecToUVMCreateOpts(ctx context.Context, s *specs.Spec, id, owner string) (
 		lopts.EnableScratchEncryption = ParseAnnotationsBool(ctx, s.Annotations, annotations.EncryptedScratchDisk, lopts.EnableScratchEncryption)
 		lopts.SecurityPolicy = parseAnnotationsString(s.Annotations, annotations.SecurityPolicy, lopts.SecurityPolicy)
 		lopts.SecurityPolicyEnforcer = parseAnnotationsString(s.Annotations, annotations.SecurityPolicyEnforcer, lopts.SecurityPolicyEnforcer)
+		lopts.SignedUVMMeasurementFile = parseAnnotationsString(s.Annotations, annotations.SignedUVMReferenceFile, lopts.SignedUVMMeasurementFile)
 		lopts.KernelBootOptions = parseAnnotationsString(s.Annotations, annotations.KernelBootOptions, lopts.KernelBootOptions)
 		lopts.DisableTimeSyncService = ParseAnnotationsBool(ctx, s.Annotations, annotations.DisableLCOWTimeSyncService, lopts.DisableTimeSyncService)
 		handleAnnotationPreferredRootFSType(ctx, s.Annotations, lopts)

--- a/internal/protocol/guestresource/resources.go
+++ b/internal/protocol/guestresource/resources.go
@@ -160,7 +160,7 @@ type SignalProcessOptionsWCOW struct {
 }
 
 type LCOWConfidentialOptions struct {
-	EnforcerType             string `json:"EnforcerType,omitempty"`
-	EncodedSecurityPolicy    string `json:"EncodedSecurityPolicy,omitempty"`
-	EncodedSignedMeasurement string `json:"EncodedSignedMeasurement,omitempty"`
+	EnforcerType          string `json:"EnforcerType,omitempty"`
+	EncodedSecurityPolicy string `json:"EncodedSecurityPolicy,omitempty"`
+	EncodedUVMReference   string `json:"EncodedUVMReference,omitempty"`
 }

--- a/internal/protocol/guestresource/resources.go
+++ b/internal/protocol/guestresource/resources.go
@@ -159,7 +159,8 @@ type SignalProcessOptionsWCOW struct {
 	Signal guestrequest.SignalValueWCOW `json:",omitempty"`
 }
 
-type LCOWSecurityPolicyEnforcer struct {
-	EnforcerType          string `json:"EnforcerType,omitempty"`
-	EncodedSecurityPolicy string `json:"EncodedSecurityPolicy,omitempty"`
+type LCOWConfidentialOptions struct {
+	EnforcerType             string `json:"EnforcerType,omitempty"`
+	EncodedSecurityPolicy    string `json:"EncodedSecurityPolicy,omitempty"`
+	EncodedSignedMeasurement string `json:"EncodedSignedMeasurement,omitempty"`
 }

--- a/internal/tools/uvmboot/lcow.go
+++ b/internal/tools/uvmboot/lcow.go
@@ -268,7 +268,7 @@ func runLCOW(ctx context.Context, options *uvm.OptionsLCOW, c *cli.Context) erro
 		return err
 	}
 
-	if err := vm.SetSecurityPolicy(ctx, "", options.SecurityPolicy); err != nil {
+	if err := vm.SetConfidentialUVMOptions(ctx, uvm.WithSecurityPolicy(options.SecurityPolicy)); err != nil {
 		return fmt.Errorf("could not set UVM security policy: %w", err)
 	}
 

--- a/internal/uvm/create_lcow.go
+++ b/internal/uvm/create_lcow.go
@@ -77,43 +77,42 @@ const (
 	// GuestStateFile is the default file name for a vmgs (VM Guest State) file
 	// which combines kernel and initrd and is used to boot from in the SNP case.
 	GuestStateFile = "kernelinitrd.vmgs"
-	// SignedUVMMeasurementFile is the default file name for a COSE1 signed
-	// digest of the combined kernel (bzImage) and initrd, which is made
-	// available to workload containers and can be used for validation
-	// purposes.
-	SignedUVMMeasurementFile = "measurement.cose"
+	// UVMReferenceInfoFile is the default file name for a COSE_Sign1
+	// reference UVM info, which can be made available to workload containers
+	// and can be used for validation purposes.
+	UVMReferenceInfoFile = "reference_info.cose"
 )
 
 // OptionsLCOW are the set of options passed to CreateLCOW() to create a utility vm.
 type OptionsLCOW struct {
 	*Options
 
-	BootFilesPath            string              // Folder in which kernel and root file system reside. Defaults to \Program Files\Linux Containers
-	KernelFile               string              // Filename under `BootFilesPath` for the kernel. Defaults to `kernel`
-	KernelDirect             bool                // Skip UEFI and boot directly to `kernel`
-	RootFSFile               string              // Filename under `BootFilesPath` for the UVMs root file system. Defaults to `InitrdFile`
-	KernelBootOptions        string              // Additional boot options for the kernel
-	EnableGraphicsConsole    bool                // If true, enable a graphics console for the utility VM
-	ConsolePipe              string              // The named pipe path to use for the serial console.  eg \\.\pipe\vmpipe
-	UseGuestConnection       bool                // Whether the HCS should connect to the UVM's GCS. Defaults to true
-	ExecCommandLine          string              // The command line to exec from init. Defaults to GCS
-	ForwardStdout            bool                // Whether stdout will be forwarded from the executed program. Defaults to false
-	ForwardStderr            bool                // Whether stderr will be forwarded from the executed program. Defaults to true
-	OutputHandler            OutputHandler       `json:"-"` // Controls how output received over HVSocket from the UVM is handled. Defaults to parsing output as logrus messages
-	VPMemDeviceCount         uint32              // Number of VPMem devices. Defaults to `DefaultVPMEMCount`. Limit at 128. If booting UVM from VHD, device 0 is taken.
-	VPMemSizeBytes           uint64              // Size of the VPMem devices. Defaults to `DefaultVPMemSizeBytes`.
-	VPMemNoMultiMapping      bool                // Disables LCOW layer multi mapping
-	PreferredRootFSType      PreferredRootFSType // If `KernelFile` is `InitrdFile` use `PreferredRootFSTypeInitRd`. If `KernelFile` is `VhdFile` use `PreferredRootFSTypeVHD`
-	EnableColdDiscardHint    bool                // Whether the HCS should use cold discard hints. Defaults to false
-	VPCIEnabled              bool                // Whether the kernel should enable pci
-	EnableScratchEncryption  bool                // Whether the scratch should be encrypted
-	SecurityPolicy           string              // Optional security policy
-	SecurityPolicyEnabled    bool                // Set when there is a security policy to apply on actual SNP hardware, use this rathen than checking the string length
-	SecurityPolicyEnforcer   string              // Set which security policy enforcer to use (open door, standard or rego). This allows for better fallback mechanic.
-	SignedUVMMeasurementFile string              // Filename under `BootFilesPath` for signed UVM image reference information.
-	UseGuestStateFile        bool                // Use a vmgs file that contains a kernel and initrd, required for SNP
-	GuestStateFile           string              // The vmgs file to load
-	DisableTimeSyncService   bool                // Disables the time synchronization service
+	BootFilesPath           string              // Folder in which kernel and root file system reside. Defaults to \Program Files\Linux Containers
+	KernelFile              string              // Filename under `BootFilesPath` for the kernel. Defaults to `kernel`
+	KernelDirect            bool                // Skip UEFI and boot directly to `kernel`
+	RootFSFile              string              // Filename under `BootFilesPath` for the UVMs root file system. Defaults to `InitrdFile`
+	KernelBootOptions       string              // Additional boot options for the kernel
+	EnableGraphicsConsole   bool                // If true, enable a graphics console for the utility VM
+	ConsolePipe             string              // The named pipe path to use for the serial console.  eg \\.\pipe\vmpipe
+	UseGuestConnection      bool                // Whether the HCS should connect to the UVM's GCS. Defaults to true
+	ExecCommandLine         string              // The command line to exec from init. Defaults to GCS
+	ForwardStdout           bool                // Whether stdout will be forwarded from the executed program. Defaults to false
+	ForwardStderr           bool                // Whether stderr will be forwarded from the executed program. Defaults to true
+	OutputHandler           OutputHandler       `json:"-"` // Controls how output received over HVSocket from the UVM is handled. Defaults to parsing output as logrus messages
+	VPMemDeviceCount        uint32              // Number of VPMem devices. Defaults to `DefaultVPMEMCount`. Limit at 128. If booting UVM from VHD, device 0 is taken.
+	VPMemSizeBytes          uint64              // Size of the VPMem devices. Defaults to `DefaultVPMemSizeBytes`.
+	VPMemNoMultiMapping     bool                // Disables LCOW layer multi mapping
+	PreferredRootFSType     PreferredRootFSType // If `KernelFile` is `InitrdFile` use `PreferredRootFSTypeInitRd`. If `KernelFile` is `VhdFile` use `PreferredRootFSTypeVHD`
+	EnableColdDiscardHint   bool                // Whether the HCS should use cold discard hints. Defaults to false
+	VPCIEnabled             bool                // Whether the kernel should enable pci
+	EnableScratchEncryption bool                // Whether the scratch should be encrypted
+	SecurityPolicy          string              // Optional security policy
+	SecurityPolicyEnabled   bool                // Set when there is a security policy to apply on actual SNP hardware, use this rathen than checking the string length
+	SecurityPolicyEnforcer  string              // Set which security policy enforcer to use (open door, standard or rego). This allows for better fallback mechanic.
+	UVMReferenceInfoFile    string              // Filename under `BootFilesPath` for (potentially signed) UVM image reference information.
+	UseGuestStateFile       bool                // Use a vmgs file that contains a kernel and initrd, required for SNP
+	GuestStateFile          string              // The vmgs file to load
+	DisableTimeSyncService  bool                // Disables the time synchronization service
 }
 
 // defaultLCOWOSBootFilesPath returns the default path used to locate the LCOW
@@ -139,32 +138,32 @@ func NewDefaultOptionsLCOW(id, owner string) *OptionsLCOW {
 	// Use KernelDirect boot by default on all builds that support it.
 	kernelDirectSupported := osversion.Build() >= 18286
 	opts := &OptionsLCOW{
-		Options:                  newDefaultOptions(id, owner),
-		BootFilesPath:            defaultLCOWOSBootFilesPath(),
-		KernelFile:               KernelFile,
-		KernelDirect:             kernelDirectSupported,
-		RootFSFile:               InitrdFile,
-		KernelBootOptions:        "",
-		EnableGraphicsConsole:    false,
-		ConsolePipe:              "",
-		UseGuestConnection:       true,
-		ExecCommandLine:          fmt.Sprintf("/bin/gcs -v4 -log-format json -loglevel %s", logrus.StandardLogger().Level.String()),
-		ForwardStdout:            false,
-		ForwardStderr:            true,
-		OutputHandler:            parseLogrus(id),
-		VPMemDeviceCount:         DefaultVPMEMCount,
-		VPMemSizeBytes:           DefaultVPMemSizeBytes,
-		VPMemNoMultiMapping:      osversion.Get().Build < osversion.V19H1,
-		PreferredRootFSType:      PreferredRootFSTypeInitRd,
-		EnableColdDiscardHint:    false,
-		VPCIEnabled:              false,
-		EnableScratchEncryption:  false,
-		SecurityPolicyEnabled:    false,
-		SecurityPolicyEnforcer:   "",
-		SecurityPolicy:           "",
-		SignedUVMMeasurementFile: SignedUVMMeasurementFile,
-		GuestStateFile:           "",
-		DisableTimeSyncService:   false,
+		Options:                 newDefaultOptions(id, owner),
+		BootFilesPath:           defaultLCOWOSBootFilesPath(),
+		KernelFile:              KernelFile,
+		KernelDirect:            kernelDirectSupported,
+		RootFSFile:              InitrdFile,
+		KernelBootOptions:       "",
+		EnableGraphicsConsole:   false,
+		ConsolePipe:             "",
+		UseGuestConnection:      true,
+		ExecCommandLine:         fmt.Sprintf("/bin/gcs -v4 -log-format json -loglevel %s", logrus.StandardLogger().Level.String()),
+		ForwardStdout:           false,
+		ForwardStderr:           true,
+		OutputHandler:           parseLogrus(id),
+		VPMemDeviceCount:        DefaultVPMEMCount,
+		VPMemSizeBytes:          DefaultVPMemSizeBytes,
+		VPMemNoMultiMapping:     osversion.Get().Build < osversion.V19H1,
+		PreferredRootFSType:     PreferredRootFSTypeInitRd,
+		EnableColdDiscardHint:   false,
+		VPCIEnabled:             false,
+		EnableScratchEncryption: false,
+		SecurityPolicyEnabled:   false,
+		SecurityPolicyEnforcer:  "",
+		SecurityPolicy:          "",
+		UVMReferenceInfoFile:    UVMReferenceInfoFile,
+		GuestStateFile:          "",
+		DisableTimeSyncService:  false,
 	}
 
 	if _, err := os.Stat(filepath.Join(opts.BootFilesPath, VhdFile)); err == nil {

--- a/internal/uvm/create_lcow.go
+++ b/internal/uvm/create_lcow.go
@@ -74,39 +74,46 @@ const (
 	// UncompressedKernelFile is the default file name for an uncompressed
 	// kernel used to boot LCOW with KernelDirect.
 	UncompressedKernelFile = "vmlinux"
-	// In the SNP case both the kernel (bzImage) and initrd are stored in a vmgs (VM Guest State) file
+	// GuestStateFile is the default file name for a vmgs (VM Guest State) file
+	// which combines kernel and initrd and is used to boot from in the SNP case.
 	GuestStateFile = "kernelinitrd.vmgs"
+	// SignedUVMMeasurementFile is the default file name for a COSE1 signed
+	// digest of the combined kernel (bzImage) and initrd, which is made
+	// available to workload containers and can be used for validation
+	// purposes.
+	SignedUVMMeasurementFile = "measurement.cose"
 )
 
 // OptionsLCOW are the set of options passed to CreateLCOW() to create a utility vm.
 type OptionsLCOW struct {
 	*Options
 
-	BootFilesPath           string              // Folder in which kernel and root file system reside. Defaults to \Program Files\Linux Containers
-	KernelFile              string              // Filename under `BootFilesPath` for the kernel. Defaults to `kernel`
-	KernelDirect            bool                // Skip UEFI and boot directly to `kernel`
-	RootFSFile              string              // Filename under `BootFilesPath` for the UVMs root file system. Defaults to `InitrdFile`
-	KernelBootOptions       string              // Additional boot options for the kernel
-	EnableGraphicsConsole   bool                // If true, enable a graphics console for the utility VM
-	ConsolePipe             string              // The named pipe path to use for the serial console.  eg \\.\pipe\vmpipe
-	UseGuestConnection      bool                // Whether the HCS should connect to the UVM's GCS. Defaults to true
-	ExecCommandLine         string              // The command line to exec from init. Defaults to GCS
-	ForwardStdout           bool                // Whether stdout will be forwarded from the executed program. Defaults to false
-	ForwardStderr           bool                // Whether stderr will be forwarded from the executed program. Defaults to true
-	OutputHandler           OutputHandler       `json:"-"` // Controls how output received over HVSocket from the UVM is handled. Defaults to parsing output as logrus messages
-	VPMemDeviceCount        uint32              // Number of VPMem devices. Defaults to `DefaultVPMEMCount`. Limit at 128. If booting UVM from VHD, device 0 is taken.
-	VPMemSizeBytes          uint64              // Size of the VPMem devices. Defaults to `DefaultVPMemSizeBytes`.
-	VPMemNoMultiMapping     bool                // Disables LCOW layer multi mapping
-	PreferredRootFSType     PreferredRootFSType // If `KernelFile` is `InitrdFile` use `PreferredRootFSTypeInitRd`. If `KernelFile` is `VhdFile` use `PreferredRootFSTypeVHD`
-	EnableColdDiscardHint   bool                // Whether the HCS should use cold discard hints. Defaults to false
-	VPCIEnabled             bool                // Whether the kernel should enable pci
-	EnableScratchEncryption bool                // Whether the scratch should be encrypted
-	SecurityPolicy          string              // Optional security policy
-	SecurityPolicyEnabled   bool                // Set when there is a security policy to apply on actual SNP hardware, use this rathen than checking the string length
-	SecurityPolicyEnforcer  string              // Set which security policy enforcer to use (open door, standard or rego). This allows for better fallback mechanic.
-	UseGuestStateFile       bool                // Use a vmgs file that contains a kernel and initrd, required for SNP
-	GuestStateFile          string              // The vmgs file to load
-	DisableTimeSyncService  bool                // Disables the time synchronization service
+	BootFilesPath            string              // Folder in which kernel and root file system reside. Defaults to \Program Files\Linux Containers
+	KernelFile               string              // Filename under `BootFilesPath` for the kernel. Defaults to `kernel`
+	KernelDirect             bool                // Skip UEFI and boot directly to `kernel`
+	RootFSFile               string              // Filename under `BootFilesPath` for the UVMs root file system. Defaults to `InitrdFile`
+	KernelBootOptions        string              // Additional boot options for the kernel
+	EnableGraphicsConsole    bool                // If true, enable a graphics console for the utility VM
+	ConsolePipe              string              // The named pipe path to use for the serial console.  eg \\.\pipe\vmpipe
+	UseGuestConnection       bool                // Whether the HCS should connect to the UVM's GCS. Defaults to true
+	ExecCommandLine          string              // The command line to exec from init. Defaults to GCS
+	ForwardStdout            bool                // Whether stdout will be forwarded from the executed program. Defaults to false
+	ForwardStderr            bool                // Whether stderr will be forwarded from the executed program. Defaults to true
+	OutputHandler            OutputHandler       `json:"-"` // Controls how output received over HVSocket from the UVM is handled. Defaults to parsing output as logrus messages
+	VPMemDeviceCount         uint32              // Number of VPMem devices. Defaults to `DefaultVPMEMCount`. Limit at 128. If booting UVM from VHD, device 0 is taken.
+	VPMemSizeBytes           uint64              // Size of the VPMem devices. Defaults to `DefaultVPMemSizeBytes`.
+	VPMemNoMultiMapping      bool                // Disables LCOW layer multi mapping
+	PreferredRootFSType      PreferredRootFSType // If `KernelFile` is `InitrdFile` use `PreferredRootFSTypeInitRd`. If `KernelFile` is `VhdFile` use `PreferredRootFSTypeVHD`
+	EnableColdDiscardHint    bool                // Whether the HCS should use cold discard hints. Defaults to false
+	VPCIEnabled              bool                // Whether the kernel should enable pci
+	EnableScratchEncryption  bool                // Whether the scratch should be encrypted
+	SecurityPolicy           string              // Optional security policy
+	SecurityPolicyEnabled    bool                // Set when there is a security policy to apply on actual SNP hardware, use this rathen than checking the string length
+	SecurityPolicyEnforcer   string              // Set which security policy enforcer to use (open door, standard or rego). This allows for better fallback mechanic.
+	SignedUVMMeasurementFile string              // Filename under `BootFilesPath` for signed UVM image reference information.
+	UseGuestStateFile        bool                // Use a vmgs file that contains a kernel and initrd, required for SNP
+	GuestStateFile           string              // The vmgs file to load
+	DisableTimeSyncService   bool                // Disables the time synchronization service
 }
 
 // defaultLCOWOSBootFilesPath returns the default path used to locate the LCOW
@@ -132,31 +139,32 @@ func NewDefaultOptionsLCOW(id, owner string) *OptionsLCOW {
 	// Use KernelDirect boot by default on all builds that support it.
 	kernelDirectSupported := osversion.Build() >= 18286
 	opts := &OptionsLCOW{
-		Options:                 newDefaultOptions(id, owner),
-		BootFilesPath:           defaultLCOWOSBootFilesPath(),
-		KernelFile:              KernelFile,
-		KernelDirect:            kernelDirectSupported,
-		RootFSFile:              InitrdFile,
-		KernelBootOptions:       "",
-		EnableGraphicsConsole:   false,
-		ConsolePipe:             "",
-		UseGuestConnection:      true,
-		ExecCommandLine:         fmt.Sprintf("/bin/gcs -v4 -log-format json -loglevel %s", logrus.StandardLogger().Level.String()),
-		ForwardStdout:           false,
-		ForwardStderr:           true,
-		OutputHandler:           parseLogrus(id),
-		VPMemDeviceCount:        DefaultVPMEMCount,
-		VPMemSizeBytes:          DefaultVPMemSizeBytes,
-		VPMemNoMultiMapping:     osversion.Get().Build < osversion.V19H1,
-		PreferredRootFSType:     PreferredRootFSTypeInitRd,
-		EnableColdDiscardHint:   false,
-		VPCIEnabled:             false,
-		EnableScratchEncryption: false,
-		SecurityPolicyEnabled:   false,
-		SecurityPolicyEnforcer:  "",
-		SecurityPolicy:          "",
-		GuestStateFile:          "",
-		DisableTimeSyncService:  false,
+		Options:                  newDefaultOptions(id, owner),
+		BootFilesPath:            defaultLCOWOSBootFilesPath(),
+		KernelFile:               KernelFile,
+		KernelDirect:             kernelDirectSupported,
+		RootFSFile:               InitrdFile,
+		KernelBootOptions:        "",
+		EnableGraphicsConsole:    false,
+		ConsolePipe:              "",
+		UseGuestConnection:       true,
+		ExecCommandLine:          fmt.Sprintf("/bin/gcs -v4 -log-format json -loglevel %s", logrus.StandardLogger().Level.String()),
+		ForwardStdout:            false,
+		ForwardStderr:            true,
+		OutputHandler:            parseLogrus(id),
+		VPMemDeviceCount:         DefaultVPMEMCount,
+		VPMemSizeBytes:           DefaultVPMemSizeBytes,
+		VPMemNoMultiMapping:      osversion.Get().Build < osversion.V19H1,
+		PreferredRootFSType:      PreferredRootFSTypeInitRd,
+		EnableColdDiscardHint:    false,
+		VPCIEnabled:              false,
+		EnableScratchEncryption:  false,
+		SecurityPolicyEnabled:    false,
+		SecurityPolicyEnforcer:   "",
+		SecurityPolicy:           "",
+		SignedUVMMeasurementFile: SignedUVMMeasurementFile,
+		GuestStateFile:           "",
+		DisableTimeSyncService:   false,
 	}
 
 	if _, err := os.Stat(filepath.Join(opts.BootFilesPath, VhdFile)); err == nil {

--- a/internal/uvm/security_policy.go
+++ b/internal/uvm/security_policy.go
@@ -4,7 +4,9 @@ package uvm
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
+	"os"
 
 	hcsschema "github.com/Microsoft/hcsshim/internal/hcs/schema2"
 	"github.com/Microsoft/hcsshim/internal/protocol/guestrequest"
@@ -12,37 +14,72 @@ import (
 	"github.com/Microsoft/hcsshim/pkg/securitypolicy"
 )
 
-// SetSecurityPolicy tells the gcs instance in the UVM what policy to apply.
+type ConfidentialUVMOpt func(ctx context.Context, r *guestresource.LCOWConfidentialOptions) error
+
+func WithSecurityPolicy(policy string) ConfidentialUVMOpt {
+	return func(ctx context.Context, r *guestresource.LCOWConfidentialOptions) error {
+		if policy == "" {
+			openDoorPolicy := securitypolicy.NewOpenDoorPolicy()
+			policyString, err := openDoorPolicy.EncodeToString()
+			if err != nil {
+				return err
+			}
+			policy = policyString
+		}
+		r.EncodedSecurityPolicy = policy
+		return nil
+	}
+}
+
+func WithSecurityPolicyEnforcer(enforcer string) ConfidentialUVMOpt {
+	return func(ctx context.Context, r *guestresource.LCOWConfidentialOptions) error {
+		r.EnforcerType = enforcer
+		return nil
+	}
+}
+
+func WithSignedUVMMeasurement(measurementPath string) ConfidentialUVMOpt {
+	return func(ctx context.Context, r *guestresource.LCOWConfidentialOptions) error {
+		var encodedMeasurement string
+		content, err := os.ReadFile(measurementPath)
+		if err != nil {
+			if !os.IsNotExist(err) {
+				return err
+			}
+		} else {
+			encodedMeasurement = base64.StdEncoding.EncodeToString(content)
+		}
+		r.EncodedSignedMeasurement = encodedMeasurement
+		return nil
+	}
+}
+
+// SetConfidentialUVMOptions sends information required to run the UVM on
+// SNP hardware, e.g., security policy and enforcer type, signed UVM reference
+// information, etc.
 //
 // This has to happen before we start mounting things or generally changing
 // the state of the UVM after is has been measured at startup
-func (uvm *UtilityVM) SetSecurityPolicy(ctx context.Context, enforcer, policy string) error {
+func (uvm *UtilityVM) SetConfidentialUVMOptions(ctx context.Context, opts ...ConfidentialUVMOpt) error {
 	if uvm.operatingSystem != "linux" {
 		return errNotSupported
-	}
-
-	if policy == "" {
-		openDoorPolicy := securitypolicy.NewOpenDoorPolicy()
-		policyString, err := openDoorPolicy.EncodeToString()
-		if err != nil {
-			return err
-		}
-		policy = policyString
 	}
 
 	uvm.m.Lock()
 	defer uvm.m.Unlock()
 
+	confOpts := &guestresource.LCOWConfidentialOptions{}
+	for _, o := range opts {
+		if err := o(ctx, confOpts); err != nil {
+			return err
+		}
+	}
 	modification := &hcsschema.ModifySettingRequest{
 		RequestType: guestrequest.RequestTypeAdd,
-	}
-
-	modification.GuestRequest = guestrequest.ModificationRequest{
-		ResourceType: guestresource.ResourceTypeSecurityPolicy,
-		RequestType:  guestrequest.RequestTypeAdd,
-		Settings: guestresource.LCOWSecurityPolicyEnforcer{
-			EnforcerType:          enforcer,
-			EncodedSecurityPolicy: policy,
+		GuestRequest: guestrequest.ModificationRequest{
+			ResourceType: guestresource.ResourceTypeSecurityPolicy,
+			RequestType:  guestrequest.RequestTypeAdd,
+			Settings:     *confOpts,
 		},
 	}
 

--- a/pkg/annotations/annotations.go
+++ b/pkg/annotations/annotations.go
@@ -274,6 +274,9 @@ const (
 	// SecurityPolicyEnv specifies if SECURITY_POLICY variable should be injected for a container.
 	SecurityPolicyEnv = "io.microsoft.virtualmachine.lcow.securitypolicy.env"
 
+	// SignedUVMReferenceFile specifies the filename of a signed UVM reference file to be passed to UVM.
+	SignedUVMReferenceFile = "io.microsoft.virtualmachine.lcow.signed-uvm-reference-file"
+
 	// DisableLCOWTimeSyncService is used to disable the chronyd time
 	// synchronization service inside the LCOW UVM.
 	DisableLCOWTimeSyncService = "io.microsoft.virtualmachine.lcow.timesync.disable"

--- a/pkg/annotations/annotations.go
+++ b/pkg/annotations/annotations.go
@@ -271,11 +271,12 @@ const (
 	// GuestStateFile specifies the path of the vmgs file to use if required. Only applies in SNP mode.
 	GuestStateFile = "io.microsoft.virtualmachine.lcow.gueststatefile"
 
-	// SecurityPolicyEnv specifies if SECURITY_POLICY variable should be injected for a container.
+	// SecurityPolicyEnv specifies if SECURITY_POLICY and
+	// HCSSHIM_UVM_REFERENCE_INFO variables should be injected for a container.
 	SecurityPolicyEnv = "io.microsoft.virtualmachine.lcow.securitypolicy.env"
 
-	// SignedUVMReferenceFile specifies the filename of a signed UVM reference file to be passed to UVM.
-	SignedUVMReferenceFile = "io.microsoft.virtualmachine.lcow.signed-uvm-reference-file"
+	// UVMReferenceInfoFile specifies the filename of a signed UVM reference file to be passed to UVM.
+	UVMReferenceInfoFile = "io.microsoft.virtualmachine.lcow.uvm-reference-info-file"
 
 	// DisableLCOWTimeSyncService is used to disable the chronyd time
 	// synchronization service inside the LCOW UVM.

--- a/test/cri-containerd/policy_test.go
+++ b/test/cri-containerd/policy_test.go
@@ -789,15 +789,17 @@ func Test_RunContainer_WithPolicy_And_SecurityPolicyEnv_Annotation(t *testing.T)
 					t.Fatalf("error reading log file: %s", err)
 				}
 				policyEnv := fmt.Sprintf("SECURITY_POLICY=%s", config.policy)
-				measurementEnv := "SIGNED_UVM_REFERENCE_INFO="
+				measurementEnv := "HCSSHIM_UVM_REFERENCE_INFO="
 				if setPolicyEnv {
 					// make sure that the expected environment variable was set
 					if !strings.Contains(string(content), policyEnv) || !strings.Contains(string(content), measurementEnv) {
-						t.Fatalf("SECURITY_POLICY env var should be set for init process:\n%s\n", string(content))
+						t.Fatalf("SECURITY_POLICY and HCSSHIM_UVM_REFERENCE_INFO env vars should be set for init"+
+							" process:\n%s\n", string(content))
 					}
 				} else {
 					if strings.Contains(string(content), policyEnv) || strings.Contains(string(content), measurementEnv) {
-						t.Fatalf("SECURITY_POLICY env var shouldn't be set for init process:\n%s\n",
+						t.Fatalf("SECURITY_POLICY and HCSSHIM_UVM_REFERENCE_INFO env vars shouldn't be set for init"+
+							" process:\n%s\n",
 							string(content))
 					}
 				}

--- a/test/cri-containerd/policy_test.go
+++ b/test/cri-containerd/policy_test.go
@@ -731,7 +731,7 @@ func Test_RunContainer_WithPolicy_And_SecurityPolicyEnv_Annotation(t *testing.T)
 
 	// The command prints environment variables to stdout, which we can capture
 	// and validate later
-	alpineCmd := []string{"ash", "-c", "env"}
+	alpineCmd := []string{"ash", "-c", "env && sleep 1"}
 
 	for _, config := range []struct {
 		name   string
@@ -781,7 +781,7 @@ func Test_RunContainer_WithPolicy_And_SecurityPolicyEnv_Annotation(t *testing.T)
 				startContainer(t, client, ctx, containerID)
 				requireContainerState(ctx, t, client, containerID, runtime.ContainerState_CONTAINER_RUNNING)
 
-				stopContainer(t, client, ctx, containerID)
+				// no need to stop the container since it'll exit by itself
 				requireContainerState(ctx, t, client, containerID, runtime.ContainerState_CONTAINER_EXITED)
 
 				content, err := os.ReadFile(logPath)
@@ -789,13 +789,14 @@ func Test_RunContainer_WithPolicy_And_SecurityPolicyEnv_Annotation(t *testing.T)
 					t.Fatalf("error reading log file: %s", err)
 				}
 				policyEnv := fmt.Sprintf("SECURITY_POLICY=%s", config.policy)
+				measurementEnv := "SIGNED_UVM_REFERENCE_INFO="
 				if setPolicyEnv {
 					// make sure that the expected environment variable was set
-					if !strings.Contains(string(content), policyEnv) {
+					if !strings.Contains(string(content), policyEnv) || !strings.Contains(string(content), measurementEnv) {
 						t.Fatalf("SECURITY_POLICY env var should be set for init process:\n%s\n", string(content))
 					}
 				} else {
-					if strings.Contains(string(content), policyEnv) {
+					if strings.Contains(string(content), policyEnv) || strings.Contains(string(content), measurementEnv) {
 						t.Fatalf("SECURITY_POLICY env var shouldn't be set for init process:\n%s\n",
 							string(content))
 					}

--- a/test/internal/uvm/lcow.go
+++ b/test/internal/uvm/lcow.go
@@ -40,7 +40,7 @@ func CreateLCOW(ctx context.Context, t testing.TB, opts *uvm.OptionsLCOW) *uvm.U
 }
 
 func SetSecurityPolicy(ctx context.Context, t testing.TB, vm *uvm.UtilityVM, policy string) {
-	if err := vm.SetSecurityPolicy(ctx, "allow_all", policy); err != nil {
+	if err := vm.SetConfidentialUVMOptions(ctx, uvm.WithSecurityPolicyEnforcer("allow_all"), uvm.WithSecurityPolicy(policy)); err != nil {
 		t.Helper()
 		t.Fatalf("could not set vm security policy to %q: %v", policy, err)
 	}


### PR DESCRIPTION
Workload containers need to be aware of the reference UVM measurement
they are currently running on. The expectation is that the signed UVM
measurement file will be a part of the package and located in the
same directory as the rest of the boot files (e.g. kernel, initrd
or VMGS). The file itself is a COSE_Sign1 document containing the
measurement and related information.
The content of the file will be plumbed to the UVM as
part of setting the security policy request and can later be
presented to the containers via an environment variable.

Signed-off-by: Maksim An <maksiman@microsoft.com>