### PR TITLE
Moving rego api test fixtures to a separate file

### DIFF
--- a/pkg/securitypolicy/api.rego
+++ b/pkg/securitypolicy/api.rego
@@ -3,25 +3,7 @@ package api
 svn := "0.1.0"
 
 enforcement_points := {
-	"mount_device": {"introducedVersion": "0.1.0", "allowedByDefault": false},
-	"mount_overlay": {"introducedVersion": "0.1.0", "allowedByDefault": false},
-	"create_container": {"introducedVersion": "0.1.0", "allowedByDefault": false},
-    # the following rules are used for testing the default behavior logic. DO NOT REMOVE.
-    "__fixture_for_future_test__": {"introducedVersion": "100.0.0", "allowedByDefault": true},
-    "__fixture_for_allowed_test_true__": {"introducedVersion": "0.0.2", "allowedByDefault": true},
-    "__fixture_for_allowed_test_false__": {"introducedVersion": "0.0.2", "allowedByDefault": false},
-}
-
-default enforcement_point_info := {"available": false, "allowed": false, "unknown": true, "invalid": false}
-
-enforcement_point_info := {"available": available, "allowed": allowed, "unknown": false, "invalid": false} {
-	enforcement_point := enforcement_points[input.name]
-	semver.compare(svn, enforcement_point.introducedVersion) >= 0
-	available := semver.compare(data.policy.api_svn, enforcement_point.introducedVersion) >= 0
-	allowed := enforcement_point.allowedByDefault
-}
-
-enforcement_point_info := {"available": false, "allowed": false, "unknown": false, "invalid": true} {
-	enforcement_point := enforcement_points[input.name]
-	semver.compare(svn, enforcement_point.introducedVersion) < 0
+    "mount_device": {"introducedVersion": "0.1.0", "allowedByDefault": false},
+    "mount_overlay": {"introducedVersion": "0.1.0", "allowedByDefault": false},
+    "create_container": {"introducedVersion": "0.1.0", "allowedByDefault": false},
 }

--- a/pkg/securitypolicy/api_test.rego
+++ b/pkg/securitypolicy/api_test.rego
@@ -1,0 +1,9 @@
+package api
+
+svn := "0.0.2"
+
+enforcement_points := {
+    "__fixture_for_future_test__": {"introducedVersion": "100.0.0", "allowedByDefault": true},
+    "__fixture_for_allowed_test_true__": {"introducedVersion": "0.0.2", "allowedByDefault": true},
+    "__fixture_for_allowed_test_false__": {"introducedVersion": "0.0.2", "allowedByDefault": false},
+}

--- a/pkg/securitypolicy/framework.rego
+++ b/pkg/securitypolicy/framework.rego
@@ -118,6 +118,20 @@ mountList_ok(container) {
     }
 }
 
+default enforcement_point_info := {"available": false, "allowed": false, "unknown": true, "invalid": false}
+
+enforcement_point_info := {"available": available, "allowed": allowed, "unknown": false, "invalid": false} {
+    enforcement_point := data.api.enforcement_points[input.name]
+    semver.compare(data.api.svn, enforcement_point.introducedVersion) >= 0
+    available := semver.compare(data.policy.api_svn, enforcement_point.introducedVersion) >= 0
+    allowed := enforcement_point.allowedByDefault
+}
+
+enforcement_point_info := {"available": false, "allowed": false, "unknown": false, "invalid": true} {
+    enforcement_point := data.api.enforcement_points[input.name]
+    semver.compare(data.api.svn, enforcement_point.introducedVersion) < 0
+}
+
 # error messages
 
 default container_started := false

--- a/pkg/securitypolicy/securitypolicyenforcer_rego.go
+++ b/pkg/securitypolicy/securitypolicyenforcer_rego.go
@@ -193,7 +193,7 @@ func (policy *regoEnforcer) queryEnforcementPoint(enforcementPoint string) (enfo
 	input := map[string]interface{}{"name": enforcementPoint}
 	input["rule"] = enforcementPoint
 	query := rego.New(
-		rego.Query("data.api.enforcement_point_info"),
+		rego.Query("data.framework.enforcement_point_info"),
 		rego.Input(input),
 		rego.Compiler(policy.compiledModules))
 


### PR DESCRIPTION
This PR moves the API test fixtures to a separate `api_test.rego` file. In order to avoid code duplication, the logic to check enforcement point information was moved to the framework. This PR also addresses some whitespace issues that crept into the Rego files.