### PR TITLE
Open Door fix for Rego policies

### DIFF
--- a/pkg/securitypolicy/securitypolicyenforcer_rego.go
+++ b/pkg/securitypolicy/securitypolicyenforcer_rego.go
@@ -103,6 +103,10 @@ func createRegoEnforcer(base64EncodedPolicy string,
 			containers[i] = &cConf
 		}
 
+		if securityPolicy.AllowAll {
+			return createOpenDoorEnforcer(base64EncodedPolicy, defaultMounts, privilegedMounts)
+		}
+
 		code, err = marshalRego(securityPolicy.AllowAll, containers)
 		if err != nil {
 			return nil, fmt.Errorf("error marshaling the policy to Rego: %w", err)


### PR DESCRIPTION
Returning OpenDoorSecurityPolicyEnforcer (when appropriate) for Rego policies. This change reverts an unintended behaviour change when calling `CreateSecurityPolicyEnforcer` with:

1. `enforcer = ""` indicating to use the default (which, with the `rego` build tag, will be `rego`)
2. `base64EncodedPolicy` = a JSON policy with `AllowAll=True` and no containers
3. Empty default and privileged mounts

In the past this would have produced an `OpenDoorSecurityPolicyEnforcer` but after the change to accept authored Rego policies, it would produce a `RegoEnforcer` with an allow all policy (which allows all enforcement points). There are changes in the pipe which will make a `RegoEnforcer` created in this way have the same properties as `OpenDoorSecurityPolicyEnforcer`, but for the time being this change reverts to the previous state.