### PR TITLE
Adding required environment variable rules logic.

### DIFF
--- a/pkg/securitypolicy/api.rego
+++ b/pkg/securitypolicy/api.rego
@@ -1,6 +1,6 @@
 package api
 
-svn := "0.1.0"
+svn := "0.1.1"
 
 enforcement_points := {
     "mount_device": {"introducedVersion": "0.1.0", "allowedByDefault": false},

--- a/pkg/securitypolicy/framework.rego
+++ b/pkg/securitypolicy/framework.rego
@@ -39,10 +39,24 @@ env_ok(pattern, "re2", value) {
     regex.match(pattern, value)
 }
 
+rule_ok(rule, env) {
+    not rule.required
+}
+
+rule_ok(rule, env) {
+    rule.required
+    env_ok(rule.pattern, rule.strategy, env)
+}
+
 envList_ok(container) {
     every env in input.envList {
         some rule in container.env_rules
         env_ok(rule.pattern, rule.strategy, env)
+    }
+
+    every rule in container.env_rules {
+        some env in input.envList
+        rule_ok(rule, env)
     }
 }
 

--- a/pkg/securitypolicy/securitypolicy.go
+++ b/pkg/securitypolicy/securitypolicy.go
@@ -39,6 +39,7 @@ type AuthConfig struct {
 type EnvRuleConfig struct {
 	Strategy EnvVarRule `json:"strategy" toml:"strategy"`
 	Rule     string     `json:"rule" toml:"rule"`
+	Required bool       `json:"required" toml:"required"`
 }
 
 // ContainerConfig contains toml or JSON config for container described

--- a/pkg/securitypolicy/securitypolicy_marshal.go
+++ b/pkg/securitypolicy/securitypolicy_marshal.go
@@ -173,7 +173,7 @@ func writeCommand(builder *strings.Builder, command []string, indent string) {
 }
 
 func (e EnvRuleConfig) marshalRego() string {
-	return fmt.Sprintf(`{"pattern": "%s", "strategy": "%s"}`, e.Rule, e.Strategy)
+	return fmt.Sprintf(`{"pattern": "%s", "strategy": "%s", "required": %v}`, e.Rule, e.Strategy, e.Required)
 }
 
 type envRuleArray []EnvRuleConfig

--- a/pkg/securitypolicy/securitypolicy_test.go
+++ b/pkg/securitypolicy/securitypolicy_test.go
@@ -834,6 +834,7 @@ func (*SecurityPolicy) Generate(r *rand.Rand, _ int) reflect.Value {
 			rule := EnvRuleConfig{
 				Strategy: "string",
 				Rule:     randVariableString(r, maxGeneratedEnvironmentVariableRuleLength),
+				Required: false,
 			}
 			c.EnvRules.Elements[strconv.Itoa(j)] = rule
 		}


### PR DESCRIPTION
If an environment variable rule is marked as "required", then it must be defined in the container. This is enforced in the Rego in the following way:

``` rego
env_ok(pattern, "string", value) {
    pattern == value
}

env_ok(pattern, "re2", value) {
    regex.match(pattern, value)
}

rule_ok(rule, env) {
    not rule.required
}

rule_ok(rule, env) {
    rule.required
    env_ok(rule.pattern, rule.strategy, env)
}

envList_ok(container) {
    every env in input.envList {
        some rule in container.env_rules
        env_ok(rule.pattern, rule.strategy, env)
    }

    every rule in container.env_rules {
        some env in input.envList
        rule_ok(rule, env)
    }
}
```

Signed-off-by: Matthew A Johnson <matjoh@microsoft.com>