### PR TITLE
Adding the `exec_in_container` enforcement point

### DIFF
--- a/internal/guest/bridge/bridge_v2.go
+++ b/internal/guest/bridge/bridge_v2.go
@@ -195,18 +195,7 @@ func (b *Bridge) execProcessV2(r *Request) (_ RequestResponse, err error) {
 		conSettings.StdErr = &request.Settings.VsockStdioRelaySettings.StdErr
 	}
 
-	var pid int
-	var c *hcsv2.Container
-	if params.IsExternal || request.ContainerID == hcsv2.UVMContainerID {
-		pid, err = b.hostState.RunExternalProcess(ctx, params, conSettings)
-	} else if c, err = b.hostState.GetCreatedContainer(request.ContainerID); err == nil {
-		// We found a V2 container. Treat this as a V2 process.
-		if params.OCIProcess == nil {
-			pid, err = c.Start(ctx, conSettings)
-		} else {
-			pid, err = c.ExecProcess(ctx, params.OCIProcess, conSettings)
-		}
-	}
+	pid, err := b.hostState.ExecProcess(ctx, request.ContainerID, params, conSettings)
 
 	if err != nil {
 		return nil, err

--- a/internal/guest/runtime/hcsv2/uvm.go
+++ b/internal/guest/runtime/hcsv2/uvm.go
@@ -435,8 +435,45 @@ func (*Host) Shutdown() {
 	_ = syscall.Reboot(syscall.LINUX_REBOOT_CMD_POWER_OFF)
 }
 
+func (h *Host) ExecProcess(ctx context.Context, containerID string, params prot.ProcessParameters, conSettings stdio.ConnectionSettings) (_ int, err error) {
+	var pid int
+	var c *Container
+	if params.IsExternal || containerID == UVMContainerID {
+		pid, err = h.runExternalProcess(ctx, params, conSettings)
+	} else if c, err = h.GetCreatedContainer(containerID); err == nil {
+		// We found a V2 container. Treat this as a V2 process.
+		if params.OCIProcess == nil {
+			// We've already done policy enforcement for creating a container so
+			// there's no policy enforcement to do for starting
+			pid, err = c.Start(ctx, conSettings)
+		} else {
+			// Windows uses a different field for command, there's no enforcement
+			// around this yet for Windows so this is Linux specific at the moment.
+			err = h.securityPolicyEnforcer.EnforceExecInContainerPolicy(containerID, params.OCIProcess.Args, params.OCIProcess.Env, params.OCIProcess.Cwd)
+			if err != nil {
+				return pid, errors.Wrapf(err, "exec in container denied due to policy")
+			}
+
+			pid, err = c.ExecProcess(ctx, params.OCIProcess, conSettings)
+		}
+	}
+
+	return pid, err
+}
+
+func (h *Host) GetExternalProcess(pid int) (Process, error) {
+	h.externalProcessesMutex.Lock()
+	defer h.externalProcessesMutex.Unlock()
+
+	p, ok := h.externalProcesses[pid]
+	if !ok {
+		return nil, gcserr.NewHresultError(gcserr.HrErrNotFound)
+	}
+	return p, nil
+}
+
 // RunExternalProcess runs a process in the utility VM.
-func (h *Host) RunExternalProcess(
+func (h *Host) runExternalProcess(
 	ctx context.Context,
 	params prot.ProcessParameters,
 	conSettings stdio.ConnectionSettings,
@@ -526,17 +563,6 @@ func (h *Host) RunExternalProcess(
 	h.externalProcesses[p.Pid()] = p
 	h.externalProcessesMutex.Unlock()
 	return p.Pid(), nil
-}
-
-func (h *Host) GetExternalProcess(pid int) (Process, error) {
-	h.externalProcessesMutex.Lock()
-	defer h.externalProcessesMutex.Unlock()
-
-	p, ok := h.externalProcesses[pid]
-	if !ok {
-		return nil, gcserr.NewHresultError(gcserr.HrErrNotFound)
-	}
-	return p, nil
 }
 
 func newInvalidRequestTypeError(rt guestrequest.RequestType) error {

--- a/internal/guest/storage/test/policy/mountmonitoringsecuritypolicyenforcer.go
+++ b/internal/guest/storage/test/policy/mountmonitoringsecuritypolicyenforcer.go
@@ -46,3 +46,7 @@ func (MountMonitoringSecurityPolicyEnforcer) ExtendDefaultMounts(_ []oci.Mount) 
 func (MountMonitoringSecurityPolicyEnforcer) EncodedSecurityPolicy() string {
 	return ""
 }
+
+func (MountMonitoringSecurityPolicyEnforcer) EnforceExecInContainerPolicy(_ string, _ []string, _ []string, _ string) error {
+	return nil
+}

--- a/internal/tools/securitypolicy/helpers/helpers.go
+++ b/internal/tools/securitypolicy/helpers/helpers.go
@@ -160,6 +160,7 @@ func PolicyContainersFromConfigs(containerConfigs []securitypolicy.ContainerConf
 			workingDir,
 			containerConfig.Mounts,
 			containerConfig.AllowElevated,
+			containerConfig.ExecProcesses,
 		)
 		if err != nil {
 			return nil, err

--- a/pkg/securitypolicy/api.rego
+++ b/pkg/securitypolicy/api.rego
@@ -1,9 +1,11 @@
 package api
 
-svn := "0.1.1"
+svn := "0.2.0"
 
 enforcement_points := {
     "mount_device": {"introducedVersion": "0.1.0", "allowedByDefault": false},
     "mount_overlay": {"introducedVersion": "0.1.0", "allowedByDefault": false},
     "create_container": {"introducedVersion": "0.1.0", "allowedByDefault": false},
+    "unmount_device": {"introducedVersion": "0.2.0", "allowedByDefault": true},
+    "exec_in_container": {"introducedVersion": "0.2.0", "allowedByDefault": true},
 }

--- a/pkg/securitypolicy/open_door.rego
+++ b/pkg/securitypolicy/open_door.rego
@@ -1,5 +1,9 @@
 package policy
 
-mount_device := true
-mount_overlay := true
-create_container := true 
+api_svn := "0.2.0"
+
+mount_device := {"allowed": true}
+mount_overlay := {"allowed": true}
+create_container := {"allowed": true}
+unmount_device := {"allowed": true}
+exec_in_container := {"allowed": true}

--- a/pkg/securitypolicy/policy.rego
+++ b/pkg/securitypolicy/policy.rego
@@ -1,25 +1,15 @@
 package policy
 
-api_svn := "0.1.0"
+api_svn := "0.2.0"
 
 import future.keywords.every
 import future.keywords.in
 
 ##OBJECTS##
 
-default mount_device := false
-mount_device := true {
-    data.framework.mount_device
-}
-
-default mount_overlay := false
-mount_overlay := true {
-    data.framework.mount_overlay
-}
-
-default create_container := false
-create_container := true {
-    data.framework.create_container
-}
-
-reason := data.framework.reason
+mount_device := data.framework.mount_device
+unmount_device := data.framework.unmount_device
+mount_overlay := data.framework.mount_overlay
+create_container := data.framework.create_container
+exec_in_container := data.framework.exec_in_container
+reason := {"errors": data.framework.errors}

--- a/pkg/securitypolicy/securitypolicy.go
+++ b/pkg/securitypolicy/securitypolicy.go
@@ -45,13 +45,14 @@ type EnvRuleConfig struct {
 // ContainerConfig contains toml or JSON config for container described
 // in security policy.
 type ContainerConfig struct {
-	ImageName     string          `json:"image_name" toml:"image_name"`
-	Command       []string        `json:"command" toml:"command"`
-	Auth          AuthConfig      `json:"auth" toml:"auth"`
-	EnvRules      []EnvRuleConfig `json:"env_rules" toml:"env_rule"`
-	WorkingDir    string          `json:"working_dir" toml:"working_dir"`
-	Mounts        []MountConfig   `json:"mounts" toml:"mount"`
-	AllowElevated bool            `json:"allow_elevated" toml:"allow_elevated"`
+	ImageName     string              `json:"image_name" toml:"image_name"`
+	Command       []string            `json:"command" toml:"command"`
+	Auth          AuthConfig          `json:"auth" toml:"auth"`
+	EnvRules      []EnvRuleConfig     `json:"env_rules" toml:"env_rule"`
+	WorkingDir    string              `json:"working_dir" toml:"working_dir"`
+	Mounts        []MountConfig       `json:"mounts" toml:"mount"`
+	AllowElevated bool                `json:"allow_elevated" toml:"allow_elevated"`
+	ExecProcesses []ExecProcessConfig `json:"exec_processes" toml:"exec_process"`
 }
 
 // MountConfig contains toml or JSON config for mount security policy
@@ -60,6 +61,12 @@ type MountConfig struct {
 	HostPath      string `json:"host_path" toml:"host_path"`
 	ContainerPath string `json:"container_path" toml:"container_path"`
 	Readonly      bool   `json:"readonly" toml:"readonly"`
+}
+
+// ExecProcessConfig contains toml or JSON config for exec process security
+// policy constraint description
+type ExecProcessConfig struct {
+	Command []string `json:"command" toml:"command"`
 }
 
 // NewEnvVarRules creates slice of EnvRuleConfig's from environment variables
@@ -136,6 +143,7 @@ type Container struct {
 	WorkingDir    string      `json:"working_dir"`
 	Mounts        Mounts      `json:"mounts"`
 	AllowElevated bool        `json:"allow_elevated"`
+	ExecProcesses []ExecProcessConfig
 }
 
 // StringArrayMap wraps an array of strings as a string map.
@@ -175,6 +183,7 @@ func CreateContainerPolicy(
 	workingDir string,
 	mounts []MountConfig,
 	allowElevated bool,
+	execProcesses []ExecProcessConfig,
 ) (*Container, error) {
 	if err := validateEnvRules(envRules); err != nil {
 		return nil, err
@@ -189,6 +198,7 @@ func CreateContainerPolicy(
 		WorkingDir:    workingDir,
 		Mounts:        newMountConstraints(mounts),
 		AllowElevated: allowElevated,
+		ExecProcesses: execProcesses,
 	}, nil
 }
 

--- a/pkg/securitypolicy/securitypolicy_internal.go
+++ b/pkg/securitypolicy/securitypolicy_internal.go
@@ -27,6 +27,13 @@ type securityPolicyContainer struct {
 	// A list of constraints for determining if a given mount is allowed.
 	Mounts        []mountInternal
 	AllowElevated bool
+	// A list of lists of commands that can be used to execute additional
+	// processes within the container
+	ExecProcesses []containerExecProcess
+}
+
+type containerExecProcess struct {
+	Command []string
 }
 
 // Internal version of Mount
@@ -57,6 +64,13 @@ func (c Container) toInternal() (securityPolicyContainer, error) {
 	if err != nil {
 		return securityPolicyContainer{}, err
 	}
+
+	var execProcesses []containerExecProcess
+	for _, ep := range c.ExecProcesses {
+		cep := containerExecProcess(ep)
+		execProcesses = append(execProcesses, cep)
+	}
+
 	return securityPolicyContainer{
 		Command:  command,
 		EnvRules: envRules,
@@ -66,6 +80,7 @@ func (c Container) toInternal() (securityPolicyContainer, error) {
 		WorkingDir:    c.WorkingDir,
 		Mounts:        mounts,
 		AllowElevated: c.AllowElevated,
+		ExecProcesses: execProcesses,
 	}, nil
 }
 

--- a/pkg/securitypolicy/securitypolicy_marshal.go
+++ b/pkg/securitypolicy/securitypolicy_marshal.go
@@ -209,12 +209,26 @@ func writeMounts(builder *strings.Builder, mounts []mountInternal, indent string
 	writeLine(builder, `%s"mounts": [%s],`, indent, strings.Join(values, ","))
 }
 
+func (p containerExecProcess) marshalRego() string {
+	command := stringArray(p.Command).marshalRego()
+	return fmt.Sprintf(`{"command": %s}`, command)
+}
+
+func writeExecProcesses(builder *strings.Builder, execProcesses []containerExecProcess, indent string) {
+	values := make([]string, len(execProcesses))
+	for i, process := range execProcesses {
+		values[i] = process.marshalRego()
+	}
+	writeLine(builder, `%s"exec_processes": [%s],`, indent, strings.Join(values, ","))
+}
+
 func writeContainer(builder *strings.Builder, container *securityPolicyContainer, indent string, end string) {
 	writeLine(builder, "%s{", indent)
 	writeCommand(builder, container.Command, indent+indentUsing)
 	writeEnvRules(builder, container.EnvRules, indent+indentUsing)
 	writeLayers(builder, container.Layers, indent+indentUsing)
 	writeMounts(builder, container.Mounts, indent+indentUsing)
+	writeExecProcesses(builder, container.ExecProcesses, indent+indentUsing)
 	writeLine(builder, `%s"allow_elevated": %v,`, indent+indentUsing, container.AllowElevated)
 	writeLine(builder, `%s"working_dir": "%s"`, indent+indentUsing, container.WorkingDir)
 	writeLine(builder, "%s}%s", indent, end)

--- a/pkg/securitypolicy/securitypolicyenforcer.go
+++ b/pkg/securitypolicy/securitypolicyenforcer.go
@@ -44,6 +44,7 @@ type SecurityPolicyEnforcer interface {
 		argList []string, envList []string, workingDir string, mounts []oci.Mount) (err error)
 	ExtendDefaultMounts([]oci.Mount) error
 	EncodedSecurityPolicy() string
+	EnforceExecInContainerPolicy(containerID string, argList []string, envList []string, workingDir string) error
 }
 
 func newSecurityPolicyFromBase64JSON(base64EncodedPolicy string) (*SecurityPolicy, error) {
@@ -431,6 +432,12 @@ func (pe *StandardSecurityPolicyEnforcer) EnforceCreateContainerPolicy(
 	return nil
 }
 
+// Stub. We are deprecating the standard enforcer. Newly added enforcement
+// points are simply allowed.
+func (*StandardSecurityPolicyEnforcer) EnforceExecInContainerPolicy(_ string, _ []string, _ []string, _ string) error {
+	return nil
+}
+
 func (pe *StandardSecurityPolicyEnforcer) enforceCommandPolicy(containerID string, argList []string) (err error) {
 	// Get a list of all the indexes into our security policy's list of
 	// containers that are possible matches for this containerID based
@@ -720,6 +727,10 @@ func (OpenDoorSecurityPolicyEnforcer) EnforceCreateContainerPolicy(_, _ string, 
 	return nil
 }
 
+func (OpenDoorSecurityPolicyEnforcer) EnforceExecInContainerPolicy(_ string, _ []string, _ []string, _ string) error {
+	return nil
+}
+
 func (OpenDoorSecurityPolicyEnforcer) ExtendDefaultMounts(_ []oci.Mount) error {
 	return nil
 }
@@ -748,6 +759,10 @@ func (ClosedDoorSecurityPolicyEnforcer) EnforceOverlayMountPolicy(_ string, _ []
 
 func (ClosedDoorSecurityPolicyEnforcer) EnforceCreateContainerPolicy(_, _ string, _ []string, _ []string, _ string, _ []oci.Mount) error {
 	return errors.New("running commands is denied by policy")
+}
+
+func (ClosedDoorSecurityPolicyEnforcer) EnforceExecInContainerPolicy(_ string, _ []string, _ []string, _ string) error {
+	return errors.New("starting additional processes in a container is denied by policy")
 }
 
 func (ClosedDoorSecurityPolicyEnforcer) ExtendDefaultMounts(_ []oci.Mount) error {


### PR DESCRIPTION
This commit adds the `exec_in_container` enforcement point, but as part of this change we must also perform a refactoring of the framework to enable supporting this and other additional enforcement points which come _after_ creating a container. Due to the number of possible matches and the way in which each subsequent enforcement point narrows the list of matches, we need to maintain for each container ID a list of potentially matching containers.

As part of making this change to the framework, we took the opportunity to build a more flexible system for a policy to store data for use in evaluating later rules. This has the beneficial side effect of removing more policy logic from the Go code while also creating a far more powerful and flexible system for policy authoring.

Before, a policy would define a simple `true`/`false` rule for something like `mount_device`. Now, the `mount_device` rule (along with all others) is expected to return an object, as seen below:

``` rego
device_mounted(target) {
    data.metadata.devices[target]
}

default mount_device := {"allowed": false}

mount_device := {"devices": devices, "allowed": true} {
    not device_mounted(input.target)
    some container in data.policy.containers
    some layer in container.layers
    input.deviceHash == layer
    devices := {
        "action": "add",
        "key": input.target,
        "value": input.deviceHash
    }
}
```

This object contains a member called `allowed` which indicates whether the operation should proceed, but also includes one or more "metadata" commands, of the following form:

``` json
{
    "<name>": {
        "action": "<add|update|remove>",
        "key": "<key>",
        "value": "<optional value>"
    }
}
```

These metadata commands alter a special `metadata` namespace. The Go code, which previously contained logic for maintaining various data structures for use by the framework, now executes these metadata commands instead. This both means that the Go code contains almost no policy logic at this point, but also that authored policies can take advantage of all the same kinds of data caching logic upon which the framework is based.

A consequence of this change is that `unmount_device` is now a new enforcement point, allowing policy authors to have control from the Rego side of how devices are unmounted (as they do with mounting devices at the moment).