### PR TITLE
update security policy and uvm reference env var names

### DIFF
--- a/internal/guest/runtime/hcsv2/uvm.go
+++ b/internal/guest/runtime/hcsv2/uvm.go
@@ -315,8 +315,8 @@ func (h *Host) CreateContainer(ctx context.Context, id string, settings *prot.VM
 	// in the security policy as its value is not available security policy
 	// construction time.
 	if oci.ParseAnnotationsBool(ctx, settings.OCISpecification.Annotations, annotations.SecurityPolicyEnv, false) {
-		secPolicyEnv := fmt.Sprintf("SECURITY_POLICY=%s", h.securityPolicyEnforcer.EncodedSecurityPolicy())
-		uvmReferenceInfo := fmt.Sprintf("HCSSHIM_UVM_REFERENCE_INFO=%s", h.uvmReferenceInfo)
+		secPolicyEnv := fmt.Sprintf("UVM_SECURITY_POLICY=%s", h.securityPolicyEnforcer.EncodedSecurityPolicy())
+		uvmReferenceInfo := fmt.Sprintf("UVM_REFERENCE_INFO=%s", h.uvmReferenceInfo)
 		settings.OCISpecification.Process.Env = append(settings.OCISpecification.Process.Env, secPolicyEnv, uvmReferenceInfo)
 	}
 

--- a/pkg/annotations/annotations.go
+++ b/pkg/annotations/annotations.go
@@ -271,8 +271,8 @@ const (
 	// GuestStateFile specifies the path of the vmgs file to use if required. Only applies in SNP mode.
 	GuestStateFile = "io.microsoft.virtualmachine.lcow.gueststatefile"
 
-	// SecurityPolicyEnv specifies if SECURITY_POLICY and
-	// HCSSHIM_UVM_REFERENCE_INFO variables should be injected for a container.
+	// SecurityPolicyEnv specifies if UVM_SECURITY_POLICY and
+	// UVM_REFERENCE_INFO variables should be injected for a container.
 	SecurityPolicyEnv = "io.microsoft.virtualmachine.lcow.securitypolicy.env"
 
 	// UVMReferenceInfoFile specifies the filename of a signed UVM reference file to be passed to UVM.

--- a/test/cri-containerd/policy_test.go
+++ b/test/cri-containerd/policy_test.go
@@ -788,17 +788,17 @@ func Test_RunContainer_WithPolicy_And_SecurityPolicyEnv_Annotation(t *testing.T)
 				if err != nil {
 					t.Fatalf("error reading log file: %s", err)
 				}
-				policyEnv := fmt.Sprintf("SECURITY_POLICY=%s", config.policy)
-				measurementEnv := "HCSSHIM_UVM_REFERENCE_INFO="
+				policyEnv := fmt.Sprintf("UVM_SECURITY_POLICY=%s", config.policy)
+				measurementEnv := "UVM_REFERENCE_INFO="
 				if setPolicyEnv {
 					// make sure that the expected environment variable was set
 					if !strings.Contains(string(content), policyEnv) || !strings.Contains(string(content), measurementEnv) {
-						t.Fatalf("SECURITY_POLICY and HCSSHIM_UVM_REFERENCE_INFO env vars should be set for init"+
+						t.Fatalf("UVM_SECURITY_POLICY and UVM_REFERENCE_INFO env vars should be set for init"+
 							" process:\n%s\n", string(content))
 					}
 				} else {
 					if strings.Contains(string(content), policyEnv) || strings.Contains(string(content), measurementEnv) {
-						t.Fatalf("SECURITY_POLICY and HCSSHIM_UVM_REFERENCE_INFO env vars shouldn't be set for init"+
+						t.Fatalf("UVM_SECURITY_POLICY and UVM_REFERENCE_INFO env vars shouldn't be set for init"+
 							" process:\n%s\n",
 							string(content))
 					}


### PR DESCRIPTION
Make sure the naming of security policy and uvm reference env vars are consistent. Drop `HCSSHIM_` prefix and use `UVM_` instead. The env vars now become `UVM_SECURITY_POLICY` and `UVM_REFERENCE_INFO`.

Signed-off-by: Maksim An <maksiman@microsoft.com>