### PR TITLE
Use alpine and pause images from MSFT mirrors in tests

### DIFF
--- a/test/cri-containerd/container_test.go
+++ b/test/cri-containerd/container_test.go
@@ -68,7 +68,7 @@ func runContainerLifetime(t *testing.T, client runtime.RuntimeServiceClient, ctx
 func Test_RotateLogs_LCOW(t *testing.T) {
 	requireFeatures(t, featureLCOW)
 
-	image := "alpine:latest"
+	image := imageLcowAlpine
 	dir := t.TempDir()
 	log := filepath.Join(dir, "log.txt")
 	logArchive := filepath.Join(dir, "log-archive.txt")

--- a/test/cri-containerd/main_test.go
+++ b/test/cri-containerd/main_test.go
@@ -49,8 +49,8 @@ const (
 	testVMServiceBinary  = "C:\\Containerplat\\vmservice.exe"
 
 	lcowRuntimeHandler       = "runhcs-lcow"
-	imageLcowK8sPause        = "k8s.gcr.io/pause:3.1"
-	imageLcowAlpine          = "docker.io/library/alpine:latest"
+	imageLcowK8sPause        = "mcr.microsoft.com/oss/kubernetes/pause:3.1"
+	imageLcowAlpine          = "mcr.microsoft.com/mirror/docker/library/alpine:3.16"
 	imageLcowAlpineCoreDump  = "cplatpublic.azurecr.io/stackoverflow-alpine:latest"
 	imageLcowCosmos          = "cosmosarno/spark-master:2.4.1_2019-04-18_8e864ce"
 	imageLcowCustomUser      = "cplatpublic.azurecr.io/linux_custom_user:latest"

--- a/test/cri-containerd/policy_test.go
+++ b/test/cri-containerd/policy_test.go
@@ -48,7 +48,7 @@ func alpineSecurityPolicy(t *testing.T, policyType string, opts ...securitypolic
 	defaultContainers := helpers.DefaultContainerConfigs()
 
 	alpineContainer := securitypolicy.ContainerConfig{
-		ImageName: "alpine:latest",
+		ImageName: imageLcowAlpine,
 		Command:   validPolicyAlpineCommand,
 	}
 
@@ -142,7 +142,7 @@ func Test_RunSimpleAlpineContainer_WithPolicy_Allowed(t *testing.T) {
 			containerRequest := getCreateContainerRequest(
 				podID,
 				"alpine-with-policy",
-				"alpine:latest",
+				imageLcowAlpine,
 				validPolicyAlpineCommand,
 				sandboxRequest.Config,
 			)
@@ -214,7 +214,7 @@ func Test_RunContainer_WithPolicy_And_ValidConfigs(t *testing.T) {
 				containerRequest := getCreateContainerRequest(
 					podID,
 					"alpine-with-policy",
-					"alpine:latest",
+					imageLcowAlpine,
 					validPolicyAlpineCommand,
 					sandboxRequest.Config,
 				)
@@ -287,7 +287,7 @@ func Test_RunContainer_WithPolicy_And_InvalidConfigs(t *testing.T) {
 			containerRequest := getCreateContainerRequest(
 				podID,
 				"alpine-with-policy",
-				"alpine:latest",
+				imageLcowAlpine,
 				validPolicyAlpineCommand,
 				sandboxRequest.Config,
 			)
@@ -416,7 +416,7 @@ func Test_RunContainer_WithPolicy_And_MountConstraints_Allowed(t *testing.T) {
 				containerRequest := getCreateContainerRequest(
 					podID,
 					"alpine-with-policy",
-					"alpine:latest",
+					imageLcowAlpine,
 					validPolicyAlpineCommand,
 					sandboxRequest.Config,
 				)
@@ -567,7 +567,7 @@ func Test_RunContainer_WithPolicy_And_MountConstraints_NotAllowed(t *testing.T) 
 			containerRequest := getCreateContainerRequest(
 				podID,
 				"alpine-with-policy",
-				"alpine:latest",
+				imageLcowAlpine,
 				validPolicyAlpineCommand,
 				sandboxRequest.Config,
 			)
@@ -618,7 +618,7 @@ func Test_RunPrivilegedContainer_WithPolicy_And_AllowElevated_Set(t *testing.T) 
 			contRequest := getCreateContainerRequest(
 				podID,
 				"alpine-privileged",
-				"alpine:latest",
+				imageLcowAlpine,
 				validPolicyAlpineCommand,
 				sandboxRequest.Config,
 			)
@@ -661,7 +661,7 @@ func Test_RunPrivilegedContainer_WithPolicy_And_AllowElevated_NotSet(t *testing.
 	contRequest := getCreateContainerRequest(
 		podID,
 		"alpine-privileged",
-		"alpine:latest",
+		imageLcowAlpine,
 		validPolicyAlpineCommand,
 		sandboxRequest.Config,
 	)
@@ -762,7 +762,7 @@ func Test_RunContainer_WithPolicy_And_SecurityPolicyEnv_Annotation(t *testing.T)
 				containerRequest := getCreateContainerRequest(
 					podID,
 					"alpine-with-policy",
-					"alpine:latest",
+					imageLcowAlpine,
 					alpineCmd,
 					sandboxRequest.Config,
 				)


### PR DESCRIPTION
Occasionally we've started seeing issues with docker rate limiting image pulls when running cri-containerd tests locally. Switch to MSFT mirrors.

Signed-off-by: Maksim An <maksiman@microsoft.com>