### PR TITLE
Add policy enforcement for shutting down a container

### DIFF
--- a/internal/guest/bridge/bridge_v2.go
+++ b/internal/guest/bridge/bridge_v2.go
@@ -216,7 +216,7 @@ func (b *Bridge) killContainerV2(r *Request) (RequestResponse, error) {
 	defer span.End()
 	span.AddAttributes(trace.StringAttribute("cid", r.ContainerID))
 
-	return b.signalContainerV2(ctx, span, r, unix.SIGKILL)
+	return b.signalContainerShutdownV2(ctx, span, r, false)
 }
 
 // shutdownContainerV2 is a user requested shutdown of the container and all
@@ -229,17 +229,18 @@ func (b *Bridge) shutdownContainerV2(r *Request) (RequestResponse, error) {
 	defer span.End()
 	span.AddAttributes(trace.StringAttribute("cid", r.ContainerID))
 
-	return b.signalContainerV2(ctx, span, r, unix.SIGTERM)
+	return b.signalContainerShutdownV2(ctx, span, r, true)
 }
 
-// signalContainerV2 is not a handler func. This is because the actual signal is
-// implied based on the message type of either `killContainerV2` or
-// `shutdownContainerV2`.
-func (b *Bridge) signalContainerV2(ctx context.Context, span *trace.Span, r *Request, signal syscall.Signal) (_ RequestResponse, err error) {
+// signalContainerV2 is not a handler func. It is called from either
+// `killContainerV2` or `shutdownContainerV2` to deliver a SIGTERM or SIGKILL
+// respectively
+func (b *Bridge) signalContainerShutdownV2(ctx context.Context, span *trace.Span, r *Request, graceful bool) (_ RequestResponse, err error) {
 	defer func() { oc.SetSpanStatus(span, err) }()
 	span.AddAttributes(
 		trace.StringAttribute("cid", r.ContainerID),
-		trace.Int64Attribute("signal", int64(signal)))
+		trace.BoolAttribute("graceful", graceful),
+	)
 
 	var request prot.MessageBase
 	if err := commonutils.UnmarshalJSONWithHresult(r.Message, &request); err != nil {
@@ -249,19 +250,11 @@ func (b *Bridge) signalContainerV2(ctx context.Context, span *trace.Span, r *Req
 	// If this is targeting the UVM send the request to the host itself.
 	if request.ContainerID == hcsv2.UVMContainerID {
 		// We are asking to shutdown the UVM itself.
-		if signal != unix.SIGTERM {
-			log.G(ctx).Error("invalid signal for uvm")
-		}
 		// This is a destructive call. We do not respond to the HCS
 		b.quitChan <- true
 		b.hostState.Shutdown()
 	} else {
-		c, err := b.hostState.GetCreatedContainer(request.ContainerID)
-		if err != nil {
-			return nil, err
-		}
-
-		err = c.Kill(ctx, signal)
+		err = b.hostState.ShutdownContainer(ctx, request.ContainerID, graceful)
 		if err != nil {
 			return nil, err
 		}
@@ -285,23 +278,14 @@ func (b *Bridge) signalProcessV2(r *Request) (_ RequestResponse, err error) {
 		trace.Int64Attribute("pid", int64(request.ProcessID)),
 		trace.Int64Attribute("signal", int64(request.Options.Signal)))
 
-	c, err := b.hostState.GetCreatedContainer(request.ContainerID)
-	if err != nil {
-		return nil, err
-	}
-
-	p, err := c.GetProcess(request.ProcessID)
-	if err != nil {
-		return nil, err
-	}
-
 	var signal syscall.Signal
 	if request.Options.Signal == 0 {
 		signal = unix.SIGKILL
 	} else {
 		signal = syscall.Signal(request.Options.Signal)
 	}
-	if err := p.Kill(ctx, signal); err != nil {
+
+	if err := b.hostState.SignalContainerProcess(ctx, request.ContainerID, request.ProcessID, signal); err != nil {
 		return nil, err
 	}
 

--- a/internal/guest/storage/test/policy/mountmonitoringsecuritypolicyenforcer.go
+++ b/internal/guest/storage/test/policy/mountmonitoringsecuritypolicyenforcer.go
@@ -54,3 +54,7 @@ func (MountMonitoringSecurityPolicyEnforcer) EnforceExecInContainerPolicy(_ stri
 func (MountMonitoringSecurityPolicyEnforcer) EnforceExecExternalProcessPolicy(_ []string, _ []string, _ string) error {
 	return nil
 }
+
+func (MountMonitoringSecurityPolicyEnforcer) EnforceShutdownContainerPolicy(_ string) error {
+	return nil
+}

--- a/pkg/securitypolicy/api.rego
+++ b/pkg/securitypolicy/api.rego
@@ -1,6 +1,6 @@
 package api
 
-svn := "0.3.0"
+svn := "0.4.0"
 
 enforcement_points := {
     "mount_device": {"introducedVersion": "0.1.0", "allowedByDefault": false},
@@ -8,5 +8,6 @@ enforcement_points := {
     "create_container": {"introducedVersion": "0.1.0", "allowedByDefault": false},
     "unmount_device": {"introducedVersion": "0.2.0", "allowedByDefault": true},
     "exec_in_container": {"introducedVersion": "0.2.0", "allowedByDefault": true},
-    "exec_external": {"introducedVersion": "0.3.0", "allowedByDefault": true}
+    "exec_external": {"introducedVersion": "0.3.0", "allowedByDefault": true},
+    "shutdown_container": {"introducedVersion": "0.4.0", "allowedByDefault": true}
 }

--- a/pkg/securitypolicy/framework.rego
+++ b/pkg/securitypolicy/framework.rego
@@ -215,6 +215,16 @@ exec_in_container := {"matches": matches, "allowed": true} {
     }
 }
 
+default shutdown_container := {"allowed": false}
+
+shutdown_container := {"started": remove, "matches": remove, "allowed": true} {
+    container_started
+    remove := {
+        "action": "remove",
+        "key": input.containerID,
+    }
+}
+
 default enforcement_point_info := {"available": false, "allowed": false, "unknown": true, "invalid": false}
 
 enforcement_point_info := {"available": available, "allowed": allowed, "unknown": false, "invalid": false} {
@@ -261,7 +271,7 @@ errors["container already started"] {
 }
 
 errors["container not started"] {
-    input.rule == "exec_in_container"
+    input.rule in ["exec_in_container", "shutdown_container"]
     not container_started
 }
 

--- a/pkg/securitypolicy/open_door.rego
+++ b/pkg/securitypolicy/open_door.rego
@@ -1,6 +1,6 @@
 package policy
 
-api_svn := "0.3.0"
+api_svn := "0.4.0"
 
 mount_device := {"allowed": true}
 mount_overlay := {"allowed": true}
@@ -8,3 +8,4 @@ create_container := {"allowed": true}
 unmount_device := {"allowed": true}
 exec_in_container := {"allowed": true}
 exec_external := {"allowed": true}
+shutdown_container := {"allowed": true}

--- a/pkg/securitypolicy/policy.rego
+++ b/pkg/securitypolicy/policy.rego
@@ -1,6 +1,6 @@
 package policy
 
-api_svn := "0.3.0"
+api_svn := "0.4.0"
 
 import future.keywords.every
 import future.keywords.in
@@ -13,4 +13,5 @@ mount_overlay := data.framework.mount_overlay
 create_container := data.framework.create_container
 exec_in_container := data.framework.exec_in_container
 exec_external := data.framework.exec_external
+shutdown_container := data.framework.shutdown_container
 reason := {"errors": data.framework.errors}

--- a/pkg/securitypolicy/regopolicy_test.go
+++ b/pkg/securitypolicy/regopolicy_test.go
@@ -1305,6 +1305,38 @@ func Test_Rego_ExecExternalProcessPolicy_WorkingDir_No_Match(t *testing.T) {
 	}
 }
 
+func Test_Rego_ShutdownContainerPolicy_Running_Container(t *testing.T) {
+	p := generateConstraints(testRand, maxContainersInGeneratedConstraints, maxExternalProcessesInGeneratedConstraints)
+
+	tc, err := setupRegoRunningContainerTest(p)
+	if err != nil {
+		t.Fatalf("Unable to set up test: %v", err)
+	}
+
+	container := selectContainerFromRunningContainers(tc.runningContainers, testRand)
+
+	err = tc.policy.EnforceShutdownContainerPolicy(container.containerID)
+	if err != nil {
+		t.Fatal("Expected shutdown of running container to be allowed, it wasn't")
+	}
+}
+
+func Test_Rego_ShutdownContainerPolicy_Not_Running_Container(t *testing.T) {
+	p := generateConstraints(testRand, maxContainersInGeneratedConstraints, maxExternalProcessesInGeneratedConstraints)
+
+	tc, err := setupRegoRunningContainerTest(p)
+	if err != nil {
+		t.Fatalf("Unable to set up test: %v", err)
+	}
+
+	notRunningContainerID := testDataGenerator.uniqueContainerID()
+
+	err = tc.policy.EnforceShutdownContainerPolicy(notRunningContainerID)
+	if err == nil {
+		t.Fatal("Expected shutdown of not running container to be denied, it wasn't")
+	}
+}
+
 //
 // Setup and "fixtures" follow...
 //

--- a/pkg/securitypolicy/securitypolicyenforcer.go
+++ b/pkg/securitypolicy/securitypolicyenforcer.go
@@ -46,6 +46,7 @@ type SecurityPolicyEnforcer interface {
 	EncodedSecurityPolicy() string
 	EnforceExecInContainerPolicy(containerID string, argList []string, envList []string, workingDir string) error
 	EnforceExecExternalProcessPolicy(argList []string, envList []string, workingDir string) error
+	EnforceShutdownContainerPolicy(containerID string) error
 }
 
 func newSecurityPolicyFromBase64JSON(base64EncodedPolicy string) (*SecurityPolicy, error) {
@@ -445,6 +446,12 @@ func (*StandardSecurityPolicyEnforcer) EnforceExecExternalProcessPolicy(_ []stri
 	return nil
 }
 
+// Stub. We are deprecating the standard enforcer. Newly added enforcement
+// points are simply allowed.
+func (*StandardSecurityPolicyEnforcer) EnforceShutdownContainerPolicy(_ string) error {
+	return nil
+}
+
 func (pe *StandardSecurityPolicyEnforcer) enforceCommandPolicy(containerID string, argList []string) (err error) {
 	// Get a list of all the indexes into our security policy's list of
 	// containers that are possible matches for this containerID based
@@ -742,6 +749,12 @@ func (OpenDoorSecurityPolicyEnforcer) EnforceExecExternalProcessPolicy(_ []strin
 	return nil
 }
 
+// Stub. We are deprecating the standard enforcer. Newly added enforcement
+// points are simply allowed.
+func (*OpenDoorSecurityPolicyEnforcer) EnforceShutdownContainerPolicy(_ string) error {
+	return nil
+}
+
 func (OpenDoorSecurityPolicyEnforcer) ExtendDefaultMounts(_ []oci.Mount) error {
 	return nil
 }
@@ -778,6 +791,12 @@ func (ClosedDoorSecurityPolicyEnforcer) EnforceExecInContainerPolicy(_ string, _
 
 func (ClosedDoorSecurityPolicyEnforcer) EnforceExecExternalProcessPolicy(_ []string, _ []string, _ string) error {
 	return errors.New("starting additional processes in uvm is denied by policy")
+}
+
+// Stub. We are deprecating the standard enforcer. Newly added enforcement
+// points are simply allowed.
+func (*ClosedDoorSecurityPolicyEnforcer) EnforceShutdownContainerPolicy(_ string) error {
+	return nil
 }
 
 func (ClosedDoorSecurityPolicyEnforcer) ExtendDefaultMounts(_ []oci.Mount) error {

--- a/pkg/securitypolicy/securitypolicyenforcer_rego.go
+++ b/pkg/securitypolicy/securitypolicyenforcer_rego.go
@@ -615,3 +615,11 @@ func (policy *regoEnforcer) EnforceExecExternalProcessPolicy(argList []string, e
 
 	return policy.enforce("exec_external", input)
 }
+
+func (policy *regoEnforcer) EnforceShutdownContainerPolicy(containerID string) error {
+	input := map[string]interface{}{
+		"containerID": containerID,
+	}
+
+	return policy.enforce("shutdown_container", input)
+}


### PR DESCRIPTION
Adds policy enforcement around shutting down a container. In the supplied framework, shutting down a container is always allowed. We update metadata based on the change in state that will be used by other framework rules. This enforcement point is important for custom policies for metadata tracking and also for allowing the creation of rules like "this container isn't allowed to shutdown if some other container is running".

This commit rewrites `signalContainerV2` and gives it a new name. `signalContainerV2` was only called from the kill and shutdown container functions. Despite only having 2 possible signals it could receive, it accepted any signal. There's a replacement method called `signalContainerShutdownV2` that has "the same functionality" as `signalContainerV2`. `signalContainerShutdownV2` doesn't accept arbitrary signals. Instead, it takes a boolean for whether the shutdown should be graceful (aka `SIGTERM`) or if we should do a non-graceful shutdown of `SIGKILL`.

This commit aims to keep things "as they are" except for changes that are required for proper and non-evadable policy enforcement.

Actual policy enforcement is in a new method `ShutdownContainer` on the `Host` type in `uvm.go`. It is our design goal to have all enforcement functions called from within methods in `uvm.go`.

There's an additional new method on the `Host` as well: `SignalContainerProcess`. `SignalContainerProcess` allows for the sending of arbitrary signals from the untrusted host computer to the UVM. The code has been extracted from `signalProcessV2` in the bridge and moved onto the `Host` type. The move was required in order to add additional logic to `SignalContainerProcess` that `signalProcessV2` lacked.

`SignalContainerProcess` will check to see if the process being signaled is the init process of the container. If it is and the signal is `SIGTERM` or `SIGKILL` then the shutdown container enforcement rule will be used. We create this "special case" as shutting down a container is the process of sending `SIGTERM` or `SIGKILL` to the container's init process. The information for whether a process is the init process for a container is available, but not from the module that bridge is part of, thus the move of functionality into `Host`.

The creation of `SignalContainerProcess` was going to be required for when we add support for enforcing policy around sending arbitrary signals to processes. The current `SignalContainerProcess` was written with that forthcoming changing in mind, but doesn't include any logic for the additional enforcement as that will be coming in a commit that will arrive "in the not so distant future".

Shutdown container policy, because it is always allowed by our framework, doesn't require changing the `securitypolicy` policy generation tool as there's no user provided input to the new policy rule `shutdown_container`.

When not using an open door policy, a "container not started" error will be returned if a shutdown is attempted on a container identifier that wasn't used to start a container.