### PR TITLE
Add pause container security policy fragment injection

### DIFF
--- a/cmd/containerd-shim-runhcs-v1/pod.go
+++ b/cmd/containerd-shim-runhcs-v1/pod.go
@@ -154,6 +154,7 @@ func createPod(ctx context.Context, events publisher, req *task.CreateTaskReques
 				uvm.WithSecurityPolicyEnforcer(lopts.SecurityPolicyEnforcer),
 				uvm.WithSecurityPolicy(lopts.SecurityPolicy),
 				uvm.WithUVMReferenceInfo(lopts.BootFilesPath, lopts.UVMReferenceInfoFile),
+				uvm.WithPauseContainerFragmentUVMPath(lopts.PauseContainerFragmentUVMPath),
 			); err != nil {
 				return nil, errors.Wrap(err, "unable to set security policy")
 			}

--- a/internal/oci/uvm.go
+++ b/internal/oci/uvm.go
@@ -279,6 +279,7 @@ func SpecToUVMCreateOpts(ctx context.Context, s *specs.Spec, id, owner string) (
 		lopts.SecurityPolicy = parseAnnotationsString(s.Annotations, annotations.SecurityPolicy, lopts.SecurityPolicy)
 		lopts.SecurityPolicyEnforcer = parseAnnotationsString(s.Annotations, annotations.SecurityPolicyEnforcer, lopts.SecurityPolicyEnforcer)
 		lopts.UVMReferenceInfoFile = parseAnnotationsString(s.Annotations, annotations.UVMReferenceInfoFile, lopts.UVMReferenceInfoFile)
+		lopts.PauseContainerFragmentUVMPath = parseAnnotationsString(s.Annotations, annotations.PauseContainerFragmentUVMPath, lopts.PauseContainerFragmentUVMPath)
 		lopts.KernelBootOptions = parseAnnotationsString(s.Annotations, annotations.KernelBootOptions, lopts.KernelBootOptions)
 		lopts.DisableTimeSyncService = ParseAnnotationsBool(ctx, s.Annotations, annotations.DisableLCOWTimeSyncService, lopts.DisableTimeSyncService)
 		handleAnnotationPreferredRootFSType(ctx, s.Annotations, lopts)

--- a/internal/protocol/guestresource/resources.go
+++ b/internal/protocol/guestresource/resources.go
@@ -162,10 +162,13 @@ type SignalProcessOptionsWCOW struct {
 	Signal guestrequest.SignalValueWCOW `json:",omitempty"`
 }
 
+// LCOWConfidentialOptions is used to set various confidential container specific
+// options.
 type LCOWConfidentialOptions struct {
-	EnforcerType          string `json:"EnforcerType,omitempty"`
-	EncodedSecurityPolicy string `json:"EncodedSecurityPolicy,omitempty"`
-	EncodedUVMReference   string `json:"EncodedUVMReference,omitempty"`
+	EnforcerType                  string `json:"EnforcerType,omitempty"`
+	EncodedSecurityPolicy         string `json:"EncodedSecurityPolicy,omitempty"`
+	EncodedUVMReference           string `json:"EncodedUVMReference,omitempty"`
+	PauseContainerFragmentUVMPath string `json:"PauseContainerFragmentUVMPath,omitempty"`
 }
 
 type LCOWSecurityPolicyFragment struct {

--- a/internal/uvm/security_policy.go
+++ b/internal/uvm/security_policy.go
@@ -59,6 +59,17 @@ func WithUVMReferenceInfo(referenceRoot string, referenceName string) Confidenti
 	}
 }
 
+// WithPauseContainerFragmentUVMPath sets the expected path of the pause image fragment inside UVM.
+func WithPauseContainerFragmentUVMPath(uvmPath string) ConfidentialUVMOpt {
+	return func(ctx context.Context, r *guestresource.LCOWConfidentialOptions) error {
+		if uvmPath == "" {
+			return nil
+		}
+		r.PauseContainerFragmentUVMPath = uvmPath
+		return nil
+	}
+}
+
 // SetConfidentialUVMOptions sends information required to run the UVM on
 // SNP hardware, e.g., security policy and enforcer type, signed UVM reference
 // information, etc.

--- a/pkg/annotations/annotations.go
+++ b/pkg/annotations/annotations.go
@@ -278,6 +278,10 @@ const (
 	// UVMReferenceInfoFile specifies the filename of a signed UVM reference file to be passed to UVM.
 	UVMReferenceInfoFile = "io.microsoft.virtualmachine.lcow.uvm-reference-info-file"
 
+	// PauseContainerFragmentUVMPath specifies the file path for the pause container inside UVM. This assumes that
+	// the fragment is part of the LCOW UVM rootfs.
+	PauseContainerFragmentUVMPath = "io.microsoft.virtualmachine.lcow.pause-container-uvm-path"
+
 	// DisableLCOWTimeSyncService is used to disable the chronyd time
 	// synchronization service inside the LCOW UVM.
 	DisableLCOWTimeSyncService = "io.microsoft.virtualmachine.lcow.timesync.disable"

--- a/test/gcs/main_test.go
+++ b/test/gcs/main_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"github.com/Microsoft/hcsshim/internal/protocol/guestresource"
 	"log"
 	"os"
 	"strconv"
@@ -132,7 +133,10 @@ func getHost(_ context.Context, t testing.TB, rt runtime.Runtime) *hcsv2.Host {
 
 func getHostErr(rt runtime.Runtime, tp transport.Transport) (*hcsv2.Host, error) {
 	h := hcsv2.NewHost(rt, tp)
-	if err := h.SetConfidentialUVMOptions("", securityPolicy, ""); err != nil {
+	cOpts := &guestresource.LCOWConfidentialOptions{
+		EncodedSecurityPolicy: securityPolicy,
+	}
+	if err := h.SetConfidentialUVMOptions(context.TODO(), cOpts); err != nil {
 		return nil, fmt.Errorf("could not set host security policy: %w", err)
 	}
 


### PR DESCRIPTION
In general case the fragment injection will happen via sandbox task update request. However, the pause container fragment injection needs to happen before the pod even exists.

This PR addresses this issue by adding functionality to read pause container fragment from UVM's file system.
The assumption is that the fragment will be embedded into the UVM and the path will be supplied as part of confidential UVM options together with security policy and UVM reference.

The actual calling into fragment validation and injection could be changed in the future.

Signed-off-by: Maksim An <maksiman@microsoft.com>