### PR TITLE
Add pod startup security policy fragment injection

### DIFF
--- a/cmd/containerd-shim-runhcs-v1/pod.go
+++ b/cmd/containerd-shim-runhcs-v1/pod.go
@@ -154,6 +154,7 @@ func createPod(ctx context.Context, events publisher, req *task.CreateTaskReques
 				uvm.WithSecurityPolicyEnforcer(lopts.SecurityPolicyEnforcer),
 				uvm.WithSecurityPolicy(lopts.SecurityPolicy),
 				uvm.WithUVMReferenceInfo(lopts.BootFilesPath, lopts.UVMReferenceInfoFile),
+				uvm.WithPodStartupFragmentUVMPath(lopts.PodStartupFragmentUVMPath),
 			); err != nil {
 				return nil, errors.Wrap(err, "unable to set security policy")
 			}

--- a/internal/guest/runtime/hcsv2/uvm.go
+++ b/internal/guest/runtime/hcsv2/uvm.go
@@ -6,6 +6,7 @@ package hcsv2
 import (
 	"bufio"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -75,26 +76,25 @@ func NewHost(rtime runtime.Runtime, vsock transport.Transport) *Host {
 	}
 }
 
-// SetConfidentialUVMOptions takes a security policy enforcer type, base64
-// encoded security policy and base64 encoded UVM reference information to set
-// up our internal data structures we use to store said policy. The signed
-// UVM measurement can be presented to the workload containers via an
-// environment variable if client requests so.
-//
-// The security policy is transmitted as json in an annotation,
-// so we first have to remove the base64 encoding that allows
-// the JSON based policy to be passed as a string. From there,
-// we decode the JSON and setup our security policy state
-func (h *Host) SetConfidentialUVMOptions(enforcerType string, base64EncodedPolicy string, base64UVMReference string) error {
+// SetConfidentialUVMOptions takes guestresource.LCOWConfidentialOptions
+// to set up our internal data structures we use to store and enforce
+// security policy. The options can contain security policy enforcer type,
+// encoded security policy, signed UVM reference information and a UVM path
+// of an arbitrary pod startup security policy fragment. The security policy
+// and uvm reference information can be further presented to workload
+// containers for validation and attestation purposes.
+func (h *Host) SetConfidentialUVMOptions(ctx context.Context, r *guestresource.LCOWConfidentialOptions) error {
 	h.policyMutex.Lock()
 	defer h.policyMutex.Unlock()
 	if h.securityPolicyEnforcerSet {
 		return errors.New("security policy has already been set")
 	}
 
+	// Initialize security policy enforcer for a given enforcer type and
+	// encoded security policy.
 	p, err := securitypolicy.CreateSecurityPolicyEnforcer(
-		enforcerType,
-		base64EncodedPolicy,
+		r.EnforcerType,
+		r.EncodedSecurityPolicy,
 		policy.DefaultCRIMounts(),
 		policy.DefaultCRIPrivilegedMounts(),
 	)
@@ -102,7 +102,7 @@ func (h *Host) SetConfidentialUVMOptions(enforcerType string, base64EncodedPolic
 		return err
 	}
 
-	hostData, err := securitypolicy.NewSecurityPolicyDigest(base64EncodedPolicy)
+	hostData, err := securitypolicy.NewSecurityPolicyDigest(r.EncodedSecurityPolicy)
 	if err != nil {
 		return err
 	}
@@ -113,7 +113,20 @@ func (h *Host) SetConfidentialUVMOptions(enforcerType string, base64EncodedPolic
 
 	h.securityPolicyEnforcer = p
 	h.securityPolicyEnforcerSet = true
-	h.uvmReferenceInfo = base64UVMReference
+	h.uvmReferenceInfo = r.EncodedUVMReference
+
+	if r.PodStartupFragment != "" {
+		fragmentData, err := os.ReadFile(r.PodStartupFragment)
+		if err != nil {
+			return err
+		}
+
+		encodedFragment := base64.StdEncoding.EncodeToString(fragmentData)
+		// TODO (maksiman): Replace with internal fragment injection calls, when they're implemented
+		if err := h.InjectFragment(ctx, &guestresource.LCOWSecurityPolicyFragment{Fragment: encodedFragment}); err != nil {
+			return err
+		}
+	}
 
 	return nil
 }
@@ -397,7 +410,7 @@ func (h *Host) modifyHostSettings(ctx context.Context, containerID string, req *
 		if !ok {
 			return errors.New("the request's settings are not of type LCOWConfidentialOptions")
 		}
-		return h.SetConfidentialUVMOptions(r.EnforcerType, r.EncodedSecurityPolicy, r.EncodedUVMReference)
+		return h.SetConfidentialUVMOptions(ctx, r)
 	case guestresource.ResourceTypePolicyFragment:
 		r, ok := req.Settings.(*guestresource.LCOWSecurityPolicyFragment)
 		if !ok {

--- a/internal/oci/uvm.go
+++ b/internal/oci/uvm.go
@@ -279,6 +279,7 @@ func SpecToUVMCreateOpts(ctx context.Context, s *specs.Spec, id, owner string) (
 		lopts.SecurityPolicy = parseAnnotationsString(s.Annotations, annotations.SecurityPolicy, lopts.SecurityPolicy)
 		lopts.SecurityPolicyEnforcer = parseAnnotationsString(s.Annotations, annotations.SecurityPolicyEnforcer, lopts.SecurityPolicyEnforcer)
 		lopts.UVMReferenceInfoFile = parseAnnotationsString(s.Annotations, annotations.UVMReferenceInfoFile, lopts.UVMReferenceInfoFile)
+		lopts.PodStartupFragmentUVMPath = parseAnnotationsString(s.Annotations, annotations.PodStartupFragmentUVMPath, lopts.PodStartupFragmentUVMPath)
 		lopts.KernelBootOptions = parseAnnotationsString(s.Annotations, annotations.KernelBootOptions, lopts.KernelBootOptions)
 		lopts.DisableTimeSyncService = ParseAnnotationsBool(ctx, s.Annotations, annotations.DisableLCOWTimeSyncService, lopts.DisableTimeSyncService)
 		handleAnnotationPreferredRootFSType(ctx, s.Annotations, lopts)

--- a/internal/protocol/guestresource/resources.go
+++ b/internal/protocol/guestresource/resources.go
@@ -162,10 +162,13 @@ type SignalProcessOptionsWCOW struct {
 	Signal guestrequest.SignalValueWCOW `json:",omitempty"`
 }
 
+// LCOWConfidentialOptions is used to set various confidential container specific
+// options.
 type LCOWConfidentialOptions struct {
 	EnforcerType          string `json:"EnforcerType,omitempty"`
 	EncodedSecurityPolicy string `json:"EncodedSecurityPolicy,omitempty"`
 	EncodedUVMReference   string `json:"EncodedUVMReference,omitempty"`
+	PodStartupFragment    string `json:"PodStartupFragment,omitempty"`
 }
 
 type LCOWSecurityPolicyFragment struct {

--- a/internal/uvm/create_lcow.go
+++ b/internal/uvm/create_lcow.go
@@ -83,9 +83,20 @@ const (
 	UVMReferenceInfoFile = "reference_info.cose"
 )
 
+type ConfidentialOptions struct {
+	GuestStateFile            string // The vmgs file to load
+	UseGuestStateFile         bool   // Use a vmgs file that contains a kernel and initrd, required for SNP
+	SecurityPolicy            string // Optional security policy
+	SecurityPolicyEnabled     bool   // Set when there is a security policy to apply on actual SNP hardware, use this rathen than checking the string length
+	SecurityPolicyEnforcer    string // Set which security policy enforcer to use (open door, standard or rego). This allows for better fallback mechanic.
+	UVMReferenceInfoFile      string // Filename under `BootFilesPath` for (potentially signed) UVM image reference information.
+	PodStartupFragmentUVMPath string // Filepath inside UVM that contains pod startup security policy fragment.
+}
+
 // OptionsLCOW are the set of options passed to CreateLCOW() to create a utility vm.
 type OptionsLCOW struct {
 	*Options
+	*ConfidentialOptions
 
 	BootFilesPath           string              // Folder in which kernel and root file system reside. Defaults to \Program Files\Linux Containers
 	KernelFile              string              // Filename under `BootFilesPath` for the kernel. Defaults to `kernel`
@@ -106,12 +117,6 @@ type OptionsLCOW struct {
 	EnableColdDiscardHint   bool                // Whether the HCS should use cold discard hints. Defaults to false
 	VPCIEnabled             bool                // Whether the kernel should enable pci
 	EnableScratchEncryption bool                // Whether the scratch should be encrypted
-	SecurityPolicy          string              // Optional security policy
-	SecurityPolicyEnabled   bool                // Set when there is a security policy to apply on actual SNP hardware, use this rathen than checking the string length
-	SecurityPolicyEnforcer  string              // Set which security policy enforcer to use (open door, standard or rego). This allows for better fallback mechanic.
-	UVMReferenceInfoFile    string              // Filename under `BootFilesPath` for (potentially signed) UVM image reference information.
-	UseGuestStateFile       bool                // Use a vmgs file that contains a kernel and initrd, required for SNP
-	GuestStateFile          string              // The vmgs file to load
 	DisableTimeSyncService  bool                // Disables the time synchronization service
 }
 
@@ -158,12 +163,11 @@ func NewDefaultOptionsLCOW(id, owner string) *OptionsLCOW {
 		EnableColdDiscardHint:   false,
 		VPCIEnabled:             false,
 		EnableScratchEncryption: false,
-		SecurityPolicyEnabled:   false,
-		SecurityPolicyEnforcer:  "",
-		SecurityPolicy:          "",
-		UVMReferenceInfoFile:    UVMReferenceInfoFile,
-		GuestStateFile:          "",
 		DisableTimeSyncService:  false,
+		ConfidentialOptions: &ConfidentialOptions{
+			SecurityPolicyEnabled: false,
+			UVMReferenceInfoFile:  UVMReferenceInfoFile,
+		},
 	}
 
 	if _, err := os.Stat(filepath.Join(opts.BootFilesPath, VhdFile)); err == nil {

--- a/internal/uvm/security_policy.go
+++ b/internal/uvm/security_policy.go
@@ -59,6 +59,17 @@ func WithUVMReferenceInfo(referenceRoot string, referenceName string) Confidenti
 	}
 }
 
+// WithPodStartupFragmentUVMPath sets the expected path of the pause image fragment inside UVM.
+func WithPodStartupFragmentUVMPath(uvmPath string) ConfidentialUVMOpt {
+	return func(ctx context.Context, r *guestresource.LCOWConfidentialOptions) error {
+		if uvmPath == "" {
+			return nil
+		}
+		r.PodStartupFragment = uvmPath
+		return nil
+	}
+}
+
 // SetConfidentialUVMOptions sends information required to run the UVM on
 // SNP hardware, e.g., security policy and enforcer type, signed UVM reference
 // information, etc.

--- a/pkg/annotations/annotations.go
+++ b/pkg/annotations/annotations.go
@@ -278,6 +278,10 @@ const (
 	// UVMReferenceInfoFile specifies the filename of a signed UVM reference file to be passed to UVM.
 	UVMReferenceInfoFile = "io.microsoft.virtualmachine.lcow.uvm-reference-info-file"
 
+	// PodStartupFragmentUVMPath specifies the file path within the UVM for an arbitrary pod startup fragment, e.g.
+	// pause container fragment. This assumes that the fragment is part of the LCOW UVM rootfs.
+	PodStartupFragmentUVMPath = "io.microsoft.virtualmachine.lcow.pod-startup-fragment-uvm-path"
+
 	// DisableLCOWTimeSyncService is used to disable the chronyd time
 	// synchronization service inside the LCOW UVM.
 	DisableLCOWTimeSyncService = "io.microsoft.virtualmachine.lcow.timesync.disable"

--- a/test/gcs/main_test.go
+++ b/test/gcs/main_test.go
@@ -11,6 +11,8 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/Microsoft/hcsshim/internal/protocol/guestresource"
+
 	"github.com/containerd/cgroups"
 	"github.com/sirupsen/logrus"
 
@@ -132,7 +134,10 @@ func getHost(_ context.Context, t testing.TB, rt runtime.Runtime) *hcsv2.Host {
 
 func getHostErr(rt runtime.Runtime, tp transport.Transport) (*hcsv2.Host, error) {
 	h := hcsv2.NewHost(rt, tp)
-	if err := h.SetConfidentialUVMOptions("", securityPolicy, ""); err != nil {
+	cOpts := &guestresource.LCOWConfidentialOptions{
+		EncodedSecurityPolicy: securityPolicy,
+	}
+	if err := h.SetConfidentialUVMOptions(context.Background(), cOpts); err != nil {
 		return nil, fmt.Errorf("could not set host security policy: %w", err)
 	}
 


### PR DESCRIPTION
In general case the fragment injection will happen via sandbox task update request. However, we may need to inject fragments before the pod is created and ready to accept the update request. One of the examples is the pause container, which holds the pod network namespace.

This PR addresses this issue by adding functionality to read an arbitrary security policy fragment from UVM's file system. The assumption is that the fragment will be embedded into the UVM and the path will be supplied as part of confidential UVM options together with security policy and UVM reference.

The actual calling into fragment validation and injection could be changed in the future.

Signed-off-by: Maksim An <maksiman@microsoft.com>