### PR TITLE
fix wrong parameters passed to EnforceExecExternalProcessPolicy

### DIFF
--- a/internal/guest/runtime/hcsv2/uvm.go
+++ b/internal/guest/runtime/hcsv2/uvm.go
@@ -474,7 +474,11 @@ func (h *Host) ExecProcess(ctx context.Context, containerID string, params prot.
 	var pid int
 	var c *Container
 	if params.IsExternal || containerID == UVMContainerID {
-		err = h.securityPolicyEnforcer.EnforceExecExternalProcessPolicy(params.OCIProcess.Args, params.OCIProcess.Env, params.OCIProcess.Cwd)
+		err = h.securityPolicyEnforcer.EnforceExecExternalProcessPolicy(
+			params.CommandArgs,
+			processParamEnvToOCIEnv(params.Environment),
+			params.WorkingDirectory,
+		)
 		if err != nil {
 			return pid, errors.Wrapf(err, "exec in container denied due to policy")
 		}


### PR DESCRIPTION
Fixes GCS panic, because OCIProcess for exec external is nil.

For exec external process we don't use OCIProcess field of ProcessParameters, but instead use the top level CommandArgs, Environment and WorkingDirectory.

Signed-off-by: Maksim An <maksiman@microsoft.com>