### PR TITLE
Update policy enforcer overlay error message to be more descriptive

### DIFF
--- a/pkg/securitypolicy/securitypolicyenforcer.go
+++ b/pkg/securitypolicy/securitypolicyenforcer.go
@@ -375,7 +375,7 @@ func (pe *StandardSecurityPolicyEnforcer) EnforceOverlayMountPolicy(containerID 
 	for _, i := range matchedContainers {
 		existing := pe.ContainerIndexToContainerIds[i]
 		if len(existing) >= len(matchedContainers) {
-			errmsg := fmt.Sprintf("layerPaths '%v' already used in maximum number of container overlays", layerPaths)
+			errmsg := fmt.Sprintf("layerPaths '%v' already used in maximum number of container overlays. This is likely because the security policy allows the container to be run only once.", layerPaths)
 			return errors.New(errmsg)
 		}
 		pe.expandMatchesForContainerIndex(i, containerID)


### PR DESCRIPTION
For the "layerPaths... " message, adding the root cause of the error to be displayed to the user in addition to the symptom of the failure.