### PR TITLE
Add enforcement of sending signals to arbitrary processes in a container

### DIFF
--- a/internal/guest/storage/test/policy/mountmonitoringsecuritypolicyenforcer.go
+++ b/internal/guest/storage/test/policy/mountmonitoringsecuritypolicyenforcer.go
@@ -4,6 +4,8 @@
 package policy
 
 import (
+	"syscall"
+
 	oci "github.com/opencontainers/runtime-spec/specs-go"
 
 	"github.com/Microsoft/hcsshim/pkg/securitypolicy"
@@ -56,5 +58,9 @@ func (MountMonitoringSecurityPolicyEnforcer) EnforceExecExternalProcessPolicy(_ 
 }
 
 func (MountMonitoringSecurityPolicyEnforcer) EnforceShutdownContainerPolicy(_ string) error {
+	return nil
+}
+
+func (MountMonitoringSecurityPolicyEnforcer) EnforceSignalContainerProcessPolicy(_ string, _ syscall.Signal, _ bool, _ []string) error {
 	return nil
 }

--- a/internal/tools/securitypolicy/helpers/helpers.go
+++ b/internal/tools/securitypolicy/helpers/helpers.go
@@ -161,6 +161,7 @@ func PolicyContainersFromConfigs(containerConfigs []securitypolicy.ContainerConf
 			containerConfig.Mounts,
 			containerConfig.AllowElevated,
 			containerConfig.ExecProcesses,
+			containerConfig.Signals,
 		)
 		if err != nil {
 			return nil, err

--- a/pkg/securitypolicy/api.rego
+++ b/pkg/securitypolicy/api.rego
@@ -1,6 +1,6 @@
 package api
 
-svn := "0.4.0"
+svn := "0.5.0"
 
 enforcement_points := {
     "mount_device": {"introducedVersion": "0.1.0", "allowedByDefault": false},
@@ -9,5 +9,6 @@ enforcement_points := {
     "unmount_device": {"introducedVersion": "0.2.0", "allowedByDefault": true},
     "exec_in_container": {"introducedVersion": "0.2.0", "allowedByDefault": true},
     "exec_external": {"introducedVersion": "0.3.0", "allowedByDefault": true},
-    "shutdown_container": {"introducedVersion": "0.4.0", "allowedByDefault": true}
+    "shutdown_container": {"introducedVersion": "0.4.0", "allowedByDefault": true},
+    "signal_container_process": {"introducedVersion": "0.5.0", "allowedByDefault": true}
 }

--- a/pkg/securitypolicy/open_door.rego
+++ b/pkg/securitypolicy/open_door.rego
@@ -1,6 +1,6 @@
 package policy
 
-api_svn := "0.4.0"
+api_svn := "0.5.0"
 
 mount_device := {"allowed": true}
 mount_overlay := {"allowed": true}
@@ -9,3 +9,4 @@ unmount_device := {"allowed": true}
 exec_in_container := {"allowed": true}
 exec_external := {"allowed": true}
 shutdown_container := {"allowed": true}
+signal_container_process := {"allowed": true}

--- a/pkg/securitypolicy/policy.rego
+++ b/pkg/securitypolicy/policy.rego
@@ -1,6 +1,6 @@
 package policy
 
-api_svn := "0.4.0"
+api_svn := "0.5.0"
 
 import future.keywords.every
 import future.keywords.in
@@ -14,4 +14,5 @@ create_container := data.framework.create_container
 exec_in_container := data.framework.exec_in_container
 exec_external := data.framework.exec_external
 shutdown_container := data.framework.shutdown_container
+signal_container_process := data.framework.signal_container_process
 reason := {"errors": data.framework.errors}

--- a/pkg/securitypolicy/securitypolicy.go
+++ b/pkg/securitypolicy/securitypolicy.go
@@ -8,6 +8,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"syscall"
 
 	"github.com/Microsoft/hcsshim/internal/guestpath"
 	"github.com/pkg/errors"
@@ -60,6 +61,7 @@ type ContainerConfig struct {
 	Mounts        []MountConfig       `json:"mounts" toml:"mount"`
 	AllowElevated bool                `json:"allow_elevated" toml:"allow_elevated"`
 	ExecProcesses []ExecProcessConfig `json:"exec_processes" toml:"exec_process"`
+	Signals       []syscall.Signal    `json:"signals" toml:"signals"`
 }
 
 // MountConfig contains toml or JSON config for mount security policy
@@ -73,7 +75,8 @@ type MountConfig struct {
 // ExecProcessConfig contains toml or JSON config for exec process security
 // policy constraint description
 type ExecProcessConfig struct {
-	Command []string `json:"command" toml:"command"`
+	Command []string         `json:"command" toml:"command"`
+	Signals []syscall.Signal `json:"signals" toml:"signals"`
 }
 
 // NewEnvVarRules creates slice of EnvRuleConfig's from environment variables
@@ -151,6 +154,7 @@ type Container struct {
 	Mounts        Mounts      `json:"mounts"`
 	AllowElevated bool        `json:"allow_elevated"`
 	ExecProcesses []ExecProcessConfig
+	Signals       []syscall.Signal
 }
 
 // StringArrayMap wraps an array of strings as a string map.
@@ -191,6 +195,7 @@ func CreateContainerPolicy(
 	mounts []MountConfig,
 	allowElevated bool,
 	execProcesses []ExecProcessConfig,
+	signals []syscall.Signal,
 ) (*Container, error) {
 	if err := validateEnvRules(envRules); err != nil {
 		return nil, err
@@ -206,6 +211,7 @@ func CreateContainerPolicy(
 		Mounts:        newMountConstraints(mounts),
 		AllowElevated: allowElevated,
 		ExecProcesses: execProcesses,
+		Signals:       signals,
 	}, nil
 }
 

--- a/pkg/securitypolicy/securitypolicy_internal.go
+++ b/pkg/securitypolicy/securitypolicy_internal.go
@@ -3,6 +3,7 @@ package securitypolicy
 import (
 	"fmt"
 	"strconv"
+	"syscall"
 )
 
 // Internal version of SecurityPolicy
@@ -31,10 +32,15 @@ type securityPolicyContainer struct {
 	// A list of lists of commands that can be used to execute additional
 	// processes within the container
 	ExecProcesses []containerExecProcess
+	// A list of signals that are allowed to be sent to the container's init
+	// process.
+	Signals []syscall.Signal
 }
 
 type containerExecProcess struct {
 	Command []string
+	// A list of signals that are allowed to be sent to this process
+	Signals []syscall.Signal
 }
 
 type externalProcess struct {
@@ -88,6 +94,7 @@ func (c Container) toInternal() (securityPolicyContainer, error) {
 		Mounts:        mounts,
 		AllowElevated: c.AllowElevated,
 		ExecProcesses: execProcesses,
+		Signals:       c.Signals,
 	}, nil
 }
 

--- a/pkg/securitypolicy/securitypolicyenforcer_rego.go
+++ b/pkg/securitypolicy/securitypolicyenforcer_rego.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"strconv"
 	"sync"
+	"syscall"
 
 	"github.com/Microsoft/hcsshim/internal/guest/spec"
 	"github.com/Microsoft/hcsshim/internal/guestpath"
@@ -622,4 +623,15 @@ func (policy *regoEnforcer) EnforceShutdownContainerPolicy(containerID string) e
 	}
 
 	return policy.enforce("shutdown_container", input)
+}
+
+func (policy *regoEnforcer) EnforceSignalContainerProcessPolicy(containerID string, signal syscall.Signal, isInitProcess bool, startupArgList []string) error {
+	input := map[string]interface{}{
+		"containerID":   containerID,
+		"signal":        signal,
+		"isInitProcess": isInitProcess,
+		"argList":       startupArgList,
+	}
+
+	return policy.enforce("signal_container_process", input)
 }


### PR DESCRIPTION
Most people tend to think of a container as thing that does a single thing and by extension, as a thing that is a single process. This isn't the case but it is the mental model that people bring to containers. It also happens to be an incredibly common scenario where a container "equals" a single process.

Our model for representing "container constraints" in the policy engine in GCS doesn't break out the init process of a container into a process representation. Instead, signals going to an init process are represented as signals "on the container" and signals going to other processes in the container are represented as signals on an "exec_process".

This makes understanding how to apply constraints to a container easier for folks getting started with confidential containers. It also means that we need to have two different bits of code for enforcing signal constraints on processes in GCS.

For any pid and container id combo we do the following:

If the pid is for the init process of a container, then we know to use the container signal list for determining if sending the signal is allowed.

If the pid isn't for an init process, then we have a bit more work to do. We don't have any mapping of a pid to policy entry if the pid isn't for the init process of a container. But, we can still map from the incoming pid to set of 0 or more valid policy exec_process entries.

GCS stores a collection, on a per container basis, of all processes that were started including the OCI Spec for each process started. We can match the pid to the OCI Spec used to start the process with said pid. We can then use the command from that process to find any valid exec process entries in the policy for the container and see if any of them allow the signal in question. Any matching exec process entries can then be used to do further narrowing on possible container matches in the policy for the given container id.
