### PR TITLE
fix create-scratch and other `runhcs` subucommands

### DIFF
--- a/cmd/runhcs/create-scratch.go
+++ b/cmd/runhcs/create-scratch.go
@@ -70,7 +70,9 @@ var createScratchCommand = cli.Command{
 		if err := convertUVM.Start(ctx); err != nil {
 			return errors.Wrapf(err, "failed to start '%s'", opts.ID)
 		}
-
+		if err := convertUVM.SetConfidentialUVMOptions(ctx); err != nil {
+			return err
+		}
 		if err := lcow.CreateScratch(ctx, convertUVM, dest, sizeGB, context.String("cache-path")); err != nil {
 			return errors.Wrapf(err, "failed to create ext4vhdx for '%s'", opts.ID)
 		}

--- a/cmd/runhcs/prepare-disk.go
+++ b/cmd/runhcs/prepare-disk.go
@@ -57,7 +57,9 @@ var prepareDiskCommand = cli.Command{
 		if err := preparediskUVM.Start(ctx); err != nil {
 			return errors.Wrapf(err, "failed to start '%s'", opts.ID)
 		}
-
+		if err := preparediskUVM.SetConfidentialUVMOptions(ctx); err != nil {
+			return err
+		}
 		if err := lcow.FormatDisk(ctx, preparediskUVM, dest); err != nil {
 			return errors.Wrapf(err, "failed to format disk '%s' with ext4", opts.ID)
 		}

--- a/cmd/runhcs/vm.go
+++ b/cmd/runhcs/vm.go
@@ -11,7 +11,7 @@ import (
 	"os"
 	"syscall"
 
-	winio "github.com/Microsoft/go-winio"
+	"github.com/Microsoft/go-winio"
 	"github.com/Microsoft/hcsshim/internal/appargs"
 	"github.com/Microsoft/hcsshim/internal/logfields"
 	"github.com/Microsoft/hcsshim/internal/runhcs"
@@ -86,6 +86,9 @@ var vmshimCommand = cli.Command{
 		}
 		defer vm.Close()
 		if err = vm.Start(gcontext.Background()); err != nil {
+			return err
+		}
+		if err := vm.SetConfidentialUVMOptions(gcontext.Background()); err != nil {
 			return err
 		}
 

--- a/internal/guest/runtime/hcsv2/uvm.go
+++ b/internal/guest/runtime/hcsv2/uvm.go
@@ -498,7 +498,7 @@ func (h *Host) ExecProcess(ctx context.Context, containerID string, params prot.
 			params.WorkingDirectory,
 		)
 		if err != nil {
-			return pid, errors.Wrapf(err, "exec in container denied due to policy")
+			return pid, errors.Wrapf(err, "exec is denied due to policy")
 		}
 		pid, err = h.runExternalProcess(ctx, params, conSettings)
 	} else if c, err = h.GetCreatedContainer(containerID); err == nil {

--- a/test/cri-containerd/runpodsandbox_test.go
+++ b/test/cri-containerd/runpodsandbox_test.go
@@ -1066,6 +1066,10 @@ func createExt4VHD(ctx context.Context, t *testing.T, path string) {
 	uvm := testuvm.CreateAndStartLCOW(ctx, t, t.Name()+"-createExt4VHD")
 	defer uvm.Close()
 
+	if err := uvm.SetConfidentialUVMOptions(ctx); err != nil {
+		t.Fatal(err)
+	}
+
 	if err := lcow.CreateScratch(ctx, uvm, path, 2, ""); err != nil {
 		t.Fatal(err)
 	}

--- a/test/internal/uvm/lcow.go
+++ b/test/internal/uvm/lcow.go
@@ -40,7 +40,7 @@ func CreateLCOW(ctx context.Context, t testing.TB, opts *uvm.OptionsLCOW) *uvm.U
 }
 
 func SetSecurityPolicy(ctx context.Context, t testing.TB, vm *uvm.UtilityVM, policy string) {
-	if err := vm.SetConfidentialUVMOptions(ctx, uvm.WithSecurityPolicyEnforcer("allow_all"), uvm.WithSecurityPolicy(policy)); err != nil {
+	if err := vm.SetConfidentialUVMOptions(ctx, uvm.WithSecurityPolicy(policy)); err != nil {
 		t.Helper()
 		t.Fatalf("could not set vm security policy to %q: %v", policy, err)
 	}


### PR DESCRIPTION
`runhcs` subcommands were missing a call to `SetConfidentialUVMOptions` after the uVM has been booted. This results in closed door policy to be set for all UVM operations, including (now) execs into UVM. Previously the exec would succeed, UVM exited and we had our scratch.

Additionally GCS has been updated to set the policy to "open door" when both enforcer and security policy options are empty.

Signed-off-by: Maksim An <maksiman@microsoft.com>