### PR TITLE
Ignoring unneeded fields in JSON policy marshalling.

### DIFF
--- a/pkg/securitypolicy/securitypolicy.go
+++ b/pkg/securitypolicy/securitypolicy.go
@@ -147,14 +147,14 @@ type Containers struct {
 }
 
 type Container struct {
-	Command       CommandArgs `json:"command"`
-	EnvRules      EnvRules    `json:"env_rules"`
-	Layers        Layers      `json:"layers"`
-	WorkingDir    string      `json:"working_dir"`
-	Mounts        Mounts      `json:"mounts"`
-	AllowElevated bool        `json:"allow_elevated"`
-	ExecProcesses []ExecProcessConfig
-	Signals       []syscall.Signal
+	Command       CommandArgs         `json:"command"`
+	EnvRules      EnvRules            `json:"env_rules"`
+	Layers        Layers              `json:"layers"`
+	WorkingDir    string              `json:"working_dir"`
+	Mounts        Mounts              `json:"mounts"`
+	AllowElevated bool                `json:"allow_elevated"`
+	ExecProcesses []ExecProcessConfig `json:"-"`
+	Signals       []syscall.Signal    `json:"-"`
 }
 
 // StringArrayMap wraps an array of strings as a string map.


### PR DESCRIPTION
The `ExecProcesses` and `Signals` fields on `Container`, which are needed for newly added enforcement points, were not being ignored during JSON marshalling. These values should not be included in the marshalled object because the new enforcement points that require them are not implemented for the `StandardSecurityPolicyEnforcer` which uses the JSON representation for policies.
