### PR TITLE
set confidential UVM options during UVM start

### DIFF
--- a/cmd/containerd-shim-runhcs-v1/pod.go
+++ b/cmd/containerd-shim-runhcs-v1/pod.go
@@ -148,17 +148,6 @@ func createPod(ctx context.Context, events publisher, req *task.CreateTaskReques
 			return nil, err
 		}
 
-		if lopts != nil {
-			if err := parent.SetConfidentialUVMOptions(
-				ctx,
-				uvm.WithSecurityPolicyEnforcer(lopts.SecurityPolicyEnforcer),
-				uvm.WithSecurityPolicy(lopts.SecurityPolicy),
-				uvm.WithUVMReferenceInfo(lopts.BootFilesPath, lopts.UVMReferenceInfoFile),
-				uvm.WithPodStartupFragmentUVMPath(lopts.PodStartupFragmentUVMPath),
-			); err != nil {
-				return nil, errors.Wrap(err, "unable to set security policy")
-			}
-		}
 	} else if oci.IsJobContainer(s) {
 		// If we're making a job container fake a task (i.e reuse the wcowPodSandbox logic)
 		p.sandboxTask = newWcowPodSandboxTask(ctx, events, req.ID, req.Bundle, parent, "")

--- a/cmd/runhcs/create-scratch.go
+++ b/cmd/runhcs/create-scratch.go
@@ -70,9 +70,6 @@ var createScratchCommand = cli.Command{
 		if err := convertUVM.Start(ctx); err != nil {
 			return errors.Wrapf(err, "failed to start '%s'", opts.ID)
 		}
-		if err := convertUVM.SetConfidentialUVMOptions(ctx); err != nil {
-			return err
-		}
 		if err := lcow.CreateScratch(ctx, convertUVM, dest, sizeGB, context.String("cache-path")); err != nil {
 			return errors.Wrapf(err, "failed to create ext4vhdx for '%s'", opts.ID)
 		}

--- a/cmd/runhcs/prepare-disk.go
+++ b/cmd/runhcs/prepare-disk.go
@@ -57,9 +57,6 @@ var prepareDiskCommand = cli.Command{
 		if err := preparediskUVM.Start(ctx); err != nil {
 			return errors.Wrapf(err, "failed to start '%s'", opts.ID)
 		}
-		if err := preparediskUVM.SetConfidentialUVMOptions(ctx); err != nil {
-			return err
-		}
 		if err := lcow.FormatDisk(ctx, preparediskUVM, dest); err != nil {
 			return errors.Wrapf(err, "failed to format disk '%s' with ext4", opts.ID)
 		}

--- a/cmd/runhcs/vm.go
+++ b/cmd/runhcs/vm.go
@@ -88,9 +88,6 @@ var vmshimCommand = cli.Command{
 		if err = vm.Start(gcontext.Background()); err != nil {
 			return err
 		}
-		if err := vm.SetConfidentialUVMOptions(gcontext.Background()); err != nil {
-			return err
-		}
 
 		// Asynchronously wait for the VM to exit.
 		exitCh := make(chan error)

--- a/internal/uvm/create_lcow.go
+++ b/internal/uvm/create_lcow.go
@@ -756,6 +756,7 @@ func CreateLCOW(ctx context.Context, opts *OptionsLCOW) (_ *UtilityVM, err error
 		vpmemMultiMapping:       !opts.VPMemNoMultiMapping,
 		encryptScratch:          opts.EnableScratchEncryption,
 		noWritableFileShares:    opts.NoWritableFileShares,
+		confidentialUVMOptions:  opts.ConfidentialOptions,
 	}
 
 	defer func() {

--- a/internal/uvm/start.go
+++ b/internal/uvm/start.go
@@ -274,6 +274,17 @@ func (uvm *UtilityVM) Start(ctx context.Context) (err error) {
 		uvm.protocol = properties.GuestConnectionInfo.ProtocolVersion
 	}
 
+	if uvm.confidentialUVMOptions != nil && uvm.OS() == "linux" {
+		if err := uvm.SetConfidentialUVMOptions(ctx,
+			WithSecurityPolicy(uvm.confidentialUVMOptions.SecurityPolicy),
+			WithSecurityPolicyEnforcer(uvm.confidentialUVMOptions.SecurityPolicyEnforcer),
+			WithUVMReferenceInfo(defaultLCOWOSBootFilesPath(), uvm.confidentialUVMOptions.UVMReferenceInfoFile),
+			WithPodStartupFragmentUVMPath(uvm.confidentialUVMOptions.PodStartupFragmentUVMPath),
+		); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 

--- a/internal/uvm/types.go
+++ b/internal/uvm/types.go
@@ -146,4 +146,7 @@ type UtilityVM struct {
 	// noInheritHostTimezone specifies whether to not inherit the hosts timezone for the UVM. UTC will be set as the default instead.
 	// This only applies for WCOW.
 	noInheritHostTimezone bool
+
+	// confidentialUVMOptions hold confidential UVM specific options
+	confidentialUVMOptions *ConfidentialOptions
 }

--- a/test/cri-containerd/runpodsandbox_test.go
+++ b/test/cri-containerd/runpodsandbox_test.go
@@ -1066,10 +1066,6 @@ func createExt4VHD(ctx context.Context, t *testing.T, path string) {
 	uvm := testuvm.CreateAndStartLCOW(ctx, t, t.Name()+"-createExt4VHD")
 	defer uvm.Close()
 
-	if err := uvm.SetConfidentialUVMOptions(ctx); err != nil {
-		t.Fatal(err)
-	}
-
 	if err := lcow.CreateScratch(ctx, uvm, path, 2, ""); err != nil {
 		t.Fatal(err)
 	}

--- a/test/functional/lcow_container_bench_test.go
+++ b/test/functional/lcow_container_bench_test.go
@@ -35,7 +35,6 @@ func BenchmarkLCOW_Container(b *testing.B) {
 
 	b.Run("Create", func(b *testing.B) {
 		vm := uvm.CreateAndStartLCOWFromOpts(ctx, b, defaultLCOWOptions(b))
-		uvm.SetSecurityPolicy(ctx, b, vm, "")
 		cache := layers.CacheFile(ctx, b, "")
 
 		b.StopTimer()
@@ -83,7 +82,6 @@ func BenchmarkLCOW_Container(b *testing.B) {
 
 	b.Run("Start", func(b *testing.B) {
 		vm := uvm.CreateAndStartLCOWFromOpts(ctx, b, defaultLCOWOptions(b))
-		uvm.SetSecurityPolicy(ctx, b, vm, "")
 		cache := layers.CacheFile(ctx, b, "")
 
 		b.StopTimer()
@@ -116,7 +114,6 @@ func BenchmarkLCOW_Container(b *testing.B) {
 
 	b.Run("InitExec", func(b *testing.B) {
 		vm := uvm.CreateAndStartLCOWFromOpts(ctx, b, defaultLCOWOptions(b))
-		uvm.SetSecurityPolicy(ctx, b, vm, "")
 		cache := layers.CacheFile(ctx, b, "")
 
 		b.StopTimer()
@@ -150,7 +147,6 @@ func BenchmarkLCOW_Container(b *testing.B) {
 
 	b.Run("InitExecKill", func(b *testing.B) {
 		vm := uvm.CreateAndStartLCOWFromOpts(ctx, b, defaultLCOWOptions(b))
-		uvm.SetSecurityPolicy(ctx, b, vm, "")
 		cache := layers.CacheFile(ctx, b, "")
 
 		b.StopTimer()
@@ -179,7 +175,6 @@ func BenchmarkLCOW_Container(b *testing.B) {
 
 	b.Run("ContainerKill", func(b *testing.B) {
 		vm := uvm.CreateAndStartLCOWFromOpts(ctx, b, defaultLCOWOptions(b))
-		uvm.SetSecurityPolicy(ctx, b, vm, "")
 		cache := layers.CacheFile(ctx, b, "")
 
 		b.StopTimer()

--- a/test/functional/lcow_container_test.go
+++ b/test/functional/lcow_container_test.go
@@ -31,7 +31,6 @@ func TestLCOW_ContainerLifecycle(t *testing.T) {
 
 	opts := defaultLCOWOptions(t)
 	vm := uvm.CreateAndStartLCOWFromOpts(ctx, t, opts)
-	uvm.SetSecurityPolicy(ctx, t, vm, "")
 
 	scratch, _ := layers.ScratchSpace(ctx, t, vm, "", "", "")
 
@@ -89,7 +88,6 @@ func TestLCOW_ContainerIO(t *testing.T) {
 	opts := defaultLCOWOptions(t)
 	cache := layers.CacheFile(ctx, t, "")
 	vm := uvm.CreateAndStartLCOWFromOpts(ctx, t, opts)
-	uvm.SetSecurityPolicy(ctx, t, vm, "")
 
 	for _, tt := range ioTests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -133,7 +131,6 @@ func TestLCOW_ContainerExec(t *testing.T) {
 
 	opts := defaultLCOWOptions(t)
 	vm := uvm.CreateAndStartLCOWFromOpts(ctx, t, opts)
-	uvm.SetSecurityPolicy(ctx, t, vm, "")
 
 	id := strings.ReplaceAll(t.Name(), "/", "")
 	scratch, _ := layers.ScratchSpace(ctx, t, vm, "", "", "")

--- a/test/functional/uvm_plannine_test.go
+++ b/test/functional/uvm_plannine_test.go
@@ -31,7 +31,6 @@ func TestPlan9(t *testing.T) {
 
 	vm := testuvm.CreateAndStartLCOWFromOpts(ctx, t, defaultLCOWOptions(t))
 	defer vm.Close()
-	testuvm.SetSecurityPolicy(ctx, t, vm, "")
 
 	dir := t.TempDir()
 	var iterations uint32 = 64
@@ -63,7 +62,6 @@ func TestPlan9_Writable(t *testing.T) {
 	opts.NoWritableFileShares = true
 	vm := testuvm.CreateAndStartLCOWFromOpts(ctx, t, opts)
 	defer vm.Close()
-	testuvm.SetSecurityPolicy(ctx, t, vm, "")
 
 	dir := t.TempDir()
 

--- a/test/internal/uvm/lcow.go
+++ b/test/internal/uvm/lcow.go
@@ -38,10 +38,3 @@ func CreateLCOW(ctx context.Context, t testing.TB, opts *uvm.OptionsLCOW) *uvm.U
 
 	return vm
 }
-
-func SetSecurityPolicy(ctx context.Context, t testing.TB, vm *uvm.UtilityVM, policy string) {
-	if err := vm.SetConfidentialUVMOptions(ctx, uvm.WithSecurityPolicy(policy)); err != nil {
-		t.Helper()
-		t.Fatalf("could not set vm security policy to %q: %v", policy, err)
-	}
-}


### PR DESCRIPTION
To make the interface cleaner for cases when security policy isn't required, call to `SetConfidentialUVMOptions` within `Start`. When no enforcer or policy are supplied GCS will initialize an open door enforcer.

UtilityVM object now holds the confidential options to use them during `Start`.

By default the UVM reference is expected to be located at the directory as the shim executable rather than under linux boot files. This has been done to avoid holding this information on the UVM object.

`uvmboot` has been updated to take a `security-policy-enforcer` parameter.

Signed-off-by: Maksim An <maksiman@microsoft.com>