### PR TITLE
Add `t.Helper` calls, test helpers linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,9 +11,19 @@ run:
 
 linters:
   enable:
-    - gofmt
-    - nolintlint
-    - stylecheck
+    # defaults:
+    # - errcheck
+    # - gosimple
+    # - govet
+    # - ineffassign
+    # - staticcheck
+    # - typecheck
+    # - unused
+
+    - gofmt # whether code was gofmt-ed
+    - nolintlint # ill-formed or insufficient nolint directives
+    - stylecheck # golint replacement
+    - thelper #  test helpers without t.Helper()
 
 linters-settings:
   stylecheck:

--- a/cmd/containerd-shim-runhcs-v1/exec_wcow_podsandbox_test.go
+++ b/cmd/containerd-shim-runhcs-v1/exec_wcow_podsandbox_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func verifyWcowPodSandboxExecStatus(t *testing.T, wasStarted bool, es containerd_v1_types.Status, status *task.StateResponse) {
+	t.Helper()
 	if status.ID != t.Name() {
 		t.Fatalf("expected id: '%s' got: '%s'", t.Name(), status.ID)
 	}

--- a/cmd/containerd-shim-runhcs-v1/pod_test.go
+++ b/cmd/containerd-shim-runhcs-v1/pod_test.go
@@ -89,6 +89,7 @@ func (tsp *testShimPod) DeleteTask(ctx context.Context, tid string) error {
 // Pod tests
 
 func setupTestPodWithFakes(t *testing.T) (*pod, *testShimTask) {
+	t.Helper()
 	st := &testShimTask{
 		id:    t.Name(),
 		exec:  newTestShimExec(t.Name(), t.Name(), 10),
@@ -105,6 +106,7 @@ func setupTestPodWithFakes(t *testing.T) (*pod, *testShimTask) {
 }
 
 func setupTestTaskInPod(t *testing.T, p *pod) *testShimTask {
+	t.Helper()
 	tid := strconv.Itoa(rand.Int())
 	wt := &testShimTask{
 		id:   tid,

--- a/cmd/containerd-shim-runhcs-v1/service_internal_podshim_test.go
+++ b/cmd/containerd-shim-runhcs-v1/service_internal_podshim_test.go
@@ -19,6 +19,7 @@ import (
 )
 
 func setupPodServiceWithFakes(t *testing.T) (*service, *testShimTask, *testShimTask, *testShimExec) {
+	t.Helper()
 	tid := strconv.Itoa(rand.Int())
 
 	s, err := NewService(WithTID(tid), WithIsSandbox(true))

--- a/cmd/containerd-shim-runhcs-v1/service_internal_taskshim_test.go
+++ b/cmd/containerd-shim-runhcs-v1/service_internal_taskshim_test.go
@@ -19,6 +19,7 @@ import (
 )
 
 func setupTaskServiceWithFakes(t *testing.T) (*service, *testShimTask, *testShimExec) {
+	t.Helper()
 	tid := strconv.Itoa(rand.Int())
 
 	s, err := NewService(WithTID(tid), WithIsSandbox(false))

--- a/cmd/containerd-shim-runhcs-v1/service_internal_test.go
+++ b/cmd/containerd-shim-runhcs-v1/service_internal_test.go
@@ -16,6 +16,7 @@ import (
 )
 
 func verifyExpectedError(t *testing.T, resp interface{}, actual, expected error) {
+	t.Helper()
 	if actual == nil || errors.Cause(actual) != expected || !errors.Is(actual, expected) {
 		t.Fatalf("expected error: %v, got: %v", expected, actual)
 	}
@@ -33,6 +34,7 @@ func verifyExpectedError(t *testing.T, resp interface{}, actual, expected error)
 }
 
 func verifyExpectedStats(t *testing.T, isWCOW, ownsHost bool, s *stats.Statistics) {
+	t.Helper()
 	if isWCOW {
 		verifyExpectedWindowsContainerStatistics(t, s.GetWindows())
 	} else {
@@ -44,6 +46,7 @@ func verifyExpectedStats(t *testing.T, isWCOW, ownsHost bool, s *stats.Statistic
 }
 
 func verifyExpectedWindowsContainerStatistics(t *testing.T, w *stats.WindowsContainerStatistics) {
+	t.Helper()
 	if w == nil {
 		t.Fatal("expected non-nil WindowsContainerStatistics")
 	}
@@ -92,6 +95,7 @@ func verifyExpectedWindowsContainerStatistics(t *testing.T, w *stats.WindowsCont
 }
 
 func verifyExpectedCgroupMetrics(t *testing.T, v *v1.Metrics) {
+	t.Helper()
 	if v == nil {
 		t.Fatal("expected non-nil cgroups Metrics")
 	}
@@ -116,6 +120,7 @@ func verifyExpectedCgroupMetrics(t *testing.T, v *v1.Metrics) {
 }
 
 func verifyExpectedVirtualMachineStatistics(t *testing.T, v *stats.VirtualMachineStatistics) {
+	t.Helper()
 	if v == nil {
 		t.Fatal("expected non-nil VirtualMachineStatistics")
 	}

--- a/cmd/containerd-shim-runhcs-v1/task_hcs_test.go
+++ b/cmd/containerd-shim-runhcs-v1/task_hcs_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func setupTestHcsTask(t *testing.T) (*hcsTask, *testShimExec, *testShimExec) {
+	t.Helper()
 	initExec := newTestShimExec(t.Name(), t.Name(), int(rand.Int31()))
 	lt := &hcsTask{
 		events: newFakePublisher(),
@@ -127,6 +128,7 @@ func Test_hcsTask_KillExec_2ndExecID_All_Error(t *testing.T) {
 }
 
 func verifyDeleteFailureValues(t *testing.T, pid int, status uint32, at time.Time) {
+	t.Helper()
 	if pid != 0 {
 		t.Fatalf("pid expected '0' got: '%d'", pid)
 	}
@@ -139,6 +141,7 @@ func verifyDeleteFailureValues(t *testing.T, pid int, status uint32, at time.Tim
 }
 
 func verifyDeleteSuccessValues(t *testing.T, pid int, status uint32, at time.Time, e *testShimExec) {
+	t.Helper()
 	if pid != e.pid {
 		t.Fatalf("pid expected '%d' got: '%d'", e.pid, pid)
 	}

--- a/cmd/gcstools/generichook.go
+++ b/cmd/gcstools/generichook.go
@@ -73,7 +73,6 @@ func logDebugFile(debugFilePath string) {
 		i += 1
 		startBytes += chunkSize
 	}
-
 }
 
 func genericHookMain() {

--- a/ext4/dmverity/dmverity_test.go
+++ b/ext4/dmverity/dmverity_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func tempFileWithContentLength(t *testing.T, length int) *os.File {
+	t.Helper()
 	tmpFile, err := os.CreateTemp("", "")
 	if err != nil {
 		t.Fatalf("failed to create temp file")

--- a/ext4/internal/compactext4/compact_test.go
+++ b/ext4/internal/compactext4/compact_test.go
@@ -64,6 +64,7 @@ func (tf *testFile) Reader() io.Reader {
 }
 
 func createTestFile(t *testing.T, w *Writer, tf testFile) {
+	t.Helper()
 	var err error
 	if tf.File != nil {
 		tf.File.Size = int64(len(tf.Data))
@@ -136,6 +137,7 @@ func fileEqual(f1, f2 *File) bool {
 }
 
 func runTestsOnFiles(t *testing.T, testFiles []testFile, opts ...Option) {
+	t.Helper()
 	image := "testfs.img"
 	imagef, err := os.Create(image)
 	if err != nil {

--- a/ext4/internal/compactext4/verify_linux_test.go
+++ b/ext4/internal/compactext4/verify_linux_test.go
@@ -134,7 +134,6 @@ func verifyTestFile(t *testing.T, mountPath string, tf testFile) {
 			!timeEqual(st.Atim, tf.File.Atime) ||
 			!timeEqual(st.Mtim, tf.File.Mtime) ||
 			!timeEqual(st.Ctim, tf.File.Ctime) {
-
 			t.Errorf("%s: stat mismatch, expected: %#v got: %#v", tf.Path, tf.File, st)
 		}
 

--- a/ext4/internal/compactext4/verify_test.go
+++ b/ext4/internal/compactext4/verify_test.go
@@ -6,14 +6,18 @@ package compactext4
 import "testing"
 
 func verifyTestFile(t *testing.T, mountPath string, tf testFile) {
+	t.Helper()
 }
 
 func mountImage(t *testing.T, image string, mountPath string) bool {
+	t.Helper()
 	return false
 }
 
 func unmountImage(t *testing.T, mountPath string) {
+	t.Helper()
 }
 
 func fsck(t *testing.T, image string) {
+	t.Helper()
 }

--- a/hcn/hcnendpoint_test.go
+++ b/hcn/hcnendpoint_test.go
@@ -362,5 +362,4 @@ func TestApplyTierAclPolicyOnEndpoint(t *testing.T) {
 	if len(foundEndpoint.Policies) == 0 {
 		t.Fatal("No Endpoint Policies found")
 	}
-
 }

--- a/hcn/hcnnamespace_test.go
+++ b/hcn/hcnnamespace_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func newGUID(t *testing.T) guid.GUID {
+	t.Helper()
 	g, err := guid.NewV4()
 	if err != nil {
 		t.Fatal(err)

--- a/hcn/hcnnetwork_test.go
+++ b/hcn/hcnnetwork_test.go
@@ -36,6 +36,7 @@ func TestCreateDeleteNetworks(t *testing.T) {
 }
 
 func CreateDeleteNetworksHelper(t *testing.T, networkFunction HcnNetworkMakerFunc) error {
+	t.Helper()
 	network, err := networkFunction()
 	if err != nil {
 		return err
@@ -96,6 +97,7 @@ func TestListNetwork(t *testing.T) {
 }
 
 func testNetworkPolicy(t *testing.T, policiesToTest *PolicyNetworkRequest) {
+	t.Helper()
 	network, err := CreateTestOverlayNetwork()
 	if err != nil {
 		t.Fatal(err)
@@ -150,7 +152,6 @@ func testNetworkPolicy(t *testing.T, policiesToTest *PolicyNetworkRequest) {
 }
 
 func TestAddRemoveRemoteSubnetRoutePolicy(t *testing.T) {
-
 	remoteSubnetRoutePolicy, err := HcnCreateTestRemoteSubnetRoute()
 	if err != nil {
 		t.Fatal(err)
@@ -160,7 +161,6 @@ func TestAddRemoveRemoteSubnetRoutePolicy(t *testing.T) {
 }
 
 func TestAddRemoveHostRoutePolicy(t *testing.T) {
-
 	hostRoutePolicy, err := HcnCreateTestHostRoute()
 	if err != nil {
 		t.Fatal(err)
@@ -170,18 +170,15 @@ func TestAddRemoveHostRoutePolicy(t *testing.T) {
 }
 
 func TestAddRemoveNetworACLPolicy(t *testing.T) {
-
 	networkACLPolicy, err := HcnCreateNetworkACLs()
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	testNetworkPolicy(t, networkACLPolicy)
-
 }
 
 func TestNetworkFlags(t *testing.T) {
-
 	network, err := CreateTestOverlayNetwork()
 	if err != nil {
 		t.Fatal(err)

--- a/hcn/hcnutils_test.go
+++ b/hcn/hcnutils_test.go
@@ -401,11 +401,9 @@ func HcnCreateTestL2BridgeNetwork() (*HostComputeNetwork, error) {
 	}
 
 	return network.Create()
-
 }
 
 func HcnCreateTierAcls() (*PolicyEndpointRequest, error) {
-
 	policy := make([]EndpointPolicy, 6)
 
 	tiers := make([]TierAclPolicySetting, 6)

--- a/hcn/hnsv1_test.go
+++ b/hcn/hnsv1_test.go
@@ -37,7 +37,6 @@ func CreateTestNetwork() (*hcsshim.HNSNetwork, error) {
 }
 
 func TestEndpoint(t *testing.T) {
-
 	network, err := CreateTestNetwork()
 	if err != nil {
 		t.Fatal(err)

--- a/internal/cni/registry_test.go
+++ b/internal/cni/registry_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func newGUID(t *testing.T) guid.GUID {
+	t.Helper()
 	g, err := guid.NewV4()
 	if err != nil {
 		t.Fatal(err)

--- a/internal/gcs/bridge_test.go
+++ b/internal/gcs/bridge_test.go
@@ -34,6 +34,7 @@ func pipeConn() (*stitched, *stitched) {
 }
 
 func sendMessage(t *testing.T, w io.Writer, typ msgType, id int64, msg []byte) {
+	t.Helper()
 	var h [16]byte
 	binary.LittleEndian.PutUint32(h[:], uint32(typ))
 	binary.LittleEndian.PutUint32(h[4:], uint32(len(msg)+16))
@@ -51,6 +52,7 @@ func sendMessage(t *testing.T, w io.Writer, typ msgType, id int64, msg []byte) {
 }
 
 func reflector(t *testing.T, rw io.ReadWriteCloser, delay time.Duration) {
+	t.Helper()
 	defer rw.Close()
 	for {
 		id, typ, msg, err := readMessage(rw)
@@ -77,6 +79,7 @@ type testResp struct {
 }
 
 func startReflectedBridge(t *testing.T, delay time.Duration) *bridge {
+	t.Helper()
 	s, c := pipeConn()
 	b := newBridge(s, nil, logrus.NewEntry(logrus.StandardLogger()))
 	b.Start()
@@ -149,6 +152,7 @@ func TestBridgeRPCBridgeClosed(t *testing.T) {
 }
 
 func sendJSON(t *testing.T, w io.Writer, typ msgType, id int64, msg interface{}) error {
+	t.Helper()
 	msgb, err := json.Marshal(msg)
 	if err != nil {
 		return err
@@ -158,6 +162,7 @@ func sendJSON(t *testing.T, w io.Writer, typ msgType, id int64, msg interface{})
 }
 
 func notifyThroughBridge(t *testing.T, typ msgType, msg interface{}, fn notifyFunc) error {
+	t.Helper()
 	s, c := pipeConn()
 	b := newBridge(s, fn, logrus.NewEntry(logrus.StandardLogger()))
 	b.Start()

--- a/internal/gcs/guestconnection_test.go
+++ b/internal/gcs/guestconnection_test.go
@@ -36,6 +36,7 @@ func dialPort(port uint32) (net.Conn, error) {
 }
 
 func simpleGcs(t *testing.T, rwc io.ReadWriteCloser) {
+	t.Helper()
 	defer rwc.Close()
 	err := simpleGcsLoop(t, rwc)
 	if err != nil {
@@ -44,6 +45,7 @@ func simpleGcs(t *testing.T, rwc io.ReadWriteCloser) {
 }
 
 func simpleGcsLoop(t *testing.T, rw io.ReadWriter) error {
+	t.Helper()
 	for {
 		id, typ, b, err := readMessage(rw)
 		if err != nil {
@@ -142,6 +144,7 @@ func simpleGcsLoop(t *testing.T, rw io.ReadWriter) error {
 }
 
 func connectGcs(ctx context.Context, t *testing.T) *GuestConnection {
+	t.Helper()
 	s, c := pipeConn()
 	if ctx != context.Background() && ctx != context.TODO() {
 		go func() {

--- a/internal/guest/bridge/bridge_unit_test.go
+++ b/internal/guest/bridge/bridge_unit_test.go
@@ -168,6 +168,7 @@ func Test_Bridge_Mux_Handler_NilRequest_Panic(t *testing.T) {
 }
 
 func verifyResponseIsDefaultHandler(t *testing.T, resp RequestResponse) {
+	t.Helper()
 	if resp == nil {
 		t.Fatal("The response is nil")
 	}

--- a/internal/guest/network/netns.go
+++ b/internal/guest/network/netns.go
@@ -178,7 +178,6 @@ func NetNSConfig(ctx context.Context, ifStr string, nsPid int, adapter *prot.Net
 				if err := netlink.RouteAdd(&route); err != nil {
 					return errors.Wrapf(err, "netlink.RouteAdd(%#v) failed", route)
 				}
-
 			}
 		}
 	} else {

--- a/internal/guest/runtime/hcsv2/nvidia_utils.go
+++ b/internal/guest/runtime/hcsv2/nvidia_utils.go
@@ -79,7 +79,6 @@ func addNvidiaDeviceHook(ctx context.Context, spec *oci.Spec) error {
 // gcstool's `install-drivers` binary.
 func getNvidiaDriversUsrLibPath() string {
 	return fmt.Sprintf("%s/content/usr/lib", guestpath.LCOWNvidiaMountPath)
-
 }
 
 // Helper function to find the usr/bin path for the installed nvidia tools.

--- a/internal/guest/storage/crypt/crypt.go
+++ b/internal/guest/storage/crypt/crypt.go
@@ -164,7 +164,6 @@ func mkfsExt4Command(args []string) error {
 //     4.4. Do a sparse copy of the filesystem into the unencrypted block device.
 //     This updates the integrity tags.
 func EncryptDevice(ctx context.Context, source string) (path string, err error) {
-
 	uniqueName, err := getUniqueName(source)
 	if err != nil {
 		return "", errors.Wrapf(err, "failed to generate unique name: %s", source)

--- a/internal/guest/storage/devicemapper/devicemapper_test.go
+++ b/internal/guest/storage/devicemapper/devicemapper_test.go
@@ -29,6 +29,7 @@ func TestMain(m *testing.M) {
 }
 
 func validateDevice(t *testing.T, p string, sectors int64, writable bool) {
+	t.Helper()
 	dev, err := os.OpenFile(p, os.O_RDWR|os.O_SYNC, 0)
 	if err != nil {
 		t.Fatal(err)
@@ -55,7 +56,6 @@ func validateDevice(t *testing.T, p string, sectors int64, writable bool) {
 	} else if !errors.Is(err, unix.EPERM) {
 		t.Fatalf("expected EPERM, got %s", err)
 	}
-
 }
 
 type device struct {

--- a/internal/hcs/errors_test.go
+++ b/internal/hcs/errors_test.go
@@ -1,3 +1,5 @@
+//go:build windows
+
 package hcs
 
 import (

--- a/internal/jobcontainers/cpurate_test.go
+++ b/internal/jobcontainers/cpurate_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func assertEqual(t *testing.T, a uint32, b uint32) {
+	t.Helper()
 	if a != b {
 		t.Fatalf("%d != %d", a, b)
 	}

--- a/internal/jobcontainers/path_test.go
+++ b/internal/jobcontainers/path_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func assertStr(t *testing.T, a string, b string) {
+	t.Helper()
 	if !strings.EqualFold(a, b) {
 		t.Fatalf("expected %s, got %s", a, b)
 	}
@@ -43,6 +44,7 @@ type config struct {
 }
 
 func runGetApplicationNameTests(t *testing.T, tests []*config) {
+	t.Helper()
 	for _, cfg := range tests {
 		t.Run(cfg.name, func(t *testing.T) {
 			path, cmdLine, err := getApplicationName(cfg.commandLine, cfg.workDir, cfg.pathEnv)

--- a/internal/memory/pool_test.go
+++ b/internal/memory/pool_test.go
@@ -6,6 +6,7 @@ import (
 
 // helper function to test and validate minimal allocation scenario
 func testAllocate(t *testing.T, ma *PoolAllocator, sz uint64) {
+	t.Helper()
 	_, err := ma.Allocate(sz)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)

--- a/internal/regstate/regstate_test.go
+++ b/internal/regstate/regstate_test.go
@@ -10,6 +10,7 @@ import (
 var testKey = "runhcs-test-test-key"
 
 func prepTest(t *testing.T) {
+	t.Helper()
 	err := RemoveAll(testKey, true)
 	if err != nil && !os.IsNotExist(err) {
 		t.Fatal(err)

--- a/internal/safefile/safeopen.go
+++ b/internal/safefile/safeopen.go
@@ -345,7 +345,6 @@ func MkdirRelative(path string, root *os.File) error {
 func MkdirAllRelative(path string, root *os.File) error {
 	pathParts := strings.Split(filepath.Clean(path), (string)(filepath.Separator))
 	for index := range pathParts {
-
 		partialPath := filepath.Join(pathParts[0 : index+1]...)
 		stat, err := LstatRelative(partialPath, root)
 

--- a/internal/safefile/safeopen_test.go
+++ b/internal/safefile/safeopen_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func tempRoot(t *testing.T) (*os.File, error) {
+	t.Helper()
 	name := t.TempDir()
 	f, err := OpenRoot(name)
 	if err != nil {

--- a/internal/security/grantvmgroupaccess_test.go
+++ b/internal/security/grantvmgroupaccess_test.go
@@ -88,7 +88,6 @@ func TestGrantVmGroupAccessDefault(t *testing.T) {
 		f2Path,
 		[]string{`(I)(R)`},
 	)
-
 }
 
 func TestGrantVMGroupAccess_File_DesiredPermissions(t *testing.T) {
@@ -237,6 +236,7 @@ func TestGrantVMGroupAccess_Directory_Permissions(t *testing.T) {
 }
 
 func TestGrantVmGroupAccess_Invalid_AccessMask(t *testing.T) {
+	t.Helper()
 	for _, access := range []accessMask{
 		0,          // no bits set
 		1,          // invalid bit set
@@ -261,6 +261,7 @@ func TestGrantVmGroupAccess_Invalid_AccessMask(t *testing.T) {
 }
 
 func verifyVMAccountDACLs(t *testing.T, name string, permissions []string) {
+	t.Helper()
 	cmd := exec.Command("icacls", name)
 	outb, err := cmd.CombinedOutput()
 	if err != nil {

--- a/internal/uvm/create_lcow.go
+++ b/internal/uvm/create_lcow.go
@@ -620,7 +620,6 @@ func makeLCOWDoc(ctx context.Context, opts *OptionsLCOW, uvm *UtilityVM) (_ *hcs
 				ReadOnly: true,
 			}
 			uvm.scsiLocations[0][0] = newSCSIMount(uvm, rootfsFullPath, "/", "VirtualDisk", "", 1, 0, 0, true, false)
-
 		}
 	}
 

--- a/internal/uvm/vpmem_mapped_test.go
+++ b/internal/uvm/vpmem_mapped_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func setupNewVPMemScenario(ctx context.Context, t *testing.T, size uint64, hostPath, uvmPath string) (*vPMemInfoMulti, *mappedDeviceInfo) {
+	t.Helper()
 	pmem := newPackedVPMemDevice()
 	memReg, err := pmem.Allocate(size)
 	if err != nil {

--- a/pkg/securitypolicy/securitypolicy_test.go
+++ b/pkg/securitypolicy/securitypolicy_test.go
@@ -53,7 +53,6 @@ var testDataGenerator *dataGenerator
 func init() {
 	seed := time.Now().Unix()
 	if seedStr, ok := os.LookupEnv("SEED"); ok {
-
 		if parsedSeed, err := strconv.ParseInt(seedStr, 10, 64); err != nil {
 			fmt.Fprintf(os.Stderr, "failed to parse seed: %d\n", seed)
 		} else {

--- a/test/containerd-shim-runhcs-v1/delete_test.go
+++ b/test/containerd-shim-runhcs-v1/delete_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func verifyDeleteCommandSuccess(t *testing.T, stdout, stderr string, runerr error, begin, end time.Time) {
+	t.Helper()
 	if runerr != nil {
 		t.Fatalf("expected `delete` command success got err: %v", runerr)
 	}

--- a/test/containerd-shim-runhcs-v1/global_command_test.go
+++ b/test/containerd-shim-runhcs-v1/global_command_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func runGlobalCommand(t *testing.T, args []string) (string, string, error) {
+	t.Helper()
 	wd, err := os.Getwd()
 	if err != nil {
 		t.Fatalf("failed os.Getwd() with: %v", err)
@@ -31,6 +32,7 @@ func runGlobalCommand(t *testing.T, args []string) (string, string, error) {
 }
 
 func verifyGlobalCommandSuccess(t *testing.T, expectedStdout, stdout, expectedStderr, stderr string, runerr error) {
+	t.Helper()
 	if runerr != nil {
 		t.Fatalf("expected no error got stdout: '%s', stderr: '%s', err: '%v'", stdout, stderr, runerr)
 	}
@@ -39,6 +41,7 @@ func verifyGlobalCommandSuccess(t *testing.T, expectedStdout, stdout, expectedSt
 }
 
 func verifyGlobalCommandFailure(t *testing.T, expectedStdout, stdout, expectedStderr, stderr string, runerr error) {
+	t.Helper()
 	if runerr == nil || runerr.Error() != "exit status 1" {
 		t.Fatalf("expected error: 'exit status 1', got: '%v'", runerr)
 	}
@@ -47,6 +50,7 @@ func verifyGlobalCommandFailure(t *testing.T, expectedStdout, stdout, expectedSt
 }
 
 func verifyGlobalCommandOut(t *testing.T, expectedStdout, stdout, expectedStderr, stderr string) {
+	t.Helper()
 	// stdout verify
 	if expectedStdout == "" && expectedStdout != stdout {
 		t.Fatalf("expected stdout empty got: %s", stdout)

--- a/test/containerd-shim-runhcs-v1/start_test.go
+++ b/test/containerd-shim-runhcs-v1/start_test.go
@@ -23,10 +23,12 @@ import (
 )
 
 func createStartCommand(t *testing.T) (*exec.Cmd, *bytes.Buffer, *bytes.Buffer) {
+	t.Helper()
 	return createStartCommandWithID(t, t.Name())
 }
 
 func createStartCommandWithID(t *testing.T, id string) (*exec.Cmd, *bytes.Buffer, *bytes.Buffer) {
+	t.Helper()
 	bundleDir := t.TempDir()
 	wd, err := os.Getwd()
 	if err != nil {
@@ -49,6 +51,7 @@ func createStartCommandWithID(t *testing.T, id string) (*exec.Cmd, *bytes.Buffer
 }
 
 func cleanupTestBundle(t *testing.T, dir string) {
+	t.Helper()
 	err := os.RemoveAll(dir)
 	if err != nil {
 		t.Errorf("failed removing test bundle with: %v", err)
@@ -56,6 +59,7 @@ func cleanupTestBundle(t *testing.T, dir string) {
 }
 
 func writeBundleConfig(t *testing.T, dir string, cfg *specs.Spec) {
+	t.Helper()
 	cf, err := os.Create(filepath.Join(dir, "config.json"))
 	if err != nil {
 		t.Fatalf("failed to create config.json with error: %v", err)
@@ -69,6 +73,7 @@ func writeBundleConfig(t *testing.T, dir string, cfg *specs.Spec) {
 }
 
 func verifyStartCommandSuccess(t *testing.T, expectedNamespace, expectedID string, cmd *exec.Cmd, stdout, stderr *bytes.Buffer) {
+	t.Helper()
 	err := cmd.Run()
 	if err != nil {
 		t.Fatalf("expected `start` command to succeed failed with: %v, stdout: %v, stderr: %v", err, stdout.String(), stderr.String())

--- a/test/cri-containerd/clone_test.go
+++ b/test/cri-containerd/clone_test.go
@@ -117,6 +117,7 @@ func getClonedContainerConfig(uniqueID int, templateid string) *runtime.CreateCo
 }
 
 func waitForTemplateSave(ctx context.Context, t *testing.T, templatePodID string) {
+	t.Helper()
 	app := "hcsdiag"
 	arg0 := "list"
 	for {
@@ -138,6 +139,7 @@ func waitForTemplateSave(ctx context.Context, t *testing.T, templatePodID string
 }
 
 func createPodAndContainer(ctx context.Context, t *testing.T, client runtime.RuntimeServiceClient, sandboxRequest *runtime.RunPodSandboxRequest, containerRequest *runtime.CreateContainerRequest, podID, containerID *string) {
+	t.Helper()
 	// This is required in order to avoid leaking a pod and/or container in case somethings fails
 	// during container creation of startup. The podID (and containerID if container creation was
 	// successful) will be set to correct values so that the caller can correctly cleanup them even
@@ -165,6 +167,7 @@ func createTemplateContainer(
 	templateContainerRequest *runtime.CreateContainerRequest,
 	templatePodID, templateContainerID *string,
 ) {
+	t.Helper()
 	createPodAndContainer(ctx, t, client, templateSandboxRequest, templateContainerRequest, templatePodID, templateContainerID)
 
 	// Send a context with deadline for waitForTemplateSave function
@@ -185,6 +188,7 @@ func createClonedContainer(
 	cloneNumber int,
 	clonedPodID, clonedContainerID *string,
 ) {
+	t.Helper()
 	cloneSandboxRequest := getClonedPodConfig(cloneNumber, templatePodID)
 	cloneContainerRequest := getClonedContainerConfig(cloneNumber, templateContainerID)
 	createPodAndContainer(ctx, t, client, cloneSandboxRequest, cloneContainerRequest, clonedPodID, clonedContainerID)
@@ -192,6 +196,7 @@ func createClonedContainer(
 
 // Runs a command inside given container and verifies if the command executes successfully.
 func verifyContainerExec(ctx context.Context, t *testing.T, client runtime.RuntimeServiceClient, containerID string) {
+	t.Helper()
 	execCommand := []string{
 		"ping",
 		"127.0.0.1",
@@ -216,6 +221,7 @@ func verifyContainerExec(ctx context.Context, t *testing.T, client runtime.Runti
 }
 
 func cleanupPod(t *testing.T, client runtime.RuntimeServiceClient, ctx context.Context, podID *string) {
+	t.Helper()
 	if *podID == "" {
 		// Do nothing for empty podID
 		return
@@ -225,6 +231,7 @@ func cleanupPod(t *testing.T, client runtime.RuntimeServiceClient, ctx context.C
 }
 
 func cleanupContainer(t *testing.T, client runtime.RuntimeServiceClient, ctx context.Context, containerID *string) {
+	t.Helper()
 	if *containerID == "" {
 		// Do nothing for empty containerID
 		return

--- a/test/cri-containerd/container_layers_packing_test.go
+++ b/test/cri-containerd/container_layers_packing_test.go
@@ -21,6 +21,7 @@ const (
 )
 
 func validateTargets(ctx context.Context, t *testing.T, deviceNumber int, podID string, expected int) {
+	t.Helper()
 	dmDiag := shimDiagExecOutput(ctx, t, podID, []string{"ls", "-l", "/dev/mapper"})
 	dmPattern := fmt.Sprintf("dm-linear-pmem%d", deviceNumber)
 	dmLines := filterStrings(strings.Split(dmDiag, "\n"), dmPattern)

--- a/test/cri-containerd/container_test.go
+++ b/test/cri-containerd/container_test.go
@@ -23,6 +23,7 @@ import (
 )
 
 func runLogRotationContainer(t *testing.T, sandboxRequest *runtime.RunPodSandboxRequest, request *runtime.CreateContainerRequest, log string, logArchive string) {
+	t.Helper()
 	client := newTestRuntimeClient(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -60,6 +61,7 @@ func runLogRotationContainer(t *testing.T, sandboxRequest *runtime.RunPodSandbox
 }
 
 func runContainerLifetime(t *testing.T, client runtime.RuntimeServiceClient, ctx context.Context, containerID string) {
+	t.Helper()
 	defer removeContainer(t, client, ctx, containerID)
 	startContainer(t, client, ctx, containerID)
 	stopContainer(t, client, ctx, containerID)
@@ -522,6 +524,7 @@ func Test_RunContainer_ShareScratch_LCOW(t *testing.T) {
 }
 
 func findOverlaySize(t *testing.T, ctx context.Context, client runtime.RuntimeServiceClient, cid string) []string {
+	t.Helper()
 	cmd := []string{"df"}
 	containerExecReq := &runtime.ExecSyncRequest{
 		ContainerId: cid,

--- a/test/cri-containerd/container_virtual_device_test.go
+++ b/test/cri-containerd/container_virtual_device_test.go
@@ -38,6 +38,7 @@ func makeGPUExecCommand(os string, containerID string) *runtime.ExecSyncRequest 
 // verifyGPUIsPresent is a helper function that runs a command in the container
 // to verify the existence of a GPU and fails the running test is none are found
 func verifyGPUIsPresentLCOW(t *testing.T, client runtime.RuntimeServiceClient, ctx context.Context, containerID string) {
+	t.Helper()
 	execReq := makeGPUExecCommand("linux", containerID)
 	response := execSync(t, client, ctx, execReq)
 	if len(response.Stderr) != 0 {
@@ -49,6 +50,7 @@ func verifyGPUIsPresentLCOW(t *testing.T, client runtime.RuntimeServiceClient, c
 }
 
 func isGPUPresentWCOW(t *testing.T, client runtime.RuntimeServiceClient, ctx context.Context, containerID string) bool {
+	t.Helper()
 	execReq := makeGPUExecCommand("windows", containerID)
 	response := execSync(t, client, ctx, execReq)
 	if len(response.Stderr) != 0 {
@@ -71,6 +73,7 @@ func isGPUPresentWCOW(t *testing.T, client runtime.RuntimeServiceClient, ctx con
 // to verify that there are no GPUs present in the container and fails the running test
 // if any are found
 func verifyGPUIsNotPresentLCOW(t *testing.T, client runtime.RuntimeServiceClient, ctx context.Context, containerID string) {
+	t.Helper()
 	execReq := makeGPUExecCommand("linux", containerID)
 	response := execSync(t, client, ctx, execReq)
 	if len(response.Stderr) == 0 {
@@ -132,6 +135,7 @@ var lcowPodGPUAnnotations = map[string]string{
 }
 
 func getGPUContainerRequestLCOW(t *testing.T, podID string, podConfig *runtime.PodSandboxConfig, device *runtime.Device) *runtime.CreateContainerRequest {
+	t.Helper()
 	return &runtime.CreateContainerRequest{
 		Config: &runtime.ContainerConfig{
 			Metadata: &runtime.ContainerMetadata{
@@ -157,6 +161,7 @@ func getGPUContainerRequestLCOW(t *testing.T, podID string, podConfig *runtime.P
 }
 
 func getGPUContainerRequestWCOW(t *testing.T, podID string, podConfig *runtime.PodSandboxConfig, device *runtime.Device) *runtime.CreateContainerRequest {
+	t.Helper()
 	return &runtime.CreateContainerRequest{
 		Config: &runtime.ContainerConfig{
 			Metadata: &runtime.ContainerMetadata{
@@ -274,7 +279,6 @@ func Test_RunContainer_VirtualDevice_GPU_Multiple_LCOW(t *testing.T) {
 	defer cancel()
 
 	for i := 0; i < numContainers; i++ {
-
 		name := t.Name() + "-Container-" + fmt.Sprintf("%d", i)
 		containerRequest.Config.Metadata.Name = name
 

--- a/test/cri-containerd/createcontainer_test.go
+++ b/test/cri-containerd/createcontainer_test.go
@@ -19,11 +19,13 @@ import (
 )
 
 func runCreateContainerTest(t *testing.T, runtimeHandler string, request *runtime.CreateContainerRequest) {
+	t.Helper()
 	sandboxRequest := getRunPodSandboxRequest(t, runtimeHandler)
 	runCreateContainerTestWithSandbox(t, sandboxRequest, request)
 }
 
 func runCreateContainerTestWithSandbox(t *testing.T, sandboxRequest *runtime.RunPodSandboxRequest, request *runtime.CreateContainerRequest) {
+	t.Helper()
 	client := newTestRuntimeClient(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/test/cri-containerd/execcontainer_test.go
+++ b/test/cri-containerd/execcontainer_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func runexecContainerTestWithSandbox(t *testing.T, sandboxRequest *runtime.RunPodSandboxRequest, request *runtime.CreateContainerRequest, execReq *runtime.ExecSyncRequest) *runtime.ExecSyncResponse {
+	t.Helper()
 	client := newTestRuntimeClient(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -35,6 +36,7 @@ func runexecContainerTestWithSandbox(t *testing.T, sandboxRequest *runtime.RunPo
 }
 
 func execContainerLCOW(t *testing.T, uid int64, cmd []string) *runtime.ExecSyncResponse {
+	t.Helper()
 	pullRequiredLCOWImages(t, []string{imageLcowK8sPause, imageLcowCosmos})
 
 	// run podsandbox request

--- a/test/cri-containerd/helper_container_test.go
+++ b/test/cri-containerd/helper_container_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func createContainer(t *testing.T, client runtime.RuntimeServiceClient, ctx context.Context, request *runtime.CreateContainerRequest) string {
+	t.Helper()
 	response, err := client.CreateContainer(ctx, request)
 	if err != nil {
 		t.Fatalf("failed CreateContainer in sandbox: %s, with: %v", request.PodSandboxId, err)
@@ -22,6 +23,7 @@ func createContainer(t *testing.T, client runtime.RuntimeServiceClient, ctx cont
 }
 
 func startContainer(t *testing.T, client runtime.RuntimeServiceClient, ctx context.Context, containerID string) {
+	t.Helper()
 	_, err := client.StartContainer(ctx, &runtime.StartContainerRequest{
 		ContainerId: containerID,
 	})
@@ -31,10 +33,12 @@ func startContainer(t *testing.T, client runtime.RuntimeServiceClient, ctx conte
 }
 
 func stopContainer(t *testing.T, client runtime.RuntimeServiceClient, ctx context.Context, containerID string) {
+	t.Helper()
 	stopContainerWithTimeout(t, client, ctx, containerID, 0)
 }
 
 func stopContainerWithTimeout(t *testing.T, client runtime.RuntimeServiceClient, ctx context.Context, containerID string, timeout int64) {
+	t.Helper()
 	_, err := client.StopContainer(ctx, &runtime.StopContainerRequest{
 		ContainerId: containerID,
 		Timeout:     timeout,
@@ -45,6 +49,7 @@ func stopContainerWithTimeout(t *testing.T, client runtime.RuntimeServiceClient,
 }
 
 func removeContainer(t *testing.T, client runtime.RuntimeServiceClient, ctx context.Context, containerID string) {
+	t.Helper()
 	_, err := client.RemoveContainer(ctx, &runtime.RemoveContainerRequest{
 		ContainerId: containerID,
 	})
@@ -70,16 +75,19 @@ func getCreateContainerRequest(podID string, name string, image string, command 
 }
 
 func getContainerStatus(t *testing.T, client runtime.RuntimeServiceClient, ctx context.Context, containerID string) runtime.ContainerState {
+	t.Helper()
 	return getContainerStatusFull(t, client, ctx, containerID).State
 }
 
 func assertContainerState(t *testing.T, client runtime.RuntimeServiceClient, ctx context.Context, containerID string, state runtime.ContainerState) {
+	t.Helper()
 	if st := getContainerStatus(t, client, ctx, containerID); st != state {
 		t.Fatalf("got container %q state %q; wanted %v", containerID, st.String(), state.String())
 	}
 }
 
 func getContainerStatusFull(t *testing.T, client runtime.RuntimeServiceClient, ctx context.Context, containerID string) *runtime.ContainerStatus {
+	t.Helper()
 	response, err := client.ContainerStatus(ctx, &runtime.ContainerStatusRequest{
 		ContainerId: containerID,
 	})
@@ -98,6 +106,7 @@ func requireContainerState(
 	containerID string,
 	expectedState runtime.ContainerState,
 ) {
+	t.Helper()
 	require.NoError(t, func() error {
 		start := time.Now()
 		var lastState runtime.ContainerState

--- a/test/cri-containerd/helper_cri_plugins_test.go
+++ b/test/cri-containerd/helper_cri_plugins_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func newTestPluginClient(t *testing.T) cri.CRIPluginServiceClient {
+	t.Helper()
 	ctx, cancel := context.WithTimeout(context.Background(), connectTimeout)
 	defer cancel()
 	conn, err := createGRPCConn(ctx)
@@ -21,6 +22,7 @@ func newTestPluginClient(t *testing.T) cri.CRIPluginServiceClient {
 }
 
 func resetContainer(t *testing.T, client cri.CRIPluginServiceClient, ctx context.Context, containerID string) {
+	t.Helper()
 	_, err := client.ResetContainer(ctx, &cri.ResetContainerRequest{
 		ContainerId: containerID,
 	})
@@ -30,6 +32,7 @@ func resetContainer(t *testing.T, client cri.CRIPluginServiceClient, ctx context
 }
 
 func resetPodSandbox(t *testing.T, client cri.CRIPluginServiceClient, ctx context.Context, podID string) {
+	t.Helper()
 	_, err := client.ResetPodSandbox(ctx, &cri.ResetPodSandboxRequest{
 		PodSandboxId: podID,
 	})

--- a/test/cri-containerd/helper_exec_test.go
+++ b/test/cri-containerd/helper_exec_test.go
@@ -18,6 +18,7 @@ import (
 )
 
 func execSync(t *testing.T, client runtime.RuntimeServiceClient, ctx context.Context, request *runtime.ExecSyncRequest) *runtime.ExecSyncResponse {
+	t.Helper()
 	response, err := client.ExecSync(ctx, request)
 	if err != nil {
 		t.Fatalf("failed ExecSync request with: %v", err)
@@ -26,6 +27,7 @@ func execSync(t *testing.T, client runtime.RuntimeServiceClient, ctx context.Con
 }
 
 func execRequest(t *testing.T, client runtime.RuntimeServiceClient, ctx context.Context, request *runtime.ExecRequest) string {
+	t.Helper()
 	response, err := client.Exec(ctx, request)
 	if err != nil {
 		t.Fatalf("failed Exec request with: %v", err)
@@ -77,6 +79,7 @@ func execInHost(ctx context.Context, client shimdiag.ShimDiagService, args []str
 
 // shimDiagExecOutput is a small wrapper on top of execInHost, that returns the exec output
 func shimDiagExecOutput(ctx context.Context, t *testing.T, podID string, cmd []string) string {
+	t.Helper()
 	shimName := fmt.Sprintf("k8s.io-%s", podID)
 	shim, err := shimdiag.GetShim(shimName)
 	if err != nil {

--- a/test/cri-containerd/helper_gmsa_test.go
+++ b/test/cri-containerd/helper_gmsa_test.go
@@ -31,6 +31,7 @@ func generateCredSpec(path string) error {
 // Tries to generate a cred spec to use for gmsa test cases. Returns the cred
 // spec and an error if any.
 func gmsaSetup(t *testing.T) string {
+	t.Helper()
 	csPath := filepath.Join(t.TempDir(), "credspec.json")
 	if err := generateCredSpec(csPath); err != nil {
 		t.Fatal(err)

--- a/test/cri-containerd/helper_sandbox_test.go
+++ b/test/cri-containerd/helper_sandbox_test.go
@@ -38,6 +38,7 @@ func WithSandboxLabels(labels map[string]string) SandboxConfigOpt {
 }
 
 func runPodSandbox(t *testing.T, client runtime.RuntimeServiceClient, ctx context.Context, request *runtime.RunPodSandboxRequest) string {
+	t.Helper()
 	response, err := client.RunPodSandbox(ctx, request)
 	if err != nil {
 		t.Fatalf("failed RunPodSandbox request with: %v", err)
@@ -46,6 +47,7 @@ func runPodSandbox(t *testing.T, client runtime.RuntimeServiceClient, ctx contex
 }
 
 func stopPodSandbox(t *testing.T, client runtime.RuntimeServiceClient, ctx context.Context, podID string) {
+	t.Helper()
 	_, err := client.StopPodSandbox(ctx, &runtime.StopPodSandboxRequest{
 		PodSandboxId: podID,
 	})
@@ -55,6 +57,7 @@ func stopPodSandbox(t *testing.T, client runtime.RuntimeServiceClient, ctx conte
 }
 
 func removePodSandbox(t *testing.T, client runtime.RuntimeServiceClient, ctx context.Context, podID string) {
+	t.Helper()
 	_, err := client.RemovePodSandbox(ctx, &runtime.RemovePodSandboxRequest{
 		PodSandboxId: podID,
 	})
@@ -64,6 +67,7 @@ func removePodSandbox(t *testing.T, client runtime.RuntimeServiceClient, ctx con
 }
 
 func getPodSandboxStatus(t *testing.T, client runtime.RuntimeServiceClient, ctx context.Context, podID string) *runtime.PodSandboxStatus {
+	t.Helper()
 	status, err := client.PodSandboxStatus(ctx, &runtime.PodSandboxStatusRequest{
 		PodSandboxId: podID,
 	})
@@ -74,12 +78,14 @@ func getPodSandboxStatus(t *testing.T, client runtime.RuntimeServiceClient, ctx 
 }
 
 func assertPodSandboxState(t *testing.T, client runtime.RuntimeServiceClient, ctx context.Context, podID string, state runtime.PodSandboxState) {
+	t.Helper()
 	if st := getPodSandboxStatus(t, client, ctx, podID).State; st != state {
 		t.Fatalf("got pod sandbox %q state %q; wanted %v", podID, st.String(), state.String())
 	}
 }
 
 func getTestSandboxConfig(t *testing.T, opts ...SandboxConfigOpt) *runtime.PodSandboxConfig {
+	t.Helper()
 	c := &runtime.PodSandboxConfig{
 		Metadata: &runtime.PodSandboxMetadata{
 			Name:      t.Name(),
@@ -101,6 +107,7 @@ func getTestSandboxConfig(t *testing.T, opts ...SandboxConfigOpt) *runtime.PodSa
 
 	for _, o := range opts {
 		if err := o(c); err != nil {
+			t.Helper()
 			t.Fatalf("failed to apply PodSandboxConfig option: %s", err)
 		}
 	}
@@ -108,6 +115,7 @@ func getTestSandboxConfig(t *testing.T, opts ...SandboxConfigOpt) *runtime.PodSa
 }
 
 func getRunPodSandboxRequest(t *testing.T, runtimeHandler string, sandboxOpts ...SandboxConfigOpt) *runtime.RunPodSandboxRequest {
+	t.Helper()
 	return &runtime.RunPodSandboxRequest{
 		Config:         getTestSandboxConfig(t, sandboxOpts...),
 		RuntimeHandler: runtimeHandler,

--- a/test/cri-containerd/helper_service_test.go
+++ b/test/cri-containerd/helper_service_test.go
@@ -80,12 +80,14 @@ func stopService(serviceName string) error {
 }
 
 func startContainerd(t *testing.T) {
+	t.Helper()
 	if err := startService(*flagContainerdServiceName); err != nil {
 		t.Fatal(err)
 	}
 }
 
 func stopContainerd(t *testing.T) {
+	t.Helper()
 	if err := stopService(*flagContainerdServiceName); err != nil {
 		t.Fatal(err)
 	}

--- a/test/cri-containerd/helper_update_utilities_test.go
+++ b/test/cri-containerd/helper_update_utilities_test.go
@@ -29,6 +29,7 @@ func createJobObjectsGetUtilArgs(ctx context.Context, cid, toolPath string, opti
 }
 
 func checkLCOWResourceLimit(t *testing.T, ctx context.Context, client runtime.RuntimeServiceClient, cid, path string, expected uint64) {
+	t.Helper()
 	cmd := []string{"cat", path}
 	containerExecReq := &runtime.ExecSyncRequest{
 		ContainerId: cid,
@@ -50,6 +51,7 @@ func checkLCOWResourceLimit(t *testing.T, ctx context.Context, client runtime.Ru
 }
 
 func checkWCOWResourceLimit(t *testing.T, ctx context.Context, runtimeHandler, shimName, cid, query string, expected uint64) {
+	t.Helper()
 	shim, err := shimdiag.GetShim(shimName)
 	if err != nil {
 		t.Fatalf("failed to find shim %v: %v", shimName, err)

--- a/test/cri-containerd/jobcontainer_test.go
+++ b/test/cri-containerd/jobcontainer_test.go
@@ -25,6 +25,7 @@ import (
 )
 
 func getJobContainerPodRequestWCOW(t *testing.T) *runtime.RunPodSandboxRequest {
+	t.Helper()
 	p := getRunPodSandboxRequest(t, wcowProcessRuntimeHandler)
 	if p.Config.Windows == nil {
 		p.Config.Windows = &runtime.WindowsPodSandboxConfig{}
@@ -37,6 +38,7 @@ func getJobContainerPodRequestWCOW(t *testing.T) *runtime.RunPodSandboxRequest {
 }
 
 func getJobContainerRequestWCOW(t *testing.T, podID string, podConfig *runtime.PodSandboxConfig, image string, user string, mounts []*runtime.Mount) *runtime.CreateContainerRequest {
+	t.Helper()
 	inheritUser := "true"
 	if user != "" {
 		inheritUser = "false"

--- a/test/cri-containerd/logging_binary_test.go
+++ b/test/cri-containerd/logging_binary_test.go
@@ -150,6 +150,7 @@ func Test_Run_Container_With_Binary_Logger(t *testing.T) {
 }
 
 func createAndRunContainer(t *testing.T, client runtime.RuntimeServiceClient, ctx context.Context, conReq *runtime.CreateContainerRequest) {
+	t.Helper()
 	containerID := createContainer(t, client, ctx, conReq)
 	defer removeContainer(t, client, ctx, containerID)
 

--- a/test/cri-containerd/main_test.go
+++ b/test/cri-containerd/main_test.go
@@ -135,6 +135,7 @@ func TestMain(m *testing.M) {
 // was enabled, and skips the test if any are missing. If the flagFeatures set
 // is empty, the function returns (by default all features are enabled).
 func requireFeatures(t *testing.T, features ...string) {
+	t.Helper()
 	set := flagFeatures.ValueSet()
 	if len(set) == 0 {
 		return
@@ -150,6 +151,7 @@ func requireFeatures(t *testing.T, features ...string) {
 // binary.
 // Returns full binary path if it exists, otherwise, skips the test.
 func requireBinary(t *testing.T, binary string) string {
+	t.Helper()
 	executable, err := os.Executable()
 	if err != nil {
 		t.Skipf("error locating executable: %s", err)
@@ -190,6 +192,7 @@ func createGRPCConn(ctx context.Context) (*grpc.ClientConn, error) {
 }
 
 func newTestRuntimeClient(t *testing.T) runtime.RuntimeServiceClient {
+	t.Helper()
 	ctx, cancel := context.WithTimeout(context.Background(), connectTimeout)
 	defer cancel()
 	conn, err := createGRPCConn(ctx)
@@ -200,6 +203,7 @@ func newTestRuntimeClient(t *testing.T) runtime.RuntimeServiceClient {
 }
 
 func newTestEventService(t *testing.T) containerd.EventService {
+	t.Helper()
 	ctx, cancel := context.WithTimeout(context.Background(), connectTimeout)
 	defer cancel()
 	conn, err := createGRPCConn(ctx)
@@ -210,6 +214,7 @@ func newTestEventService(t *testing.T) containerd.EventService {
 }
 
 func newTestImageClient(t *testing.T) runtime.ImageServiceClient {
+	t.Helper()
 	ctx, cancel := context.WithTimeout(context.Background(), connectTimeout)
 	defer cancel()
 	conn, err := createGRPCConn(ctx)
@@ -258,6 +263,7 @@ func convertEvent(e *types.Any) (string, interface{}, error) {
 }
 
 func pullRequiredImages(t *testing.T, images []string, opts ...SandboxConfigOpt) {
+	t.Helper()
 	opts = append(opts, WithSandboxLabels(map[string]string{
 		"sandbox-platform": "windows/amd64", // Not required for Windows but makes the test safer depending on defaults in the config.
 	}))
@@ -265,6 +271,7 @@ func pullRequiredImages(t *testing.T, images []string, opts ...SandboxConfigOpt)
 }
 
 func pullRequiredLCOWImages(t *testing.T, images []string, opts ...SandboxConfigOpt) {
+	t.Helper()
 	opts = append(opts, WithSandboxLabels(map[string]string{
 		"sandbox-platform": "linux/amd64",
 	}))
@@ -272,6 +279,7 @@ func pullRequiredLCOWImages(t *testing.T, images []string, opts ...SandboxConfig
 }
 
 func pullRequiredImagesWithOptions(t *testing.T, images []string, opts ...SandboxConfigOpt) {
+	t.Helper()
 	if len(images) < 1 {
 		return
 	}
@@ -301,6 +309,7 @@ func pullRequiredImagesWithOptions(t *testing.T, images []string, opts ...Sandbo
 }
 
 func removeImages(t *testing.T, images []string) {
+	t.Helper()
 	if len(images) < 1 {
 		return
 	}

--- a/test/cri-containerd/policy_test.go
+++ b/test/cri-containerd/policy_test.go
@@ -36,6 +36,7 @@ func securityPolicyFromContainers(policyType string, containers []securitypolicy
 }
 
 func sandboxSecurityPolicy(t *testing.T, policyType string) string {
+	t.Helper()
 	defaultContainers := helpers.DefaultContainerConfigs()
 	policyString, err := securityPolicyFromContainers(policyType, defaultContainers)
 	if err != nil {
@@ -45,6 +46,7 @@ func sandboxSecurityPolicy(t *testing.T, policyType string) string {
 }
 
 func alpineSecurityPolicy(t *testing.T, policyType string, opts ...securitypolicy.ContainerConfigOpt) string {
+	t.Helper()
 	defaultContainers := helpers.DefaultContainerConfigs()
 
 	alpineContainer := securitypolicy.ContainerConfig{
@@ -67,6 +69,7 @@ func alpineSecurityPolicy(t *testing.T, policyType string, opts ...securitypolic
 }
 
 func sandboxRequestWithPolicy(t *testing.T, policy string) *runtime.RunPodSandboxRequest {
+	t.Helper()
 	return getRunPodSandboxRequest(
 		t,
 		lcowRuntimeHandler,
@@ -633,7 +636,6 @@ func Test_RunPrivilegedContainer_WithPolicy_And_AllowElevated_Set(t *testing.T) 
 			defer stopContainer(t, client, ctx, containerID)
 		})
 	}
-
 }
 
 // todo (maksiman): add coverage for rego enforcer

--- a/test/cri-containerd/removepodsandbox_test.go
+++ b/test/cri-containerd/removepodsandbox_test.go
@@ -24,6 +24,7 @@ type TestConfig struct {
 
 // Utility function to test removal of a sandbox with no containers and no previous call to stop the pod
 func runPodSandboxTestWithoutPodStop(t *testing.T, request *runtime.RunPodSandboxRequest) {
+	t.Helper()
 	client := newTestRuntimeClient(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -43,6 +44,7 @@ func runPodSandboxTestWithoutPodStop(t *testing.T, request *runtime.RunPodSandbo
 
 // Utility function to start sandbox with one container and make sure that sandbox is removed in the end
 func runPodWithContainer(t *testing.T, client runtime.RuntimeServiceClient, ctx context.Context, tc *TestConfig) (string, string) {
+	t.Helper()
 	request := getRunPodSandboxRequest(t, tc.runtimeHandler)
 	podID := runPodSandbox(t, client, ctx, request)
 	defer removePodSandbox(t, client, ctx, podID)
@@ -56,6 +58,7 @@ func runPodWithContainer(t *testing.T, client runtime.RuntimeServiceClient, ctx 
 
 // Utility function to test removal of a sandbox with one container and no previous call to stop the pod or container
 func runContainerInSandboxTest(t *testing.T, tc *TestConfig) {
+	t.Helper()
 	client := newTestRuntimeClient(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/test/cri-containerd/runpodsandbox_test.go
+++ b/test/cri-containerd/runpodsandbox_test.go
@@ -30,6 +30,7 @@ import (
 )
 
 func runPodSandboxTest(t *testing.T, request *runtime.RunPodSandboxRequest) {
+	t.Helper()
 	client := newTestRuntimeClient(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -1055,6 +1056,7 @@ func Test_RunPodSandbox_CPUGroup(t *testing.T) {
 }
 
 func createExt4VHD(ctx context.Context, t *testing.T, path string) {
+	t.Helper()
 	// UVM related functions called below produce a lot debug logs. Set the logger
 	// output to Discard if verbose flag is not set. This way we can still capture
 	// these logs in a wpr session.
@@ -1754,6 +1756,7 @@ func Test_RunPodSandbox_Timezone_NoInherit_WCOW_Hypervisor(t *testing.T) {
 }
 
 func createSandboxContainerAndExecForCustomScratch(t *testing.T, annots map[string]string) (string, string, int) {
+	t.Helper()
 	cmd := []string{
 		"df",
 	}
@@ -1770,6 +1773,7 @@ func createContainerInSandbox(
 	mounts []*runtime.Mount,
 	podConfig *runtime.PodSandboxConfig,
 ) string {
+	t.Helper()
 	cRequest := getCreateContainerRequest(podID, containerName, imageName, command, podConfig)
 	cRequest.Config.Annotations = annots
 	cRequest.Config.Mounts = mounts
@@ -1786,6 +1790,7 @@ func execContainer(
 	containerID string,
 	command []string,
 ) (string, string, int) {
+	t.Helper()
 	execRequest := &runtime.ExecSyncRequest{
 		ContainerId: containerID,
 		Cmd:         command,
@@ -1801,6 +1806,7 @@ func execContainer(
 }
 
 func createSandboxContainerAndExec(t *testing.T, annots map[string]string, mounts []*runtime.Mount, execCommand []string) (output string, errorMsg string, exitCode int) {
+	t.Helper()
 	client := newTestRuntimeClient(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/test/cri-containerd/stats_test.go
+++ b/test/cri-containerd/stats_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 func runContainerAndQueryStats(t *testing.T, client runtime.RuntimeServiceClient, ctx context.Context, request *runtime.CreateContainerRequest) {
+	t.Helper()
 	containerID := createContainer(t, client, ctx, request)
 	defer removeContainer(t, client, ctx, containerID)
 	startContainer(t, client, ctx, containerID)
@@ -34,6 +35,7 @@ func runContainerAndQueryStats(t *testing.T, client runtime.RuntimeServiceClient
 }
 
 func runContainerAndQueryListStats(t *testing.T, client runtime.RuntimeServiceClient, ctx context.Context, request *runtime.CreateContainerRequest) {
+	t.Helper()
 	containerID := createContainer(t, client, ctx, request)
 	defer removeContainer(t, client, ctx, containerID)
 	startContainer(t, client, ctx, containerID)
@@ -58,6 +60,7 @@ func runContainerAndQueryListStats(t *testing.T, client runtime.RuntimeServiceCl
 }
 
 func verifyStatsContent(t *testing.T, stat *runtime.ContainerStats) {
+	t.Helper()
 	if stat == nil {
 		t.Fatal("expected stat to be non nil")
 	}
@@ -78,6 +81,7 @@ func verifyStatsContent(t *testing.T, stat *runtime.ContainerStats) {
 // Physically backed working set should be equal to the amount of memory we assigned
 // to the UVM.
 func verifyPhysicallyBackedWorkingSet(t *testing.T, num uint64, stat *runtime.ContainerStats) {
+	t.Helper()
 	if stat == nil {
 		t.Fatal("expected stat to be non nil")
 	}
@@ -253,7 +257,6 @@ func Test_ContainerStats_ContainerID(t *testing.T) {
 			runContainerAndQueryStats(t, client, ctx, request)
 		})
 	}
-
 }
 
 func Test_ContainerStats_List_ContainerID(t *testing.T) {

--- a/test/functional/lcow_test.go
+++ b/test/functional/lcow_test.go
@@ -72,6 +72,7 @@ func TestLCOW_UVMNoSCSISingleVPMemVHD(t *testing.T) {
 }
 
 func testLCOWUVMNoSCSISingleVPMem(t *testing.T, opts *uvm.OptionsLCOW, expected ...string) {
+	t.Helper()
 	require.Build(t, osversion.RS5)
 	requireFeatures(t, featureLCOW)
 	ctx := context.Background()
@@ -87,11 +88,13 @@ func testLCOWUVMNoSCSISingleVPMem(t *testing.T, opts *uvm.OptionsLCOW, expected 
 	out, err := io.Output()
 
 	if err != nil {
+		t.Helper()
 		t.Fatalf("uvm exec failed with: %s", err)
 	}
 
 	for _, s := range expected {
 		if !strings.Contains(out, s) {
+			t.Helper()
 			t.Fatalf("Expected dmesg output to have %q: %s", s, out)
 		}
 	}
@@ -136,6 +139,7 @@ func TestLCOW_UVMStart_KernelDirect_InitRd(t *testing.T) {
 }
 
 func testLCOWTimeUVMStart(t *testing.T, kernelDirect bool, rfsType uvm.PreferredRootFSType) {
+	t.Helper()
 	requireFeatures(t, featureLCOW)
 
 	for i := 0; i < 3; i++ {
@@ -246,7 +250,6 @@ func TestLCOWSimplePodScenario(t *testing.T) {
 	// Start the init process in each container and grab it's stdout comparing to expected
 	runInitProcess(t, c1hcsSystem, "hello lcow container one")
 	runInitProcess(t, c2hcsSystem, "hello lcow container two")
-
 }
 
 // Helper to run the init process in an LCOW container; verify it exits with exit
@@ -254,6 +257,7 @@ func TestLCOWSimplePodScenario(t *testing.T) {
 //
 //nolint:unused // unused since tests are skipped
 func runInitProcess(t *testing.T, s cow.Container, expected string) {
+	t.Helper()
 	var errB bytes.Buffer
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()

--- a/test/functional/main_test.go
+++ b/test/functional/main_test.go
@@ -139,8 +139,9 @@ func CreateContainerTestWrapper(ctx context.Context, options *hcsoci.CreateOptio
 	return s, r, err
 }
 
-func requireFeatures(t testing.TB, features ...string) {
-	require.Features(t, flagFeatures.S, features...)
+func requireFeatures(tb testing.TB, features ...string) {
+	tb.Helper()
+	require.Features(tb, flagFeatures.S, features...)
 }
 
 func getContainerdOptions() testctrd.ContainerdClientOptions {
@@ -150,20 +151,23 @@ func getContainerdOptions() testctrd.ContainerdClientOptions {
 	}
 }
 
-func newContainerdClient(ctx context.Context, t testing.TB) (context.Context, context.CancelFunc, *containerd.Client) {
-	return getContainerdOptions().NewClient(ctx, t)
+func newContainerdClient(ctx context.Context, tb testing.TB) (context.Context, context.CancelFunc, *containerd.Client) {
+	tb.Helper()
+	return getContainerdOptions().NewClient(ctx, tb)
 }
 
-func defaultLCOWOptions(t testing.TB) *uvm.OptionsLCOW {
-	opts := uvm.NewDefaultOptionsLCOW(cleanName(t.Name()), "")
+func defaultLCOWOptions(tb testing.TB) *uvm.OptionsLCOW {
+	tb.Helper()
+	opts := uvm.NewDefaultOptionsLCOW(cleanName(tb.Name()), "")
 	opts.BootFilesPath = *flagLinuxBootFilesPath
 
 	return opts
 }
 
 //nolint:deadcode,unused // will be used when WCOW tests are updated
-func defaultWCOWOptions(t testing.TB) *uvm.OptionsWCOW {
-	opts := uvm.NewDefaultOptionsWCOW(cleanName(t.Name()), "")
+func defaultWCOWOptions(tb testing.TB) *uvm.OptionsWCOW {
+	tb.Helper()
+	opts := uvm.NewDefaultOptionsWCOW(cleanName(tb.Name()), "")
 
 	return opts
 }

--- a/test/functional/uvm_mem_backingtype_test.go
+++ b/test/functional/uvm_mem_backingtype_test.go
@@ -19,18 +19,21 @@ import (
 
 //nolint:unused // unused since tests are skipped
 func runMemStartLCOWTest(t *testing.T, opts *uvm.OptionsLCOW) {
+	t.Helper()
 	u := tuvm.CreateAndStartLCOWFromOpts(context.Background(), t, opts)
 	u.Close()
 }
 
 //nolint:unused // unused since tests are skipped
 func runMemStartWCOWTest(t *testing.T, opts *uvm.OptionsWCOW) {
+	t.Helper()
 	u, _, _ := tuvm.CreateWCOWUVMFromOptsWithImage(context.Background(), t, opts, "microsoft/nanoserver")
 	u.Close()
 }
 
 //nolint:unused // unused since tests are skipped
 func runMemTests(t *testing.T, os string) {
+	t.Helper()
 	type testCase struct {
 		allowOvercommit      bool
 		enableDeferredCommit bool
@@ -77,6 +80,7 @@ func TestMemBackingTypeLCOW(t *testing.T) {
 
 //nolint:unused // unused since tests are skipped
 func runBenchMemStartTest(b *testing.B, opts *uvm.OptionsLCOW) {
+	b.Helper()
 	// Cant use testutilities here because its `testing.B` not `testing.T`
 	u, err := uvm.CreateLCOW(context.Background(), opts)
 	if err != nil {
@@ -90,6 +94,7 @@ func runBenchMemStartTest(b *testing.B, opts *uvm.OptionsLCOW) {
 
 //nolint:unused // unused since tests are skipped
 func runBenchMemStartLcowTest(b *testing.B, allowOvercommit bool, enableDeferredCommit bool) {
+	b.Helper()
 	for i := 0; i < b.N; i++ {
 		opts := uvm.NewDefaultOptionsLCOW(b.Name(), "")
 		opts.MemorySizeInMB = 512

--- a/test/functional/uvm_scsi_test.go
+++ b/test/functional/uvm_scsi_test.go
@@ -37,7 +37,6 @@ func TestSCSIAddRemoveLCOW(t *testing.T) {
 	defer u.Close()
 
 	testSCSIAddRemoveMultiple(t, u, `/run/gcs/c/0/scsi`, "linux", []string{})
-
 }
 
 // TestSCSIAddRemoveWCOW validates adding and removing SCSI disks
@@ -89,6 +88,7 @@ func testRemoveAllSCSI(u *uvm.UtilityVM, disks []string) error {
 //
 //nolint:unused // unused since tests are skipped
 func testSCSIAddRemoveSingle(t *testing.T, u *uvm.UtilityVM, pathPrefix string, operatingSystem string, wcowImageLayerFolders []string) {
+	t.Helper()
 	numDisks := 63 // Windows: 63 as the UVM scratch is at 0:0
 	if operatingSystem == "linux" {
 		numDisks++ //
@@ -140,6 +140,7 @@ func testSCSIAddRemoveSingle(t *testing.T, u *uvm.UtilityVM, pathPrefix string, 
 
 //nolint:unused // unused since tests are skipped
 func testSCSIAddRemoveMultiple(t *testing.T, u *uvm.UtilityVM, pathPrefix string, operatingSystem string, wcowImageLayerFolders []string) {
+	t.Helper()
 	numDisks := 63 // Windows: 63 as the UVM scratch is at 0:0
 	if operatingSystem == "linux" {
 		numDisks++ //

--- a/test/functional/uvm_vsmb_test.go
+++ b/test/functional/uvm_vsmb_test.go
@@ -81,5 +81,4 @@ func TestVSMB_Writable(t *testing.T) {
 	if err != nil {
 		t.Fatalf("AddVSMB failed: %s", err)
 	}
-
 }

--- a/test/functional/wcow_test.go
+++ b/test/functional/wcow_test.go
@@ -183,6 +183,7 @@ import (
 //
 //nolint:unused // unused since tests are skipped
 func stopContainer(t *testing.T, c interface{}) {
+	t.Helper()
 	switch c := c.(type) {
 	case cow.Container:
 		if err := c.Shutdown(context.Background()); err == nil {
@@ -221,7 +222,7 @@ func runShimCommand(t *testing.T,
 	expectedExitCode int,
 	expectedOutput string,
 ) {
-
+	t.Helper()
 	if c == nil {
 		t.Fatalf("requested container to start is nil!")
 	}
@@ -234,7 +235,6 @@ func runShimCommand(t *testing.T,
 	})
 	if err != nil {
 		t.Fatalf("Failed Create Process: %s", err)
-
 	}
 	defer p.Close()
 	if err := p.Wait(); err != nil {
@@ -263,6 +263,7 @@ func runShimCommand(t *testing.T,
 
 //nolint:unused // unused since tests are skipped
 func runShimCommands(t *testing.T, c hcsshim.Container) {
+	t.Helper()
 	runShimCommand(t, c, `echo Hello`, `c:\`, 0, "Hello")
 
 	// Check that read-only doesn't allow deletion or creation
@@ -281,6 +282,7 @@ func runShimCommands(t *testing.T, c hcsshim.Container) {
 
 //nolint:unused // unused since tests are skipped
 func runHcsCommands(t *testing.T, c cow.Container) {
+	t.Helper()
 	runHcsCommand(t, c, `echo Hello`, `c:\`, 0, "Hello")
 
 	// Check that read-only doesn't allow deletion or creation
@@ -307,7 +309,7 @@ func runHcsCommand(t *testing.T,
 	workdir string,
 	expectedExitCode int,
 	expectedOutput string) {
-
+	t.Helper()
 	if c == nil {
 		t.Fatalf("requested container to start is nil!")
 	}
@@ -322,7 +324,6 @@ func runHcsCommand(t *testing.T,
 		})
 	if err != nil {
 		t.Fatalf("Failed Create Process: %s", err)
-
 	}
 	defer p.Close()
 	if err := p.Wait(); err != nil {
@@ -354,6 +355,7 @@ const imageName = "busyboxw"
 //
 //nolint:unused // unused since tests are skipped
 func createTestMounts(t *testing.T) (string, string) {
+	t.Helper()
 	// Create two temp folders for mapped directories.
 	hostRWSharedDirectory := t.TempDir()
 	hostROSharedDirectory := t.TempDir()
@@ -368,6 +370,7 @@ func createTestMounts(t *testing.T) (string, string) {
 //
 //nolint:unused // unused since tests are skipped
 func generateShimLayersStruct(t *testing.T, imageLayers []string) []hcsshim.Layer {
+	t.Helper()
 	var layers []hcsshim.Layer
 	for _, layerFolder := range imageLayers {
 		guid, _ := wclayer.NameToGuid(context.Background(), filepath.Base(layerFolder))
@@ -452,7 +455,6 @@ func TestWCOWArgonShim(t *testing.T) {
 		t.Fatal(err)
 	}
 	argonShimMounted = false
-
 }
 
 // Xenon through HCSShim interface (v1)
@@ -509,6 +511,7 @@ func TestWCOWXenonShim(t *testing.T) {
 
 //nolint:unused // unused since tests are skipped
 func generateWCOWOciTestSpec(t *testing.T, imageLayers []string, scratchPath, hostRWSharedDirectory, hostROSharedDirectory string) *specs.Spec {
+	t.Helper()
 	return &specs.Spec{
 		Windows: &specs.Windows{
 			LayerFolders: append(imageLayers, scratchPath),
@@ -682,7 +685,6 @@ func TestWCOWArgonOciV2(t *testing.T) {
 		t.Fatal(err)
 	}
 	argonOci2Mounted = false
-
 }
 
 // Xenon through HCSOCI interface (v2)
@@ -737,7 +739,6 @@ func TestWCOWXenonOciV2(t *testing.T) {
 	if err := xenonOci2UVM.Start(context.Background()); err != nil {
 		xenonOci2UVM.Close()
 		t.Fatalf("Failed start UVM: %s", err)
-
 	}
 
 	spec := generateWCOWOciTestSpec(t, imageLayers, xenonOci2ScratchDir, hostRWSharedDirectory, hostROSharedDirectory)

--- a/test/gcs/container_bench_test.go
+++ b/test/gcs/container_bench_test.go
@@ -200,26 +200,27 @@ func BenchmarkContainerExec(b *testing.B) {
 
 func standaloneContainerRequest(
 	ctx context.Context,
-	t testing.TB,
+	tb testing.TB,
 	host *hcsv2.Host,
 	extra ...oci.SpecOpts,
 ) (string, *prot.VMHostedContainerSettingsV2, func()) {
+	tb.Helper()
 	ctx = namespaces.WithNamespace(ctx, testoci.DefaultNamespace)
-	id := t.Name() + cri_util.GenerateID()
-	scratch, rootfs := mountRootfs(ctx, t, host, id)
+	id := tb.Name() + cri_util.GenerateID()
+	scratch, rootfs := mountRootfs(ctx, tb, host, id)
 
 	opts := testoci.DefaultLinuxSpecOpts(id,
 		oci.WithRootFSPath(rootfs),
 		oci.WithProcessArgs("/bin/sh", "-c", tailNull),
 	)
 	opts = append(opts, extra...)
-	s := testoci.CreateLinuxSpec(ctx, t, id, opts...)
+	s := testoci.CreateLinuxSpec(ctx, tb, id, opts...)
 	r := &prot.VMHostedContainerSettingsV2{
 		OCIBundlePath:    scratch,
 		OCISpecification: s,
 	}
 	f := func() {
-		unmountRootfs(ctx, t, scratch)
+		unmountRootfs(ctx, tb, scratch)
 	}
 
 	return id, r, f

--- a/test/gcs/cri_bench_test.go
+++ b/test/gcs/cri_bench_test.go
@@ -211,15 +211,16 @@ func BenchmarkCRIWorkload(b *testing.B) {
 
 func workloadContainerRequest(
 	ctx context.Context,
-	t testing.TB,
+	tb testing.TB,
 	host *hcsv2.Host,
 	sid string,
 	spid uint32,
 	nns string,
 ) (string, *prot.VMHostedContainerSettingsV2, func()) {
+	tb.Helper()
 	id := sid + cri_util.GenerateID()
-	scratch, rootfs := mountRootfs(ctx, t, host, id)
-	spec := containerSpec(ctx, t,
+	scratch, rootfs := mountRootfs(ctx, tb, host, id)
+	spec := containerSpec(ctx, tb,
 		sid,
 		spid,
 		"test-bench-container",
@@ -235,7 +236,7 @@ func workloadContainerRequest(
 		OCISpecification: spec,
 	}
 	f := func() {
-		unmountRootfs(ctx, t, scratch)
+		unmountRootfs(ctx, tb, scratch)
 	}
 
 	return id, r, f

--- a/test/gcs/helper_container_test.go
+++ b/test/gcs/helper_container_test.go
@@ -35,56 +35,57 @@ const tailNull = "tail -f /dev/null"
 // Creates an overlay mount, and then a container using that mount that runs until stopped.
 // The container is created on its own, and not associated with a sandbox pod, and is therefore not CRI compliant.
 // [unmountRootfs] is added to the test cleanup.
-func createStandaloneContainer(ctx context.Context, t testing.TB, host *hcsv2.Host, id string, extra ...ctrdoci.SpecOpts) *hcsv2.Container {
+func createStandaloneContainer(ctx context.Context, tb testing.TB, host *hcsv2.Host, id string, extra ...ctrdoci.SpecOpts) *hcsv2.Container {
+	tb.Helper()
 	ctx = namespaces.WithNamespace(ctx, testoci.DefaultNamespace)
-	scratch, rootfs := mountRootfs(ctx, t, host, id)
+	scratch, rootfs := mountRootfs(ctx, tb, host, id)
 	// spec is passed in from containerd and then updated in internal\hcsoci\create.go:CreateContainer()
 	opts := testoci.DefaultLinuxSpecOpts(id,
 		ctrdoci.WithRootFSPath(rootfs),
 		ctrdoci.WithProcessArgs("/bin/sh", "-c", tailNull),
 	)
 	opts = append(opts, extra...)
-	s := testoci.CreateLinuxSpec(ctx, t, id, opts...)
+	s := testoci.CreateLinuxSpec(ctx, tb, id, opts...)
 	r := &prot.VMHostedContainerSettingsV2{
 		OCIBundlePath:    scratch,
 		OCISpecification: s,
 	}
 
-	t.Cleanup(func() {
-		unmountRootfs(ctx, t, scratch)
+	tb.Cleanup(func() {
+		unmountRootfs(ctx, tb, scratch)
 	})
 
-	return createContainer(ctx, t, host, id, r)
+	return createContainer(ctx, tb, host, id, r)
 }
 
-func createContainer(ctx context.Context, t testing.TB, host *hcsv2.Host, id string, s *prot.VMHostedContainerSettingsV2) *hcsv2.Container {
+func createContainer(ctx context.Context, tb testing.TB, host *hcsv2.Host, id string, s *prot.VMHostedContainerSettingsV2) *hcsv2.Container {
+	tb.Helper()
 	c, err := host.CreateContainer(ctx, id, s)
 	if err != nil {
-		t.Helper()
-		t.Fatalf("could not create container %q: %v", id, err)
+		tb.Fatalf("could not create container %q: %v", id, err)
 	}
 
 	return c
 }
 
-func removeContainer(_ context.Context, _ testing.TB, host *hcsv2.Host, id string) {
+func removeContainer(_ context.Context, tb testing.TB, host *hcsv2.Host, id string) {
+	tb.Helper()
 	host.RemoveContainer(id)
 }
 
-func startContainer(ctx context.Context, t testing.TB, c *hcsv2.Container, conn stdio.ConnectionSettings) hcsv2.Process {
+func startContainer(ctx context.Context, tb testing.TB, c *hcsv2.Container, conn stdio.ConnectionSettings) hcsv2.Process {
+	tb.Helper()
 	pid, err := c.Start(ctx, conn)
 	if err != nil {
-		t.Helper()
-		t.Fatalf("could not start container %q: %v", c.ID(), err)
+		tb.Fatalf("could not start container %q: %v", c.ID(), err)
 	}
 
-	return getProcess(ctx, t, c, uint32(pid))
+	return getProcess(ctx, tb, c, uint32(pid))
 }
 
 // waitContainer waits on the container's init process, p.
-func waitContainer(ctx context.Context, t testing.TB, c *hcsv2.Container, p hcsv2.Process, forced bool) {
-	t.Helper()
-
+func waitContainer(ctx context.Context, tb testing.TB, c *hcsv2.Container, p hcsv2.Process, forced bool) {
+	tb.Helper()
 	var e int
 	ch := make(chan prot.NotificationType)
 
@@ -101,7 +102,7 @@ func waitContainer(ctx context.Context, t testing.TB, c *hcsv2.Container, p hcsv
 	select {
 	case n, ok := <-ch:
 		if !ok {
-			t.Fatalf("container %q did not return a notification", c.ID())
+			tb.Fatalf("container %q did not return a notification", c.ID())
 		}
 
 		switch {
@@ -110,17 +111,17 @@ func waitContainer(ctx context.Context, t testing.TB, c *hcsv2.Container, p hcsv
 		case n == prot.NtUnexpectedExit:
 		case forced && n == prot.NtForcedExit:
 		default:
-			t.Fatalf("container %q exited with %s", c.ID(), n)
+			tb.Fatalf("container %q exited with %s", c.ID(), n)
 		}
 	case <-ctx.Done():
-		t.Fatalf("context canceled: %v", ctx.Err())
+		tb.Fatalf("context canceled: %v", ctx.Err())
 	}
 
 	switch {
 	case e == 0:
 	case forced && e == 137:
 	default:
-		t.Fatalf("got exit code %d", e)
+		tb.Fatalf("got exit code %d", e)
 	}
 }
 
@@ -134,69 +135,69 @@ func waitContainerRaw(c *hcsv2.Container, p hcsv2.Process) (int, prot.Notificati
 	return r, n
 }
 
-func execProcess(ctx context.Context, t testing.TB, c *hcsv2.Container, p *oci.Process, con stdio.ConnectionSettings) hcsv2.Process {
+func execProcess(ctx context.Context, tb testing.TB, c *hcsv2.Container, p *oci.Process, con stdio.ConnectionSettings) hcsv2.Process {
+	tb.Helper()
 	pid, err := c.ExecProcess(ctx, p, con)
 	if err != nil {
-		t.Helper()
-		t.Fatalf("could not exec process: %v", err)
+		tb.Fatalf("could not exec process: %v", err)
 	}
 
-	return getProcess(ctx, t, c, uint32(pid))
+	return getProcess(ctx, tb, c, uint32(pid))
 }
 
-func getProcess(_ context.Context, t testing.TB, c *hcsv2.Container, pid uint32) hcsv2.Process {
+func getProcess(_ context.Context, tb testing.TB, c *hcsv2.Container, pid uint32) hcsv2.Process {
+	tb.Helper()
 	p, err := c.GetProcess(pid)
 	if err != nil {
-		t.Helper()
-		t.Fatalf("could not get process %d: %v", pid, err)
+		tb.Fatalf("could not get process %d: %v", pid, err)
 	}
 
 	return p
 }
 
-func killContainer(ctx context.Context, t testing.TB, c *hcsv2.Container) {
+func killContainer(ctx context.Context, tb testing.TB, c *hcsv2.Container) {
+	tb.Helper()
 	if err := c.Kill(ctx, syscall.SIGKILL); err != nil {
-		t.Helper()
-		t.Fatalf("could not kill container %q: %v", c.ID(), err)
+		tb.Fatalf("could not kill container %q: %v", c.ID(), err)
 	}
 }
 
-func deleteContainer(ctx context.Context, t testing.TB, c *hcsv2.Container) {
+func deleteContainer(ctx context.Context, tb testing.TB, c *hcsv2.Container) {
+	tb.Helper()
 	if err := c.Delete(ctx); err != nil {
-		t.Helper()
-		t.Fatalf("could not delete container %q: %v", c.ID(), err)
+		tb.Fatalf("could not delete container %q: %v", c.ID(), err)
 	}
 }
 
-func cleanupContainer(ctx context.Context, t testing.TB, host *hcsv2.Host, c *hcsv2.Container) {
-	deleteContainer(ctx, t, c)
-	removeContainer(ctx, t, host, c.ID())
+func cleanupContainer(ctx context.Context, tb testing.TB, host *hcsv2.Host, c *hcsv2.Container) {
+	tb.Helper()
+	deleteContainer(ctx, tb, c)
+	removeContainer(ctx, tb, host, c.ID())
 }
 
 //
 // runtime
 //
 
-func listContainerStates(_ context.Context, t testing.TB, rt runtime.Runtime) []runtime.ContainerState {
+func listContainerStates(_ context.Context, tb testing.TB, rt runtime.Runtime) []runtime.ContainerState {
+	tb.Helper()
 	css, err := rt.ListContainerStates()
 	if err != nil {
-		t.Helper()
-		t.Fatalf("could not list containers: %v", err)
+		tb.Fatalf("could not list containers: %v", err)
 	}
 
 	return css
 }
 
 // assertNumberContainers asserts that n containers are found, and then returns the container states.
-func assertNumberContainers(ctx context.Context, t testing.TB, rt runtime.Runtime, n int) {
+func assertNumberContainers(ctx context.Context, tb testing.TB, rt runtime.Runtime, n int) {
+	tb.Helper()
 	fmt := "found %d running containers, wanted %d"
-	css := listContainerStates(ctx, t, rt)
+	css := listContainerStates(ctx, tb, rt)
 	nn := len(css)
 	if nn != n {
-		t.Helper()
-
 		if nn == 0 {
-			t.Fatalf(fmt, nn, n)
+			tb.Fatalf(fmt, nn, n)
 		}
 
 		cs := make([]string, nn)
@@ -204,12 +205,13 @@ func assertNumberContainers(ctx context.Context, t testing.TB, rt runtime.Runtim
 			cs[i] = c.ID
 		}
 
-		t.Fatalf(fmt+":\n%#+v", nn, n, cs)
+		tb.Fatalf(fmt+":\n%#+v", nn, n, cs)
 	}
 }
 
-func getContainerState(ctx context.Context, t testing.TB, rt runtime.Runtime, id string) runtime.ContainerState {
-	css := listContainerStates(ctx, t, rt)
+func getContainerState(ctx context.Context, tb testing.TB, rt runtime.Runtime, id string) runtime.ContainerState {
+	tb.Helper()
+	css := listContainerStates(ctx, tb, rt)
 
 	for _, cs := range css {
 		if cs.ID == id {
@@ -217,16 +219,15 @@ func getContainerState(ctx context.Context, t testing.TB, rt runtime.Runtime, id
 		}
 	}
 
-	t.Helper()
-	t.Fatalf("could not find container %q", id)
+	tb.Fatalf("could not find container %q", id)
 	return runtime.ContainerState{} // just to make the linter happy
 }
 
-func assertContainerState(ctx context.Context, t testing.TB, rt runtime.Runtime, id, state string) {
-	cs := getContainerState(ctx, t, rt, id)
+func assertContainerState(ctx context.Context, tb testing.TB, rt runtime.Runtime, id, state string) {
+	tb.Helper()
+	cs := getContainerState(ctx, tb, rt, id)
 	if cs.Status != state {
-		t.Helper()
-		t.Fatalf("got container %q status %q, wanted %q", id, cs.Status, state)
+		tb.Fatalf("got container %q status %q, wanted %q", id, cs.Status, state)
 	}
 }
 
@@ -234,7 +235,8 @@ func assertContainerState(ctx context.Context, t testing.TB, rt runtime.Runtime,
 // mount management
 //
 
-func mountRootfs(ctx context.Context, t testing.TB, host *hcsv2.Host, id string) (scratch string, rootfs string) {
+func mountRootfs(ctx context.Context, tb testing.TB, host *hcsv2.Host, id string) (scratch string, rootfs string) {
+	tb.Helper()
 	scratch = filepath.Join(guestpath.LCOWRootPrefixInUVM, id)
 	rootfs = filepath.Join(scratch, "rootfs")
 	if err := overlay.MountLayer(ctx,
@@ -246,19 +248,19 @@ func mountRootfs(ctx context.Context, t testing.TB, host *hcsv2.Host, id string)
 		id,
 		host.SecurityPolicyEnforcer(),
 	); err != nil {
-		t.Helper()
-		t.Fatalf("could not mount overlay layers from %q: %v", *flagRootfsPath, err)
+		tb.Fatalf("could not mount overlay layers from %q: %v", *flagRootfsPath, err)
 	}
 
 	return scratch, rootfs
 }
 
-func unmountRootfs(ctx context.Context, t testing.TB, path string) {
+func unmountRootfs(ctx context.Context, tb testing.TB, path string) {
+	tb.Helper()
 	if err := storage.UnmountAllInPath(ctx, path, true); err != nil {
-		t.Fatalf("could not unmount container rootfs: %v", err)
+		tb.Fatalf("could not unmount container rootfs: %v", err)
 	}
 	if err := os.RemoveAll(path); err != nil {
-		t.Fatalf("could not remove container directory: %v", err)
+		tb.Fatalf("could not remove container directory: %v", err)
 	}
 }
 
@@ -266,17 +268,17 @@ func unmountRootfs(ctx context.Context, t testing.TB, path string) {
 // network namespaces
 //
 
-func createNamespace(ctx context.Context, t testing.TB, nns string) {
+func createNamespace(ctx context.Context, tb testing.TB, nns string) {
+	tb.Helper()
 	ns := hcsv2.GetOrAddNetworkNamespace(nns)
 	if err := ns.Sync(ctx); err != nil {
-		t.Helper()
-		t.Fatalf("could not sync new namespace %q: %v", nns, err)
+		tb.Fatalf("could not sync new namespace %q: %v", nns, err)
 	}
 }
 
-func removeNamespace(ctx context.Context, t testing.TB, nns string) {
+func removeNamespace(ctx context.Context, tb testing.TB, nns string) {
+	tb.Helper()
 	if err := hcsv2.RemoveNetworkNamespace(ctx, nns); err != nil {
-		t.Helper()
-		t.Fatalf("could not remove namespace %q: %v", nns, err)
+		tb.Fatalf("could not remove namespace %q: %v", nns, err)
 	}
 }

--- a/test/gcs/helper_cri_test.go
+++ b/test/gcs/helper_cri_test.go
@@ -20,26 +20,29 @@ import (
 
 func sandboxSpec(
 	ctx context.Context,
-	t testing.TB,
+	tb testing.TB,
 	name string,
 	id string,
 	nns string,
 	root string,
 	extra ...oci.SpecOpts,
 ) *oci.Spec {
+	tb.Helper()
 	ctx = namespaces.WithNamespace(ctx, testoci.CRINamespace)
-	opts := sandboxSpecOpts(ctx, t, name, id, nns, root)
+	opts := sandboxSpecOpts(ctx, tb, name, id, nns, root)
 	opts = append(opts, extra...)
 
-	return testoci.CreateLinuxSpec(ctx, t, id, opts...)
+	return testoci.CreateLinuxSpec(ctx, tb, id, opts...)
 }
 
-func sandboxSpecOpts(_ context.Context, t testing.TB,
+func sandboxSpecOpts(_ context.Context,
+	tb testing.TB,
 	name string,
 	id string,
 	nns string,
 	root string,
 ) []oci.SpecOpts {
+	tb.Helper()
 	img := testoci.LinuxSandboxImageConfig(*flagSandboxPause)
 	cfg := testoci.LinuxSandboxRuntimeConfig(name)
 
@@ -58,8 +61,7 @@ func sandboxSpecOpts(_ context.Context, t testing.TB,
 	}
 
 	if len(img.Entrypoint) == 0 && len(img.Cmd) == 0 {
-		t.Helper()
-		t.Fatalf("invalid empty entrypoint and cmd in image config %+v", img)
+		tb.Fatalf("invalid empty entrypoint and cmd in image config %+v", img)
 	}
 	opts = append(opts, oci.WithProcessArgs(append(img.Entrypoint, img.Cmd...)...))
 
@@ -76,7 +78,7 @@ func sandboxSpecOpts(_ context.Context, t testing.TB,
 
 func containerSpec(
 	ctx context.Context,
-	t testing.TB,
+	tb testing.TB,
 	sandboxID string,
 	sandboxPID uint32,
 	name string,
@@ -88,14 +90,15 @@ func containerSpec(
 	root string,
 	extra ...oci.SpecOpts,
 ) *oci.Spec {
+	tb.Helper()
 	ctx = namespaces.WithNamespace(ctx, testoci.CRINamespace)
-	opts := containerSpecOpts(ctx, t, sandboxID, sandboxPID, name, cmd, args, wd, nns, root)
+	opts := containerSpecOpts(ctx, tb, sandboxID, sandboxPID, name, cmd, args, wd, nns, root)
 	opts = append(opts, extra...)
 
-	return testoci.CreateLinuxSpec(ctx, t, id, opts...)
+	return testoci.CreateLinuxSpec(ctx, tb, id, opts...)
 }
 
-func containerSpecOpts(_ context.Context, _ testing.TB,
+func containerSpecOpts(_ context.Context, tb testing.TB,
 	sandboxID string,
 	sandboxPID uint32,
 	name string,
@@ -105,6 +108,7 @@ func containerSpecOpts(_ context.Context, _ testing.TB,
 	nns string,
 	root string,
 ) []oci.SpecOpts {
+	tb.Helper()
 	cfg := testoci.LinuxWorkloadRuntimeConfig(name, cmd, args, wd)
 	img := testoci.LinuxWorkloadImageConfig()
 

--- a/test/gcs/main_test.go
+++ b/test/gcs/main_test.go
@@ -116,17 +116,17 @@ func setup() (err error) {
 // host and runtime management
 //
 
-func getTestState(ctx context.Context, t testing.TB) (*hcsv2.Host, runtime.Runtime) {
-	rt := getRuntime(ctx, t)
-
-	return getHost(ctx, t, rt), rt
+func getTestState(ctx context.Context, tb testing.TB) (*hcsv2.Host, runtime.Runtime) {
+	tb.Helper()
+	rt := getRuntime(ctx, tb)
+	return getHost(ctx, tb, rt), rt
 }
 
-func getHost(_ context.Context, t testing.TB, rt runtime.Runtime) *hcsv2.Host {
+func getHost(_ context.Context, tb testing.TB, rt runtime.Runtime) *hcsv2.Host {
+	tb.Helper()
 	h, err := getHostErr(rt, getTransport())
 	if err != nil {
-		t.Helper()
-		t.Fatalf("could not get host: %v", err)
+		tb.Fatalf("could not get host: %v", err)
 	}
 
 	return h
@@ -144,11 +144,11 @@ func getHostErr(rt runtime.Runtime, tp transport.Transport) (*hcsv2.Host, error)
 	return h, nil
 }
 
-func getRuntime(_ context.Context, t testing.TB) runtime.Runtime {
+func getRuntime(_ context.Context, tb testing.TB) runtime.Runtime {
+	tb.Helper()
 	rt, err := getRuntimeErr()
 	if err != nil {
-		t.Helper()
-		t.Fatalf("could not get runtime: %v", err)
+		tb.Fatalf("could not get runtime: %v", err)
 	}
 
 	return rt
@@ -167,6 +167,7 @@ func getTransport() transport.Transport {
 	return &PipeTransport{}
 }
 
-func requireFeatures(t testing.TB, features ...string) {
-	require.Features(t, flagFeatures.S, features...)
+func requireFeatures(tb testing.TB, features ...string) {
+	tb.Helper()
+	require.Features(tb, flagFeatures.S, features...)
 }

--- a/test/internal/cmd/cmd.go
+++ b/test/internal/cmd/cmd.go
@@ -41,49 +41,45 @@ func Create(ctx context.Context, _ testing.TB, c cow.ProcessHost, p *specs.Proce
 	return cc
 }
 
-func Start(_ context.Context, t testing.TB, c *cmd.Cmd) {
+func Start(_ context.Context, tb testing.TB, c *cmd.Cmd) {
+	tb.Helper()
 	if err := c.Start(); err != nil {
-		t.Helper()
-		t.Fatalf("failed to start %q: %v", desc(c), err)
+		tb.Fatalf("failed to start %q: %v", desc(c), err)
 	}
 }
 
-func Run(ctx context.Context, t testing.TB, c *cmd.Cmd) int {
-	Start(ctx, t, c)
-	e := Wait(ctx, t, c)
-
-	return e
+func Run(ctx context.Context, tb testing.TB, c *cmd.Cmd) int {
+	tb.Helper()
+	Start(ctx, tb, c)
+	return Wait(ctx, tb, c)
 }
 
-func Wait(_ context.Context, t testing.TB, c *cmd.Cmd) int {
+func Wait(_ context.Context, tb testing.TB, c *cmd.Cmd) int {
+	tb.Helper()
 	// todo, wait on context.Done
 	if err := c.Wait(); err != nil {
-		t.Helper()
-
 		ee := &cmd.ExitError{}
 		if errors.As(err, &ee) {
 			return ee.ExitCode()
 		}
-		t.Fatalf("failed to wait on %q: %v", desc(c), err)
+		tb.Fatalf("failed to wait on %q: %v", desc(c), err)
 	}
-
 	return 0
 }
 
-func WaitExitCode(ctx context.Context, t testing.TB, c *cmd.Cmd, e int) {
-	if ee := Wait(ctx, t, c); ee != e {
-		t.Helper()
-		t.Errorf("got exit code %d, wanted %d", ee, e)
+func WaitExitCode(ctx context.Context, tb testing.TB, c *cmd.Cmd, e int) {
+	tb.Helper()
+	if ee := Wait(ctx, tb, c); ee != e {
+		tb.Errorf("got exit code %d, wanted %d", ee, e)
 	}
 }
 
-func Kill(ctx context.Context, t testing.TB, c *cmd.Cmd) {
+func Kill(ctx context.Context, tb testing.TB, c *cmd.Cmd) {
+	tb.Helper()
 	ok, err := c.Process.Kill(ctx)
 	if !ok {
-		t.Helper()
-		t.Fatalf("could not deliver kill to %q", desc(c))
+		tb.Fatalf("could not deliver kill to %q", desc(c))
 	} else if err != nil {
-		t.Helper()
-		t.Fatalf("could not kill %q: %v", desc(c), err)
+		tb.Fatalf("could not kill %q: %v", desc(c), err)
 	}
 }

--- a/test/internal/cmd/io.go
+++ b/test/internal/cmd/io.go
@@ -35,15 +35,15 @@ func (b *BufferedIO) Output() (_ string, err error) {
 	return o, err
 }
 
-func (b *BufferedIO) TestOutput(t testing.TB, out string, err error) {
-	t.Helper()
+func (b *BufferedIO) TestOutput(tb testing.TB, out string, err error) {
+	tb.Helper()
 
 	outGive, errGive := b.Output()
 	if !errors.Is(errGive, err) {
-		t.Fatalf("got stderr: %v; wanted: %v", errGive, err)
+		tb.Fatalf("got stderr: %v; wanted: %v", errGive, err)
 	}
 	if outGive != out {
-		t.Fatalf("got stdout %q; wanted %q", outGive, out)
+		tb.Fatalf("got stdout %q; wanted %q", outGive, out)
 	}
 }
 

--- a/test/internal/container/container.go
+++ b/test/internal/container/container.go
@@ -19,15 +19,15 @@ import (
 
 func Create(
 	ctx context.Context,
-	t testing.TB,
+	tb testing.TB,
 	vm *uvm.UtilityVM,
 	spec *specs.Spec,
 	name, owner string,
 ) (cow.Container, *resources.Resources, func()) {
-	t.Helper()
+	tb.Helper()
 
 	if spec.Windows == nil || spec.Windows.Network == nil || spec.Windows.LayerFolders == nil {
-		t.Fatalf("improperly configured windows spec for container %q: %#+v", name, spec.Windows)
+		tb.Fatalf("improperly configured windows spec for container %q: %#+v", name, spec.Windows)
 	}
 
 	co := &hcsoci.CreateOptions{
@@ -41,43 +41,44 @@ func Create(
 
 	c, r, err := hcsoci.CreateContainer(ctx, co)
 	if err != nil {
-		t.Fatalf("could not create container %q: %v", co.ID, err)
+		tb.Fatalf("could not create container %q: %v", co.ID, err)
 	}
 	f := func() {
 		if err := resources.ReleaseResources(ctx, r, vm, true); err != nil {
-			t.Errorf("failed to release container resources: %v", err)
+			tb.Errorf("failed to release container resources: %v", err)
 		}
 		if err := c.Close(); err != nil {
-			t.Errorf("could not close container %q: %v", c.ID(), err)
+			tb.Errorf("could not close container %q: %v", c.ID(), err)
 		}
 	}
 
 	return c, r, f
 }
 
-func Start(ctx context.Context, t testing.TB, c cow.Container, io *testcmd.BufferedIO) *cmd.Cmd {
-	t.Helper()
-
+func Start(ctx context.Context, tb testing.TB, c cow.Container, io *testcmd.BufferedIO) *cmd.Cmd {
+	tb.Helper()
 	if err := c.Start(ctx); err != nil {
-		t.Fatalf("could not start %q: %v", c.ID(), err)
+		tb.Fatalf("could not start %q: %v", c.ID(), err)
 	}
 
 	// OCI spec is nil to tell bridge to start container's init process
-	init := testcmd.Create(ctx, t, c, nil, io)
-	testcmd.Start(ctx, t, init)
+	init := testcmd.Create(ctx, tb, c, nil, io)
+	testcmd.Start(ctx, tb, init)
 
 	return init
 }
 
-func Wait(_ context.Context, t testing.TB, c cow.Container) {
+func Wait(_ context.Context, tb testing.TB, c cow.Container) {
+	tb.Helper()
 	// todo: add wait on ctx.Done
 	if err := c.Wait(); err != nil {
-		t.Fatalf("could not wait on container %q: %v", c.ID(), err)
+		tb.Fatalf("could not wait on container %q: %v", c.ID(), err)
 	}
 }
 
-func Kill(ctx context.Context, t testing.TB, c cow.Container) {
+func Kill(ctx context.Context, tb testing.TB, c cow.Container) {
+	tb.Helper()
 	if err := c.Shutdown(ctx); err != nil {
-		t.Fatalf("could not terminate container %q: %v", c.ID(), err)
+		tb.Fatalf("could not terminate container %q: %v", c.ID(), err)
 	}
 }

--- a/test/internal/defaultlinuxspec.go
+++ b/test/internal/defaultlinuxspec.go
@@ -11,6 +11,7 @@ import (
 )
 
 func GetDefaultLinuxSpec(t *testing.T) *specs.Spec {
+	t.Helper()
 	content, err := os.ReadFile(`assets\defaultlinuxspec.json`)
 	if err != nil {
 		t.Fatalf("failed to read defaultlinuxspec.json: %s", err.Error())

--- a/test/internal/defaultwindowsspec.go
+++ b/test/internal/defaultwindowsspec.go
@@ -11,6 +11,7 @@ import (
 )
 
 func GetDefaultWindowsSpec(t *testing.T) *specs.Spec {
+	t.Helper()
 	content, err := os.ReadFile(`assets\defaultwindowsspec.json`)
 	if err != nil {
 		t.Fatalf("failed to read defaultwindowsspec.json: %s", err.Error())

--- a/test/internal/layers/layerfolders.go
+++ b/test/internal/layers/layerfolders.go
@@ -25,28 +25,31 @@ func init() {
 }
 
 // FromImage returns thee layer paths of a given image, pulling it if necessary
-func FromImage(ctx context.Context, t testing.TB, client *containerd.Client, ref, platform, snapshotter string) []string {
-	chainID := testctrd.PullImage(ctx, t, client, ref, platform)
-	return FromChainID(ctx, t, client, chainID, snapshotter)
+func FromImage(ctx context.Context, tb testing.TB, client *containerd.Client, ref, platform, snapshotter string) []string {
+	tb.Helper()
+	chainID := testctrd.PullImage(ctx, tb, client, ref, platform)
+	return FromChainID(ctx, tb, client, chainID, snapshotter)
 }
 
 // FromChainID returns thee layer paths of a given image chain ID
-func FromChainID(ctx context.Context, t testing.TB, client *containerd.Client, chainID, snapshotter string) []string {
-	ms := testctrd.CreateViewSnapshot(ctx, t, client, snapshotter, chainID, chainID+"view")
+func FromChainID(ctx context.Context, tb testing.TB, client *containerd.Client, chainID, snapshotter string) []string {
+	tb.Helper()
+	ms := testctrd.CreateViewSnapshot(ctx, tb, client, snapshotter, chainID, chainID+"view")
 	if len(ms) != 1 {
-		t.Fatalf("Rootfs does not contain exactly 1 mount for the root file system")
+		tb.Fatalf("Rootfs does not contain exactly 1 mount for the root file system")
 	}
 
-	return FromMount(ctx, t, ms[0])
+	return FromMount(ctx, tb, ms[0])
 }
 
 // FromMount returns the layer paths of a given mount
-func FromMount(_ context.Context, t testing.TB, m mount.Mount) (layers []string) {
+func FromMount(_ context.Context, tb testing.TB, m mount.Mount) (layers []string) {
+	tb.Helper()
 	for _, option := range m.Options {
 		if strings.HasPrefix(option, mount.ParentLayerPathsFlag) {
 			err := json.Unmarshal([]byte(option[len(mount.ParentLayerPathsFlag):]), &layers)
 			if err != nil {
-				t.Fatalf("failed to unmarshal parent layer paths from mount: %v", err)
+				tb.Fatalf("failed to unmarshal parent layer paths from mount: %v", err)
 			}
 		}
 	}
@@ -56,38 +59,41 @@ func FromMount(_ context.Context, t testing.TB, m mount.Mount) (layers []string)
 }
 
 // Deprecated: This relies on docker. Use [FromChainID] or [FromMount] instead.
-func LayerFolders(t testing.TB, imageName string) []string {
+func LayerFolders(tb testing.TB, imageName string) []string {
+	tb.Helper()
 	if _, ok := imageLayers[imageName]; !ok {
-		imageLayers[imageName] = getLayers(t, imageName)
+		imageLayers[imageName] = getLayers(tb, imageName)
 	}
 	return imageLayers[imageName]
 }
 
-func getLayers(t testing.TB, imageName string) []string {
+func getLayers(tb testing.TB, imageName string) []string {
+	tb.Helper()
 	cmd := exec.Command("docker", "inspect", imageName, "-f", `"{{.GraphDriver.Data.dir}}"`)
 	var out bytes.Buffer
 	cmd.Stdout = &out
 	if err := cmd.Run(); err != nil {
-		t.Skipf("Failed to find layers for %q. Check docker images", imageName)
+		tb.Skipf("Failed to find layers for %q. Check docker images", imageName)
 	}
 	imagePath := strings.Replace(strings.TrimSpace(out.String()), `"`, ``, -1)
-	layers := getLayerChain(t, imagePath)
+	layers := getLayerChain(tb, imagePath)
 	return append([]string{imagePath}, layers...)
 }
 
-func getLayerChain(t testing.TB, layerFolder string) []string {
+func getLayerChain(tb testing.TB, layerFolder string) []string {
+	tb.Helper()
 	jPath := filepath.Join(layerFolder, "layerchain.json")
 	content, err := os.ReadFile(jPath)
 	if os.IsNotExist(err) {
-		t.Fatalf("layerchain not found")
+		tb.Fatalf("layerchain not found")
 	} else if err != nil {
-		t.Fatalf("failed to read layerchain")
+		tb.Fatalf("failed to read layerchain")
 	}
 
 	var layerChain []string
 	err = json.Unmarshal(content, &layerChain)
 	if err != nil {
-		t.Fatalf("failed to unmarshal layerchain")
+		tb.Fatalf("failed to unmarshal layerchain")
 	}
 	return layerChain
 }

--- a/test/internal/layers/scratch.go
+++ b/test/internal/layers/scratch.go
@@ -17,9 +17,10 @@ const (
 	UVMScratchSpaceName = "uvmscratch.vhdx"
 )
 
-func CacheFile(_ context.Context, t testing.TB, dir string) string {
+func CacheFile(_ context.Context, tb testing.TB, dir string) string {
+	tb.Helper()
 	if dir == "" {
-		dir = t.TempDir()
+		dir = tb.TempDir()
 	}
 	cache := filepath.Join(dir, CacheFileName)
 	return cache
@@ -28,12 +29,13 @@ func CacheFile(_ context.Context, t testing.TB, dir string) string {
 // ScratchSpace creates an LCOW scratch space VHD at `dir\name`, and returns the dir and name.
 // If name, dir, or chache are empty, ScratchSpace uses a default name or creates a temporary
 // directory, respectively.
-func ScratchSpace(ctx context.Context, t testing.TB, vm *uvm.UtilityVM, name, dir, cache string) (string, string) {
+func ScratchSpace(ctx context.Context, tb testing.TB, vm *uvm.UtilityVM, name, dir, cache string) (string, string) {
+	tb.Helper()
 	if dir == "" {
-		dir = t.TempDir()
+		dir = tb.TempDir()
 	}
 	if cache == "" {
-		cache = CacheFile(ctx, t, dir)
+		cache = CacheFile(ctx, tb, dir)
 	}
 	if name == "" {
 		name = ScratchSpaceName
@@ -41,8 +43,7 @@ func ScratchSpace(ctx context.Context, t testing.TB, vm *uvm.UtilityVM, name, di
 	scratch := filepath.Join(dir, name)
 
 	if err := lcow.CreateScratch(ctx, vm, scratch, lcow.DefaultScratchSizeGB, cache); err != nil {
-		t.Helper()
-		t.Fatalf("could not create scratch space %q using vm %q and cache file %q: %v", scratch, vm.ID(), cache, err)
+		tb.Fatalf("could not create scratch space %q using vm %q and cache file %q: %v", scratch, vm.ID(), cache, err)
 	}
 
 	return dir, scratch

--- a/test/internal/oci/oci.go
+++ b/test/internal/oci/oci.go
@@ -44,32 +44,34 @@ func DefaultLinuxSpecOpts(nns string, extra ...ctrdoci.SpecOpts) []ctrdoci.SpecO
 
 // DefaultLinuxSpec returns a default OCI spec for a Linux container.
 // See CreateSpecWithPlatform for more details.
-func DefaultLinuxSpec(ctx context.Context, t testing.TB, nns string) *specs.Spec {
-	return CreateLinuxSpec(ctx, t, t.Name(), DefaultLinuxSpecOpts(nns)...)
+func DefaultLinuxSpec(ctx context.Context, tb testing.TB, nns string) *specs.Spec {
+	tb.Helper()
+	return CreateLinuxSpec(ctx, tb, tb.Name(), DefaultLinuxSpecOpts(nns)...)
 }
 
 // CreateLinuxSpec returns the OCI spec for a Linux container.
 // See CreateSpecWithPlatform for more details.
-func CreateLinuxSpec(ctx context.Context, t testing.TB, id string, opts ...ctrdoci.SpecOpts) *specs.Spec {
-	return CreateSpecWithPlatform(ctx, t, constants.PlatformLinux, id, opts...)
+func CreateLinuxSpec(ctx context.Context, tb testing.TB, id string, opts ...ctrdoci.SpecOpts) *specs.Spec {
+	tb.Helper()
+	return CreateSpecWithPlatform(ctx, tb, constants.PlatformLinux, id, opts...)
 }
 
 // CreateWindowsSpec returns the OCI spec for a Windows container.
 // See CreateSpecWithPlatform for more details.
-func CreateWindowsSpec(ctx context.Context, t testing.TB, id string, opts ...ctrdoci.SpecOpts) *specs.Spec {
-	return CreateSpecWithPlatform(ctx, t, constants.PlatformWindows, id, opts...)
+func CreateWindowsSpec(ctx context.Context, tb testing.TB, id string, opts ...ctrdoci.SpecOpts) *specs.Spec {
+	tb.Helper()
+	return CreateSpecWithPlatform(ctx, tb, constants.PlatformWindows, id, opts...)
 }
 
 // CreateSpecWithPlatform returns the OCI spec for the specified platform.
 // The context must contain a containerd namespace (via "github.com/containerd/containerd/namespaces".WithNamespace)
-func CreateSpecWithPlatform(ctx context.Context, t testing.TB, plat, id string, opts ...ctrdoci.SpecOpts) *specs.Spec {
-	// ctx = namespaces.WithNamespace(ctx, ns)
+func CreateSpecWithPlatform(ctx context.Context, tb testing.TB, plat, id string, opts ...ctrdoci.SpecOpts) *specs.Spec {
+	tb.Helper()
 	container := &containers.Container{ID: id}
 
 	spec, err := ctrdoci.GenerateSpecWithPlatform(ctx, nil, plat, container, opts...)
 	if err != nil {
-		t.Helper()
-		t.Fatalf("failed to generate spec for container %q: %v", id, err)
+		tb.Fatalf("failed to generate spec for container %q: %v", id, err)
 	}
 
 	return spec

--- a/test/internal/require/build.go
+++ b/test/internal/require/build.go
@@ -10,14 +10,16 @@ import (
 	_ "github.com/Microsoft/hcsshim/test/internal/manifest" // manifest test binary automatically
 )
 
-func Build(t testing.TB, b uint16) {
+func Build(tb testing.TB, b uint16) {
+	tb.Helper()
 	if osversion.Build() < b {
-		t.Skipf("Requires build %d+", b)
+		tb.Skipf("Requires build %d+", b)
 	}
 }
 
-func ExactBuild(t testing.TB, b uint16) {
+func ExactBuild(tb testing.TB, b uint16) {
+	tb.Helper()
 	if osversion.Build() != b {
-		t.Skipf("Requires exact build %d", b)
+		tb.Skipf("Requires exact build %d", b)
 	}
 }

--- a/test/internal/require/requires.go
+++ b/test/internal/require/requires.go
@@ -11,14 +11,15 @@ import (
 // Features checks the wanted features are present in given,
 // and skips the test if any are missing. If the given set is empty,
 // the function returns (by default all features are enabled).
-func Features(t testing.TB, given flag.StringSet, want ...string) {
+func Features(tb testing.TB, given flag.StringSet, want ...string) {
+	tb.Helper()
 	if len(given) == 0 {
 		return
 	}
 	for _, f := range want {
 		ff := flag.Standardize(f)
 		if _, ok := given[ff]; !ok {
-			t.Skipf("skipping test due to feature not set: %s", f)
+			tb.Skipf("skipping test due to feature not set: %s", f)
 		}
 	}
 }
@@ -26,34 +27,36 @@ func Features(t testing.TB, given flag.StringSet, want ...string) {
 // Binary checks if `binary` exists in the same directory as the test
 // binary.
 // Returns full binary path if it exists, otherwise, skips the test.
-func Binary(t testing.TB, binary string) string {
+func Binary(tb testing.TB, binary string) string {
+	tb.Helper()
 	executable, err := os.Executable()
 	if err != nil {
-		t.Skipf("error locating executable: %s", err)
+		tb.Skipf("error locating executable: %s", err)
 		return ""
 	}
 
 	baseDir := filepath.Dir(executable)
-	return File(t, baseDir, binary)
+	return File(tb, baseDir, binary)
 }
 
 // File checks if `file` exists in `path`, and returns the full path
 // if it exists. Otherwise, it skips the test.
-func File(t testing.TB, path, file string) string {
+func File(tb testing.TB, path, file string) string {
+	tb.Helper()
 	path, err := filepath.Abs(path)
 	if err != nil {
-		t.Fatalf("could not resolve path %q: %v", path, err)
+		tb.Fatalf("could not resolve path %q: %v", path, err)
 	}
 
 	p := filepath.Join(path, file)
 	fi, err := os.Stat(p)
 	switch {
 	case os.IsNotExist(err):
-		t.Skipf("file %q not found", p)
+		tb.Skipf("file %q not found", p)
 	case err != nil:
-		t.Fatalf("could not stat file %q: %v", p, err)
+		tb.Fatalf("could not stat file %q: %v", p, err)
 	case fi.IsDir():
-		t.Fatalf("path %q is a directory", p)
+		tb.Fatalf("path %q is a directory", p)
 	default:
 	}
 

--- a/test/internal/schemaversion_test.go
+++ b/test/internal/schemaversion_test.go
@@ -19,6 +19,7 @@ func init() {
 }
 
 func TestDetermineSchemaVersion(t *testing.T) {
+	t.Helper()
 	osv := osversion.Get()
 
 	if osv.Build >= osversion.RS5 {
@@ -41,7 +42,6 @@ func TestDetermineSchemaVersion(t *testing.T) {
 		if err := schemaversion.IsSupported(schemaversion.SchemaV10()); err != nil {
 			t.Fatalf("v1 expected to be supported")
 		}
-
 	} else {
 		if sv := schemaversion.DetermineSchemaVersion(nil); !schemaversion.IsV10(sv) {
 			t.Fatalf("expected v1")

--- a/test/internal/scratch.go
+++ b/test/internal/scratch.go
@@ -33,7 +33,7 @@ func init() {
 // space. The VHD is created with VM group access
 // TODO: This is wrong. Need to search the folders.
 func CreateWCOWBlankRWLayer(t *testing.T, imageLayers []string) string {
-
+	t.Helper()
 	//	uvmFolder, err := LocateUVMFolder(imageLayers)
 	//	if err != nil {
 	//		t.Fatalf("failed to locate UVM folder from %+v: %s", imageLayers, err)
@@ -50,6 +50,7 @@ func CreateWCOWBlankRWLayer(t *testing.T, imageLayers []string) string {
 // format it ext4. This can then be used as a scratch space for a container, or
 // for a "service VM".
 func CreateLCOWBlankRWLayer(ctx context.Context, t *testing.T) string {
+	t.Helper()
 	if lcowGlobalSVM == nil {
 		lcowGlobalSVM = tuvm.CreateAndStartLCOW(ctx, t, lcowGlobalSVMID)
 		lcowCacheScratchFile = filepath.Join(t.TempDir(), "sandbox.vhdx")

--- a/test/internal/timeout/timeout.go
+++ b/test/internal/timeout/timeout.go
@@ -17,7 +17,8 @@ type ErrorFunc func(error) error
 // then passed to to [testing.Fatal].
 //
 // fe should expect nil errors.
-func WaitForError(ctx context.Context, t testing.TB, f func() error, fe ErrorFunc) {
+func WaitForError(ctx context.Context, tb testing.TB, f func() error, fe ErrorFunc) {
+	tb.Helper()
 	var err error
 	ch := make(chan struct{})
 
@@ -28,18 +29,18 @@ func WaitForError(ctx context.Context, t testing.TB, f func() error, fe ErrorFun
 
 	select {
 	case <-ch:
-		fatalOnError(t, fe, err)
+		fatalOnError(tb, fe, err)
 	case <-ctx.Done():
-		fatalOnError(t, fe, ctx.Err())
+		fatalOnError(tb, fe, ctx.Err())
 	}
 }
 
-func fatalOnError(t testing.TB, f func(error) error, err error) {
+func fatalOnError(tb testing.TB, f func(error) error, err error) {
+	tb.Helper()
 	if f != nil {
 		err = f(err)
 	}
 	if err != nil {
-		t.Helper()
-		t.Fatal(err.Error())
+		tb.Fatal(err.Error())
 	}
 }

--- a/test/internal/uvm/lcow.go
+++ b/test/internal/uvm/lcow.go
@@ -10,31 +10,39 @@ import (
 )
 
 // CreateAndStartLCOW with all default options.
-func CreateAndStartLCOW(ctx context.Context, t testing.TB, id string) *uvm.UtilityVM {
-	return CreateAndStartLCOWFromOpts(ctx, t, uvm.NewDefaultOptionsLCOW(id, ""))
+func CreateAndStartLCOW(ctx context.Context, tb testing.TB, id string) *uvm.UtilityVM {
+	tb.Helper()
+	return CreateAndStartLCOWFromOpts(ctx, tb, uvm.NewDefaultOptionsLCOW(id, ""))
 }
 
 // CreateAndStartLCOWFromOpts creates an LCOW utility VM with the specified options.
-func CreateAndStartLCOWFromOpts(ctx context.Context, t testing.TB, opts *uvm.OptionsLCOW) *uvm.UtilityVM {
-	t.Helper()
+func CreateAndStartLCOWFromOpts(ctx context.Context, tb testing.TB, opts *uvm.OptionsLCOW) *uvm.UtilityVM {
+	tb.Helper()
 
 	if opts == nil {
-		t.Fatal("opts must be set")
+		tb.Fatal("opts must be set")
 	}
 
-	vm := CreateLCOW(ctx, t, opts)
-	cleanup := Start(ctx, t, vm)
-	t.Cleanup(cleanup)
+	vm := CreateLCOW(ctx, tb, opts)
+	cleanup := Start(ctx, tb, vm)
+	tb.Cleanup(cleanup)
 
 	return vm
 }
 
-func CreateLCOW(ctx context.Context, t testing.TB, opts *uvm.OptionsLCOW) *uvm.UtilityVM {
+func CreateLCOW(ctx context.Context, tb testing.TB, opts *uvm.OptionsLCOW) *uvm.UtilityVM {
+	tb.Helper()
 	vm, err := uvm.CreateLCOW(ctx, opts)
 	if err != nil {
-		t.Helper()
-		t.Fatalf("could not create LCOW UVM: %v", err)
+		tb.Fatalf("could not create LCOW UVM: %v", err)
 	}
 
 	return vm
+}
+
+func SetSecurityPolicy(ctx context.Context, tb testing.TB, vm *uvm.UtilityVM, policy string) {
+	tb.Helper()
+	if err := vm.SetConfidentialUVMOptions(ctx, uvm.WithSecurityPolicy(policy)); err != nil {
+		tb.Fatalf("could not set vm security policy to %q: %v", policy, err)
+	}
 }

--- a/test/internal/uvm/uvm.go
+++ b/test/internal/uvm/uvm.go
@@ -12,23 +12,24 @@ import (
 	"github.com/Microsoft/hcsshim/test/internal/timeout"
 )
 
-func Start(ctx context.Context, t testing.TB, vm *uvm.UtilityVM) func() {
+func Start(ctx context.Context, tb testing.TB, vm *uvm.UtilityVM) func() {
+	tb.Helper()
 	err := vm.Start(ctx)
 	f := func() {
 		if err := vm.Close(); err != nil {
-			t.Logf("could not close vm %q: %v", vm.ID(), err)
+			tb.Logf("could not close vm %q: %v", vm.ID(), err)
 		}
 	}
 
 	if err != nil {
-		t.Helper()
-		t.Fatalf("could not start UVM: %v", err)
+		tb.Fatalf("could not start UVM: %v", err)
 	}
 
 	return f
 }
 
-func Wait(ctx context.Context, t testing.TB, vm *uvm.UtilityVM) {
+func Wait(ctx context.Context, tb testing.TB, vm *uvm.UtilityVM) {
+	tb.Helper()
 	fe := func(err error) error {
 		if err != nil {
 			err = fmt.Errorf("could not wait for uvm %q: %w", vm.ID(), err)
@@ -36,17 +37,18 @@ func Wait(ctx context.Context, t testing.TB, vm *uvm.UtilityVM) {
 
 		return err
 	}
-	timeout.WaitForError(ctx, t, vm.Wait, fe)
+	timeout.WaitForError(ctx, tb, vm.Wait, fe)
 }
 
-func Kill(ctx context.Context, t testing.TB, vm *uvm.UtilityVM) {
+func Kill(ctx context.Context, tb testing.TB, vm *uvm.UtilityVM) {
+	tb.Helper()
 	if err := vm.Terminate(ctx); err != nil {
-		t.Helper()
-		t.Fatalf("could not kill uvm %q: %v", vm.ID(), err)
+		tb.Fatalf("could not kill uvm %q: %v", vm.ID(), err)
 	}
 }
 
-func Close(ctx context.Context, t testing.TB, vm *uvm.UtilityVM) {
+func Close(ctx context.Context, tb testing.TB, vm *uvm.UtilityVM) {
+	tb.Helper()
 	// Terminate will error on context cancellation, but close does not accept contexts
 	fe := func(err error) error {
 		if err != nil {
@@ -55,5 +57,5 @@ func Close(ctx context.Context, t testing.TB, vm *uvm.UtilityVM) {
 
 		return err
 	}
-	timeout.WaitForError(ctx, t, vm.Close, fe)
+	timeout.WaitForError(ctx, tb, vm.Close, fe)
 }

--- a/test/internal/uvm/wcow.go
+++ b/test/internal/uvm/wcow.go
@@ -13,25 +13,26 @@ import (
 
 // CreateWCOWUVM creates a WCOW utility VM with all default options. Returns the
 // UtilityVM object; folder used as its scratch.
-func CreateWCOWUVM(ctx context.Context, t testing.TB, id, image string) (*uvm.UtilityVM, []string, string) {
-	return CreateWCOWUVMFromOptsWithImage(ctx, t, uvm.NewDefaultOptionsWCOW(id, ""), image)
+func CreateWCOWUVM(ctx context.Context, tb testing.TB, id, image string) (*uvm.UtilityVM, []string, string) {
+	tb.Helper()
+	return CreateWCOWUVMFromOptsWithImage(ctx, tb, uvm.NewDefaultOptionsWCOW(id, ""), image)
 }
 
 // CreateWCOWUVMFromOpts creates a WCOW utility VM with the passed opts.
-func CreateWCOWUVMFromOpts(ctx context.Context, t testing.TB, opts *uvm.OptionsWCOW) *uvm.UtilityVM {
-	t.Helper()
+func CreateWCOWUVMFromOpts(ctx context.Context, tb testing.TB, opts *uvm.OptionsWCOW) *uvm.UtilityVM {
+	tb.Helper()
 
 	if opts == nil || len(opts.LayerFolders) < 2 {
-		t.Fatalf("opts must bet set with LayerFolders")
+		tb.Fatalf("opts must bet set with LayerFolders")
 	}
 
 	vm, err := uvm.CreateWCOW(ctx, opts)
 	if err != nil {
-		t.Fatal(err)
+		tb.Fatal(err)
 	}
 	if err := vm.Start(ctx); err != nil {
 		vm.Close()
-		t.Fatal(err)
+		tb.Fatal(err)
 	}
 
 	return vm
@@ -44,20 +45,20 @@ func CreateWCOWUVMFromOpts(ctx context.Context, t testing.TB, opts *uvm.OptionsW
 //nolint:staticcheck // SA5011: staticcheck thinks `opts` may be nil, even though we fail if it is
 func CreateWCOWUVMFromOptsWithImage(
 	ctx context.Context,
-	t testing.TB,
+	tb testing.TB,
 	opts *uvm.OptionsWCOW,
 	image string,
 ) (*uvm.UtilityVM, []string, string) {
-	t.Helper()
+	tb.Helper()
 	if opts == nil {
-		t.Fatal("opts must be set")
+		tb.Fatal("opts must be set")
 	}
 
 	//nolint:staticcheck // SA1019: TODO: switch from LayerFolders
-	uvmLayers := layers.LayerFolders(t, image)
-	scratchDir := t.TempDir()
+	uvmLayers := layers.LayerFolders(tb, image)
+	scratchDir := tb.TempDir()
 	opts.LayerFolders = append(opts.LayerFolders, uvmLayers...)
 	opts.LayerFolders = append(opts.LayerFolders, scratchDir)
 
-	return CreateWCOWUVMFromOpts(ctx, t, opts), uvmLayers, scratchDir
+	return CreateWCOWUVMFromOpts(ctx, tb, opts), uvmLayers, scratchDir
 }

--- a/test/runhcs/e2e_matrix_test.go
+++ b/test/runhcs/e2e_matrix_test.go
@@ -58,6 +58,7 @@ type testIO struct {
 }
 
 func newTestIO(t *testing.T) *testIO {
+	t.Helper()
 	var err error
 	tio := &testIO{
 		outBuff: &bytes.Buffer{},
@@ -134,6 +135,7 @@ func (t *testIO) Wait() error {
 }
 
 func getWindowsImageNameByVersion(t *testing.T, bv int) string {
+	t.Helper()
 	switch bv {
 	case osversion.RS1:
 		return "mcr.microsoft.com/windows/nanoserver:sac2016"
@@ -164,6 +166,7 @@ func readPidFile(path string) (int, error) {
 }
 
 func testWindows(t *testing.T, version int, isolated bool) {
+	t.Helper()
 	var err error
 
 	// Make the bundle
@@ -300,14 +303,17 @@ func testWindows(t *testing.T, version int, isolated bool) {
 }
 
 func testWindowsPod(t *testing.T, version int, isolated bool) {
+	t.Helper()
 	t.Skip("not implemented")
 }
 
 func testLCOW(t *testing.T) {
+	t.Helper()
 	t.Skip("not implemented")
 }
 
 func testLCOWPod(t *testing.T) {
+	t.Helper()
 	t.Skip("not implemented")
 }
 


### PR DESCRIPTION
Add `t.Helper()` calls to testing helpers so the correct test name and line number is shown during logs
[ref](https://pkg.go.dev/testing#B.Helper).

This allows logs to show the line number within a test that raised the error, rather than the line within the helper funciton that emitted the log (eg, `runpodsandbox_test.go:89` instead of `helper_sandbox_test.go:43`)

`t.Log`, `t.Error`, and co. use the [call stack](https://pkg.go.dev/runtime#Callers) to track which function issued the logging statement. Therefore, even if a helper function does not log or fail, it should still call `t.Helper` in case its callee's do.

Add [`thelper`](https://github.com/kulti/thelper) linter to settings to make sure testing helpers correctly call `t.Helper`.

Renamed `t testing.TB` to `tb testing.TB` to satisfy `thelper`.

Signed-off-by: Hamza El-Saawy <hamzaelsaawy@microsoft.com>