### PR TITLE
Add policy enforcement for overlay unmounting

### DIFF
--- a/internal/guest/runtime/hcsv2/uvm.go
+++ b/internal/guest/runtime/hcsv2/uvm.go
@@ -778,9 +778,17 @@ func modifyCombinedLayers(
 			workdirPath = filepath.Join(cl.ScratchPath, "work")
 		}
 
+		if err := securityPolicy.EnforceOverlayMountPolicy(cl.ContainerID, layerPaths, cl.ContainerRootPath); err != nil {
+			return errors.Wrap(err, "overlay creation denied by policy")
+		}
+
 		return overlay.MountLayer(ctx, layerPaths, upperdirPath, workdirPath,
-			cl.ContainerRootPath, readonly, cl.ContainerID, securityPolicy)
+			cl.ContainerRootPath, readonly, cl.ContainerID)
 	case guestrequest.RequestTypeRemove:
+		if err := securityPolicy.EnforceOverlayUnmountPolicy(cl.ContainerRootPath); err != nil {
+			return errors.Wrap(err, "overlay removal denied by policy")
+		}
+
 		return storage.UnmountPath(ctx, cl.ContainerRootPath, true)
 	default:
 		return newInvalidRequestTypeError(rt)

--- a/internal/guest/storage/overlay/overlay.go
+++ b/internal/guest/storage/overlay/overlay.go
@@ -13,7 +13,6 @@ import (
 	"github.com/Microsoft/hcsshim/internal/log"
 	"github.com/Microsoft/hcsshim/internal/memory"
 	"github.com/Microsoft/hcsshim/internal/oc"
-	"github.com/Microsoft/hcsshim/pkg/securitypolicy"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"go.opencensus.io/trace"
@@ -65,15 +64,11 @@ func MountLayer(
 	upperdirPath, workdirPath, rootfsPath string,
 	readonly bool,
 	containerID string,
-	securityPolicy securitypolicy.SecurityPolicyEnforcer,
 ) (err error) {
 	_, span := oc.StartSpan(ctx, "overlay::MountLayer")
 	defer span.End()
 	defer func() { oc.SetSpanStatus(span, err) }()
 
-	if err := securityPolicy.EnforceOverlayMountPolicy(containerID, layerPaths); err != nil {
-		return err
-	}
 	return Mount(ctx, layerPaths, upperdirPath, workdirPath, rootfsPath, readonly)
 }
 

--- a/internal/guest/storage/overlay/overlay_test.go
+++ b/internal/guest/storage/overlay/overlay_test.go
@@ -8,8 +8,6 @@ import (
 	"errors"
 	"os"
 	"testing"
-
-	"github.com/Microsoft/hcsshim/pkg/securitypolicy"
 )
 
 const (
@@ -83,7 +81,7 @@ func Test_Mount_Success(t *testing.T) {
 		return nil
 	}
 
-	err := MountLayer(context.Background(), []string{"/layer1", "/layer2"}, "/upper", "/work", "/root", false, fakeContainerID, openDoorSecurityPolicyEnforcer())
+	err := MountLayer(context.Background(), []string{"/layer1", "/layer2"}, "/upper", "/work", "/root", false, fakeContainerID)
 	if err != nil {
 		t.Fatalf("expected no error got: %v", err)
 	}
@@ -127,15 +125,11 @@ func Test_Mount_Readonly_Success(t *testing.T) {
 		return nil
 	}
 
-	err := MountLayer(context.Background(), []string{"/layer1", "/layer2"}, "", "", "/root", false, fakeContainerID, openDoorSecurityPolicyEnforcer())
+	err := MountLayer(context.Background(), []string{"/layer1", "/layer2"}, "", "", "/root", false, fakeContainerID)
 	if err != nil {
 		t.Fatalf("expected no error got: %v", err)
 	}
 	if !rootCreated {
 		t.Fatal("expected root to be created")
 	}
-}
-
-func openDoorSecurityPolicyEnforcer() securitypolicy.SecurityPolicyEnforcer {
-	return &securitypolicy.OpenDoorSecurityPolicyEnforcer{}
 }

--- a/pkg/securitypolicy/api.rego
+++ b/pkg/securitypolicy/api.rego
@@ -7,6 +7,7 @@ enforcement_points := {
     "mount_overlay": {"introducedVersion": "0.1.0", "allowedByDefault": false},
     "create_container": {"introducedVersion": "0.1.0", "allowedByDefault": false},
     "unmount_device": {"introducedVersion": "0.2.0", "allowedByDefault": true},
+    "unmount_overlay": {"introducedVersion": "0.6.0", "allowedByDefault": true},
     "exec_in_container": {"introducedVersion": "0.2.0", "allowedByDefault": true},
     "exec_external": {"introducedVersion": "0.3.0", "allowedByDefault": true},
     "shutdown_container": {"introducedVersion": "0.4.0", "allowedByDefault": true},

--- a/pkg/securitypolicy/open_door.rego
+++ b/pkg/securitypolicy/open_door.rego
@@ -6,6 +6,7 @@ mount_device := {"allowed": true}
 mount_overlay := {"allowed": true}
 create_container := {"allowed": true}
 unmount_device := {"allowed": true}
+unmount_overlay := {"allowed": true}
 exec_in_container := {"allowed": true}
 exec_external := {"allowed": true}
 shutdown_container := {"allowed": true}

--- a/pkg/securitypolicy/policy.rego
+++ b/pkg/securitypolicy/policy.rego
@@ -10,6 +10,7 @@ import future.keywords.in
 mount_device := data.framework.mount_device
 unmount_device := data.framework.unmount_device
 mount_overlay := data.framework.mount_overlay
+unmount_overlay := data.framework.unmount_overlay
 create_container := data.framework.create_container
 exec_in_container := data.framework.exec_in_container
 exec_external := data.framework.exec_external

--- a/pkg/securitypolicy/regopolicy_test.go
+++ b/pkg/securitypolicy/regopolicy_test.go
@@ -178,7 +178,7 @@ func Test_Rego_EnforceOverlayMountPolicy_No_Matches(t *testing.T) {
 			return false
 		}
 
-		err = tc.policy.EnforceOverlayMountPolicy(tc.containerID, tc.layers)
+		err = tc.policy.EnforceOverlayMountPolicy(tc.containerID, tc.layers, testDataGenerator.uniqueMountTarget())
 
 		if err == nil {
 			return false
@@ -206,7 +206,7 @@ func Test_Rego_EnforceOverlayMountPolicy_Matches(t *testing.T) {
 			return false
 		}
 
-		err = tc.policy.EnforceOverlayMountPolicy(tc.containerID, tc.layers)
+		err = tc.policy.EnforceOverlayMountPolicy(tc.containerID, tc.layers, testDataGenerator.uniqueMountTarget())
 
 		// getting an error means something is broken
 		return err == nil
@@ -244,7 +244,7 @@ func Test_Rego_EnforceOverlayMountPolicy_Layers_With_Same_Root_Hash(t *testing.T
 		t.Fatalf("error creating valid overlay: %v", err)
 	}
 
-	err = policy.EnforceOverlayMountPolicy(containerID, layers)
+	err = policy.EnforceOverlayMountPolicy(containerID, layers, testDataGenerator.uniqueMountTarget())
 	if err != nil {
 		t.Fatalf("Unable to create an overlay where root hashes are the same")
 	}
@@ -294,7 +294,7 @@ func Test_Rego_EnforceOverlayMountPolicy_Layers_Shared_Layers(t *testing.T) {
 		containerOneOverlay[len(containerOneOverlay)-i-1] = mount
 	}
 
-	err = policy.EnforceOverlayMountPolicy(containerID, containerOneOverlay)
+	err = policy.EnforceOverlayMountPolicy(containerID, containerOneOverlay, testDataGenerator.uniqueMountTarget())
 	if err != nil {
 		t.Fatalf("Unexpected error mounting overlay: %v", err)
 	}
@@ -323,7 +323,7 @@ func Test_Rego_EnforceOverlayMountPolicy_Layers_Shared_Layers(t *testing.T) {
 		containerTwoOverlay[len(containerTwoOverlay)-i-1] = mount
 	}
 
-	err = policy.EnforceOverlayMountPolicy(containerID, containerTwoOverlay)
+	err = policy.EnforceOverlayMountPolicy(containerID, containerTwoOverlay, testDataGenerator.uniqueMountTarget())
 	if err != nil {
 		t.Fatalf("Unexpected error mounting overlay: %v", err)
 	}
@@ -344,12 +344,12 @@ func Test_Rego_EnforceOverlayMountPolicy_Overlay_Single_Container_Twice(t *testi
 			return false
 		}
 
-		if err := tc.policy.EnforceOverlayMountPolicy(tc.containerID, tc.layers); err != nil {
+		if err := tc.policy.EnforceOverlayMountPolicy(tc.containerID, tc.layers, testDataGenerator.uniqueMountTarget()); err != nil {
 			t.Errorf("expected nil error got: %v", err)
 			return false
 		}
 
-		if err := tc.policy.EnforceOverlayMountPolicy(tc.containerID, tc.layers); err == nil {
+		if err := tc.policy.EnforceOverlayMountPolicy(tc.containerID, tc.layers, testDataGenerator.uniqueMountTarget()); err == nil {
 			t.Errorf("able to create overlay for the same container twice")
 			return false
 		} else {
@@ -389,7 +389,7 @@ func Test_Rego_EnforceOverlayMountPolicy_Reusing_ID_Across_Overlays(t *testing.T
 		t.Fatalf("Unexpected error creating valid overlay: %v", err)
 	}
 
-	err = policy.EnforceOverlayMountPolicy(containerID, layerPaths)
+	err = policy.EnforceOverlayMountPolicy(containerID, layerPaths, testDataGenerator.uniqueMountTarget())
 	if err != nil {
 		t.Fatalf("Unexpected error mounting overlay filesystem: %v", err)
 	}
@@ -400,7 +400,7 @@ func Test_Rego_EnforceOverlayMountPolicy_Reusing_ID_Across_Overlays(t *testing.T
 		t.Fatalf("Unexpected error creating valid overlay: %v", err)
 	}
 
-	err = policy.EnforceOverlayMountPolicy(containerID, layerPaths)
+	err = policy.EnforceOverlayMountPolicy(containerID, layerPaths, testDataGenerator.uniqueMountTarget())
 	if err == nil {
 		t.Fatalf("Unexpected success mounting overlay filesystem")
 	}
@@ -439,11 +439,70 @@ func Test_Rego_EnforceOverlayMountPolicy_Multiple_Instances_Same_Container(t *te
 			}
 
 			id := testDataGenerator.uniqueContainerID()
-			err = policy.EnforceOverlayMountPolicy(id, layerPaths)
+			err = policy.EnforceOverlayMountPolicy(id, layerPaths, testDataGenerator.uniqueMountTarget())
 			if err != nil {
 				t.Fatalf("failed with %d containers", containersToCreate)
 			}
 		}
+	}
+}
+
+func Test_Rego_EnforceOverlayUnmountPolicy(t *testing.T) {
+	f := func(p *generatedConstraints) bool {
+		tc, err := setupRegoOverlayTest(p, true)
+		if err != nil {
+			t.Error(err)
+			return false
+		}
+
+		target := testDataGenerator.uniqueMountTarget()
+		err = tc.policy.EnforceOverlayMountPolicy(tc.containerID, tc.layers, target)
+		if err != nil {
+			t.Errorf("Failure setting up overlay for testing: %v", err)
+			return false
+		}
+
+		err = tc.policy.EnforceOverlayUnmountPolicy(target)
+		if err != nil {
+			t.Errorf("Unexpected policy enforcement failure: %v", err)
+			return false
+		}
+
+		return true
+	}
+
+	if err := quick.Check(f, &quick.Config{MaxCount: 50, Rand: testRand}); err != nil {
+		t.Errorf("Test_Rego_EnforceOverlayUnmountPolicy: %v", err)
+	}
+}
+
+func Test_Rego_EnforceOverlayUnmountPolicy_No_Matches(t *testing.T) {
+	f := func(p *generatedConstraints) bool {
+		tc, err := setupRegoOverlayTest(p, true)
+		if err != nil {
+			t.Error(err)
+			return false
+		}
+
+		target := testDataGenerator.uniqueMountTarget()
+		err = tc.policy.EnforceOverlayMountPolicy(tc.containerID, tc.layers, target)
+		if err != nil {
+			t.Errorf("Failure setting up overlay for testing: %v", err)
+			return false
+		}
+
+		badTarget := testDataGenerator.uniqueMountTarget()
+		err = tc.policy.EnforceOverlayUnmountPolicy(badTarget)
+		if err == nil {
+			t.Errorf("Unexpected policy enforcement success: %v", err)
+			return false
+		}
+
+		return true
+	}
+
+	if err := quick.Check(f, &quick.Config{MaxCount: 50, Rand: testRand}); err != nil {
+		t.Errorf("Test_Rego_EnforceOverlayUnmountPolicy: %v", err)
 	}
 }
 
@@ -2143,7 +2202,7 @@ func mountImageForContainer(policy *regoEnforcer, container *securityPolicyConta
 	}
 
 	// see NOTE_TESTCOPY
-	err = policy.EnforceOverlayMountPolicy(containerID, copyStrings(layerPaths))
+	err = policy.EnforceOverlayMountPolicy(containerID, copyStrings(layerPaths), testDataGenerator.uniqueMountTarget())
 	if err != nil {
 		return "", fmt.Errorf("error mounting filesystem: %w", err)
 	}

--- a/pkg/securitypolicy/securitypolicy_test.go
+++ b/pkg/securitypolicy/securitypolicy_test.go
@@ -210,7 +210,7 @@ func Test_EnforceOverlayMountPolicy_No_Matches(t *testing.T) {
 			return false
 		}
 
-		err = tc.policy.EnforceOverlayMountPolicy(tc.containerID, tc.layers)
+		err = tc.policy.EnforceOverlayMountPolicy(tc.containerID, tc.layers, generateMountTarget(testRand))
 
 		// not getting an error means something is broken
 		return err != nil
@@ -231,7 +231,7 @@ func Test_EnforceOverlayMountPolicy_Matches(t *testing.T) {
 			return false
 		}
 
-		err = tc.policy.EnforceOverlayMountPolicy(tc.containerID, tc.layers)
+		err = tc.policy.EnforceOverlayMountPolicy(tc.containerID, tc.layers, generateMountTarget(testRand))
 
 		// getting an error means something is broken
 		return err == nil
@@ -250,11 +250,11 @@ func Test_EnforceOverlayMountPolicy_Overlay_Single_Container_Twice(t *testing.T)
 		t.Fatalf("expected nil error got: %v", err)
 	}
 
-	if err := tc.policy.EnforceOverlayMountPolicy(tc.containerID, tc.layers); err != nil {
+	if err := tc.policy.EnforceOverlayMountPolicy(tc.containerID, tc.layers, generateMountTarget(testRand)); err != nil {
 		t.Fatalf("expected nil error got: %v", err)
 	}
 
-	if err := tc.policy.EnforceOverlayMountPolicy(tc.containerID, tc.layers); err == nil {
+	if err := tc.policy.EnforceOverlayMountPolicy(tc.containerID, tc.layers, generateMountTarget(testRand)); err == nil {
 		t.Fatal("able to create overlay for the same container twice")
 	}
 }
@@ -286,7 +286,7 @@ func Test_EnforceOverlayMountPolicy_Multiple_Instances_Same_Container(t *testing
 			}
 
 			id := testDataGenerator.uniqueContainerID()
-			err = sp.EnforceOverlayMountPolicy(id, layerPaths)
+			err = sp.EnforceOverlayMountPolicy(id, layerPaths, generateMountTarget(testRand))
 			if err != nil {
 				t.Fatalf("failed with %d containers", containersToCreate)
 			}
@@ -315,12 +315,12 @@ func Test_EnforceOverlayMountPolicy_Overlay_Single_Container_Twice_With_Differen
 		t.Fatalf("expected nil error got: %v", err)
 	}
 
-	err = sp.EnforceOverlayMountPolicy(containerIDOne, layerPaths)
+	err = sp.EnforceOverlayMountPolicy(containerIDOne, layerPaths, generateMountTarget(testRand))
 	if err != nil {
 		t.Fatalf("expected nil error got: %v", err)
 	}
 
-	err = sp.EnforceOverlayMountPolicy(containerIDTwo, layerPaths)
+	err = sp.EnforceOverlayMountPolicy(containerIDTwo, layerPaths, generateMountTarget(testRand))
 	if err == nil {
 		t.Fatal("able to reuse an overlay across containers")
 	}
@@ -334,7 +334,7 @@ func Test_EnforceCommandPolicy_Matches(t *testing.T) {
 			return false
 		}
 
-		if err := tc.policy.EnforceOverlayMountPolicy(tc.containerID, tc.layers); err != nil {
+		if err := tc.policy.EnforceOverlayMountPolicy(tc.containerID, tc.layers, generateMountTarget(testRand)); err != nil {
 			t.Errorf("failed to enforce overlay mount policy: %s", err)
 			return false
 		}
@@ -358,7 +358,7 @@ func Test_EnforceCommandPolicy_NoMatches(t *testing.T) {
 			return false
 		}
 
-		if err := tc.policy.EnforceOverlayMountPolicy(tc.containerID, tc.layers); err != nil {
+		if err := tc.policy.EnforceOverlayMountPolicy(tc.containerID, tc.layers, generateMountTarget(testRand)); err != nil {
 			t.Errorf("failed to enforce overlay mount policy: %s", err)
 			return false
 		}
@@ -410,7 +410,7 @@ func Test_EnforceCommandPolicy_NarrowingMatches(t *testing.T) {
 				return false
 			}
 
-			err = policy.EnforceOverlayMountPolicy(containerID, layerPaths)
+			err = policy.EnforceOverlayMountPolicy(containerID, layerPaths, generateMountTarget(testRand))
 			if err != nil {
 				return false
 			}
@@ -483,7 +483,7 @@ func Test_EnforceEnvironmentVariablePolicy_Matches(t *testing.T) {
 			t.Error(err)
 			return false
 		}
-		if err = tc.policy.EnforceOverlayMountPolicy(tc.containerID, tc.layers); err != nil {
+		if err = tc.policy.EnforceOverlayMountPolicy(tc.containerID, tc.layers, generateMountTarget(testRand)); err != nil {
 			t.Errorf("failed to enforce overlay mount policy: %s", err)
 			return false
 		}
@@ -521,7 +521,7 @@ func Test_EnforceEnvironmentVariablePolicy_Re2Match(t *testing.T) {
 		t.Fatalf("expected nil error got: %v", err)
 	}
 
-	err = policy.EnforceOverlayMountPolicy(containerID, layerPaths)
+	err = policy.EnforceOverlayMountPolicy(containerID, layerPaths, generateMountTarget(testRand))
 	if err != nil {
 		t.Fatalf("expected nil error got: %v", err)
 	}
@@ -543,7 +543,7 @@ func Test_EnforceEnvironmentVariablePolicy_NotAllMatches(t *testing.T) {
 			t.Error(err)
 			return false
 		}
-		if err = tc.policy.EnforceOverlayMountPolicy(tc.containerID, tc.layers); err != nil {
+		if err = tc.policy.EnforceOverlayMountPolicy(tc.containerID, tc.layers, generateMountTarget(testRand)); err != nil {
 			t.Errorf("failed to enforce overlay mount policy: %s", err)
 			return false
 		}
@@ -599,7 +599,7 @@ func Test_EnforceEnvironmentVariablePolicy_NarrowingMatches(t *testing.T) {
 				return false
 			}
 
-			err = policy.EnforceOverlayMountPolicy(containerID, layerPaths)
+			err = policy.EnforceOverlayMountPolicy(containerID, layerPaths, generateMountTarget(testRand))
 			if err != nil {
 				t.Error(err)
 				return false
@@ -676,7 +676,7 @@ func Test_WorkingDirectoryPolicy_Matches(t *testing.T) {
 			return false
 		}
 
-		if err := tc.policy.EnforceOverlayMountPolicy(tc.containerID, tc.layers); err != nil {
+		if err := tc.policy.EnforceOverlayMountPolicy(tc.containerID, tc.layers, generateMountTarget(testRand)); err != nil {
 			t.Errorf("failed to enforce overlay mount policy: %s", err)
 			return false
 		}
@@ -698,7 +698,7 @@ func Test_WorkingDirectoryPolicy_NoMatches(t *testing.T) {
 			return false
 		}
 
-		if err := tc.policy.EnforceOverlayMountPolicy(tc.containerID, tc.layers); err != nil {
+		if err := tc.policy.EnforceOverlayMountPolicy(tc.containerID, tc.layers, generateMountTarget(testRand)); err != nil {
 			t.Errorf("failed to enforce overlay mount policy: %s", err)
 			return false
 		}
@@ -746,7 +746,7 @@ func Test_Overlay_Duplicate_Layers(t *testing.T) {
 			overlay[i] = mountTargets[numLayers-i-1]
 		}
 		containerID := randString(testRand, 32)
-		if err := policy.EnforceOverlayMountPolicy(containerID, overlay); err != nil {
+		if err := policy.EnforceOverlayMountPolicy(containerID, overlay, generateMountTarget(testRand)); err != nil {
 			t.Errorf("failed to enforce overlay mount policy: %s", err)
 			return false
 		}

--- a/pkg/securitypolicy/securitypolicyenforcer_rego.go
+++ b/pkg/securitypolicy/securitypolicyenforcer_rego.go
@@ -526,13 +526,22 @@ func (policy *regoEnforcer) EnforceDeviceMountPolicy(target string, deviceHash s
 	return policy.enforce("mount_device", input)
 }
 
-func (policy *regoEnforcer) EnforceOverlayMountPolicy(containerID string, layerPaths []string) error {
+func (policy *regoEnforcer) EnforceOverlayMountPolicy(containerID string, layerPaths []string, target string) error {
 	input := map[string]interface{}{
 		"containerID": containerID,
 		"layerPaths":  layerPaths,
+		"target":      target,
 	}
 
 	return policy.enforce("mount_overlay", input)
+}
+
+func (policy *regoEnforcer) EnforceOverlayUnmountPolicy(target string) error {
+	input := map[string]interface{}{
+		"unmountTarget": target,
+	}
+
+	return policy.enforce("unmount_overlay", input)
 }
 
 // Rego does not have a way to determine the OS path separator

--- a/test/gcs/helper_container_test.go
+++ b/test/gcs/helper_container_test.go
@@ -244,7 +244,6 @@ func mountRootfs(ctx context.Context, t testing.TB, host *hcsv2.Host, id string)
 		rootfs,
 		false, // readonly
 		id,
-		host.SecurityPolicyEnforcer(),
 	); err != nil {
 		t.Helper()
 		t.Fatalf("could not mount overlay layers from %q: %v", *flagRootfsPath, err)


### PR DESCRIPTION
We previously weren't doing any enforcement around whether an overlay should be allowed to be unmounted. The initial logic is very simple and matches our device unmounting logic:

only allow an unmount if we've seen a mount.

When we get to the hardening PRs, we'll want to revisit this basic rule and decide if we want to make it more vigorous in policy or if we want to put all hardening in GCS or some mixture in-between. That's a design discussion we'll need to have.