### PR TITLE
rego and hardening: add enforcement and hardening for encrypted scratch

### DIFF
--- a/internal/guest/runtime/hcsv2/uvm.go
+++ b/internal/guest/runtime/hcsv2/uvm.go
@@ -773,7 +773,7 @@ func modifyMappedVirtualDisk(
 		if mvd.MountPath != "" {
 			if mvd.ReadOnly {
 				if err := securityPolicy.EnforceDeviceUnmountPolicy(mvd.MountPath); err != nil {
-					return errors.Wrapf(err, "unmounting scsi device at %s denied by policy", mvd.MountPath)
+					return fmt.Errorf("unmounting scsi device at %s denied by policy: %w", mvd.MountPath, err)
 				}
 			}
 

--- a/internal/guest/runtime/hcsv2/uvm.go
+++ b/internal/guest/runtime/hcsv2/uvm.go
@@ -69,6 +69,9 @@ type Host struct {
 
 	// logging target
 	logWriter io.Writer
+	// hostMounts keeps the state of currently mounted devices and file systems,
+	// which is used for GCS hardening.
+	hostMounts *hostMounts
 }
 
 func NewHost(rtime runtime.Runtime, vsock transport.Transport, initialEnforcer securitypolicy.SecurityPolicyEnforcer, logWriter io.Writer) *Host {
@@ -80,6 +83,7 @@ func NewHost(rtime runtime.Runtime, vsock transport.Transport, initialEnforcer s
 		securityPolicyEnforcerSet: false,
 		securityPolicyEnforcer:    initialEnforcer,
 		logWriter:                 logWriter,
+		hostMounts:                newHostMounts(),
 	}
 }
 
@@ -394,16 +398,48 @@ func (h *Host) CreateContainer(ctx context.Context, id string, settings *prot.VM
 	return c, nil
 }
 
-func (h *Host) modifyHostSettings(ctx context.Context, containerID string, req *guestrequest.ModificationRequest) error {
+func (h *Host) modifyHostSettings(ctx context.Context, containerID string, req *guestrequest.ModificationRequest) (err error) {
 	switch req.ResourceType {
 	case guestresource.ResourceTypeMappedVirtualDisk:
-		return modifyMappedVirtualDisk(ctx, req.RequestType, req.Settings.(*guestresource.LCOWMappedVirtualDisk), h.securityPolicyEnforcer)
+		mvd := req.Settings.(*guestresource.LCOWMappedVirtualDisk)
+		// first we try to update the internal state for read-write attachments.
+		if !mvd.ReadOnly {
+			source, err := scsi.ControllerLunToName(ctx, mvd.Controller, mvd.Lun)
+			if err != nil {
+				return err
+			}
+			if req.RequestType == guestrequest.RequestTypeAdd {
+				if err := h.hostMounts.AddRWDevice(mvd.MountPath, source, mvd.Encrypted); err != nil {
+					return err
+				}
+				defer func() {
+					if err != nil {
+						_ = h.hostMounts.RemoveRWDevice(mvd.MountPath, source)
+					}
+				}()
+			} else if req.RequestType == guestrequest.RequestTypeRemove {
+				if err := h.hostMounts.RemoveRWDevice(mvd.MountPath, source); err != nil {
+					return err
+				}
+				defer func() {
+					if err != nil {
+						_ = h.hostMounts.AddRWDevice(mvd.MountPath, source, mvd.Encrypted)
+					}
+				}()
+			}
+		}
+		return modifyMappedVirtualDisk(ctx, req.RequestType, mvd, h.securityPolicyEnforcer)
 	case guestresource.ResourceTypeMappedDirectory:
 		return modifyMappedDirectory(ctx, h.vsock, req.RequestType, req.Settings.(*guestresource.LCOWMappedDirectory), h.securityPolicyEnforcer)
 	case guestresource.ResourceTypeVPMemDevice:
 		return modifyMappedVPMemDevice(ctx, req.RequestType, req.Settings.(*guestresource.LCOWMappedVPMemDevice), h.securityPolicyEnforcer)
 	case guestresource.ResourceTypeCombinedLayers:
-		return modifyCombinedLayers(ctx, req.RequestType, req.Settings.(*guestresource.LCOWCombinedLayers), h.securityPolicyEnforcer)
+		cl := req.Settings.(*guestresource.LCOWCombinedLayers)
+		// when cl.ScratchPath == "", we mount overlay as read-only, in which case
+		// we don't really care about scratch encryption, since the host already
+		// knows about the layers and the overlayfs.
+		encryptedScratch := cl.ScratchPath != "" && h.hostMounts.IsEncrypted(cl.ScratchPath)
+		return modifyCombinedLayers(ctx, req.RequestType, req.Settings.(*guestresource.LCOWCombinedLayers), encryptedScratch, h.securityPolicyEnforcer)
 	case guestresource.ResourceTypeNetwork:
 		return modifyNetwork(ctx, req.RequestType, req.Settings.(*guestresource.LCOWNetworkAdapter))
 	case guestresource.ResourceTypeVPCIDevice:
@@ -427,7 +463,7 @@ func (h *Host) modifyHostSettings(ctx context.Context, containerID string, req *
 		}
 		return h.InjectFragment(ctx, r)
 	default:
-		return errors.Errorf("the ResourceType \"%s\" is not supported for UVM", req.ResourceType)
+		return errors.Errorf("the ResourceType %q is not supported for UVM", req.ResourceType)
 	}
 }
 
@@ -735,14 +771,13 @@ func modifyMappedVirtualDisk(
 		return nil
 	case guestrequest.RequestTypeRemove:
 		if mvd.MountPath != "" {
-			err = securityPolicy.EnforceDeviceUnmountPolicy(mvd.MountPath)
-			if err != nil {
-				return errors.Wrapf(err, "unmounting scsi device at %s denied by policy", mvd.MountPath)
+			if mvd.ReadOnly {
+				if err := securityPolicy.EnforceDeviceUnmountPolicy(mvd.MountPath); err != nil {
+					return errors.Wrapf(err, "unmounting scsi device at %s denied by policy", mvd.MountPath)
+				}
 			}
 
-			if err := scsi.Unmount(ctx, mvd.Controller, mvd.Lun, mvd.MountPath,
-				mvd.Encrypted, mvd.VerityInfo, securityPolicy,
-			); err != nil {
+			if err := scsi.Unmount(ctx, mvd.Controller, mvd.Lun, mvd.MountPath, mvd.Encrypted, mvd.VerityInfo); err != nil {
 				return err
 			}
 		}
@@ -820,6 +855,7 @@ func modifyCombinedLayers(
 	ctx context.Context,
 	rt guestrequest.RequestType,
 	cl *guestresource.LCOWCombinedLayers,
+	scratchEncrypted bool,
 	securityPolicy securitypolicy.SecurityPolicyEnforcer,
 ) (err error) {
 	switch rt {
@@ -838,14 +874,17 @@ func modifyCombinedLayers(
 		} else {
 			upperdirPath = filepath.Join(cl.ScratchPath, "upper")
 			workdirPath = filepath.Join(cl.ScratchPath, "work")
+
+			if err := securityPolicy.EnforceScratchMountPolicy(cl.ScratchPath, scratchEncrypted); err != nil {
+				return fmt.Errorf("scratch mounting denied by policy: %w", err)
+			}
 		}
 
 		if err := securityPolicy.EnforceOverlayMountPolicy(cl.ContainerID, layerPaths, cl.ContainerRootPath); err != nil {
-			return errors.Wrap(err, "overlay creation denied by policy")
+			return fmt.Errorf("overlay creation denied by policy: %w", err)
 		}
 
-		return overlay.MountLayer(ctx, layerPaths, upperdirPath, workdirPath,
-			cl.ContainerRootPath, readonly, cl.ContainerID)
+		return overlay.MountLayer(ctx, layerPaths, upperdirPath, workdirPath, cl.ContainerRootPath, readonly)
 	case guestrequest.RequestTypeRemove:
 		if err := securityPolicy.EnforceOverlayUnmountPolicy(cl.ContainerRootPath); err != nil {
 			return errors.Wrap(err, "overlay removal denied by policy")

--- a/internal/guest/runtime/hcsv2/uvm_state.go
+++ b/internal/guest/runtime/hcsv2/uvm_state.go
@@ -38,8 +38,8 @@ func (hm *hostMounts) AddRWDevice(mountPath string, sourcePath string, encrypted
 	defer hm.stateMutex.Unlock()
 
 	mountTarget := filepath.Clean(mountPath)
-	if _, ok := hm.readWriteMounts[mountTarget]; ok {
-		return fmt.Errorf("read-write mount already exists at %q", mountPath)
+	if source, ok := hm.readWriteMounts[mountTarget]; ok {
+		return fmt.Errorf("read-write with source %q and mount target %q already exists", source.sourcePath, mountPath)
 	}
 	hm.readWriteMounts[mountTarget] = &rwDevice{
 		mountPath:  mountTarget,

--- a/internal/guest/runtime/hcsv2/uvm_state.go
+++ b/internal/guest/runtime/hcsv2/uvm_state.go
@@ -1,0 +1,96 @@
+//go:build linux
+// +build linux
+
+package hcsv2
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+	"sync"
+)
+
+type rwDevice struct {
+	mountPath  string
+	sourcePath string
+	encrypted  bool
+	overlays   map[string]struct{}
+}
+
+type hostMounts struct {
+	stateMutex sync.Mutex
+
+	// Holds information about read-write devices, which can be encrypted and
+	// contain overlay fs upper/work directory mounts.
+	readWriteMounts map[string]*rwDevice
+}
+
+func newHostMounts() *hostMounts {
+	return &hostMounts{
+		readWriteMounts: map[string]*rwDevice{},
+	}
+}
+
+// AddRWDevice adds read-write device metadata for device mounted at `mountPath`.
+// Returns an error if there's an existing device mounted at `mountPath` location.
+func (hm *hostMounts) AddRWDevice(mountPath string, sourcePath string, encrypted bool) error {
+	hm.stateMutex.Lock()
+	defer hm.stateMutex.Unlock()
+
+	mountTarget := filepath.Clean(mountPath)
+	if _, ok := hm.readWriteMounts[mountTarget]; ok {
+		return fmt.Errorf("read-write mount already exists at %q", mountPath)
+	}
+	hm.readWriteMounts[mountTarget] = &rwDevice{
+		mountPath:  mountTarget,
+		sourcePath: sourcePath,
+		encrypted:  encrypted,
+		overlays:   map[string]struct{}{},
+	}
+	return nil
+}
+
+// RemoveRWDevice removes the read-write device metadata for device mounted at
+// `mountPath`. Returns an error if the device currently has active overlays.
+func (hm *hostMounts) RemoveRWDevice(mountPath string, sourcePath string) error {
+	hm.stateMutex.Lock()
+	defer hm.stateMutex.Unlock()
+
+	unmountTarget := filepath.Clean(mountPath)
+	device, ok := hm.readWriteMounts[unmountTarget]
+	if !ok {
+		// already removed or didn't exist
+		return nil
+	}
+	if device.sourcePath != sourcePath {
+		return fmt.Errorf("wrong sourcePath %s", sourcePath)
+	}
+	if len(device.overlays) > 0 {
+		return fmt.Errorf("cannot remove read-write target with active overlays")
+	}
+
+	delete(hm.readWriteMounts, unmountTarget)
+	return nil
+}
+
+// IsEncrypted checks if the given path is a sub-path of an encrypted read-write
+// device.
+func (hm *hostMounts) IsEncrypted(path string) bool {
+	hm.stateMutex.Lock()
+	defer hm.stateMutex.Unlock()
+
+	cleanPath := filepath.Clean(path)
+	for rwPath, rwDev := range hm.readWriteMounts {
+		relPath, err := filepath.Rel(rwPath, cleanPath)
+		// skip further checks if an error is returned or the relative path
+		// contains "..", meaning that the `path` isn't directly nested under
+		// `rwPath`.
+		if err != nil || strings.HasPrefix(relPath, "..") {
+			continue
+		}
+		if rwDev.encrypted {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/guest/runtime/hcsv2/uvm_state.go
+++ b/internal/guest/runtime/hcsv2/uvm_state.go
@@ -18,7 +18,7 @@ type rwDevice struct {
 }
 
 type hostMounts struct {
-	stateMutex sync.Mutex
+	stateMutex sync.RWMutex
 
 	// Holds information about read-write devices, which can be encrypted and
 	// contain overlay fs upper/work directory mounts.
@@ -76,8 +76,8 @@ func (hm *hostMounts) RemoveRWDevice(mountPath string, sourcePath string) error 
 // IsEncrypted checks if the given path is a sub-path of an encrypted read-write
 // device.
 func (hm *hostMounts) IsEncrypted(path string) bool {
-	hm.stateMutex.Lock()
-	defer hm.stateMutex.Unlock()
+	hm.stateMutex.RLock()
+	defer hm.stateMutex.RUnlock()
 
 	cleanPath := filepath.Clean(path)
 	for rwPath, rwDev := range hm.readWriteMounts {

--- a/internal/guest/runtime/hcsv2/uvm_state_test.go
+++ b/internal/guest/runtime/hcsv2/uvm_state_test.go
@@ -1,0 +1,107 @@
+//go:build linux
+// +build linux
+
+package hcsv2
+
+import (
+	"testing"
+)
+
+func Test_Add_Remove_RWDevice(t *testing.T) {
+	hm := newHostMounts()
+	mountPath := "/run/gcs/c/abcd"
+	sourcePath := "/dev/sda"
+
+	if err := hm.AddRWDevice(mountPath, sourcePath, false); err != nil {
+		t.Fatalf("unexpected error adding RW device: %s", err)
+	}
+	if err := hm.RemoveRWDevice(mountPath, sourcePath); err != nil {
+		t.Fatalf("unexpected error removing RW device: %s", err)
+	}
+}
+
+func Test_Cannot_AddRWDevice_Twice(t *testing.T) {
+	hm := newHostMounts()
+	mountPath := "/run/gcs/c/abc"
+	sourcePath := "/dev/sda"
+
+	if err := hm.AddRWDevice(mountPath, sourcePath, false); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if err := hm.AddRWDevice(mountPath, sourcePath, false); err == nil {
+		t.Fatalf("expected error adding %q for the second time", mountPath)
+	}
+}
+
+func Test_Cannot_RemoveRWDevice_Wrong_Source(t *testing.T) {
+	hm := newHostMounts()
+	mountPath := "/run/gcs/c/abcd"
+	sourcePath := "/dev/sda"
+	wrongSource := "/dev/sdb"
+	if err := hm.AddRWDevice(mountPath, sourcePath, false); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if err := hm.RemoveRWDevice(mountPath, wrongSource); err == nil {
+		t.Fatalf("expected error removing wrong source %s", wrongSource)
+	}
+}
+
+func Test_Cannot_Remove_With_Active_Overlays(t *testing.T) {
+	hm := newHostMounts()
+	mountPath := "/run/gcs/c/abc"
+	sourcePath := "/dev/sda"
+	hm.readWriteMounts[mountPath] = &rwDevice{
+		mountPath:  mountPath,
+		sourcePath: sourcePath,
+		encrypted:  true,
+		overlays: map[string]struct{}{
+			mountPath + "/nested": {},
+		},
+	}
+	if err := hm.RemoveRWDevice(mountPath, sourcePath); err == nil {
+		t.Fatalf("expected error removing RW device with active overlays")
+	}
+}
+
+func Test_HostMounts_IsEncrypted(t *testing.T) {
+	hm := newHostMounts()
+	mountPath := "/run/gcs/c/abcd"
+	sourcePath := "/dev/sda"
+	if err := hm.AddRWDevice(mountPath, sourcePath, true); err != nil {
+		t.Fatalf("unexpected error adding RW device: %s", err)
+	}
+
+	for _, tc := range []struct {
+		name     string
+		testPath string
+		expected bool
+	}{
+		{
+			name:     "ValidSubPath1",
+			testPath: "/run/gcs/c/abcd/nested",
+			expected: true,
+		},
+		{
+			name:     "ValidSubPath2",
+			testPath: "/run/gcs/c/abcd/../abcd/nested",
+			expected: true,
+		},
+		{
+			name:     "NotSubPath2",
+			testPath: "/run/gcs/c/abcdef",
+			expected: false,
+		},
+		{
+			name:     "NotSubPath2",
+			testPath: "/run/gcs/c/../abcd",
+			expected: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			encrypted := hm.IsEncrypted(tc.testPath)
+			if encrypted != tc.expected {
+				t.Fatalf("expected encrypted %t, got %t", tc.expected, encrypted)
+			}
+		})
+	}
+}

--- a/internal/guest/runtime/hcsv2/uvm_state_test.go
+++ b/internal/guest/runtime/hcsv2/uvm_state_test.go
@@ -94,6 +94,11 @@ func Test_HostMounts_IsEncrypted(t *testing.T) {
 			testPath: "/run/gcs/c/encrypted/unencrypted/foo",
 			expected: false,
 		},
+		{
+			name:     "SamePathEncrypted",
+			testPath: "/run/gcs/c/encrypted",
+			expected: true,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			encrypted := hm.IsEncrypted(tc.testPath)

--- a/internal/guest/storage/crypt/crypt_test.go
+++ b/internal/guest/storage/crypt/crypt_test.go
@@ -39,8 +39,7 @@ func Test_Encrypt_Generate_Key_Error(t *testing.T) {
 
 	source := "/dev/sda"
 	keyfilePath := tempDir + "keyfile"
-	customErr := errors.New("expected error message")
-	expectedErr := errors.Wrapf(customErr, "failed to generate keyfile: %s", keyfilePath)
+	expectedErr := errors.New("expected error message")
 
 	_osRemoveAll = func(path string) error {
 		return nil
@@ -49,12 +48,12 @@ func Test_Encrypt_Generate_Key_Error(t *testing.T) {
 		if keyfilePath != path {
 			t.Errorf("expected path: %v, got: %v", keyfilePath, path)
 		}
-		return customErr
+		return expectedErr
 	}
 
-	_, err := EncryptDevice(context.Background(), source)
-	if err.Error() != expectedErr.Error() {
-		t.Fatalf("expected err:\n'%v'\ngot:\n'%v'", expectedErr, err)
+	_, err := EncryptDevice(context.Background(), source, "dm-crypt-target")
+	if errors.Unwrap(err) != expectedErr {
+		t.Fatalf("expected err: '%v' got: '%v'", expectedErr, err)
 	}
 }
 
@@ -74,9 +73,7 @@ func Test_Encrypt_Cryptsetup_Format_Error(t *testing.T) {
 	expectedSource := "/dev/sda"
 	expectedKeyFilePath := tempDir + "keyfile"
 
-	customErr := errors.New("expected error message")
-	expectedErr := errors.Wrapf(customErr, "luksFormat failed: %s", expectedSource)
-
+	expectedErr := errors.New("expected error message")
 	_cryptsetupFormat = func(source string, keyFilePath string) error {
 		if source != expectedSource {
 			t.Fatalf("expected source: '%s' got: '%s'", expectedSource, source)
@@ -84,12 +81,12 @@ func Test_Encrypt_Cryptsetup_Format_Error(t *testing.T) {
 		if keyFilePath != expectedKeyFilePath {
 			t.Fatalf("expected keyfile path: '%s' got: '%s'", expectedKeyFilePath, keyFilePath)
 		}
-		return customErr
+		return expectedErr
 	}
 
-	_, err := EncryptDevice(context.Background(), expectedSource)
-	if err.Error() != expectedErr.Error() {
-		t.Fatalf("expected err:\n'%v'\ngot:\n'%v'", expectedErr, err)
+	_, err := EncryptDevice(context.Background(), expectedSource, "dm-crypt-target")
+	if errors.Unwrap(err) != expectedErr {
+		t.Fatalf("expected err: '%v' got: '%v", expectedErr, err)
 	}
 }
 
@@ -110,29 +107,26 @@ func Test_Encrypt_Cryptsetup_Open_Error(t *testing.T) {
 	}
 
 	expectedSource := "/dev/sda"
-	uniqueName, _ := getUniqueName(expectedSource)
-	expectedDeviceName := fmt.Sprintf(cryptDeviceTemplate, uniqueName)
+	dmCryptName := "dm-crypt-target"
 	expectedKeyFilePath := tempDir + "keyfile"
 
-	customErr := errors.New("expected error message")
-	expectedErr := errors.Wrapf(customErr, "luksOpen failed: %s", expectedSource)
-
+	expectedErr := errors.New("expected error message")
 	_cryptsetupOpen = func(source string, deviceName string, keyFilePath string) error {
 		if source != expectedSource {
 			t.Fatalf("expected source: '%s' got: '%s'", expectedSource, source)
 		}
-		if deviceName != expectedDeviceName {
-			t.Fatalf("expected device name: '%s' got: '%s'", expectedDeviceName, deviceName)
+		if deviceName != dmCryptName {
+			t.Fatalf("expected device name: '%s' got: '%s'", dmCryptName, deviceName)
 		}
 		if keyFilePath != expectedKeyFilePath {
 			t.Fatalf("expected keyfile path: '%s' got: '%s'", expectedKeyFilePath, keyFilePath)
 		}
-		return customErr
+		return expectedErr
 	}
 
-	_, err := EncryptDevice(context.Background(), expectedSource)
-	if err.Error() != expectedErr.Error() {
-		t.Fatalf("expected err:\n'%v'\ngot:\n'%v'", expectedErr, err)
+	_, err := EncryptDevice(context.Background(), expectedSource, dmCryptName)
+	if errors.Unwrap(err) != expectedErr {
+		t.Fatalf("expected err: '%v' got: '%v'", expectedErr, err)
 	}
 }
 
@@ -159,33 +153,29 @@ func Test_Encrypt_Get_Device_Size_Error(t *testing.T) {
 	}
 
 	source := "/dev/sda"
-	uniqueName, _ := getUniqueName(source)
-	deviceName := fmt.Sprintf(cryptDeviceTemplate, uniqueName)
-	deviceNamePath := "/dev/mapper/" + deviceName
+	dmCryptName := "dm-crypt-target"
+	deviceNamePath := "/dev/mapper/" + dmCryptName
 
-	customErr := errors.New("expected error message")
-	expectedErr := errors.Wrapf(customErr, "error getting size of: %s", deviceNamePath)
-
+	expectedErr := errors.New("expected error message")
 	_getBlockDeviceSize = func(ctx context.Context, path string) (int64, error) {
-		return 0, customErr
+		return 0, expectedErr
 	}
 
-	_, err := EncryptDevice(context.Background(), source)
-	if err.Error() != expectedErr.Error() {
-		t.Fatalf("expected err:\n'%v'\ngot:\n'%v'", expectedErr, err)
+	_, err := EncryptDevice(context.Background(), source, dmCryptName)
+	if errors.Unwrap(err) != expectedErr {
+		t.Fatalf("expected err: '%v' got: '%v'", expectedErr, err)
 	}
 
 	// Check that it fails when the size of the block device is zero
 
 	expectedErr = fmt.Errorf("invalid size obtained for: %s", deviceNamePath)
-
 	_getBlockDeviceSize = func(ctx context.Context, path string) (int64, error) {
 		return 0, nil
 	}
 
-	_, err = EncryptDevice(context.Background(), source)
+	_, err = EncryptDevice(context.Background(), source, dmCryptName)
 	if err.Error() != expectedErr.Error() {
-		t.Fatalf("expected err:\n'%v'\ngot:\n'%v'", expectedErr, err)
+		t.Fatalf("expected err: '%v' got: '%v'", expectedErr, err)
 	}
 }
 
@@ -220,9 +210,7 @@ func Test_Encrypt_Create_Sparse_File_Error(t *testing.T) {
 	source := "/dev/sda"
 	tempExt4File := tempDir + "ext4.img"
 
-	customErr := errors.New("expected error message")
-	expectedErr := errors.Wrapf(customErr, "failed to create sparse filesystem file")
-
+	expectedErr := errors.New("expected error message")
 	_createSparseEmptyFile = func(ctx context.Context, path string, size int64) error {
 		// Check that the path and the size are the expected ones
 		if path != tempExt4File {
@@ -232,12 +220,12 @@ func Test_Encrypt_Create_Sparse_File_Error(t *testing.T) {
 			t.Fatalf("expected size: '%v' got: '%v'", blockDeviceSize, size)
 		}
 
-		return customErr
+		return expectedErr
 	}
 
-	_, err := EncryptDevice(context.Background(), source)
-	if err.Error() != expectedErr.Error() {
-		t.Fatalf("expected err:\n'%v'\ngot:\n'%v'", expectedErr, err)
+	_, err := EncryptDevice(context.Background(), source, "dm-crypt-name")
+	if errors.Unwrap(err) != expectedErr {
+		t.Fatalf("expected err: '%v' got: '%v'", expectedErr, err)
 	}
 }
 
@@ -275,19 +263,17 @@ func Test_Encrypt_Mkfs_Error(t *testing.T) {
 	source := "/dev/sda"
 	tempExt4File := tempDir + "ext4.img"
 
-	customErr := errors.New("expected error message")
-	expectedErr := errors.Wrapf(customErr, "mkfs.ext4 failed to format: %s", tempExt4File)
-
+	expectedErr := errors.New("expected error message")
 	_mkfsExt4Command = func(args []string) error {
 		if args[0] != tempExt4File {
-			t.Fatalf("expected args:\n'%v'\ngot:\n'%v'", tempExt4File, args[0])
+			t.Fatalf("expected args: '%v' got: '%v'", tempExt4File, args[0])
 		}
-		return customErr
+		return expectedErr
 	}
 
-	_, err := EncryptDevice(context.Background(), source)
-	if err.Error() != expectedErr.Error() {
-		t.Fatalf("expected err:\n'%v'\ngot:\n'%v'", expectedErr, err)
+	_, err := EncryptDevice(context.Background(), source, "dm-crypt-name")
+	if errors.Unwrap(err) != expectedErr {
+		t.Fatalf("expected err: '%v' got: '%v'", expectedErr, err)
 	}
 }
 
@@ -327,13 +313,10 @@ func Test_Encrypt_Sparse_Copy_Error(t *testing.T) {
 
 	source := "/dev/sda"
 	tempExt4File := tempDir + "ext4.img"
-	uniqueName, _ := getUniqueName(source)
-	deviceName := fmt.Sprintf(cryptDeviceTemplate, uniqueName)
-	deviceNamePath := "/dev/mapper/" + deviceName
+	dmCryptName := "dm-crypt-target"
+	deviceNamePath := "/dev/mapper/" + dmCryptName
 
-	customErr := errors.New("expected error message")
-	expectedErr := errors.Wrapf(customErr, "failed to do sparse copy")
-
+	expectedErr := errors.New("expected error message")
 	_copyEmptySparseFilesystem = func(source string, destination string) error {
 		if source != tempExt4File {
 			t.Fatalf("expected source: '%v' got: '%v'", tempExt4File, source)
@@ -341,12 +324,12 @@ func Test_Encrypt_Sparse_Copy_Error(t *testing.T) {
 		if destination != deviceNamePath {
 			t.Fatalf("expected destination: '%v' got: '%v'", deviceNamePath, destination)
 		}
-		return customErr
+		return expectedErr
 	}
 
-	_, err := EncryptDevice(context.Background(), source)
-	if err.Error() != expectedErr.Error() {
-		t.Fatalf("expected err:\n'%v'\ngot:\n'%v'", expectedErr, err)
+	_, err := EncryptDevice(context.Background(), source, dmCryptName)
+	if errors.Unwrap(err) != expectedErr {
+		t.Fatalf("expected err:'%v' got: '%v'", expectedErr, err)
 	}
 }
 
@@ -384,11 +367,10 @@ func Test_Encrypt_Success(t *testing.T) {
 	}
 
 	source := "/dev/sda"
-	uniqueName, _ := getUniqueName(source)
-	deviceName := fmt.Sprintf(cryptDeviceTemplate, uniqueName)
-	deviceNamePath := "/dev/mapper/" + deviceName
+	dmCryptName := "dm-crypt-name"
+	deviceNamePath := "/dev/mapper/" + dmCryptName
 
-	encryptedSource, err := EncryptDevice(context.Background(), source)
+	encryptedSource, err := EncryptDevice(context.Background(), source, dmCryptName)
 	if err != nil {
 		t.Fatalf("unexpected err: '%v'", err)
 	}
@@ -403,22 +385,19 @@ func Test_Cleanup_Dm_Crypt_Error(t *testing.T) {
 	// Test what happens when cryptsetup fails to remove an encrypted device.
 	// Verify that the arguments passed to cryptsetup are the right ones.
 
-	source := "/dev/sda"
-	uniqueName, _ := getUniqueName(source)
-	expectedDeviceName := fmt.Sprintf(cryptDeviceTemplate, uniqueName)
-	customErr := errors.New("expected error message")
-	expectedErr := errors.Wrapf(customErr, "luksClose failed: %s", expectedDeviceName)
+	dmCryptName := "dm-crypt-target"
+	expectedErr := errors.New("expected error message")
 
 	_cryptsetupClose = func(deviceName string) error {
-		if deviceName != expectedDeviceName {
-			t.Fatalf("expected device name: '%s' got: '%s'", expectedDeviceName, deviceName)
+		if deviceName != dmCryptName {
+			t.Fatalf("expected device name: '%s' got: '%s'", dmCryptName, deviceName)
 		}
-		return customErr
+		return expectedErr
 	}
 
-	err := CleanupCryptDevice(source)
-	if err.Error() != expectedErr.Error() {
-		t.Fatalf("expected err:\n'%v'\ngot:\n'%v'", expectedErr, err)
+	err := CleanupCryptDevice(dmCryptName)
+	if errors.Unwrap(err) != expectedErr {
+		t.Fatalf("expected err: '%v' got: '%v'", expectedErr, err)
 	}
 }
 

--- a/internal/guest/storage/crypt/utilities.go
+++ b/internal/guest/storage/crypt/utilities.go
@@ -8,21 +8,10 @@ import (
 	"crypto/rand"
 	"io"
 	"os"
-	"regexp"
 
 	"github.com/Microsoft/hcsshim/internal/log"
 	"github.com/pkg/errors"
 )
-
-func getUniqueName(path string) (name string, err error) {
-	// Make a Regex to say we only want letters and numbers
-	reg, err := regexp.Compile("[^a-zA-Z0-9]+")
-	if err != nil {
-		return "", err
-	}
-	// Replace all non-alphanumeric characters by dashes
-	return reg.ReplaceAllString(path, "-"), nil
-}
 
 // getBlockDeviceSize returns the size of the specified block device.
 func getBlockDeviceSize(ctx context.Context, path string) (int64, error) {

--- a/internal/guest/storage/overlay/overlay.go
+++ b/internal/guest/storage/overlay/overlay.go
@@ -63,7 +63,6 @@ func MountLayer(
 	layerPaths []string,
 	upperdirPath, workdirPath, rootfsPath string,
 	readonly bool,
-	containerID string,
 ) (err error) {
 	_, span := oc.StartSpan(ctx, "overlay::MountLayer")
 	defer span.End()

--- a/internal/guest/storage/overlay/overlay_test.go
+++ b/internal/guest/storage/overlay/overlay_test.go
@@ -10,10 +10,6 @@ import (
 	"testing"
 )
 
-const (
-	fakeContainerID = "1"
-)
-
 type undo struct {
 	osMkdirAll  func(string, os.FileMode) error
 	osRemoveAll func(string) error
@@ -81,7 +77,7 @@ func Test_Mount_Success(t *testing.T) {
 		return nil
 	}
 
-	err := MountLayer(context.Background(), []string{"/layer1", "/layer2"}, "/upper", "/work", "/root", false, fakeContainerID)
+	err := MountLayer(context.Background(), []string{"/layer1", "/layer2"}, "/upper", "/work", "/root", false)
 	if err != nil {
 		t.Fatalf("expected no error got: %v", err)
 	}
@@ -125,7 +121,7 @@ func Test_Mount_Readonly_Success(t *testing.T) {
 		return nil
 	}
 
-	err := MountLayer(context.Background(), []string{"/layer1", "/layer2"}, "", "", "/root", false, fakeContainerID)
+	err := MountLayer(context.Background(), []string{"/layer1", "/layer2"}, "", "", "/root", false)
 	if err != nil {
 		t.Fatalf("expected no error got: %v", err)
 	}

--- a/internal/guest/storage/scsi/scsi_test.go
+++ b/internal/guest/storage/scsi/scsi_test.go
@@ -10,9 +10,8 @@ import (
 	"os"
 	"testing"
 
-	"golang.org/x/sys/unix"
-
 	"github.com/Microsoft/hcsshim/internal/protocol/guestresource"
+	"golang.org/x/sys/unix"
 )
 
 func clearTestDependencies() {
@@ -21,6 +20,9 @@ func clearTestDependencies() {
 	unixMount = nil
 	controllerLunToName = nil
 	createVerityTarget = nil
+	encryptDevice = nil
+	cleanupCryptDevice = nil
+	storageUnmountPath = nil
 }
 
 func Test_Mount_Mkdir_Fails_Error(t *testing.T) {
@@ -575,5 +577,110 @@ func Test_osMkdirAllFails_And_RemoveDevice_Called(t *testing.T) {
 	}
 	if !removeDeviceCalled {
 		t.Fatal("expected removeDevice to be called")
+	}
+}
+
+func Test_Mount_EncryptDevice_Called(t *testing.T) {
+	clearTestDependencies()
+
+	osMkdirAll = func(string, os.FileMode) error {
+		return nil
+	}
+	controllerLunToName = func(context.Context, uint8, uint8) (string, error) {
+		return "", nil
+	}
+	unixMount = func(string, string, string, uintptr, string) error {
+		return nil
+	}
+	encryptDeviceCalled := false
+	encryptDevice = func(_ context.Context, source string, devName string) (string, error) {
+		expectedCryptTarget := fmt.Sprintf(cryptDeviceFmt, 0, 0)
+		if devName != expectedCryptTarget {
+			t.Fatalf("expected crypt device %q got %q", expectedCryptTarget, devName)
+		}
+		encryptDeviceCalled = true
+		return "", nil
+	}
+	if err := mount(
+		context.Background(),
+		0,
+		0,
+		"/fake/path",
+		false,
+		true,
+		nil,
+		nil,
+	); err != nil {
+		t.Fatalf("expected nil error, got: %s", err)
+	}
+	if !encryptDeviceCalled {
+		t.Fatal("expected encryptDevice to be called")
+	}
+}
+
+func Test_Mount_RemoveAllCalled_When_EncryptDevice_Fails(t *testing.T) {
+	clearTestDependencies()
+
+	osMkdirAll = func(string, os.FileMode) error {
+		return nil
+	}
+	controllerLunToName = func(context.Context, uint8, uint8) (string, error) {
+		return "", nil
+	}
+	unixMount = func(string, string, string, uintptr, string) error {
+		return nil
+	}
+	encryptDeviceError := errors.New("encrypt device error")
+	encryptDevice = func(context.Context, string, string) (string, error) {
+		return "", encryptDeviceError
+	}
+	removeAllCalled := false
+	osRemoveAll = func(string) error {
+		removeAllCalled = true
+		return nil
+	}
+
+	err := mount(
+		context.Background(),
+		0,
+		0,
+		"/fake/path",
+		false,
+		true,
+		nil,
+		nil,
+	)
+	if err == nil {
+		t.Fatalf("expected to fail")
+	}
+	if errors.Unwrap(err) != encryptDeviceError {
+		t.Fatalf("expected error %q, got %q", encryptDeviceError, err)
+	}
+	if !removeAllCalled {
+		t.Fatal("osRemoveAll was not called")
+	}
+}
+
+func Test_Unmount_CleanupCryptDevice_Called(t *testing.T) {
+	clearTestDependencies()
+
+	storageUnmountPath = func(context.Context, string, bool) error {
+		return nil
+	}
+	cleanupCryptDeviceCalled := false
+	cleanupCryptDevice = func(devName string) error {
+		expectedDevName := fmt.Sprintf(cryptDeviceFmt, 0, 0)
+		if devName != expectedDevName {
+			t.Fatalf("expected crypt target %q, got %q", expectedDevName, devName)
+		}
+		cleanupCryptDeviceCalled = true
+		return nil
+	}
+
+	if err := unmount(context.Background(), 0, 0, "/fake/path", true, nil); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if !cleanupCryptDeviceCalled {
+		t.Fatal("cleanupCryptDevice not called")
 	}
 }

--- a/internal/guest/storage/scsi/scsi_test.go
+++ b/internal/guest/storage/scsi/scsi_test.go
@@ -37,7 +37,7 @@ func Test_Mount_Mkdir_Fails_Error(t *testing.T) {
 		return "", nil
 	}
 
-	if err := mount(
+	if err := Mount(
 		context.Background(),
 		0,
 		0,
@@ -73,7 +73,7 @@ func Test_Mount_Mkdir_ExpectedPath(t *testing.T) {
 		return nil
 	}
 
-	if err := mount(
+	if err := Mount(
 		context.Background(),
 		0,
 		0,
@@ -109,7 +109,7 @@ func Test_Mount_Mkdir_ExpectedPerm(t *testing.T) {
 		return nil
 	}
 
-	if err := mount(
+	if err := Mount(
 		context.Background(),
 		0,
 		0,
@@ -145,7 +145,7 @@ func Test_Mount_ControllerLunToName_Valid_Controller(t *testing.T) {
 		return nil
 	}
 
-	if err := mount(
+	if err := Mount(
 		context.Background(),
 		expectedController,
 		0,
@@ -181,7 +181,7 @@ func Test_Mount_ControllerLunToName_Valid_Lun(t *testing.T) {
 		return nil
 	}
 
-	if err := mount(
+	if err := Mount(
 		context.Background(),
 		0,
 		expectedLun,
@@ -220,7 +220,7 @@ func Test_Mount_Calls_RemoveAll_OnMountFailure(t *testing.T) {
 		return expectedErr
 	}
 
-	if err := mount(
+	if err := Mount(
 		context.Background(),
 		0,
 		0,
@@ -257,7 +257,7 @@ func Test_Mount_Valid_Source(t *testing.T) {
 		}
 		return nil
 	}
-	err := mount(context.Background(), 0, 0, "/fake/path", false, false, nil, nil)
+	err := Mount(context.Background(), 0, 0, "/fake/path", false, false, nil, nil)
 	if err != nil {
 		t.Fatalf("expected nil err, got: %v", err)
 	}
@@ -284,7 +284,7 @@ func Test_Mount_Valid_Target(t *testing.T) {
 		return nil
 	}
 
-	if err := mount(
+	if err := Mount(
 		context.Background(),
 		0,
 		0,
@@ -319,7 +319,7 @@ func Test_Mount_Valid_FSType(t *testing.T) {
 		return nil
 	}
 
-	if err := mount(
+	if err := Mount(
 		context.Background(),
 		0,
 		0,
@@ -354,7 +354,7 @@ func Test_Mount_Valid_Flags(t *testing.T) {
 		return nil
 	}
 
-	if err := mount(
+	if err := Mount(
 		context.Background(),
 		0,
 		0,
@@ -389,7 +389,7 @@ func Test_Mount_Readonly_Valid_Flags(t *testing.T) {
 		return nil
 	}
 
-	if err := mount(
+	if err := Mount(
 		context.Background(),
 		0,
 		0,
@@ -423,7 +423,7 @@ func Test_Mount_Valid_Data(t *testing.T) {
 		return nil
 	}
 
-	if err := mount(
+	if err := Mount(
 		context.Background(),
 		0,
 		0,
@@ -458,7 +458,7 @@ func Test_Mount_Readonly_Valid_Data(t *testing.T) {
 		return nil
 	}
 
-	if err := mount(
+	if err := Mount(
 		context.Background(),
 		0,
 		0,
@@ -515,7 +515,7 @@ func Test_CreateVerityTarget_And_Mount_Called_With_Correct_Parameters(t *testing
 		return nil
 	}
 
-	if err := mount(
+	if err := Mount(
 		context.Background(),
 		0,
 		0,
@@ -563,7 +563,7 @@ func Test_osMkdirAllFails_And_RemoveDevice_Called(t *testing.T) {
 		return nil
 	}
 
-	if err := mount(
+	if err := Mount(
 		context.Background(),
 		0,
 		0,
@@ -601,7 +601,7 @@ func Test_Mount_EncryptDevice_Called(t *testing.T) {
 		encryptDeviceCalled = true
 		return "", nil
 	}
-	if err := mount(
+	if err := Mount(
 		context.Background(),
 		0,
 		0,
@@ -640,7 +640,7 @@ func Test_Mount_RemoveAllCalled_When_EncryptDevice_Fails(t *testing.T) {
 		return nil
 	}
 
-	err := mount(
+	err := Mount(
 		context.Background(),
 		0,
 		0,
@@ -677,7 +677,7 @@ func Test_Unmount_CleanupCryptDevice_Called(t *testing.T) {
 		return nil
 	}
 
-	if err := unmount(context.Background(), 0, 0, "/fake/path", true, nil); err != nil {
+	if err := Unmount(context.Background(), 0, 0, "/fake/path", true, nil); err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
 	if !cleanupCryptDeviceCalled {

--- a/internal/tools/securitypolicy/main.go
+++ b/internal/tools/securitypolicy/main.go
@@ -65,7 +65,9 @@ func main() {
 				config.AllowPropertiesAccess,
 				config.AllowDumpStacks,
 				config.AllowRuntimeLogging,
-				config.AllowEnvironmentVariableDropping)
+				config.AllowEnvironmentVariableDropping,
+				config.AllowUnencryptedScratch,
+			)
 		}
 		if err != nil {
 			return err

--- a/pkg/securitypolicy/api.rego
+++ b/pkg/securitypolicy/api.rego
@@ -17,5 +17,7 @@ enforcement_points := {
     "get_properties": {"introducedVersion": "0.7.0", "allowedByDefault": true},
     "dump_stacks": {"introducedVersion": "0.7.0", "allowedByDefault": true},
     "runtime_logging": {"introducedVersion": "0.8.0", "allowedByDefault": true},
-    "load_fragment": {"introducedVersion": "0.9.0", "allowedByDefault": false}
+    "load_fragment": {"introducedVersion": "0.9.0", "allowedByDefault": false},
+    "scratch_mount": {"introducedVersion": "0.10.0", "allowedByDefault": true},
+    "scratch_unmount": {"introducedVersion": "0.10.0", "allowedByDefault": true},
 }

--- a/pkg/securitypolicy/policy.rego
+++ b/pkg/securitypolicy/policy.rego
@@ -23,5 +23,5 @@ dump_stacks := data.framework.dump_stacks
 runtime_logging := data.framework.runtime_logging
 load_fragment := data.framework.load_fragment
 scratch_mount := data.framework.scratch_mount
-scratch_unmount := data.framework.scratch_mount
+scratch_unmount := data.framework.scratch_unmount
 reason := {"errors": data.framework.errors}

--- a/pkg/securitypolicy/policy.rego
+++ b/pkg/securitypolicy/policy.rego
@@ -22,4 +22,6 @@ get_properties := data.framework.get_properties
 dump_stacks := data.framework.dump_stacks
 runtime_logging := data.framework.runtime_logging
 load_fragment := data.framework.load_fragment
+scratch_mount := data.framework.scratch_mount
+scratch_unmount := data.framework.scratch_mount
 reason := {"errors": data.framework.errors}

--- a/pkg/securitypolicy/regopolicy_test.go
+++ b/pkg/securitypolicy/regopolicy_test.go
@@ -73,7 +73,18 @@ func Test_MarshalRego_Policy(t *testing.T) {
 			fragments[i] = fragment.toConfig()
 		}
 
-		actual, err := MarshalPolicy("rego", false, containers, externalProcesses, fragments, p.allowGetProperties, p.allowDumpStacks, p.allowRuntimeLogging, p.allowEnvironmentVariableDropping)
+		actual, err := MarshalPolicy(
+			"rego",
+			false,
+			containers,
+			externalProcesses,
+			fragments,
+			p.allowGetProperties,
+			p.allowDumpStacks,
+			p.allowRuntimeLogging,
+			p.allowEnvironmentVariableDropping,
+			p.allowUnencryptedScratch,
+		)
 		if err != nil {
 			t.Error(err)
 			return false
@@ -3055,7 +3066,7 @@ func Test_Rego_Scratch_Mount_Policy(t *testing.T) {
 		},
 	} {
 		t.Run(fmt.Sprintf("UnencryptedAllowed_%t_And_Encrypted_%t", tc.unencryptedAllowed, tc.encrypted), func(t *testing.T) {
-			gc := generateConstraints(testRand, maxContainersInGeneratedConstraints, maxExternalProcessesInGeneratedConstraints)
+			gc := generateConstraints(testRand, maxContainersInGeneratedConstraints)
 			smConfig, err := setupRegoScratchMountTest(gc, tc.unencryptedAllowed)
 			if err != nil {
 				t.Fatalf("unable to setup test: %s", err)
@@ -3102,7 +3113,7 @@ func Test_Rego_Scratch_Unmount_Policy(t *testing.T) {
 		},
 	} {
 		t.Run(fmt.Sprintf("UnencryptedAllowed_%t_And_Encrypted_%t", tc.unencryptedAllowed, tc.encrypted), func(t *testing.T) {
-			gc := generateConstraints(testRand, maxContainersInGeneratedConstraints, maxExternalProcessesInGeneratedConstraints)
+			gc := generateConstraints(testRand, maxContainersInGeneratedConstraints)
 			smConfig, err := setupRegoScratchMountTest(gc, tc.unencryptedAllowed)
 			if err != nil {
 				t.Fatalf("unable to setup test: %s", err)
@@ -3197,6 +3208,7 @@ func (constraints *generatedConstraints) toPolicy() *securityPolicyInternal {
 		AllowDumpStacks:                  constraints.allowDumpStacks,
 		AllowRuntimeLogging:              constraints.allowRuntimeLogging,
 		AllowEnvironmentVariableDropping: constraints.allowEnvironmentVariableDropping,
+		AllowUnencryptedScratch:          constraints.allowUnencryptedScratch,
 	}
 }
 

--- a/pkg/securitypolicy/securitypolicy.go
+++ b/pkg/securitypolicy/securitypolicy.go
@@ -33,6 +33,9 @@ type PolicyConfig struct {
 	AllowDumpStacks                  bool                    `json:"allow_dump_stacks" toml:"allow_dump_stacks"`
 	AllowRuntimeLogging              bool                    `json:"allow_runtime_logging" toml:"allow_runtime_logging"`
 	AllowEnvironmentVariableDropping bool                    `json:"allow_environment_variable_dropping" toml:"allow_environment_variable_dropping"`
+	// AllowUnencryptedScratch is a global policy configuration that allows
+	// all containers within a pod to be run without scratch encryption.
+	AllowUnencryptedScratch bool `json:"allow_unencrypted_scratch" toml:"allow_unencrypted_scratch"`
 }
 
 // ExternalProcessConfig contains toml or JSON config for running external processes in the UVM.

--- a/pkg/securitypolicy/securitypolicy_internal.go
+++ b/pkg/securitypolicy/securitypolicy_internal.go
@@ -15,6 +15,7 @@ type securityPolicyInternal struct {
 	AllowDumpStacks                  bool
 	AllowRuntimeLogging              bool
 	AllowEnvironmentVariableDropping bool
+	AllowUnencryptedScratch          bool
 }
 
 type securityPolicyFragment struct {
@@ -65,7 +66,9 @@ func newSecurityPolicyInternal(
 	allowPropertiesAccess bool,
 	allowDumpStacks bool,
 	allowRuntimeLogging bool,
-	allowDropEnvironmentVariables bool) (*securityPolicyInternal, error) {
+	allowDropEnvironmentVariables bool,
+	allowUnencryptedScratch bool,
+) (*securityPolicyInternal, error) {
 	containersInternal, err := containersToInternal(containers)
 	if err != nil {
 		return nil, err
@@ -79,6 +82,7 @@ func newSecurityPolicyInternal(
 		AllowDumpStacks:                  allowDumpStacks,
 		AllowRuntimeLogging:              allowRuntimeLogging,
 		AllowEnvironmentVariableDropping: allowDropEnvironmentVariables,
+		AllowUnencryptedScratch:          allowUnencryptedScratch,
 	}, nil
 }
 

--- a/pkg/securitypolicy/securitypolicy_test.go
+++ b/pkg/securitypolicy/securitypolicy_test.go
@@ -908,6 +908,7 @@ func generateConstraints(r *rand.Rand, maxContainers int32) *generatedConstraint
 		allowDumpStacks:                  randBool(r),
 		allowRuntimeLogging:              false,
 		allowEnvironmentVariableDropping: false,
+		allowUnencryptedScratch:          randBool(r),
 		namespace:                        generateFragmentNamespace(testRand),
 		svn:                              generateSVN(testRand),
 	}
@@ -1325,6 +1326,7 @@ type generatedConstraints struct {
 	allowDumpStacks                  bool
 	allowRuntimeLogging              bool
 	allowEnvironmentVariableDropping bool
+	allowUnencryptedScratch          bool
 	namespace                        string
 	svn                              string
 }

--- a/pkg/securitypolicy/securitypolicyenforcer.go
+++ b/pkg/securitypolicy/securitypolicyenforcer.go
@@ -58,6 +58,8 @@ type SecurityPolicyEnforcer interface {
 	EnforceDumpStacksPolicy() error
 	EnforceRuntimeLoggingPolicy() (err error)
 	LoadFragment(issuer string, feed string, code string) error
+	EnforceScratchMountPolicy(scratchPath string, encrypted bool) (err error)
+	EnforceScratchUnmountPolicy(scratchPath string) (err error)
 }
 
 type stringSet map[string]struct{}
@@ -532,6 +534,18 @@ func (*StandardSecurityPolicyEnforcer) LoadFragment(_ string, _ string, _ string
 	return nil
 }
 
+// Stub. We are deprecating the standard enforcer. Newly added enforcement
+// points are simply allowed.
+func (StandardSecurityPolicyEnforcer) EnforceScratchMountPolicy(string, bool) error {
+	return nil
+}
+
+// Stub. We are deprecating the standard enforcer. Newly added enforcement
+// points are simply allowed.
+func (StandardSecurityPolicyEnforcer) EnforceScratchUnmountPolicy(string) error {
+	return nil
+}
+
 func (pe *StandardSecurityPolicyEnforcer) enforceCommandPolicy(containerID string, argList []string) (err error) {
 	// Get a list of all the indexes into our security policy's list of
 	// containers that are possible matches for this containerID based
@@ -873,6 +887,14 @@ func (oe *OpenDoorSecurityPolicyEnforcer) EncodedSecurityPolicy() string {
 	return oe.encodedSecurityPolicy
 }
 
+func (OpenDoorSecurityPolicyEnforcer) EnforceScratchMountPolicy(string, bool) error {
+	return nil
+}
+
+func (OpenDoorSecurityPolicyEnforcer) EnforceScratchUnmountPolicy(string) error {
+	return nil
+}
+
 type ClosedDoorSecurityPolicyEnforcer struct {
 	encodedSecurityPolicy string //nolint:unused
 }
@@ -945,4 +967,12 @@ func (ClosedDoorSecurityPolicyEnforcer) EnforceRuntimeLoggingPolicy() error {
 
 func (ClosedDoorSecurityPolicyEnforcer) EncodedSecurityPolicy() string {
 	return ""
+}
+
+func (ClosedDoorSecurityPolicyEnforcer) EnforceScratchMountPolicy(string, bool) error {
+	return errors.New("mounting scratch is denied by the policy")
+}
+
+func (ClosedDoorSecurityPolicyEnforcer) EnforceScratchUnmountPolicy(string) error {
+	return errors.New("unmounting scratch is denied by the policy")
 }

--- a/pkg/securitypolicy/securitypolicyenforcer_rego.go
+++ b/pkg/securitypolicy/securitypolicyenforcer_rego.go
@@ -156,7 +156,17 @@ func createRegoEnforcer(base64EncodedPolicy string,
 			return createOpenDoorEnforcer(base64EncodedPolicy, defaultMounts, privilegedMounts)
 		}
 
-		code, err = marshalRego(securityPolicy.AllowAll, containers, []ExternalProcessConfig{}, []FragmentConfig{}, true, true, true, false)
+		code, err = marshalRego(
+			securityPolicy.AllowAll,
+			containers,
+			[]ExternalProcessConfig{},
+			[]FragmentConfig{},
+			true,
+			true,
+			true,
+			false,
+			true,
+		)
 		if err != nil {
 			return nil, fmt.Errorf("error marshaling the policy to Rego: %w", err)
 		}
@@ -828,8 +838,8 @@ func (policy *regoEnforcer) EnforcePlan9MountPolicy(target string) error {
 }
 
 func (policy *regoEnforcer) EnforcePlan9UnmountPolicy(target string) error {
-	input := inputData{
-		"target": target,
+	input := map[string]interface{}{
+		"unmountTarget": target,
 	}
 
 	_, err := policy.enforce("plan9_unmount", input)
@@ -913,4 +923,27 @@ func (policy *regoEnforcer) LoadFragment(issuer string, feed string, rego string
 	}
 
 	return err
+}
+
+func (policy *regoEnforcer) EnforceScratchMountPolicy(scratchPath string, encrypted bool) error {
+	input := map[string]interface{}{
+		"target":    scratchPath,
+		"encrypted": encrypted,
+	}
+	_, err := policy.enforce("scratch_mount", input)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (policy *regoEnforcer) EnforceScratchUnmountPolicy(scratchPath string) error {
+	input := map[string]interface{}{
+		"unmountTarget": scratchPath,
+	}
+	_, err := policy.enforce("scratch_unmount", input)
+	if err != nil {
+		return err
+	}
+	return nil
 }

--- a/test/cri-containerd/main_test.go
+++ b/test/cri-containerd/main_test.go
@@ -105,6 +105,7 @@ const (
 	featureCRIUpdateContainer = "UpdateContainer"
 	featureTerminateOnRestart = "TerminateOnRestart"
 	featureLCOWIntegrity      = "LCOWIntegrity"
+	featureLCOWCrypt          = "LCOWCrypt"
 )
 
 var allFeatures = []string{

--- a/test/cri-containerd/policy_test.go
+++ b/test/cri-containerd/policy_test.go
@@ -23,7 +23,12 @@ var validPolicyAlpineCommand = []string{"ash", "-c", "echo 'Hello'"}
 
 type configSideEffect func(*runtime.CreateContainerRequest) error
 
-func securityPolicyFromContainers(policyType string, containers []securitypolicy.ContainerConfig, allowEnvironmentVariableDropping bool) (string, error) {
+func securityPolicyFromContainers(
+	policyType string,
+	unencryptedScratch bool,
+	containers []securitypolicy.ContainerConfig,
+	allowEnvironmentVariableDropping bool,
+) (string, error) {
 	pc, err := helpers.PolicyContainersFromConfigs(containers)
 	if err != nil {
 		return "", err
@@ -34,7 +39,9 @@ func securityPolicyFromContainers(policyType string, containers []securitypolicy
 		true,
 		true,
 		true,
-		allowEnvironmentVariableDropping)
+		allowEnvironmentVariableDropping,
+		unencryptedScratch,
+	)
 	if err != nil {
 		return "", err
 	}
@@ -44,7 +51,7 @@ func securityPolicyFromContainers(policyType string, containers []securitypolicy
 func sandboxSecurityPolicy(t *testing.T, policyType string, allowEnvironmentVariableDropping bool) string {
 	t.Helper()
 	defaultContainers := helpers.DefaultContainerConfigs()
-	policyString, err := securityPolicyFromContainers(policyType, defaultContainers, allowEnvironmentVariableDropping)
+	policyString, err := securityPolicyFromContainers(policyType, true, defaultContainers, allowEnvironmentVariableDropping)
 	if err != nil {
 		t.Fatalf("failed to create security policy string: %s", err)
 	}
@@ -67,7 +74,7 @@ func alpineSecurityPolicy(t *testing.T, policyType string, allowEnvironmentVaria
 	}
 
 	containers := append(defaultContainers, alpineContainer)
-	policyString, err := securityPolicyFromContainers(policyType, containers, allowEnvironmentVariableDropping)
+	policyString, err := securityPolicyFromContainers(policyType, true, containers, allowEnvironmentVariableDropping)
 	if err != nil {
 		t.Fatalf("failed to create security policy string: %s", err)
 	}

--- a/test/cri-containerd/policy_test.go
+++ b/test/cri-containerd/policy_test.go
@@ -135,7 +135,7 @@ func Test_RunPodSandbox_WithPolicy_Allowed(t *testing.T) {
 
 	for _, pc := range policyTestMatrix {
 		t.Run(t.Name()+fmt.Sprintf("_Enforcer_%s_Input_%s", pc.enforcer, pc.input), func(t *testing.T) {
-			sandboxPolicy := sandboxSecurityPolicy(t, pc.input, false, true)
+			sandboxPolicy := sandboxSecurityPolicy(t, pc.input, false)
 			sandboxRequest := sandboxRequestWithPolicy(t, sandboxPolicy)
 			sandboxRequest.Config.Annotations[annotations.SecurityPolicyEnforcer] = pc.enforcer
 

--- a/test/gcs/helper_container_test.go
+++ b/test/gcs/helper_container_test.go
@@ -245,7 +245,6 @@ func mountRootfs(ctx context.Context, tb testing.TB, host *hcsv2.Host, id string
 		filepath.Join(scratch, "work"),
 		rootfs,
 		false, // readonly
-		id,
 	); err != nil {
 		tb.Fatalf("could not mount overlay layers from %q: %v", *flagRootfsPath, err)
 	}


### PR DESCRIPTION
rego and hardening: add enforcement and hardening for encrypted scratch

The request to encrypt scratch comes from the host, but in confidential
scenario, the host cannot be trusted and it may attempt to mount the
read-write overlay of a container under an unencrypted path or omit the
encryption request altogether.

To address the issue, add `scratch_mount`, `scratch_unmount` enforcement
points and `allow_unencrypted_scratch` policy config, which can be used
to (you guessed it) allow containers to run with unencrypted scratch.

Since the request to add encrypted read-write scratch disk and mounting
container overlayfs come at different times, we also introduced minimal
(for now) hardening around adding read-write devices to the UVM. We
record the mounted read-write devices when they arrive and at the time
of adding overlayfs we check if the scratch path encrypted or not and
validate against the policy before enforcing overlay policy.

The policy config can be set at the top level, e.g.:
```
allow_unencrypted_scratch := true

containers := [...]
```

The `scratch_mount` enforcement point takes an input with the following
members:
```
{
    "target": "<mount target>",
    "encrypted": [true|false],
}
```

Add `/internal/guest/runtime/hcsv2/uvm_state.go`, which adds a new
`hostMounts` struct which keeps track of mounted RW devices. This can
be extended in the future for more GCS hardening purposes, e.g. overlay,
RO layer mounts and other container lifecycle management.

Signed-off-by: Maksim An <maksiman@microsoft.com>