### PR TITLE
Adding policy fragments.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,10 +164,10 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
 
       - name: Test standard security policy
-        run: go test -mod=mod -gcflags=all=-d=checkptr -v ./pkg/securitypolicy
+        run: go test -timeout=30m -mod=mod -gcflags=all=-d=checkptr -v ./pkg/securitypolicy
 
       - name: Test rego security policy
-        run: go test --tags=rego -mod=mod -gcflags=all=-d=checkptr -v ./pkg/securitypolicy
+        run: go test --tags=rego -timeout=30m -mod=mod -gcflags=all=-d=checkptr -v ./pkg/securitypolicy
 
   test-windows:
     needs: [lint, protos, verify-vendor, go-gen]

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.18
 require (
 	github.com/BurntSushi/toml v0.4.1
 	github.com/Microsoft/go-winio v0.6.0
+	github.com/blang/semver/v4 v4.0.0
 	github.com/cenkalti/backoff/v4 v4.1.3
 	github.com/containerd/cgroups v1.0.3
 	github.com/containerd/console v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -168,6 +168,8 @@ github.com/bketelsen/crypt v0.0.4/go.mod h1:aI6NrJ0pMGgvZKL1iVgXLnfIFJtfV+bKCoqO
 github.com/bkielbasa/cyclop v1.2.0/go.mod h1:qOI0yy6A7dYC4Zgsa72Ppm9kONl0RoIlPbzot9mhmeI=
 github.com/blang/semver v3.1.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
+github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
+github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/blizzy78/varnamelen v0.3.0/go.mod h1:hbwRdBvoBqxk34XyQ6HA0UH3G0/1TKuv5AC4eaBT0Ec=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
 github.com/bombsimon/wsl/v3 v3.3.0/go.mod h1:st10JtZYLE4D5sC7b8xV4zTKZwAQjCH/Hy2Pm1FNZIc=

--- a/internal/tools/securitypolicy/README.md
+++ b/internal/tools/securitypolicy/README.md
@@ -36,9 +36,31 @@ readonly = false
 host_path = "sandbox://host/path/two"
 container_path = "/container/path/two"
 readonly = true
+
+[[container.exec_process]]
+command = ["top"]
+working_dir = "/home/user"
+
+[[container.exec_process.env_rule]]
+strategy = "string"
+rule = "FOO=bar"
+
+[[external_process]]
+command = ["bash"]
+working_dir = "/"
+
+[[fragment]]
+issuer = "did:web:contoso.com"
+feed = "contoso.azurecr.io/infra"
+minimum_svn = "1.0.1"
+include = ["containers"]
 ```
 
 ### Converted to JSON
+
+The result of the command:
+
+    securitypolicytool -c sample.toml -t json -r
 
 The above TOML configuration gets translated into the appropriate policy that is
 represented in JSON.
@@ -62,27 +84,33 @@ represented in JSON.
           "elements": {
             "0": {
               "strategy": "string",
-              "rule": "PATH=/usr/local/cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+              "rule": "PATH=/usr/local/cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+              "required": false
             },
             "1": {
               "strategy": "string",
-              "rule": "RUSTUP_HOME=/usr/local/rustup"
+              "rule": "RUSTUP_HOME=/usr/local/rustup",
+              "required": false
             },
             "2": {
               "strategy": "string",
-              "rule": "CARGO_HOME=/usr/local/cargo"
+              "rule": "CARGO_HOME=/usr/local/cargo",
+              "required": false
             },
             "3": {
               "strategy": "string",
-              "rule": "RUST_VERSION=1.52.1"
+              "rule": "RUST_VERSION=1.52.1",
+              "required": false
             },
             "4": {
               "strategy": "string",
-              "rule": "TERM=xterm"
+              "rule": "TERM=xterm",
+              "required": false
             },
             "5": {
               "strategy": "re2",
-              "rule": "PREFIX_.+=.+"
+              "rule": "PREFIX_.+=.+",
+              "required": false
             }
           }
         },
@@ -143,11 +171,13 @@ represented in JSON.
           "elements": {
             "0": {
               "strategy": "string",
-              "rule": "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+              "rule": "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+              "required": false
             },
             "1": {
               "strategy": "string",
-              "rule": "TERM=xterm"
+              "rule": "TERM=xterm",
+              "required": false
             }
           }
         },
@@ -169,15 +199,140 @@ represented in JSON.
 }
 ```
 
+## Converted to Rego Policy
+
+The result of the command:
+
+    securitypolicytool -c sample.toml -t rego -r
+
+Is the following Rego policy:
+
+``` rego
+package policy
+
+api_svn := "0.9.0"
+
+import future.keywords.every
+import future.keywords.in
+
+fragments := [
+    {"issuer": "did:web:contoso.com", "feed": "contoso.azurecr.io/infra", "minimum_svn": "1.0.1", "includes": []},
+]
+containers := [
+    {
+        "command": ["rustc","--help"],
+        "env_rules": [{"pattern": "PATH=/usr/local/cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin", "strategy": "string", "required": false},{"pattern": "RUSTUP_HOME=/usr/local/rustup", "strategy": "string", "required": false},{"pattern": "CARGO_HOME=/usr/local/cargo", "strategy": "string", "required": false},{"pattern": "RUST_VERSION=1.52.1", "strategy": "string", "required": false},{"pattern": "TERM=xterm", "strategy": "string", "required": false},{"pattern": "PREFIX_.+=.+", "strategy": "re2", "required": false}],
+        "layers": ["fe84c9d5bfddd07a2624d00333cf13c1a9c941f3a261f13ead44fc6a93bc0e7a","4dedae42847c704da891a28c25d32201a1ae440bce2aecccfa8e6f03b97a6a6c","41d64cdeb347bf236b4c13b7403b633ff11f1cf94dbc7cf881a44d6da88c5156","eb36921e1f82af46dfe248ef8f1b3afb6a5230a64181d960d10237a08cd73c79","e769d7487cc314d3ee748a4440805317c19262c7acd2fdbdb0d47d2e4613a15c","1b80f120dbd88e4355d6241b519c3e25290215c469516b49dece9cf07175a766"],
+        "mounts": [{"destination": "/container/path/one", "options": ["rbind","rshared","rw"], "source": "sandbox://host/path/one", "type": "bind"},{"destination": "/container/path/two", "options": ["rbind","rshared","ro"], "source": "sandbox://host/path/two", "type": "bind"}],
+        "exec_processes": [{"command": ["top"], "signals": []}],
+        "signals": [],
+        "allow_elevated": true,
+        "working_dir": "/home/user"
+    },
+    {
+        "command": ["/pause"],
+        "env_rules": [{"pattern": "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin", "strategy": "string", "required": false},{"pattern": "TERM=xterm", "strategy": "string", "required": false}],
+        "layers": ["16b514057a06ad665f92c02863aca074fd5976c755d26bff16365299169e8415"],
+        "mounts": [],
+        "exec_processes": [],
+        "signals": [],
+        "allow_elevated": false,
+        "working_dir": "/"
+    },
+]
+external_processes := [
+    {"command": ["bash"], "env_rules": [{"pattern": "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin", "strategy": "string", "required": true}], "working_dir": "/"},
+]
+allow_properties_access := false
+allow_dump_stacks := false
+allow_runtime_logging := false
+
+
+mount_device := data.framework.mount_device
+unmount_device := data.framework.unmount_device
+mount_overlay := data.framework.mount_overlay
+unmount_overlay := data.framework.unmount_overlay
+create_container := data.framework.create_container
+exec_in_container := data.framework.exec_in_container
+exec_external := data.framework.exec_external
+shutdown_container := data.framework.shutdown_container
+signal_container_process := data.framework.signal_container_process
+plan9_mount := data.framework.plan9_mount
+plan9_unmount := data.framework.plan9_unmount
+get_properties := data.framework.get_properties
+dump_stacks := data.framework.dump_stacks
+runtime_logging := data.framework.runtime_logging
+load_fragment := data.framework.load_fragment
+reason := {"errors": data.framework.errors}
+```
+
+## Converted to Rego Fragment
+
+The result of the command
+
+    securitypolicytool -c sample.toml -t fragment -n sample -v 1.0.0 -r
+
+is the following Rego fragment:
+
+``` rego
+package sample
+
+svn := "1.0.0"
+
+fragments := [
+    {"issuer": "did:web:contoso.com", "feed": "contoso.azurecr.io/infra", "minimum_svn": "1.0.1", "includes": ["containers"]},
+]
+containers := [
+    {
+        "command": ["rustc","--help"],
+        "env_rules": [{"pattern": "PATH=/usr/local/cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin", "strategy": "string", "required": false},{"pattern": "RUSTUP_HOME=/usr/local/rustup", "strategy": "string", "required": false},{"pattern": "CARGO_HOME=/usr/local/cargo", "strategy": "string", "required": false},{"pattern": "RUST_VERSION=1.52.1", "strategy": "string", "required": false},{"pattern": "TERM=xterm", "strategy": "string", "required": false},{"pattern": "PREFIX_.+=.+", "strategy": "re2", "required": false}],
+        "layers": ["fe84c9d5bfddd07a2624d00333cf13c1a9c941f3a261f13ead44fc6a93bc0e7a","4dedae42847c704da891a28c25d32201a1ae440bce2aecccfa8e6f03b97a6a6c","41d64cdeb347bf236b4c13b7403b633ff11f1cf94dbc7cf881a44d6da88c5156","eb36921e1f82af46dfe248ef8f1b3afb6a5230a64181d960d10237a08cd73c79","e769d7487cc314d3ee748a4440805317c19262c7acd2fdbdb0d47d2e4613a15c","1b80f120dbd88e4355d6241b519c3e25290215c469516b49dece9cf07175a766"],
+        "mounts": [{"destination": "/container/path/one", "options": ["rbind","rshared","rw"], "source": "sandbox://host/path/one", "type": "bind"},{"destination": "/container/path/two", "options": ["rbind","rshared","ro"], "source": "sandbox://host/path/two", "type": "bind"}],
+        "exec_processes": [{"command": ["top"], "signals": []}],
+        "signals": [],
+        "allow_elevated": true,
+        "working_dir": "/home/user"
+    },
+    {
+        "command": ["/pause"],
+        "env_rules": [{"pattern": "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin", "strategy": "string", "required": false},{"pattern": "TERM=xterm", "strategy": "string", "required": false}],
+        "layers": ["16b514057a06ad665f92c02863aca074fd5976c755d26bff16365299169e8415"],
+        "mounts": [],
+        "exec_processes": [],
+        "signals": [],
+        "allow_elevated": false,
+        "working_dir": "/"
+    },
+]
+external_processes := [
+    {"command": ["bash"], "env_rules": [{"pattern": "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin", "strategy": "string", "required": true}], "working_dir": "/"},
+]
+```
+
 ## CLI Options
 
-- -c
+### `-c`
 
 TOML configuration file to process (required)
 
-- -j
+### `-r`
 
-output raw JSON in addition to the Base64 encoded version
+output raw marshaled policy in addition to the base64
+
+### `-t`
+
+one of:
+- `rego`: outputs a Rego policy
+- `json`: outputs a legacy JSON policy (NOTE: some TOML elements are not supported in the legacy format)
+- `fragment`: outputs a Rego fragment. The `-n` and `-v` are required for this option.
+
+### `-n`
+
+Required for `-t fragment`. Specifies the fragment Rego namespace.
+
+### `-v`
+
+Required for `-t fragment`. Specified the fragment SVN as a semantic versioning number, *e.g.*, "1.0.0"
 
 ## Authorization
 

--- a/internal/tools/securitypolicy/main.go
+++ b/internal/tools/securitypolicy/main.go
@@ -13,9 +13,11 @@ import (
 )
 
 var (
-	configFile = flag.String("c", "", "config path")
-	outputType = flag.String("t", "", "[rego|json]")
-	outputRaw  = flag.Bool("r", false, "whether to print the raw output")
+	configFile        = flag.String("c", "", "config path")
+	outputType        = flag.String("t", "", "[rego|json|fragment]")
+	fragmentNamespace = flag.String("n", "", "fragment namespace")
+	fragmentSVN       = flag.String("v", "", "fragment svn")
+	outputRaw         = flag.Bool("r", false, "whether to print the raw output")
 )
 
 func main() {
@@ -45,14 +47,25 @@ func main() {
 			return err
 		}
 
-		policyCode, err := securitypolicy.MarshalPolicy(
-			*outputType,
-			config.AllowAll,
-			policyContainers,
-			config.ExternalProcesses,
-			config.AllowPropertiesAccess,
-			config.AllowDumpStacks,
-			config.AllowRuntimeLogging)
+		var policyCode string
+		if *outputType == "fragment" {
+			policyCode, err = securitypolicy.MarshalFragment(
+				*fragmentNamespace,
+				*fragmentSVN,
+				policyContainers,
+				config.ExternalProcesses,
+				config.Fragments)
+		} else {
+			policyCode, err = securitypolicy.MarshalPolicy(
+				*outputType,
+				config.AllowAll,
+				policyContainers,
+				config.ExternalProcesses,
+				config.Fragments,
+				config.AllowPropertiesAccess,
+				config.AllowDumpStacks,
+				config.AllowRuntimeLogging)
+		}
 		if err != nil {
 			return err
 		}

--- a/pkg/securitypolicy/api.rego
+++ b/pkg/securitypolicy/api.rego
@@ -1,6 +1,6 @@
 package api
 
-svn := "0.8.0"
+svn := "0.9.0"
 
 enforcement_points := {
     "mount_device": {"introducedVersion": "0.1.0", "allowedByDefault": false},
@@ -16,5 +16,6 @@ enforcement_points := {
     "plan9_unmount": {"introducedVersion": "0.6.0", "allowedByDefault": true},
     "get_properties": {"introducedVersion": "0.7.0", "allowedByDefault": true},
     "dump_stacks": {"introducedVersion": "0.7.0", "allowedByDefault": true},
-    "runtime_logging": {"introducedVersion": "0.8.0", "allowedByDefault": true}
+    "runtime_logging": {"introducedVersion": "0.8.0", "allowedByDefault": true},
+    "load_fragment": {"introducedVersion": "0.9.0", "allowedByDefault": false}
 }

--- a/pkg/securitypolicy/framework.rego
+++ b/pkg/securitypolicy/framework.rego
@@ -11,18 +11,15 @@ default deviceHash_ok := false
 
 # test if a device hash exists as a layer in a policy container
 deviceHash_ok {
-    some container in data.policy.containers
-    some layer in container.layers
+    layer := data.policy.containers[_].layers[_]
     input.deviceHash == layer
 }
 
 # test if a device hash exists as a layer in a fragment container
 deviceHash_ok {
-    some issuer in data.metadata.issuers
-    some feed in issuer.feeds
+    feed := data.metadata.issuers[_].feeds[_]
     some fragment in feed
-    some container in fragment.containers
-    some layer in container.layers
+    layer := fragment.containers[_].layers[_]
     input.deviceHash == layer
 }
 
@@ -74,14 +71,13 @@ mount_overlay := {"matches": matches, "overlayTargets": overlay_targets, "allowe
     # which match the overlay requested, including both
     # containers in the policy and those included from fragments.
     policy_containers := [container |
-        some container in data.policy.containers
+        container := data.policy.containers[_]
         layerPaths_ok(container.layers)
     ]
     fragment_containers := [container |
-        some issuer in data.metadata.issuers
-        some feed in issuer.feeds
+        feed := data.metadata.issuers[_].feeds[_]
         some fragment in feed
-        some container in fragment.containers
+        container := fragment.containers[_]
         layerPaths_ok(container.layers)
     ]
     containers := array.concat(policy_containers, fragment_containers)
@@ -159,7 +155,7 @@ default create_container := {"allowed": false}
 create_container := {"matches": matches, "started": started, "allowed": true} {
     not container_started
     containers := [container |
-        some container in data.metadata.matches[input.containerID]
+        container := data.metadata.matches[input.containerID][_]
         command_ok(container.command)
         envList_ok(container.env_rules)
         workingDirectory_ok(container.working_dir)
@@ -249,7 +245,7 @@ default exec_in_container := {"allowed": false}
 exec_in_container := {"matches": matches, "allowed": true} {
     container_started
     containers := [container |
-        some container in data.metadata.matches[input.containerID]
+        container := data.metadata.matches[input.containerID][_]
         envList_ok(container.env_rules)
         workingDirectory_ok(container.working_dir)
         some process in container.exec_processes
@@ -279,7 +275,7 @@ signal_container_process := {"matches": matches, "allowed": true} {
     container_started
     input.isInitProcess
     containers := [container |
-        some container in data.metadata.matches[input.containerID]
+        container := data.metadata.matches[input.containerID][_]
         signal_ok(container.signals)
     ]
     count(containers) > 0
@@ -294,7 +290,7 @@ signal_container_process := {"matches": matches, "allowed": true} {
     container_started
     not input.isInitProcess
     containers := [container |
-        some container in data.metadata.matches[input.containerID]
+        container := data.metadata.matches[input.containerID][_]
         some process in container.exec_processes
         command_ok(process.command)
         signal_ok(process.signals)
@@ -371,8 +367,7 @@ exec_external := {"allowed": true} {
 
 # test if there is a matching external process in a fragment
 exec_external := {"allowed": true} {
-    some issuer in data.metadata.issuers
-    some feed in issuer.feeds
+    feed := data.metadata.issuers[_].feeds[_]
     some fragment in feed
     some process in fragment.external_processes
     external_process_ok(process)
@@ -474,8 +469,7 @@ matching_fragment := fragment {
 
 # test if there is a matching fragment in a fragment
 matching_fragment := subfragment {
-    some iss in data.metadata.issuers
-    some feed in iss.feeds
+    feed := data.metadata.issuers[_].feeds[_]
     some fragment in feed
     some subfragment in fragment.fragments
     fragment_ok(subfragment)
@@ -533,10 +527,9 @@ overlay_matches {
 }
 
 overlay_matches {
-    some issuer in data.metadata.issuers
-    some feed in issuer.feeds
+    feed := data.metadata.issuers[_].feeds[_]
     some fragment in feed
-    some container in feed.containers
+    some container in fragment.containers
     layerPaths_ok(container.layers)
 }
 

--- a/pkg/securitypolicy/framework.rego
+++ b/pkg/securitypolicy/framework.rego
@@ -9,8 +9,19 @@ device_mounted(target) {
 
 default deviceHash_ok := false
 
+# test if a device hash exists as a layer in a policy container
 deviceHash_ok {
     some container in data.policy.containers
+    some layer in container.layers
+    input.deviceHash == layer
+}
+
+# test if a device hash exists as a layer in a fragment container
+deviceHash_ok {
+    some issuer in data.metadata.issuers
+    some feed in issuer.feeds
+    some fragment in feed
+    some container in fragment.containers
     some layer in container.layers
     input.deviceHash == layer
 }
@@ -59,10 +70,21 @@ default mount_overlay := {"allowed": false}
 
 mount_overlay := {"matches": matches, "overlayTargets": overlay_targets, "allowed": true} {
     not overlay_exists
-    containers := [container |
+    # we need to assemble a list of all possible containers
+    # which match the overlay requested, including both
+    # containers in the policy and those included from fragments.
+    policy_containers := [container |
         some container in data.policy.containers
         layerPaths_ok(container.layers)
     ]
+    fragment_containers := [container |
+        some issuer in data.metadata.issuers
+        some feed in issuer.feeds
+        some fragment in feed
+        some container in fragment.containers
+        layerPaths_ok(container.layers)
+    ]
+    containers := array.concat(policy_containers, fragment_containers)
     count(containers) > 0
     matches := {
         "action": "add",
@@ -333,13 +355,27 @@ enforcement_point_info := {"available": false, "allowed": false, "unknown": fals
     semver.compare(data.api.svn, enforcement_point.introducedVersion) < 0
 }
 
-default exec_external := {"allowed": false}
-
-exec_external := {"allowed": true} {
-    some process in data.policy.external_processes
+external_process_ok(process) {
     command_ok(process.command)
     envList_ok(process.env_rules)
     workingDirectory_ok(process.working_dir)
+}
+
+default exec_external := {"allowed": false}
+
+# test if there is a matching external process in the policy
+exec_external := {"allowed": true} {
+    some process in data.policy.external_processes
+    external_process_ok(process)
+}
+
+# test if there is a matching external process in a fragment
+exec_external := {"allowed": true} {
+    some issuer in data.metadata.issuers
+    some feed in issuer.feeds
+    some fragment in feed
+    some process in fragment.external_processes
+    external_process_ok(process)
 }
 
 default get_properties := {"allowed": false}
@@ -358,6 +394,103 @@ default runtime_logging := {"allowed": false}
 
 runtime_logging := {"allowed": true} {
     data.policy.allow_runtime_logging
+}
+
+default fragment_containers := []
+fragment_containers := data[input.namespace].containers
+
+default fragment_fragments := []
+fragment_fragments := data[input.namespace].fragments
+
+default fragment_external_processes := []
+fragment_external_processes := data[input.namespace].external_processes
+
+extract_fragment_includes(includes) := fragment {
+    objects := {
+        "containers": fragment_containers,
+        "fragments": fragment_fragments,
+        "external_processes": fragment_external_processes
+    }
+
+    fragment := {
+        include: objects[include] | include := includes[_]
+    }
+}
+
+issuer_exists(iss) {
+    data.metadata.issuers[iss]
+}
+
+feed_exists(iss, feed) {
+    data.metadata.issuers[iss].feeds[feed]
+}
+
+update_issuer(includes) := issuer {
+    feed_exists(input.issuer, input.feed)
+    old_issuer := data.metadata.issuers[input.issuer]
+    old_fragments := old_issuer.feeds[input.feed]
+    new_issuer := {
+        "feeds": {
+            input.feed: array.concat([extract_fragment_includes(includes)], old_fragments)
+        }
+    }
+    issuer := object.union(old_issuer, new_issuer)
+}
+
+update_issuer(includes) := issuer {
+    not feed_exists(input.issuer, input.feed)
+    old_issuer := data.metadata.issuers[input.issuer]
+    new_issuer := {
+        "feeds": {
+            input.feed: [extract_fragment_includes(includes)]
+        }
+    }
+    issuer := object.union(old_issuer, new_issuer)
+}
+
+update_issuer(includes) := issuer {
+    not issuer_exists(input.issuer)
+    issuer := {
+        "feeds": {
+            input.feed: [extract_fragment_includes(includes)]
+        }
+    }
+}
+
+default load_fragment := {"allowed": false}
+
+fragment_ok(fragment) {
+    input.issuer == fragment.issuer
+    input.feed == fragment.feed
+    semver.compare(data[input.namespace].svn, fragment.minimum_svn) >= 0
+}
+
+
+# test if there is a matching fragment in the policy
+matching_fragment := fragment {
+    some fragment in data.policy.fragments
+    fragment_ok(fragment)
+}
+
+# test if there is a matching fragment in a fragment
+matching_fragment := subfragment {
+    some iss in data.metadata.issuers
+    some feed in iss.feeds
+    some fragment in feed
+    some subfragment in fragment.fragments
+    fragment_ok(subfragment)
+}
+
+load_fragment := {"issuers": issuers, "add_module": add_module, "allowed": true} {
+    fragment := matching_fragment
+    issuer := update_issuer(fragment.includes)
+    issuers := {
+        "action": "update",
+        "key": input.issuer,
+        "value": issuer
+    }
+
+    add_module := "namespace" in fragment.includes
 }
 
 # error messages
@@ -396,6 +529,14 @@ default overlay_matches := false
 
 overlay_matches {
     some container in data.policy.containers
+    layerPaths_ok(container.layers)
+}
+
+overlay_matches {
+    some issuer in data.metadata.issuers
+    some feed in issuer.feeds
+    some fragment in feed
+    some container in feed.containers
     layerPaths_ok(container.layers)
 }
 
@@ -512,4 +653,58 @@ errors["device already mounted at path"] {
 errors["no device at path to unmount"] {
     input.rule == "plan9_unmount"
     not plan9_mounted(input.unmountTarget)
+}
+
+default fragment_issuer_matches := false
+
+fragment_issuer_matches {
+    some fragment in data.policy.fragments
+    fragment.issuer == input.issuer
+}
+
+fragment_issuer_matches {
+    input.issuer in data.metadata.issuers
+}
+
+errors["invalid fragment issuer"] {
+    input.rule == "load_fragment"
+    not fragment_issuer_matches
+}
+
+default fragment_feed_matches := false
+
+fragment_feed_matches {
+    some fragment in data.policy.fragments
+    fragment.issuer == input.issuer
+    fragment.feed == input.feed
+}
+
+fragment_feed_matches {
+    input.feed in data.metadata.issuers[input.issuer]
+}
+
+errors["invalid fragment feed"] {
+    input.rule == "load_fragment"
+    fragment_issuer_matches
+    not fragment_feed_matches
+}
+
+default fragment_version_is_valid := false
+
+fragment_version_is_valid {
+    some fragment in data.policy.fragments
+    fragment.issuer == input.issuer
+    fragment.feed == input.feed
+    semver.compare(data[input.namespace].svn, fragment.minimum_svn) >= 0
+}
+
+fragment_version_is_valid {
+    some fragment in data.metadata.issuers[input.issuer][input.feed]
+    semver.compare(data[input.namespace].svn, fragment.minimum_svn) >= 0
+}
+
+errors["fragment version is below the specified minimum"] {
+    input.rule == "load_fragment"
+    fragment_feed_matches
+    not fragment_version_is_valid
 }

--- a/pkg/securitypolicy/open_door.rego
+++ b/pkg/securitypolicy/open_door.rego
@@ -1,6 +1,6 @@
 package policy
 
-api_svn := "0.8.0"
+api_svn := "0.9.0"
 
 mount_device := {"allowed": true}
 mount_overlay := {"allowed": true}
@@ -16,3 +16,4 @@ plan9_unmount := {"allowed": true}
 get_properties := {"allowed": true}
 dump_stacks := {"allowed": true}
 runtime_logging := {"allowed": true}
+load_fragment := {"allowed": true}

--- a/pkg/securitypolicy/policy.rego
+++ b/pkg/securitypolicy/policy.rego
@@ -1,6 +1,6 @@
 package policy
 
-api_svn := "0.8.0"
+api_svn := "0.9.0"
 
 import future.keywords.every
 import future.keywords.in
@@ -21,4 +21,5 @@ plan9_unmount := data.framework.plan9_unmount
 get_properties := data.framework.get_properties
 dump_stacks := data.framework.dump_stacks
 runtime_logging := data.framework.runtime_logging
+load_fragment := data.framework.load_fragment
 reason := {"errors": data.framework.errors}

--- a/pkg/securitypolicy/securitypolicy.go
+++ b/pkg/securitypolicy/securitypolicy.go
@@ -28,6 +28,7 @@ type PolicyConfig struct {
 	AllowAll              bool                    `json:"allow_all" toml:"allow_all"`
 	Containers            []ContainerConfig       `json:"containers" toml:"container"`
 	ExternalProcesses     []ExternalProcessConfig `json:"external_processes" toml:"external_process"`
+	Fragments             []FragmentConfig        `json:"fragments" toml:"fragment"`
 	AllowPropertiesAccess bool                    `json:"allow_properties_access" toml:"allow_properties_access"`
 	AllowDumpStacks       bool                    `json:"allow_dump_stacks" toml:"allow_dump_stacks"`
 	AllowRuntimeLogging   bool                    `json:"allow_runtime_logging" toml:"allow_runtime_logging"`
@@ -37,6 +38,14 @@ type PolicyConfig struct {
 type ExternalProcessConfig struct {
 	Command    []string `json:"command" toml:"command"`
 	WorkingDir string   `json:"working_dir" toml:"working_dir"`
+}
+
+// FragmentConfig contains toml or JSON config for including elements from fragments.
+type FragmentConfig struct {
+	Issuer     string   `json:"issuer" toml:"issuer"`
+	Feed       string   `json:"feed" toml:"feed"`
+	MinimumSVN string   `json:"minimum_svn" toml:"minimum_svn"`
+	Includes   []string `json:"includes" toml:"include"`
 }
 
 // AuthConfig contains toml or JSON config for registry authentication.

--- a/pkg/securitypolicy/securitypolicy_test.go
+++ b/pkg/securitypolicy/securitypolicy_test.go
@@ -21,26 +21,27 @@ import (
 
 const (
 	// variables that influence generated test fixtures
-	minStringLength                            = 10
-	maxContainersInGeneratedConstraints        = 32
-	maxExternalProcessesInGeneratedConstraints = 16
-	maxLayersInGeneratedContainer              = 32
-	maxGeneratedContainerID                    = 1000000
-	maxGeneratedCommandLength                  = 128
-	maxGeneratedCommandArgs                    = 12
-	maxGeneratedEnvironmentVariables           = 24
-	maxGeneratedEnvironmentVariableRuleLength  = 64
-	maxGeneratedEnvironmentVariableRules       = 12
-	maxGeneratedMountTargetLength              = 256
-	rootHashLength                             = 64
-	maxGeneratedMounts                         = 4
-	maxGeneratedMountSourceLength              = 32
-	maxGeneratedMountDestinationLength         = 32
-	maxGeneratedMountOptions                   = 5
-	maxGeneratedMountOptionLength              = 32
-	maxGeneratedExecProcesses                  = 12
-	maxGeneratedWorkingDirLength               = 128
-	maxSignalNumber                            = 64
+	minStringLength                           = 10
+	maxContainersInGeneratedConstraints       = 32
+	maxLayersInGeneratedContainer             = 32
+	maxGeneratedContainerID                   = 1000000
+	maxGeneratedCommandLength                 = 128
+	maxGeneratedCommandArgs                   = 12
+	maxGeneratedEnvironmentVariables          = 24
+	maxGeneratedEnvironmentVariableRuleLength = 64
+	maxGeneratedEnvironmentVariableRules      = 12
+	maxGeneratedFragmentNamespaceLength       = 32
+	maxGeneratedMountTargetLength             = 256
+	maxGeneratedVersion                       = 10
+	rootHashLength                            = 64
+	maxGeneratedMounts                        = 4
+	maxGeneratedMountSourceLength             = 32
+	maxGeneratedMountDestinationLength        = 32
+	maxGeneratedMountOptions                  = 5
+	maxGeneratedMountOptionLength             = 32
+	maxGeneratedExecProcesses                 = 12
+	maxGeneratedWorkingDirLength              = 128
+	maxSignalNumber                           = 64
 	// additional consts
 	// the standard enforcer tests don't do anything with the encoded policy
 	// string. this const exists to make that explicit
@@ -243,7 +244,7 @@ func Test_EnforceOverlayMountPolicy_Matches(t *testing.T) {
 
 // Tests the specific case of trying to mount the same overlay twice using the /// same container id. This should be disallowed.
 func Test_EnforceOverlayMountPolicy_Overlay_Single_Container_Twice(t *testing.T) {
-	gc := generateConstraints(testRand, 1, 0)
+	gc := generateConstraints(testRand, 1)
 	tc, err := setupContainerWithOverlay(gc, true)
 	if err != nil {
 		t.Fatalf("expected nil error got: %v", err)
@@ -298,7 +299,7 @@ func Test_EnforceOverlayMountPolicy_Multiple_Instances_Same_Container(t *testing
 // policy, we should be able to create a single container for that overlay
 // but no more than that one.
 func Test_EnforceOverlayMountPolicy_Overlay_Single_Container_Twice_With_Different_IDs(t *testing.T) {
-	p := generateConstraints(testRand, 1, 0)
+	p := generateConstraints(testRand, 1)
 	sp := NewStandardSecurityPolicyEnforcer(p.containers, ignoredEncodedPolicyString)
 
 	var containerIDOne, containerIDTwo string
@@ -500,7 +501,7 @@ func Test_EnforceEnvironmentVariablePolicy_Matches(t *testing.T) {
 }
 
 func Test_EnforceEnvironmentVariablePolicy_Re2Match(t *testing.T) {
-	p := generateConstraints(testRand, 1, 0)
+	p := generateConstraints(testRand, 1)
 
 	container := generateConstraintsContainer(testRand, 1, 1)
 	// add a rule to re2 match
@@ -853,7 +854,7 @@ func (*SecurityPolicy) Generate(r *rand.Rand, _ int) reflect.Value {
 }
 
 func (*generatedConstraints) Generate(r *rand.Rand, _ int) reflect.Value {
-	c := generateConstraints(r, maxContainersInGeneratedConstraints, maxExternalProcessesInGeneratedConstraints)
+	c := generateConstraints(r, maxContainersInGeneratedConstraints)
 	return reflect.ValueOf(c)
 }
 
@@ -891,7 +892,7 @@ func setupContainerWithOverlay(gc *generatedConstraints, valid bool) (tc *testCo
 	}, nil
 }
 
-func generateConstraints(r *rand.Rand, maxContainers int32, maxExternalProcesses int32) *generatedConstraints {
+func generateConstraints(r *rand.Rand, maxContainers int32) *generatedConstraints {
 	var containers []*securityPolicyContainer
 
 	numContainers := (int)(atLeastOneAtMost(r, maxContainers))
@@ -899,23 +900,15 @@ func generateConstraints(r *rand.Rand, maxContainers int32, maxExternalProcesses
 		containers = append(containers, generateConstraintsContainer(r, 1, maxLayersInGeneratedContainer))
 	}
 
-	var externalProcesses []*externalProcess
-
-	numExternalProcesses := 0
-	if maxExternalProcesses >= 1 {
-		numExternalProcesses = (int)(atLeastOneAtMost(r, maxExternalProcesses))
-	}
-
-	for i := 0; i < numExternalProcesses; i++ {
-		externalProcesses = append(externalProcesses, generateExternalProcess(r))
-	}
-
 	return &generatedConstraints{
 		containers:          containers,
-		externalProcesses:   externalProcesses,
+		externalProcesses:   make([]*externalProcess, 0),
+		fragments:           make([]*fragment, 0),
 		allowGetProperties:  randBool(r),
 		allowDumpStacks:     randBool(r),
 		allowRuntimeLogging: false,
+		namespace:           generateFragmentNamespace(testRand),
+		svn:                 generateSVN(testRand),
 	}
 }
 
@@ -953,14 +946,6 @@ func generateContainerExecProcess(r *rand.Rand) containerExecProcess {
 
 func generateRootHash(r *rand.Rand) string {
 	return randString(r, rootHashLength)
-}
-
-func generateExternalProcess(r *rand.Rand) *externalProcess {
-	return &externalProcess{
-		command:    generateCommand(r),
-		envRules:   generateEnvironmentVariableRules(r),
-		workingDir: generateWorkingDir(r),
-	}
 }
 
 func generateWorkingDir(r *rand.Rand) string {
@@ -1069,6 +1054,17 @@ func generateInvalidRootHash(r *rand.Rand) string {
 	return randVariableString(r, rootHashLength-1)
 }
 
+func generateFragmentNamespace(r *rand.Rand) string {
+	return randChar(r) + randVariableString(r, maxGeneratedFragmentNamespaceLength)
+}
+
+func generateSVN(r *rand.Rand) string {
+	major := randMinMax(r, 0, maxGeneratedVersion)
+	minor := randMinMax(r, 0, maxGeneratedVersion)
+	patch := randMinMax(r, 0, maxGeneratedVersion)
+	return fmt.Sprintf("%d.%d.%d", major, minor, patch)
+}
+
 func selectRootHashFromConstraints(constraints *generatedConstraints, r *rand.Rand) string {
 	numberOfContainersInConstraints := len(constraints.containers)
 	container := constraints.containers[r.Intn(numberOfContainersInConstraints)]
@@ -1146,47 +1142,45 @@ func selectContainerFromConstraints(constraints *generatedConstraints, r *rand.R
 }
 
 type dataGenerator struct {
-	rng               *rand.Rand
-	mountTargets      map[string]struct{}
-	containerIDs      map[string]struct{}
-	sandboxIDs        map[string]struct{}
-	enforcementPoints map[string]struct{}
+	rng                *rand.Rand
+	mountTargets       map[string]struct{}
+	containerIDs       map[string]struct{}
+	sandboxIDs         map[string]struct{}
+	enforcementPoints  map[string]struct{}
+	fragmentIssuers    map[string]struct{}
+	fragmentFeeds      map[string]struct{}
+	fragmentNamespaces map[string]struct{}
 }
 
 func newDataGenerator(rng *rand.Rand) *dataGenerator {
 	return &dataGenerator{
-		rng:          rng,
-		mountTargets: map[string]struct{}{},
-		containerIDs: map[string]struct{}{},
-		sandboxIDs:   map[string]struct{}{},
-		enforcementPoints: map[string]struct{}{
-			"mount_device":      {},
-			"mount_overlay":     {},
-			"create_container":  {},
-			"unmount_device":    {},
-			"exec_in_container": {},
-		},
+		rng:                rng,
+		mountTargets:       map[string]struct{}{},
+		containerIDs:       map[string]struct{}{},
+		sandboxIDs:         map[string]struct{}{},
+		enforcementPoints:  map[string]struct{}{},
+		fragmentIssuers:    map[string]struct{}{},
+		fragmentFeeds:      map[string]struct{}{},
+		fragmentNamespaces: map[string]struct{}{},
+	}
+}
+
+func (gen *dataGenerator) uniqueString(values map[string]struct{}, generator func(*rand.Rand) string) string {
+	for {
+		s := generator(gen.rng)
+		if _, ok := values[s]; !ok {
+			values[s] = struct{}{}
+			return s
+		}
 	}
 }
 
 func (gen *dataGenerator) uniqueMountTarget() string {
-	for {
-		t := generateMountTarget(gen.rng)
-		if _, ok := gen.mountTargets[t]; !ok {
-			gen.mountTargets[t] = struct{}{}
-			return t
-		}
-	}
+	return gen.uniqueString(gen.mountTargets, generateMountTarget)
 }
 
 func (gen *dataGenerator) uniqueContainerID() string {
-	for {
-		t := generateContainerID(gen.rng)
-		if _, ok := gen.containerIDs[t]; !ok {
-			gen.containerIDs[t] = struct{}{}
-			return t
-		}
-	}
+	return gen.uniqueString(gen.containerIDs, generateContainerID)
 }
 
 func (gen *dataGenerator) createValidOverlayForContainer(enforcer SecurityPolicyEnforcer, container *securityPolicyContainer) ([]string, error) {
@@ -1297,6 +1291,11 @@ func randString(r *rand.Rand, length int32) string {
 	return sb.String()
 }
 
+func randChar(r *rand.Rand) string {
+	charset := "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+	return string(charset[r.Intn(len(charset))])
+}
+
 func randBool(r *rand.Rand) bool {
 	return randMinMax(r, 0, 1) == 0
 }
@@ -1320,9 +1319,12 @@ func atMost(r *rand.Rand, most int32) int32 {
 type generatedConstraints struct {
 	containers          []*securityPolicyContainer
 	externalProcesses   []*externalProcess
+	fragments           []*fragment
 	allowGetProperties  bool
 	allowDumpStacks     bool
 	allowRuntimeLogging bool
+	namespace           string
+	svn                 string
 }
 
 type containerInitProcess struct {

--- a/pkg/securitypolicy/securitypolicyenforcer.go
+++ b/pkg/securitypolicy/securitypolicyenforcer.go
@@ -55,6 +55,7 @@ type SecurityPolicyEnforcer interface {
 	EnforceGetPropertiesPolicy() error
 	EnforceDumpStacksPolicy() error
 	EnforceRuntimeLoggingPolicy() (err error)
+	LoadFragment(issuer string, feed string, code string) error
 }
 
 func newSecurityPolicyFromBase64JSON(base64EncodedPolicy string) (*SecurityPolicy, error) {
@@ -512,6 +513,12 @@ func (*StandardSecurityPolicyEnforcer) EnforceRuntimeLoggingPolicy() error {
 	return nil
 }
 
+// Stub. We are deprecating the standard enforcer. Newly added enforcement
+// points are simply allowed.
+func (*StandardSecurityPolicyEnforcer) LoadFragment(_ string, _ string, _ string) error {
+	return nil
+}
+
 func (pe *StandardSecurityPolicyEnforcer) enforceCommandPolicy(containerID string, argList []string) (err error) {
 	// Get a list of all the indexes into our security policy's list of
 	// containers that are possible matches for this containerID based
@@ -837,6 +844,10 @@ func (OpenDoorSecurityPolicyEnforcer) EnforceDumpStacksPolicy() error {
 	return nil
 }
 
+func (OpenDoorSecurityPolicyEnforcer) LoadFragment(_ string, _ string, _ string) error {
+	return nil
+}
+
 func (OpenDoorSecurityPolicyEnforcer) ExtendDefaultMounts(_ []oci.Mount) error {
 	return nil
 }
@@ -884,7 +895,7 @@ func (ClosedDoorSecurityPolicyEnforcer) EnforceExecExternalProcessPolicy(_ []str
 }
 
 func (*ClosedDoorSecurityPolicyEnforcer) EnforceShutdownContainerPolicy(_ string) error {
-	return errors.New("shutting down a container is denied by policy")
+	return errors.New("shutting down containers is denied by policy")
 }
 
 func (*ClosedDoorSecurityPolicyEnforcer) EnforceSignalContainerProcessPolicy(_ string, _ syscall.Signal, _ bool, _ []string) error {
@@ -905,6 +916,10 @@ func (ClosedDoorSecurityPolicyEnforcer) EnforceGetPropertiesPolicy() error {
 
 func (ClosedDoorSecurityPolicyEnforcer) EnforceDumpStacksPolicy() error {
 	return errors.New("getting stack dumps is denied by policy")
+}
+
+func (ClosedDoorSecurityPolicyEnforcer) LoadFragment(_ string, _ string, _ string) error {
+	return errors.New("loading fragments is denied by policy")
 }
 
 func (ClosedDoorSecurityPolicyEnforcer) ExtendDefaultMounts(_ []oci.Mount) error {

--- a/pkg/securitypolicy/securitypolicyenforcer_rego.go
+++ b/pkg/securitypolicy/securitypolicyenforcer_rego.go
@@ -49,6 +49,13 @@ var apiCode string
 
 const plan9Prefix = "plan9://"
 
+type module struct {
+	namespace string
+	feed      string
+	issuer    string
+	code      string
+}
+
 // RegoEnforcer is a stub implementation of a security policy, which will be
 // based on [Rego] policy language. The detailed implementation will be
 // introduced in the subsequent PRs and documentation updated accordingly.
@@ -63,8 +70,12 @@ type regoEnforcer struct {
 	data map[string]interface{}
 	// Base64 encoded (JSON) policy
 	base64policy string
+	// Modules
+	modules map[string]*module
 	// Compiled modules
 	compiledModules *ast.Compiler
+	// Debug flag
+	debug bool
 }
 
 var _ SecurityPolicyEnforcer = (*regoEnforcer)(nil)
@@ -111,7 +122,7 @@ func createRegoEnforcer(base64EncodedPolicy string,
 			return createOpenDoorEnforcer(base64EncodedPolicy, defaultMounts, privilegedMounts)
 		}
 
-		code, err = marshalRego(securityPolicy.AllowAll, containers, []ExternalProcessConfig{}, true, true, true)
+		code, err = marshalRego(securityPolicy.AllowAll, containers, []ExternalProcessConfig{}, []FragmentConfig{}, true, true, true)
 		if err != nil {
 			return nil, fmt.Errorf("error marshaling the policy to Rego: %w", err)
 		}
@@ -144,27 +155,44 @@ func newRegoPolicy(code string, defaultMounts []oci.Mount, privilegedMounts []oc
 		"plan9Prefix":      plan9Prefix,
 	}
 	policy.base64policy = ""
+	policy.debug = false
+	policy.modules = map[string]*module{
+		"policy.rego":    {namespace: "policy", code: policy.code},
+		"api.rego":       {namespace: "api", code: apiCode},
+		"framework.rego": {namespace: "framework", code: frameworkCode},
+	}
 
-	modules := map[string]string{
-		"policy.rego":    policy.code,
-		"api.rego":       apiCode,
-		"framework.rego": frameworkCode,
+	err := policy.compile()
+	if err != nil {
+		return nil, fmt.Errorf("rego compilation failed: %w", err)
+	}
+
+	return policy, nil
+}
+
+func (policy *regoEnforcer) compile() error {
+	if policy.compiledModules != nil {
+		return nil
+	}
+
+	modules := make(map[string]string)
+	for _, module := range policy.modules {
+		modules[module.namespace+".rego"] = module.code
 	}
 
 	// TODO temporary hack for debugging policies until GCS logging design
 	// and implementation is finalized. This option should be changed to
 	// "true" if debugging is desired.
 	options := ast.CompileOpts{
-		EnablePrintStatements: false,
+		EnablePrintStatements: policy.debug,
 	}
 
 	if compiled, err := ast.CompileModulesWithOpt(modules, options); err == nil {
 		policy.compiledModules = compiled
+		return nil
 	} else {
-		return nil, fmt.Errorf("rego compilation failed: %w", err)
+		return fmt.Errorf("rego compilation failed: %w", err)
 	}
-
-	return policy, nil
 }
 
 func (policy *regoEnforcer) allowed(enforcementPoint string, results map[string]interface{}) (bool, error) {
@@ -233,10 +261,18 @@ func (policy *regoEnforcer) query(enforcementPoint string, input map[string]inte
 	var buf bytes.Buffer
 	query := rego.New(
 		rego.Query(fmt.Sprintf("data.policy.%s", enforcementPoint)),
-		rego.Compiler(policy.compiledModules),
 		rego.Input(input),
 		rego.Store(store),
+		rego.EnablePrintStatements(policy.debug),
 		rego.PrintHook(topdown.NewPrintHook(&buf)))
+
+	if policy.compiledModules == nil {
+		for _, module := range policy.modules {
+			rego.Module(module.namespace, module.code)(query)
+		}
+	} else {
+		rego.Compiler(policy.compiledModules)(query)
+	}
 
 	ctx := context.Background()
 	resultSet, err := query.Eval(ctx)
@@ -433,6 +469,20 @@ func newMetadataOperation(operation interface{}) (*metadataOperation, error) {
 	return &metadataOp, nil
 }
 
+var reservedResultKeys = map[string]struct{}{
+	"allowed":    {},
+	"add_module": {},
+}
+
+func (policy *regoEnforcer) getMetadata(name string) (map[string]interface{}, error) {
+	metadata := policy.data["metadata"].(map[string]map[string]interface{})
+	if store, ok := metadata[name]; ok {
+		return store, nil
+	}
+
+	return nil, fmt.Errorf("unable to retrieve metadata store for %s", name)
+}
+
 func (policy *regoEnforcer) updateMetadata(results map[string]interface{}) error {
 	policy.mutex.Lock()
 	defer policy.mutex.Unlock()
@@ -440,7 +490,7 @@ func (policy *regoEnforcer) updateMetadata(results map[string]interface{}) error
 	// this is the top-level data namespace for metadata
 	metadata := policy.data["metadata"].(map[string]map[string]interface{})
 	for name, value := range results {
-		if name == "allowed" {
+		if _, ok := reservedResultKeys[name]; ok {
 			continue
 		}
 
@@ -491,27 +541,59 @@ func (policy *regoEnforcer) enforce(enforcementPoint string, input map[string]in
 		return err
 	}
 
+	removeModule := false
+	if enforcementPoint == "load_fragment" {
+		if addModule, ok := results["add_module"].(bool); ok {
+			if !addModule {
+				removeModule = true
+			}
+		} else {
+			removeModule = true
+		}
+	}
+
 	if allowed {
 		err = policy.updateMetadata(results)
 		if err != nil {
 			return fmt.Errorf("unable to update metadata: %w", err)
 		}
-		return nil
+	} else {
+		err = policy.getReasonNotAllowed(enforcementPoint, input)
 	}
 
+	if removeModule {
+		delete(policy.modules, moduleID(input["issuer"].(string), input["feed"].(string)))
+		if compileError := policy.compile(); compileError != nil {
+			return fmt.Errorf("post rule error: %v, was unable to re-compile module: %v", err, compileError)
+		}
+	}
+
+	return err
+}
+
+func errorString(errors interface{}) string {
+	errorArray := errors.([]interface{})
+	output := make([]string, len(errorArray))
+	for i, err := range errorArray {
+		output[i] = fmt.Sprintf("%v", err)
+	}
+	return strings.Join(output, ",")
+}
+
+func (policy *regoEnforcer) getReasonNotAllowed(enforcementPoint string, input map[string]interface{}) error {
 	inputJSON, err := json.Marshal(input)
 	if err != nil {
 		return fmt.Errorf("unable to marshal the Rego input data: %w", err)
 	}
 
 	input["rule"] = enforcementPoint
-	results, err = policy.query("reason", input)
+	results, err := policy.query("reason", input)
 	if err != nil {
 		return fmt.Errorf("%s not allowed by policy.\nInput: %s", enforcementPoint, string(inputJSON))
 	}
 
 	if errors, ok := results["errors"]; ok {
-		return fmt.Errorf("%s not allowed by policy. Errors: %v.\nInput: %s", enforcementPoint, errors, string(inputJSON))
+		return fmt.Errorf("%s not allowed by policy. Errors: %v.\nInput: %s", enforcementPoint, errorString(errors), string(inputJSON))
 	} else {
 		return fmt.Errorf("%s not allowed by policy.\nInput: %s", enforcementPoint, string(inputJSON))
 	}
@@ -684,4 +766,48 @@ func (policy *regoEnforcer) EnforceRuntimeLoggingPolicy() error {
 	input := map[string]interface{}{}
 
 	return policy.enforce("runtime_logging", input)
+}
+
+func moduleID(issuer string, feed string) string {
+	return fmt.Sprintf("%s>%s", issuer, feed)
+}
+
+func (f module) id() string {
+	return moduleID(f.issuer, f.feed)
+}
+
+func parseNamespace(rego string) (string, error) {
+	lines := strings.Split(rego, "\n")
+	parts := strings.Split(lines[0], " ")
+	if parts[0] != "package" {
+		return "", errors.New("package definition required on first line")
+	}
+
+	namespace := parts[1]
+	return namespace, nil
+}
+
+func (policy *regoEnforcer) LoadFragment(issuer string, feed string, rego string) error {
+	namespace, err := parseNamespace(rego)
+	if err != nil {
+		return fmt.Errorf("unable to load fragment: %w", err)
+	}
+
+	fragment := module{
+		issuer:    issuer,
+		feed:      feed,
+		code:      rego,
+		namespace: namespace,
+	}
+
+	policy.modules[fragment.id()] = &fragment
+	policy.compiledModules = nil
+
+	input := map[string]interface{}{
+		"issuer":    issuer,
+		"feed":      feed,
+		"namespace": namespace,
+	}
+
+	return policy.enforce("load_fragment", input)
 }

--- a/test/cri-containerd/policy_test.go
+++ b/test/cri-containerd/policy_test.go
@@ -28,11 +28,9 @@ func securityPolicyFromContainers(policyType string, containers []securitypolicy
 	if err != nil {
 		return "", err
 	}
-	policyString, err := securitypolicy.MarshalPolicy(
-		policyType,
-		false,
-		pc,
+	policyString, err := securitypolicy.MarshalPolicy(policyType, false, pc,
 		[]securitypolicy.ExternalProcessConfig{},
+		[]securitypolicy.FragmentConfig{},
 		true,
 		true,
 		true)

--- a/test/go.sum
+++ b/test/go.sum
@@ -167,6 +167,8 @@ github.com/bkielbasa/cyclop v1.2.0/go.mod h1:qOI0yy6A7dYC4Zgsa72Ppm9kONl0RoIlPbz
 github.com/blang/semver v3.1.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
+github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
+github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/blizzy78/varnamelen v0.3.0/go.mod h1:hbwRdBvoBqxk34XyQ6HA0UH3G0/1TKuv5AC4eaBT0Ec=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
 github.com/bombsimon/wsl/v3 v3.3.0/go.mod h1:st10JtZYLE4D5sC7b8xV4zTKZwAQjCH/Hy2Pm1FNZIc=

--- a/vendor/github.com/blang/semver/v4/LICENSE
+++ b/vendor/github.com/blang/semver/v4/LICENSE
@@ -1,0 +1,22 @@
+The MIT License
+
+Copyright (c) 2014 Benedikt Lang <github at benediktlang.de>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+

--- a/vendor/github.com/blang/semver/v4/json.go
+++ b/vendor/github.com/blang/semver/v4/json.go
@@ -1,0 +1,23 @@
+package semver
+
+import (
+	"encoding/json"
+)
+
+// MarshalJSON implements the encoding/json.Marshaler interface.
+func (v Version) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.String())
+}
+
+// UnmarshalJSON implements the encoding/json.Unmarshaler interface.
+func (v *Version) UnmarshalJSON(data []byte) (err error) {
+	var versionString string
+
+	if err = json.Unmarshal(data, &versionString); err != nil {
+		return
+	}
+
+	*v, err = Parse(versionString)
+
+	return
+}

--- a/vendor/github.com/blang/semver/v4/range.go
+++ b/vendor/github.com/blang/semver/v4/range.go
@@ -1,0 +1,416 @@
+package semver
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"unicode"
+)
+
+type wildcardType int
+
+const (
+	noneWildcard  wildcardType = iota
+	majorWildcard wildcardType = 1
+	minorWildcard wildcardType = 2
+	patchWildcard wildcardType = 3
+)
+
+func wildcardTypefromInt(i int) wildcardType {
+	switch i {
+	case 1:
+		return majorWildcard
+	case 2:
+		return minorWildcard
+	case 3:
+		return patchWildcard
+	default:
+		return noneWildcard
+	}
+}
+
+type comparator func(Version, Version) bool
+
+var (
+	compEQ comparator = func(v1 Version, v2 Version) bool {
+		return v1.Compare(v2) == 0
+	}
+	compNE = func(v1 Version, v2 Version) bool {
+		return v1.Compare(v2) != 0
+	}
+	compGT = func(v1 Version, v2 Version) bool {
+		return v1.Compare(v2) == 1
+	}
+	compGE = func(v1 Version, v2 Version) bool {
+		return v1.Compare(v2) >= 0
+	}
+	compLT = func(v1 Version, v2 Version) bool {
+		return v1.Compare(v2) == -1
+	}
+	compLE = func(v1 Version, v2 Version) bool {
+		return v1.Compare(v2) <= 0
+	}
+)
+
+type versionRange struct {
+	v Version
+	c comparator
+}
+
+// rangeFunc creates a Range from the given versionRange.
+func (vr *versionRange) rangeFunc() Range {
+	return Range(func(v Version) bool {
+		return vr.c(v, vr.v)
+	})
+}
+
+// Range represents a range of versions.
+// A Range can be used to check if a Version satisfies it:
+//
+//     range, err := semver.ParseRange(">1.0.0 <2.0.0")
+//     range(semver.MustParse("1.1.1") // returns true
+type Range func(Version) bool
+
+// OR combines the existing Range with another Range using logical OR.
+func (rf Range) OR(f Range) Range {
+	return Range(func(v Version) bool {
+		return rf(v) || f(v)
+	})
+}
+
+// AND combines the existing Range with another Range using logical AND.
+func (rf Range) AND(f Range) Range {
+	return Range(func(v Version) bool {
+		return rf(v) && f(v)
+	})
+}
+
+// ParseRange parses a range and returns a Range.
+// If the range could not be parsed an error is returned.
+//
+// Valid ranges are:
+//   - "<1.0.0"
+//   - "<=1.0.0"
+//   - ">1.0.0"
+//   - ">=1.0.0"
+//   - "1.0.0", "=1.0.0", "==1.0.0"
+//   - "!1.0.0", "!=1.0.0"
+//
+// A Range can consist of multiple ranges separated by space:
+// Ranges can be linked by logical AND:
+//   - ">1.0.0 <2.0.0" would match between both ranges, so "1.1.1" and "1.8.7" but not "1.0.0" or "2.0.0"
+//   - ">1.0.0 <3.0.0 !2.0.3-beta.2" would match every version between 1.0.0 and 3.0.0 except 2.0.3-beta.2
+//
+// Ranges can also be linked by logical OR:
+//   - "<2.0.0 || >=3.0.0" would match "1.x.x" and "3.x.x" but not "2.x.x"
+//
+// AND has a higher precedence than OR. It's not possible to use brackets.
+//
+// Ranges can be combined by both AND and OR
+//
+//  - `>1.0.0 <2.0.0 || >3.0.0 !4.2.1` would match `1.2.3`, `1.9.9`, `3.1.1`, but not `4.2.1`, `2.1.1`
+func ParseRange(s string) (Range, error) {
+	parts := splitAndTrim(s)
+	orParts, err := splitORParts(parts)
+	if err != nil {
+		return nil, err
+	}
+	expandedParts, err := expandWildcardVersion(orParts)
+	if err != nil {
+		return nil, err
+	}
+	var orFn Range
+	for _, p := range expandedParts {
+		var andFn Range
+		for _, ap := range p {
+			opStr, vStr, err := splitComparatorVersion(ap)
+			if err != nil {
+				return nil, err
+			}
+			vr, err := buildVersionRange(opStr, vStr)
+			if err != nil {
+				return nil, fmt.Errorf("Could not parse Range %q: %s", ap, err)
+			}
+			rf := vr.rangeFunc()
+
+			// Set function
+			if andFn == nil {
+				andFn = rf
+			} else { // Combine with existing function
+				andFn = andFn.AND(rf)
+			}
+		}
+		if orFn == nil {
+			orFn = andFn
+		} else {
+			orFn = orFn.OR(andFn)
+		}
+
+	}
+	return orFn, nil
+}
+
+// splitORParts splits the already cleaned parts by '||'.
+// Checks for invalid positions of the operator and returns an
+// error if found.
+func splitORParts(parts []string) ([][]string, error) {
+	var ORparts [][]string
+	last := 0
+	for i, p := range parts {
+		if p == "||" {
+			if i == 0 {
+				return nil, fmt.Errorf("First element in range is '||'")
+			}
+			ORparts = append(ORparts, parts[last:i])
+			last = i + 1
+		}
+	}
+	if last == len(parts) {
+		return nil, fmt.Errorf("Last element in range is '||'")
+	}
+	ORparts = append(ORparts, parts[last:])
+	return ORparts, nil
+}
+
+// buildVersionRange takes a slice of 2: operator and version
+// and builds a versionRange, otherwise an error.
+func buildVersionRange(opStr, vStr string) (*versionRange, error) {
+	c := parseComparator(opStr)
+	if c == nil {
+		return nil, fmt.Errorf("Could not parse comparator %q in %q", opStr, strings.Join([]string{opStr, vStr}, ""))
+	}
+	v, err := Parse(vStr)
+	if err != nil {
+		return nil, fmt.Errorf("Could not parse version %q in %q: %s", vStr, strings.Join([]string{opStr, vStr}, ""), err)
+	}
+
+	return &versionRange{
+		v: v,
+		c: c,
+	}, nil
+
+}
+
+// inArray checks if a byte is contained in an array of bytes
+func inArray(s byte, list []byte) bool {
+	for _, el := range list {
+		if el == s {
+			return true
+		}
+	}
+	return false
+}
+
+// splitAndTrim splits a range string by spaces and cleans whitespaces
+func splitAndTrim(s string) (result []string) {
+	last := 0
+	var lastChar byte
+	excludeFromSplit := []byte{'>', '<', '='}
+	for i := 0; i < len(s); i++ {
+		if s[i] == ' ' && !inArray(lastChar, excludeFromSplit) {
+			if last < i-1 {
+				result = append(result, s[last:i])
+			}
+			last = i + 1
+		} else if s[i] != ' ' {
+			lastChar = s[i]
+		}
+	}
+	if last < len(s)-1 {
+		result = append(result, s[last:])
+	}
+
+	for i, v := range result {
+		result[i] = strings.Replace(v, " ", "", -1)
+	}
+
+	// parts := strings.Split(s, " ")
+	// for _, x := range parts {
+	// 	if s := strings.TrimSpace(x); len(s) != 0 {
+	// 		result = append(result, s)
+	// 	}
+	// }
+	return
+}
+
+// splitComparatorVersion splits the comparator from the version.
+// Input must be free of leading or trailing spaces.
+func splitComparatorVersion(s string) (string, string, error) {
+	i := strings.IndexFunc(s, unicode.IsDigit)
+	if i == -1 {
+		return "", "", fmt.Errorf("Could not get version from string: %q", s)
+	}
+	return strings.TrimSpace(s[0:i]), s[i:], nil
+}
+
+// getWildcardType will return the type of wildcard that the
+// passed version contains
+func getWildcardType(vStr string) wildcardType {
+	parts := strings.Split(vStr, ".")
+	nparts := len(parts)
+	wildcard := parts[nparts-1]
+
+	possibleWildcardType := wildcardTypefromInt(nparts)
+	if wildcard == "x" {
+		return possibleWildcardType
+	}
+
+	return noneWildcard
+}
+
+// createVersionFromWildcard will convert a wildcard version
+// into a regular version, replacing 'x's with '0's, handling
+// special cases like '1.x.x' and '1.x'
+func createVersionFromWildcard(vStr string) string {
+	// handle 1.x.x
+	vStr2 := strings.Replace(vStr, ".x.x", ".x", 1)
+	vStr2 = strings.Replace(vStr2, ".x", ".0", 1)
+	parts := strings.Split(vStr2, ".")
+
+	// handle 1.x
+	if len(parts) == 2 {
+		return vStr2 + ".0"
+	}
+
+	return vStr2
+}
+
+// incrementMajorVersion will increment the major version
+// of the passed version
+func incrementMajorVersion(vStr string) (string, error) {
+	parts := strings.Split(vStr, ".")
+	i, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return "", err
+	}
+	parts[0] = strconv.Itoa(i + 1)
+
+	return strings.Join(parts, "."), nil
+}
+
+// incrementMajorVersion will increment the minor version
+// of the passed version
+func incrementMinorVersion(vStr string) (string, error) {
+	parts := strings.Split(vStr, ".")
+	i, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return "", err
+	}
+	parts[1] = strconv.Itoa(i + 1)
+
+	return strings.Join(parts, "."), nil
+}
+
+// expandWildcardVersion will expand wildcards inside versions
+// following these rules:
+//
+// * when dealing with patch wildcards:
+// >= 1.2.x    will become    >= 1.2.0
+// <= 1.2.x    will become    <  1.3.0
+// >  1.2.x    will become    >= 1.3.0
+// <  1.2.x    will become    <  1.2.0
+// != 1.2.x    will become    <  1.2.0 >= 1.3.0
+//
+// * when dealing with minor wildcards:
+// >= 1.x      will become    >= 1.0.0
+// <= 1.x      will become    <  2.0.0
+// >  1.x      will become    >= 2.0.0
+// <  1.0      will become    <  1.0.0
+// != 1.x      will become    <  1.0.0 >= 2.0.0
+//
+// * when dealing with wildcards without
+// version operator:
+// 1.2.x       will become    >= 1.2.0 < 1.3.0
+// 1.x         will become    >= 1.0.0 < 2.0.0
+func expandWildcardVersion(parts [][]string) ([][]string, error) {
+	var expandedParts [][]string
+	for _, p := range parts {
+		var newParts []string
+		for _, ap := range p {
+			if strings.Contains(ap, "x") {
+				opStr, vStr, err := splitComparatorVersion(ap)
+				if err != nil {
+					return nil, err
+				}
+
+				versionWildcardType := getWildcardType(vStr)
+				flatVersion := createVersionFromWildcard(vStr)
+
+				var resultOperator string
+				var shouldIncrementVersion bool
+				switch opStr {
+				case ">":
+					resultOperator = ">="
+					shouldIncrementVersion = true
+				case ">=":
+					resultOperator = ">="
+				case "<":
+					resultOperator = "<"
+				case "<=":
+					resultOperator = "<"
+					shouldIncrementVersion = true
+				case "", "=", "==":
+					newParts = append(newParts, ">="+flatVersion)
+					resultOperator = "<"
+					shouldIncrementVersion = true
+				case "!=", "!":
+					newParts = append(newParts, "<"+flatVersion)
+					resultOperator = ">="
+					shouldIncrementVersion = true
+				}
+
+				var resultVersion string
+				if shouldIncrementVersion {
+					switch versionWildcardType {
+					case patchWildcard:
+						resultVersion, _ = incrementMinorVersion(flatVersion)
+					case minorWildcard:
+						resultVersion, _ = incrementMajorVersion(flatVersion)
+					}
+				} else {
+					resultVersion = flatVersion
+				}
+
+				ap = resultOperator + resultVersion
+			}
+			newParts = append(newParts, ap)
+		}
+		expandedParts = append(expandedParts, newParts)
+	}
+
+	return expandedParts, nil
+}
+
+func parseComparator(s string) comparator {
+	switch s {
+	case "==":
+		fallthrough
+	case "":
+		fallthrough
+	case "=":
+		return compEQ
+	case ">":
+		return compGT
+	case ">=":
+		return compGE
+	case "<":
+		return compLT
+	case "<=":
+		return compLE
+	case "!":
+		fallthrough
+	case "!=":
+		return compNE
+	}
+
+	return nil
+}
+
+// MustParseRange is like ParseRange but panics if the range cannot be parsed.
+func MustParseRange(s string) Range {
+	r, err := ParseRange(s)
+	if err != nil {
+		panic(`semver: ParseRange(` + s + `): ` + err.Error())
+	}
+	return r
+}

--- a/vendor/github.com/blang/semver/v4/semver.go
+++ b/vendor/github.com/blang/semver/v4/semver.go
@@ -1,0 +1,476 @@
+package semver
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+const (
+	numbers  string = "0123456789"
+	alphas          = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ-"
+	alphanum        = alphas + numbers
+)
+
+// SpecVersion is the latest fully supported spec version of semver
+var SpecVersion = Version{
+	Major: 2,
+	Minor: 0,
+	Patch: 0,
+}
+
+// Version represents a semver compatible version
+type Version struct {
+	Major uint64
+	Minor uint64
+	Patch uint64
+	Pre   []PRVersion
+	Build []string //No Precedence
+}
+
+// Version to string
+func (v Version) String() string {
+	b := make([]byte, 0, 5)
+	b = strconv.AppendUint(b, v.Major, 10)
+	b = append(b, '.')
+	b = strconv.AppendUint(b, v.Minor, 10)
+	b = append(b, '.')
+	b = strconv.AppendUint(b, v.Patch, 10)
+
+	if len(v.Pre) > 0 {
+		b = append(b, '-')
+		b = append(b, v.Pre[0].String()...)
+
+		for _, pre := range v.Pre[1:] {
+			b = append(b, '.')
+			b = append(b, pre.String()...)
+		}
+	}
+
+	if len(v.Build) > 0 {
+		b = append(b, '+')
+		b = append(b, v.Build[0]...)
+
+		for _, build := range v.Build[1:] {
+			b = append(b, '.')
+			b = append(b, build...)
+		}
+	}
+
+	return string(b)
+}
+
+// FinalizeVersion discards prerelease and build number and only returns
+// major, minor and patch number.
+func (v Version) FinalizeVersion() string {
+	b := make([]byte, 0, 5)
+	b = strconv.AppendUint(b, v.Major, 10)
+	b = append(b, '.')
+	b = strconv.AppendUint(b, v.Minor, 10)
+	b = append(b, '.')
+	b = strconv.AppendUint(b, v.Patch, 10)
+	return string(b)
+}
+
+// Equals checks if v is equal to o.
+func (v Version) Equals(o Version) bool {
+	return (v.Compare(o) == 0)
+}
+
+// EQ checks if v is equal to o.
+func (v Version) EQ(o Version) bool {
+	return (v.Compare(o) == 0)
+}
+
+// NE checks if v is not equal to o.
+func (v Version) NE(o Version) bool {
+	return (v.Compare(o) != 0)
+}
+
+// GT checks if v is greater than o.
+func (v Version) GT(o Version) bool {
+	return (v.Compare(o) == 1)
+}
+
+// GTE checks if v is greater than or equal to o.
+func (v Version) GTE(o Version) bool {
+	return (v.Compare(o) >= 0)
+}
+
+// GE checks if v is greater than or equal to o.
+func (v Version) GE(o Version) bool {
+	return (v.Compare(o) >= 0)
+}
+
+// LT checks if v is less than o.
+func (v Version) LT(o Version) bool {
+	return (v.Compare(o) == -1)
+}
+
+// LTE checks if v is less than or equal to o.
+func (v Version) LTE(o Version) bool {
+	return (v.Compare(o) <= 0)
+}
+
+// LE checks if v is less than or equal to o.
+func (v Version) LE(o Version) bool {
+	return (v.Compare(o) <= 0)
+}
+
+// Compare compares Versions v to o:
+// -1 == v is less than o
+// 0 == v is equal to o
+// 1 == v is greater than o
+func (v Version) Compare(o Version) int {
+	if v.Major != o.Major {
+		if v.Major > o.Major {
+			return 1
+		}
+		return -1
+	}
+	if v.Minor != o.Minor {
+		if v.Minor > o.Minor {
+			return 1
+		}
+		return -1
+	}
+	if v.Patch != o.Patch {
+		if v.Patch > o.Patch {
+			return 1
+		}
+		return -1
+	}
+
+	// Quick comparison if a version has no prerelease versions
+	if len(v.Pre) == 0 && len(o.Pre) == 0 {
+		return 0
+	} else if len(v.Pre) == 0 && len(o.Pre) > 0 {
+		return 1
+	} else if len(v.Pre) > 0 && len(o.Pre) == 0 {
+		return -1
+	}
+
+	i := 0
+	for ; i < len(v.Pre) && i < len(o.Pre); i++ {
+		if comp := v.Pre[i].Compare(o.Pre[i]); comp == 0 {
+			continue
+		} else if comp == 1 {
+			return 1
+		} else {
+			return -1
+		}
+	}
+
+	// If all pr versions are the equal but one has further prversion, this one greater
+	if i == len(v.Pre) && i == len(o.Pre) {
+		return 0
+	} else if i == len(v.Pre) && i < len(o.Pre) {
+		return -1
+	} else {
+		return 1
+	}
+
+}
+
+// IncrementPatch increments the patch version
+func (v *Version) IncrementPatch() error {
+	v.Patch++
+	return nil
+}
+
+// IncrementMinor increments the minor version
+func (v *Version) IncrementMinor() error {
+	v.Minor++
+	v.Patch = 0
+	return nil
+}
+
+// IncrementMajor increments the major version
+func (v *Version) IncrementMajor() error {
+	v.Major++
+	v.Minor = 0
+	v.Patch = 0
+	return nil
+}
+
+// Validate validates v and returns error in case
+func (v Version) Validate() error {
+	// Major, Minor, Patch already validated using uint64
+
+	for _, pre := range v.Pre {
+		if !pre.IsNum { //Numeric prerelease versions already uint64
+			if len(pre.VersionStr) == 0 {
+				return fmt.Errorf("Prerelease can not be empty %q", pre.VersionStr)
+			}
+			if !containsOnly(pre.VersionStr, alphanum) {
+				return fmt.Errorf("Invalid character(s) found in prerelease %q", pre.VersionStr)
+			}
+		}
+	}
+
+	for _, build := range v.Build {
+		if len(build) == 0 {
+			return fmt.Errorf("Build meta data can not be empty %q", build)
+		}
+		if !containsOnly(build, alphanum) {
+			return fmt.Errorf("Invalid character(s) found in build meta data %q", build)
+		}
+	}
+
+	return nil
+}
+
+// New is an alias for Parse and returns a pointer, parses version string and returns a validated Version or error
+func New(s string) (*Version, error) {
+	v, err := Parse(s)
+	vp := &v
+	return vp, err
+}
+
+// Make is an alias for Parse, parses version string and returns a validated Version or error
+func Make(s string) (Version, error) {
+	return Parse(s)
+}
+
+// ParseTolerant allows for certain version specifications that do not strictly adhere to semver
+// specs to be parsed by this library. It does so by normalizing versions before passing them to
+// Parse(). It currently trims spaces, removes a "v" prefix, adds a 0 patch number to versions
+// with only major and minor components specified, and removes leading 0s.
+func ParseTolerant(s string) (Version, error) {
+	s = strings.TrimSpace(s)
+	s = strings.TrimPrefix(s, "v")
+
+	// Split into major.minor.(patch+pr+meta)
+	parts := strings.SplitN(s, ".", 3)
+	// Remove leading zeros.
+	for i, p := range parts {
+		if len(p) > 1 {
+			p = strings.TrimLeft(p, "0")
+			if len(p) == 0 || !strings.ContainsAny(p[0:1], "0123456789") {
+				p = "0" + p
+			}
+			parts[i] = p
+		}
+	}
+	// Fill up shortened versions.
+	if len(parts) < 3 {
+		if strings.ContainsAny(parts[len(parts)-1], "+-") {
+			return Version{}, errors.New("Short version cannot contain PreRelease/Build meta data")
+		}
+		for len(parts) < 3 {
+			parts = append(parts, "0")
+		}
+	}
+	s = strings.Join(parts, ".")
+
+	return Parse(s)
+}
+
+// Parse parses version string and returns a validated Version or error
+func Parse(s string) (Version, error) {
+	if len(s) == 0 {
+		return Version{}, errors.New("Version string empty")
+	}
+
+	// Split into major.minor.(patch+pr+meta)
+	parts := strings.SplitN(s, ".", 3)
+	if len(parts) != 3 {
+		return Version{}, errors.New("No Major.Minor.Patch elements found")
+	}
+
+	// Major
+	if !containsOnly(parts[0], numbers) {
+		return Version{}, fmt.Errorf("Invalid character(s) found in major number %q", parts[0])
+	}
+	if hasLeadingZeroes(parts[0]) {
+		return Version{}, fmt.Errorf("Major number must not contain leading zeroes %q", parts[0])
+	}
+	major, err := strconv.ParseUint(parts[0], 10, 64)
+	if err != nil {
+		return Version{}, err
+	}
+
+	// Minor
+	if !containsOnly(parts[1], numbers) {
+		return Version{}, fmt.Errorf("Invalid character(s) found in minor number %q", parts[1])
+	}
+	if hasLeadingZeroes(parts[1]) {
+		return Version{}, fmt.Errorf("Minor number must not contain leading zeroes %q", parts[1])
+	}
+	minor, err := strconv.ParseUint(parts[1], 10, 64)
+	if err != nil {
+		return Version{}, err
+	}
+
+	v := Version{}
+	v.Major = major
+	v.Minor = minor
+
+	var build, prerelease []string
+	patchStr := parts[2]
+
+	if buildIndex := strings.IndexRune(patchStr, '+'); buildIndex != -1 {
+		build = strings.Split(patchStr[buildIndex+1:], ".")
+		patchStr = patchStr[:buildIndex]
+	}
+
+	if preIndex := strings.IndexRune(patchStr, '-'); preIndex != -1 {
+		prerelease = strings.Split(patchStr[preIndex+1:], ".")
+		patchStr = patchStr[:preIndex]
+	}
+
+	if !containsOnly(patchStr, numbers) {
+		return Version{}, fmt.Errorf("Invalid character(s) found in patch number %q", patchStr)
+	}
+	if hasLeadingZeroes(patchStr) {
+		return Version{}, fmt.Errorf("Patch number must not contain leading zeroes %q", patchStr)
+	}
+	patch, err := strconv.ParseUint(patchStr, 10, 64)
+	if err != nil {
+		return Version{}, err
+	}
+
+	v.Patch = patch
+
+	// Prerelease
+	for _, prstr := range prerelease {
+		parsedPR, err := NewPRVersion(prstr)
+		if err != nil {
+			return Version{}, err
+		}
+		v.Pre = append(v.Pre, parsedPR)
+	}
+
+	// Build meta data
+	for _, str := range build {
+		if len(str) == 0 {
+			return Version{}, errors.New("Build meta data is empty")
+		}
+		if !containsOnly(str, alphanum) {
+			return Version{}, fmt.Errorf("Invalid character(s) found in build meta data %q", str)
+		}
+		v.Build = append(v.Build, str)
+	}
+
+	return v, nil
+}
+
+// MustParse is like Parse but panics if the version cannot be parsed.
+func MustParse(s string) Version {
+	v, err := Parse(s)
+	if err != nil {
+		panic(`semver: Parse(` + s + `): ` + err.Error())
+	}
+	return v
+}
+
+// PRVersion represents a PreRelease Version
+type PRVersion struct {
+	VersionStr string
+	VersionNum uint64
+	IsNum      bool
+}
+
+// NewPRVersion creates a new valid prerelease version
+func NewPRVersion(s string) (PRVersion, error) {
+	if len(s) == 0 {
+		return PRVersion{}, errors.New("Prerelease is empty")
+	}
+	v := PRVersion{}
+	if containsOnly(s, numbers) {
+		if hasLeadingZeroes(s) {
+			return PRVersion{}, fmt.Errorf("Numeric PreRelease version must not contain leading zeroes %q", s)
+		}
+		num, err := strconv.ParseUint(s, 10, 64)
+
+		// Might never be hit, but just in case
+		if err != nil {
+			return PRVersion{}, err
+		}
+		v.VersionNum = num
+		v.IsNum = true
+	} else if containsOnly(s, alphanum) {
+		v.VersionStr = s
+		v.IsNum = false
+	} else {
+		return PRVersion{}, fmt.Errorf("Invalid character(s) found in prerelease %q", s)
+	}
+	return v, nil
+}
+
+// IsNumeric checks if prerelease-version is numeric
+func (v PRVersion) IsNumeric() bool {
+	return v.IsNum
+}
+
+// Compare compares two PreRelease Versions v and o:
+// -1 == v is less than o
+// 0 == v is equal to o
+// 1 == v is greater than o
+func (v PRVersion) Compare(o PRVersion) int {
+	if v.IsNum && !o.IsNum {
+		return -1
+	} else if !v.IsNum && o.IsNum {
+		return 1
+	} else if v.IsNum && o.IsNum {
+		if v.VersionNum == o.VersionNum {
+			return 0
+		} else if v.VersionNum > o.VersionNum {
+			return 1
+		} else {
+			return -1
+		}
+	} else { // both are Alphas
+		if v.VersionStr == o.VersionStr {
+			return 0
+		} else if v.VersionStr > o.VersionStr {
+			return 1
+		} else {
+			return -1
+		}
+	}
+}
+
+// PreRelease version to string
+func (v PRVersion) String() string {
+	if v.IsNum {
+		return strconv.FormatUint(v.VersionNum, 10)
+	}
+	return v.VersionStr
+}
+
+func containsOnly(s string, set string) bool {
+	return strings.IndexFunc(s, func(r rune) bool {
+		return !strings.ContainsRune(set, r)
+	}) == -1
+}
+
+func hasLeadingZeroes(s string) bool {
+	return len(s) > 1 && s[0] == '0'
+}
+
+// NewBuildVersion creates a new valid build version
+func NewBuildVersion(s string) (string, error) {
+	if len(s) == 0 {
+		return "", errors.New("Buildversion is empty")
+	}
+	if !containsOnly(s, alphanum) {
+		return "", fmt.Errorf("Invalid character(s) found in build meta data %q", s)
+	}
+	return s, nil
+}
+
+// FinalizeVersion returns the major, minor and patch number only and discards
+// prerelease and build number.
+func FinalizeVersion(s string) (string, error) {
+	v, err := Parse(s)
+	if err != nil {
+		return "", err
+	}
+	v.Pre = nil
+	v.Build = nil
+
+	finalVer := v.String()
+	return finalVer, nil
+}

--- a/vendor/github.com/blang/semver/v4/sort.go
+++ b/vendor/github.com/blang/semver/v4/sort.go
@@ -1,0 +1,28 @@
+package semver
+
+import (
+	"sort"
+)
+
+// Versions represents multiple versions.
+type Versions []Version
+
+// Len returns length of version collection
+func (s Versions) Len() int {
+	return len(s)
+}
+
+// Swap swaps two versions inside the collection by its indices
+func (s Versions) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+// Less checks if version at index i is less than version at index j
+func (s Versions) Less(i, j int) bool {
+	return s[i].LT(s[j])
+}
+
+// Sort sorts a slice of versions
+func Sort(versions []Version) {
+	sort.Sort(Versions(versions))
+}

--- a/vendor/github.com/blang/semver/v4/sql.go
+++ b/vendor/github.com/blang/semver/v4/sql.go
@@ -1,0 +1,30 @@
+package semver
+
+import (
+	"database/sql/driver"
+	"fmt"
+)
+
+// Scan implements the database/sql.Scanner interface.
+func (v *Version) Scan(src interface{}) (err error) {
+	var str string
+	switch src := src.(type) {
+	case string:
+		str = src
+	case []byte:
+		str = string(src)
+	default:
+		return fmt.Errorf("version.Scan: cannot convert %T to string", src)
+	}
+
+	if t, err := Parse(str); err == nil {
+		*v = t
+	}
+
+	return
+}
+
+// Value implements the database/sql/driver.Valuer interface.
+func (v Version) Value() (driver.Value, error) {
+	return v.String(), nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -24,6 +24,9 @@ github.com/agnivade/levenshtein
 github.com/akavel/rsrc/binutil
 github.com/akavel/rsrc/coff
 github.com/akavel/rsrc/ico
+# github.com/blang/semver/v4 v4.0.0
+## explicit; go 1.14
+github.com/blang/semver/v4
 # github.com/cenkalti/backoff/v4 v4.1.3
 ## explicit; go 1.13
 github.com/cenkalti/backoff/v4


### PR DESCRIPTION
This PR adds the ability for an authored security policy to be expanded at runtime with policy fragments. It focuses purely on the policy enforcement aspect, which assumes that the fragments which the guest is asking to load have been verified to have been obtained from the issuer and feed specified.

The `load_fragment` enforcement point takes an input with the following members:

``` json
{
    "issuer": "<identifier for the issuer>",
    "feed": "<feed endpoint>"
}
```

Also, for the purpose of this call, the fragment is loaded as a module. The result is of the form:

``` json
{
    "allowed": true
    "add_module": true
}
```

If the value of `add_module` is `true`, then the fragment will continue to be loaded as a module for all future executions.

In the case that the authored security policy uses the framework, there are a variety of ways in which a policy can quickly and easily incorporate elements from fragments.  First, the policy defines a list of `fragments` which they are willing to include:

``` rego
fragments := [
    {
        "iss": "<DID for issuer>",
        "feed": "<feed endpoint>",
        "minimum_svn": "<semantic version>",
        "includes": [<one or more of "containers"|"fragments"|"external_processes"|"namespace">]
    },
    # ...other fragments
]
```

This allows the author to quickly indicate the fragments they are willing to use, what minimum version of that fragment is required, and further specify what to include:

- `containers`: include all of the containers in the fragment for use in policy enforcement
- `fragments`: include all of the fragments in the fragment. This allows fragments to themselves include fragments (with the policy author's explicit consent)
- `external_processes`: include the external processes from the fragment
- `namespace`: this indicates that `add_module` should be set to true

For most common use cases, this means that the fragment only needs to be loaded once (during the call to `load_fragment`) so that the included entities can be extracted, after which the policy can execute without them.