### PR TITLE
Adding GetProperties policy enforcement point.

### DIFF
--- a/internal/tools/securitypolicy/main.go
+++ b/internal/tools/securitypolicy/main.go
@@ -45,7 +45,7 @@ func main() {
 			return err
 		}
 
-		policyCode, err := securitypolicy.MarshalPolicy(*outputType, config.AllowAll, policyContainers, config.ExternalProcesses)
+		policyCode, err := securitypolicy.MarshalPolicy(*outputType, config.AllowAll, policyContainers, config.ExternalProcesses, config.AllowPropertiesAccess)
 		if err != nil {
 			return err
 		}

--- a/pkg/securitypolicy/api.rego
+++ b/pkg/securitypolicy/api.rego
@@ -1,6 +1,6 @@
 package api
 
-svn := "0.6.0"
+svn := "0.7.0"
 
 enforcement_points := {
     "mount_device": {"introducedVersion": "0.1.0", "allowedByDefault": false},
@@ -14,4 +14,5 @@ enforcement_points := {
     "signal_container_process": {"introducedVersion": "0.5.0", "allowedByDefault": true},
     "plan9_mount": {"introducedVersion": "0.6.0", "allowedByDefault": true},
     "plan9_unmount": {"introducedVersion": "0.6.0", "allowedByDefault": true},
+    "get_properties": {"introducedVersion": "0.7.0", "allowedByDefault": true},
 }

--- a/pkg/securitypolicy/framework.rego
+++ b/pkg/securitypolicy/framework.rego
@@ -342,6 +342,12 @@ exec_external := {"allowed": true} {
     workingDirectory_ok(process.working_dir)
 }
 
+default get_properties := {"allowed": false}
+
+get_properties := {"allowed": true} {
+    data.policy.allow_properties_access
+}
+
 # error messages
 
 errors["deviceHash not found"] {

--- a/pkg/securitypolicy/open_door.rego
+++ b/pkg/securitypolicy/open_door.rego
@@ -1,6 +1,6 @@
 package policy
 
-api_svn := "0.6.0"
+api_svn := "0.7.0"
 
 mount_device := {"allowed": true}
 mount_overlay := {"allowed": true}
@@ -13,3 +13,4 @@ shutdown_container := {"allowed": true}
 signal_container_process := {"allowed": true}
 plan9_mount := {"allowed": true}
 plan9_unmount := {"allowed": true}
+get_properties := {"allowed": true}

--- a/pkg/securitypolicy/policy.rego
+++ b/pkg/securitypolicy/policy.rego
@@ -1,6 +1,6 @@
 package policy
 
-api_svn := "0.6.0"
+api_svn := "0.7.0"
 
 import future.keywords.every
 import future.keywords.in
@@ -18,4 +18,5 @@ shutdown_container := data.framework.shutdown_container
 signal_container_process := data.framework.signal_container_process
 plan9_mount := data.framework.plan9_mount
 plan9_unmount := data.framework.plan9_unmount
+get_properties := data.framework.get_properties
 reason := {"errors": data.framework.errors}

--- a/pkg/securitypolicy/securitypolicy.go
+++ b/pkg/securitypolicy/securitypolicy.go
@@ -25,9 +25,10 @@ const (
 
 // PolicyConfig contains toml or JSON config for security policy.
 type PolicyConfig struct {
-	AllowAll          bool                    `json:"allow_all" toml:"allow_all"`
-	Containers        []ContainerConfig       `json:"containers" toml:"container"`
-	ExternalProcesses []ExternalProcessConfig `json:"external_processes" toml:"external_process"`
+	AllowAll              bool                    `json:"allow_all" toml:"allow_all"`
+	Containers            []ContainerConfig       `json:"containers" toml:"container"`
+	ExternalProcesses     []ExternalProcessConfig `json:"external_processes" toml:"external_process"`
+	AllowPropertiesAccess bool                    `json:"allow_properties_access" toml:"allow_properties_access"`
 }
 
 // ExternalProcessConfig contains toml or JSON config for running external processes in the UVM.

--- a/pkg/securitypolicy/securitypolicy_internal.go
+++ b/pkg/securitypolicy/securitypolicy_internal.go
@@ -8,8 +8,9 @@ import (
 
 // Internal version of SecurityPolicy
 type securityPolicyInternal struct {
-	Containers        []*securityPolicyContainer
-	ExternalProcesses []*externalProcess
+	Containers            []*securityPolicyContainer
+	ExternalProcesses     []*externalProcess
+	AllowPropertiesAccess bool
 }
 
 // Internal version of Container

--- a/pkg/securitypolicy/securitypolicy_marshal.go
+++ b/pkg/securitypolicy/securitypolicy_marshal.go
@@ -13,7 +13,7 @@ import (
 	"syscall"
 )
 
-type marshalFunc func(allowAll bool, containers []*Container, externalProcesses []ExternalProcessConfig) (string, error)
+type marshalFunc func(allowAll bool, containers []*Container, externalProcesses []ExternalProcessConfig, allowPropertiesAccess bool) (string, error)
 
 const (
 	jsonMarshaller = "json"
@@ -36,7 +36,7 @@ var policyRegoTemplate string
 //go:embed open_door.rego
 var openDoorRegoTemplate string
 
-func marshalJSON(allowAll bool, containers []*Container, _ []ExternalProcessConfig) (string, error) {
+func marshalJSON(allowAll bool, containers []*Container, _ []ExternalProcessConfig, _ bool) (string, error) {
 	var policy *SecurityPolicy
 	if allowAll {
 		if len(containers) > 0 {
@@ -56,7 +56,7 @@ func marshalJSON(allowAll bool, containers []*Container, _ []ExternalProcessConf
 	return string(policyCode), nil
 }
 
-func marshalRego(allowAll bool, containers []*Container, externalProcesses []ExternalProcessConfig) (string, error) {
+func marshalRego(allowAll bool, containers []*Container, externalProcesses []ExternalProcessConfig, allowPropertiesAccess bool) (string, error) {
 	if allowAll {
 		if len(containers) > 0 {
 			return "", ErrInvalidOpenDoorPolicy
@@ -81,10 +81,12 @@ func marshalRego(allowAll bool, containers []*Container, externalProcesses []Ext
 		policy.ExternalProcesses[i] = &pInternal
 	}
 
+	policy.AllowPropertiesAccess = allowPropertiesAccess
+
 	return policy.marshalRego(), nil
 }
 
-func MarshalPolicy(marshaller string, allowAll bool, containers []*Container, externalProcesses []ExternalProcessConfig) (string, error) {
+func MarshalPolicy(marshaller string, allowAll bool, containers []*Container, externalProcesses []ExternalProcessConfig, allowPropertiesAccess bool) (string, error) {
 	if marshaller == "" {
 		marshaller = defaultMarshaller
 	}
@@ -92,7 +94,7 @@ func MarshalPolicy(marshaller string, allowAll bool, containers []*Container, ex
 	if marshal, ok := registeredMarshallers[marshaller]; !ok {
 		return "", fmt.Errorf("unknown marshaller: %q", marshaller)
 	} else {
-		return marshal(allowAll, containers, externalProcesses)
+		return marshal(allowAll, containers, externalProcesses, allowPropertiesAccess)
 	}
 }
 
@@ -297,6 +299,7 @@ func (p securityPolicyInternal) marshalRego() string {
 	builder := new(strings.Builder)
 	addContainers(builder, p.Containers)
 	addExternalProcesses(builder, p.ExternalProcesses)
+	writeLine(builder, `allow_properties_access := %v`, p.AllowPropertiesAccess)
 	objects := builder.String()
 	return strings.Replace(policyRegoTemplate, "##OBJECTS##", objects, 1)
 }

--- a/pkg/securitypolicy/securitypolicy_test.go
+++ b/pkg/securitypolicy/securitypolicy_test.go
@@ -911,8 +911,9 @@ func generateConstraints(r *rand.Rand, maxContainers int32, maxExternalProcesses
 	}
 
 	return &generatedConstraints{
-		containers:        containers,
-		externalProcesses: externalProcesses,
+		containers:         containers,
+		externalProcesses:  externalProcesses,
+		allowGetProperties: randBool(r),
 	}
 }
 
@@ -1294,6 +1295,10 @@ func randString(r *rand.Rand, length int32) string {
 	return sb.String()
 }
 
+func randBool(r *rand.Rand) bool {
+	return randMinMax(r, 0, 1) == 0
+}
+
 func randMinMax(r *rand.Rand, min int32, max int32) int32 {
 	return r.Int31n(max-min+1) + min
 }
@@ -1311,8 +1316,9 @@ func atMost(r *rand.Rand, most int32) int32 {
 }
 
 type generatedConstraints struct {
-	containers        []*securityPolicyContainer
-	externalProcesses []*externalProcess
+	containers         []*securityPolicyContainer
+	externalProcesses  []*externalProcess
+	allowGetProperties bool
 }
 
 type containerInitProcess struct {

--- a/pkg/securitypolicy/securitypolicyenforcer.go
+++ b/pkg/securitypolicy/securitypolicyenforcer.go
@@ -52,6 +52,7 @@ type SecurityPolicyEnforcer interface {
 	EnforceSignalContainerProcessPolicy(containerID string, signal syscall.Signal, isInitProcess bool, startupArgList []string) error
 	EnforcePlan9MountPolicy(target string) (err error)
 	EnforcePlan9UnmountPolicy(target string) (err error)
+	EnforceGetPropertiesPolicy() error
 }
 
 func newSecurityPolicyFromBase64JSON(base64EncodedPolicy string) (*SecurityPolicy, error) {
@@ -491,6 +492,12 @@ func (*StandardSecurityPolicyEnforcer) EnforceOverlayUnmountPolicy(string) error
 	return nil
 }
 
+// Stub. We are deprecating the standard enforcer. Newly added enforcement
+// points are simply allowed.
+func (*StandardSecurityPolicyEnforcer) EnforceGetPropertiesPolicy() error {
+	return nil
+}
+
 func (pe *StandardSecurityPolicyEnforcer) enforceCommandPolicy(containerID string, argList []string) (err error) {
 	// Get a list of all the indexes into our security policy's list of
 	// containers that are possible matches for this containerID based
@@ -808,6 +815,10 @@ func (*OpenDoorSecurityPolicyEnforcer) EnforcePlan9UnmountPolicy(_ string) error
 	return nil
 }
 
+func (OpenDoorSecurityPolicyEnforcer) EnforceGetPropertiesPolicy() error {
+	return nil
+}
+
 func (OpenDoorSecurityPolicyEnforcer) ExtendDefaultMounts(_ []oci.Mount) error {
 	return nil
 }
@@ -864,6 +875,10 @@ func (*ClosedDoorSecurityPolicyEnforcer) EnforcePlan9MountPolicy(_ string) error
 
 func (*ClosedDoorSecurityPolicyEnforcer) EnforcePlan9UnmountPolicy(_ string) error {
 	return errors.New("unmounting is denied by policy")
+}
+
+func (ClosedDoorSecurityPolicyEnforcer) EnforceGetPropertiesPolicy() error {
+	return errors.New("getting container properties is denied by policy")
 }
 
 func (ClosedDoorSecurityPolicyEnforcer) ExtendDefaultMounts(_ []oci.Mount) error {

--- a/pkg/securitypolicy/securitypolicyenforcer_rego.go
+++ b/pkg/securitypolicy/securitypolicyenforcer_rego.go
@@ -111,7 +111,7 @@ func createRegoEnforcer(base64EncodedPolicy string,
 			return createOpenDoorEnforcer(base64EncodedPolicy, defaultMounts, privilegedMounts)
 		}
 
-		code, err = marshalRego(securityPolicy.AllowAll, containers, []ExternalProcessConfig{})
+		code, err = marshalRego(securityPolicy.AllowAll, containers, []ExternalProcessConfig{}, true)
 		if err != nil {
 			return nil, fmt.Errorf("error marshaling the policy to Rego: %w", err)
 		}
@@ -666,4 +666,10 @@ func (policy *regoEnforcer) EnforcePlan9UnmountPolicy(target string) error {
 	}
 
 	return policy.enforce("plan9_unmount", input)
+}
+
+func (policy *regoEnforcer) EnforceGetPropertiesPolicy() error {
+	input := make(map[string]interface{})
+
+	return policy.enforce("get_properties", input)
 }

--- a/test/cri-containerd/policy_test.go
+++ b/test/cri-containerd/policy_test.go
@@ -28,7 +28,7 @@ func securityPolicyFromContainers(policyType string, containers []securitypolicy
 	if err != nil {
 		return "", err
 	}
-	policyString, err := securitypolicy.MarshalPolicy(policyType, false, pc, []securitypolicy.ExternalProcessConfig{})
+	policyString, err := securitypolicy.MarshalPolicy(policyType, false, pc, []securitypolicy.ExternalProcessConfig{}, true)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
GetProperties allows getting information about what is running. This is related to debugging etc. This gates it with a simple yes/no for policy. This might be used for getting stats.
