### PR TITLE
Adding DumpStacks policy enforcement point.

### DIFF
--- a/internal/guest/bridge/bridge_v2.go
+++ b/internal/guest/bridge/bridge_v2.go
@@ -13,7 +13,6 @@ import (
 	"go.opencensus.io/trace"
 	"golang.org/x/sys/unix"
 
-	"github.com/Microsoft/hcsshim/internal/debug"
 	"github.com/Microsoft/hcsshim/internal/guest/commonutils"
 	"github.com/Microsoft/hcsshim/internal/guest/gcserr"
 	"github.com/Microsoft/hcsshim/internal/guest/prot"
@@ -447,8 +446,10 @@ func (b *Bridge) dumpStacksV2(r *Request) (_ RequestResponse, err error) {
 	defer span.End()
 	defer func() { oc.SetSpanStatus(span, err) }()
 
-	stacks := debug.DumpStacks()
-
+	stacks, err := b.hostState.GetStacks()
+	if err != nil {
+		return nil, err
+	}
 	return &prot.DumpStacksResponse{
 		GuestStacks: stacks,
 	}, nil

--- a/internal/guest/runtime/hcsv2/uvm.go
+++ b/internal/guest/runtime/hcsv2/uvm.go
@@ -17,6 +17,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/Microsoft/hcsshim/internal/debug"
 	"github.com/Microsoft/hcsshim/internal/guest/gcserr"
 	"github.com/Microsoft/hcsshim/internal/guest/policy"
 	"github.com/Microsoft/hcsshim/internal/guest/prot"
@@ -578,6 +579,15 @@ func (h *Host) GetProperties(ctx context.Context, containerID string, query prot
 	}
 
 	return properties, nil
+}
+
+func (h *Host) GetStacks() (string, error) {
+	err := h.securityPolicyEnforcer.EnforceDumpStacksPolicy()
+	if err != nil {
+		return "", errors.Wrapf(err, "dump stacks denied due to policy")
+	}
+
+	return debug.DumpStacks(), nil
 }
 
 // RunExternalProcess runs a process in the utility VM.

--- a/internal/tools/securitypolicy/main.go
+++ b/internal/tools/securitypolicy/main.go
@@ -45,7 +45,7 @@ func main() {
 			return err
 		}
 
-		policyCode, err := securitypolicy.MarshalPolicy(*outputType, config.AllowAll, policyContainers, config.ExternalProcesses, config.AllowPropertiesAccess)
+		policyCode, err := securitypolicy.MarshalPolicy(*outputType, config.AllowAll, policyContainers, config.ExternalProcesses, config.AllowPropertiesAccess, config.AllowDumpStacks)
 		if err != nil {
 			return err
 		}

--- a/pkg/securitypolicy/api.rego
+++ b/pkg/securitypolicy/api.rego
@@ -15,4 +15,5 @@ enforcement_points := {
     "plan9_mount": {"introducedVersion": "0.6.0", "allowedByDefault": true},
     "plan9_unmount": {"introducedVersion": "0.6.0", "allowedByDefault": true},
     "get_properties": {"introducedVersion": "0.7.0", "allowedByDefault": true},
+    "dump_stacks": {"introducedVersion": "0.7.0", "allowedByDefault": true},
 }

--- a/pkg/securitypolicy/framework.rego
+++ b/pkg/securitypolicy/framework.rego
@@ -348,6 +348,12 @@ get_properties := {"allowed": true} {
     data.policy.allow_properties_access
 }
 
+default dump_stacks := {"allowed": false}
+
+dump_stacks := {"allowed": true} {
+    data.policy.allow_dump_stacks
+}
+
 # error messages
 
 errors["deviceHash not found"] {

--- a/pkg/securitypolicy/open_door.rego
+++ b/pkg/securitypolicy/open_door.rego
@@ -14,3 +14,4 @@ signal_container_process := {"allowed": true}
 plan9_mount := {"allowed": true}
 plan9_unmount := {"allowed": true}
 get_properties := {"allowed": true}
+dump_stacks := {"allowed": true}

--- a/pkg/securitypolicy/policy.rego
+++ b/pkg/securitypolicy/policy.rego
@@ -19,4 +19,5 @@ signal_container_process := data.framework.signal_container_process
 plan9_mount := data.framework.plan9_mount
 plan9_unmount := data.framework.plan9_unmount
 get_properties := data.framework.get_properties
+dump_stacks := data.framework.dump_stacks
 reason := {"errors": data.framework.errors}

--- a/pkg/securitypolicy/securitypolicy.go
+++ b/pkg/securitypolicy/securitypolicy.go
@@ -29,6 +29,7 @@ type PolicyConfig struct {
 	Containers            []ContainerConfig       `json:"containers" toml:"container"`
 	ExternalProcesses     []ExternalProcessConfig `json:"external_processes" toml:"external_process"`
 	AllowPropertiesAccess bool                    `json:"allow_properties_access" toml:"allow_properties_access"`
+	AllowDumpStacks       bool                    `json:"allow_dump_stacks" toml:"allow_dump_stacks"`
 }
 
 // ExternalProcessConfig contains toml or JSON config for running external processes in the UVM.

--- a/pkg/securitypolicy/securitypolicy_internal.go
+++ b/pkg/securitypolicy/securitypolicy_internal.go
@@ -11,6 +11,7 @@ type securityPolicyInternal struct {
 	Containers            []*securityPolicyContainer
 	ExternalProcesses     []*externalProcess
 	AllowPropertiesAccess bool
+	AllowDumpStacks       bool
 }
 
 // Internal version of Container

--- a/pkg/securitypolicy/securitypolicy_marshal.go
+++ b/pkg/securitypolicy/securitypolicy_marshal.go
@@ -13,7 +13,7 @@ import (
 	"syscall"
 )
 
-type marshalFunc func(allowAll bool, containers []*Container, externalProcesses []ExternalProcessConfig, allowPropertiesAccess bool) (string, error)
+type marshalFunc func(allowAll bool, containers []*Container, externalProcesses []ExternalProcessConfig, allowPropertiesAccess bool, allowDumpStacks bool) (string, error)
 
 const (
 	jsonMarshaller = "json"
@@ -36,7 +36,7 @@ var policyRegoTemplate string
 //go:embed open_door.rego
 var openDoorRegoTemplate string
 
-func marshalJSON(allowAll bool, containers []*Container, _ []ExternalProcessConfig, _ bool) (string, error) {
+func marshalJSON(allowAll bool, containers []*Container, _ []ExternalProcessConfig, _ bool, _ bool) (string, error) {
 	var policy *SecurityPolicy
 	if allowAll {
 		if len(containers) > 0 {
@@ -56,7 +56,7 @@ func marshalJSON(allowAll bool, containers []*Container, _ []ExternalProcessConf
 	return string(policyCode), nil
 }
 
-func marshalRego(allowAll bool, containers []*Container, externalProcesses []ExternalProcessConfig, allowPropertiesAccess bool) (string, error) {
+func marshalRego(allowAll bool, containers []*Container, externalProcesses []ExternalProcessConfig, allowPropertiesAccess bool, allowDumpStacks bool) (string, error) {
 	if allowAll {
 		if len(containers) > 0 {
 			return "", ErrInvalidOpenDoorPolicy
@@ -82,11 +82,12 @@ func marshalRego(allowAll bool, containers []*Container, externalProcesses []Ext
 	}
 
 	policy.AllowPropertiesAccess = allowPropertiesAccess
+	policy.AllowDumpStacks = allowDumpStacks
 
 	return policy.marshalRego(), nil
 }
 
-func MarshalPolicy(marshaller string, allowAll bool, containers []*Container, externalProcesses []ExternalProcessConfig, allowPropertiesAccess bool) (string, error) {
+func MarshalPolicy(marshaller string, allowAll bool, containers []*Container, externalProcesses []ExternalProcessConfig, allowPropertiesAccess bool, allowDumpStacks bool) (string, error) {
 	if marshaller == "" {
 		marshaller = defaultMarshaller
 	}
@@ -94,7 +95,7 @@ func MarshalPolicy(marshaller string, allowAll bool, containers []*Container, ex
 	if marshal, ok := registeredMarshallers[marshaller]; !ok {
 		return "", fmt.Errorf("unknown marshaller: %q", marshaller)
 	} else {
-		return marshal(allowAll, containers, externalProcesses, allowPropertiesAccess)
+		return marshal(allowAll, containers, externalProcesses, allowPropertiesAccess, allowDumpStacks)
 	}
 }
 
@@ -300,6 +301,7 @@ func (p securityPolicyInternal) marshalRego() string {
 	addContainers(builder, p.Containers)
 	addExternalProcesses(builder, p.ExternalProcesses)
 	writeLine(builder, `allow_properties_access := %v`, p.AllowPropertiesAccess)
+	writeLine(builder, `allow_dump_stacks := %v`, p.AllowDumpStacks)
 	objects := builder.String()
 	return strings.Replace(policyRegoTemplate, "##OBJECTS##", objects, 1)
 }

--- a/pkg/securitypolicy/securitypolicy_test.go
+++ b/pkg/securitypolicy/securitypolicy_test.go
@@ -914,6 +914,7 @@ func generateConstraints(r *rand.Rand, maxContainers int32, maxExternalProcesses
 		containers:         containers,
 		externalProcesses:  externalProcesses,
 		allowGetProperties: randBool(r),
+		allowDumpStacks:    randBool(r),
 	}
 }
 
@@ -1319,6 +1320,7 @@ type generatedConstraints struct {
 	containers         []*securityPolicyContainer
 	externalProcesses  []*externalProcess
 	allowGetProperties bool
+	allowDumpStacks    bool
 }
 
 type containerInitProcess struct {

--- a/pkg/securitypolicy/securitypolicyenforcer.go
+++ b/pkg/securitypolicy/securitypolicyenforcer.go
@@ -53,6 +53,7 @@ type SecurityPolicyEnforcer interface {
 	EnforcePlan9MountPolicy(target string) (err error)
 	EnforcePlan9UnmountPolicy(target string) (err error)
 	EnforceGetPropertiesPolicy() error
+	EnforceDumpStacksPolicy() error
 }
 
 func newSecurityPolicyFromBase64JSON(base64EncodedPolicy string) (*SecurityPolicy, error) {
@@ -498,6 +499,12 @@ func (*StandardSecurityPolicyEnforcer) EnforceGetPropertiesPolicy() error {
 	return nil
 }
 
+// Stub. We are deprecating the standard enforcer. Newly added enforcement
+// points are simply allowed.
+func (*StandardSecurityPolicyEnforcer) EnforceDumpStacksPolicy() error {
+	return nil
+}
+
 func (pe *StandardSecurityPolicyEnforcer) enforceCommandPolicy(containerID string, argList []string) (err error) {
 	// Get a list of all the indexes into our security policy's list of
 	// containers that are possible matches for this containerID based
@@ -819,6 +826,10 @@ func (OpenDoorSecurityPolicyEnforcer) EnforceGetPropertiesPolicy() error {
 	return nil
 }
 
+func (OpenDoorSecurityPolicyEnforcer) EnforceDumpStacksPolicy() error {
+	return nil
+}
+
 func (OpenDoorSecurityPolicyEnforcer) ExtendDefaultMounts(_ []oci.Mount) error {
 	return nil
 }
@@ -879,6 +890,10 @@ func (*ClosedDoorSecurityPolicyEnforcer) EnforcePlan9UnmountPolicy(_ string) err
 
 func (ClosedDoorSecurityPolicyEnforcer) EnforceGetPropertiesPolicy() error {
 	return errors.New("getting container properties is denied by policy")
+}
+
+func (ClosedDoorSecurityPolicyEnforcer) EnforceDumpStacksPolicy() error {
+	return errors.New("getting stack dumps is denied by policy")
 }
 
 func (ClosedDoorSecurityPolicyEnforcer) ExtendDefaultMounts(_ []oci.Mount) error {

--- a/pkg/securitypolicy/securitypolicyenforcer_rego.go
+++ b/pkg/securitypolicy/securitypolicyenforcer_rego.go
@@ -111,7 +111,7 @@ func createRegoEnforcer(base64EncodedPolicy string,
 			return createOpenDoorEnforcer(base64EncodedPolicy, defaultMounts, privilegedMounts)
 		}
 
-		code, err = marshalRego(securityPolicy.AllowAll, containers, []ExternalProcessConfig{}, true)
+		code, err = marshalRego(securityPolicy.AllowAll, containers, []ExternalProcessConfig{}, true, true)
 		if err != nil {
 			return nil, fmt.Errorf("error marshaling the policy to Rego: %w", err)
 		}
@@ -672,4 +672,10 @@ func (policy *regoEnforcer) EnforceGetPropertiesPolicy() error {
 	input := make(map[string]interface{})
 
 	return policy.enforce("get_properties", input)
+}
+
+func (policy *regoEnforcer) EnforceDumpStacksPolicy() error {
+	input := make(map[string]interface{})
+
+	return policy.enforce("dump_stacks", input)
 }

--- a/test/cri-containerd/policy_test.go
+++ b/test/cri-containerd/policy_test.go
@@ -28,7 +28,7 @@ func securityPolicyFromContainers(policyType string, containers []securitypolicy
 	if err != nil {
 		return "", err
 	}
-	policyString, err := securitypolicy.MarshalPolicy(policyType, false, pc, []securitypolicy.ExternalProcessConfig{}, true)
+	policyString, err := securitypolicy.MarshalPolicy(policyType, false, pc, []securitypolicy.ExternalProcessConfig{}, true, true)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
DumpStacks allows access to guest stacks. Can be used for debugging etc. This gates it with a simple yes/no for policy.
