### PR TITLE
Add enforcement of logging from the GCS runtime

### DIFF
--- a/cmd/gcs/main.go
+++ b/cmd/gcs/main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/Microsoft/hcsshim/internal/guestpath"
 	"github.com/Microsoft/hcsshim/internal/log"
 	"github.com/Microsoft/hcsshim/internal/oc"
+	"github.com/Microsoft/hcsshim/pkg/securitypolicy"
 )
 
 func memoryLogFormat(metrics *cgroupstats.Metrics) logrus.Fields {
@@ -194,6 +195,9 @@ func main() {
 		false,
 		"If true do not run chronyd time synchronization service inside the UVM")
 	scrubLogs := flag.Bool("scrub-logs", false, "If true, scrub potentially sensitive information from logging")
+	initialPolicyStance := flag.String("initial-policy-stance",
+		"deny",
+		"Stance: allow, deny.")
 
 	flag.Usage = func() {
 		fmt.Fprintf(os.Stderr, "\nUsage of %s:\n", os.Args[0])
@@ -213,7 +217,7 @@ func main() {
 
 	logrus.AddHook(log.NewHook())
 
-	// Use a file instead of stdout
+	var logWriter *os.File
 	if *logFile != "" {
 		logFileHandle, err := os.OpenFile(*logFile, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
 		if err != nil {
@@ -222,7 +226,24 @@ func main() {
 				logrus.ErrorKey: err,
 			}).Fatal("failed to create log file")
 		}
-		logrus.SetOutput(logFileHandle)
+		logWriter = logFileHandle
+	} else {
+		logWriter = os.Stdout
+	}
+
+	// set up our initial stance policy enforcer
+	var initialEnforcer securitypolicy.SecurityPolicyEnforcer
+	switch *initialPolicyStance {
+	case "allow":
+		initialEnforcer = &securitypolicy.OpenDoorSecurityPolicyEnforcer{}
+		logrus.SetOutput(logWriter)
+	case "deny":
+		initialEnforcer = &securitypolicy.ClosedDoorSecurityPolicyEnforcer{}
+		logrus.SetOutput(io.Discard)
+	default:
+		logrus.WithFields(logrus.Fields{
+			"initial-policy-stance": *initialPolicyStance,
+		}).Fatal("unknown initial-policy-stance")
 	}
 
 	switch *logFormat {
@@ -277,7 +298,7 @@ func main() {
 		Handler:  mux,
 		EnableV4: *v4,
 	}
-	h := hcsv2.NewHost(rtime, tport)
+	h := hcsv2.NewHost(rtime, tport, initialEnforcer, logWriter)
 	b.AssignHandlers(mux, h)
 
 	var bridgeIn io.ReadCloser

--- a/internal/tools/securitypolicy/main.go
+++ b/internal/tools/securitypolicy/main.go
@@ -45,7 +45,14 @@ func main() {
 			return err
 		}
 
-		policyCode, err := securitypolicy.MarshalPolicy(*outputType, config.AllowAll, policyContainers, config.ExternalProcesses, config.AllowPropertiesAccess, config.AllowDumpStacks)
+		policyCode, err := securitypolicy.MarshalPolicy(
+			*outputType,
+			config.AllowAll,
+			policyContainers,
+			config.ExternalProcesses,
+			config.AllowPropertiesAccess,
+			config.AllowDumpStacks,
+			config.AllowRuntimeLogging)
 		if err != nil {
 			return err
 		}

--- a/pkg/securitypolicy/api.rego
+++ b/pkg/securitypolicy/api.rego
@@ -1,6 +1,6 @@
 package api
 
-svn := "0.7.0"
+svn := "0.8.0"
 
 enforcement_points := {
     "mount_device": {"introducedVersion": "0.1.0", "allowedByDefault": false},
@@ -16,4 +16,5 @@ enforcement_points := {
     "plan9_unmount": {"introducedVersion": "0.6.0", "allowedByDefault": true},
     "get_properties": {"introducedVersion": "0.7.0", "allowedByDefault": true},
     "dump_stacks": {"introducedVersion": "0.7.0", "allowedByDefault": true},
+    "runtime_logging": {"introducedVersion": "0.8.0", "allowedByDefault": true}
 }

--- a/pkg/securitypolicy/framework.rego
+++ b/pkg/securitypolicy/framework.rego
@@ -354,6 +354,12 @@ dump_stacks := {"allowed": true} {
     data.policy.allow_dump_stacks
 }
 
+default runtime_logging := {"allowed": false}
+
+runtime_logging := {"allowed": true} {
+    data.policy.allow_runtime_logging
+}
+
 # error messages
 
 errors["deviceHash not found"] {

--- a/pkg/securitypolicy/open_door.rego
+++ b/pkg/securitypolicy/open_door.rego
@@ -1,6 +1,6 @@
 package policy
 
-api_svn := "0.7.0"
+api_svn := "0.8.0"
 
 mount_device := {"allowed": true}
 mount_overlay := {"allowed": true}
@@ -15,3 +15,4 @@ plan9_mount := {"allowed": true}
 plan9_unmount := {"allowed": true}
 get_properties := {"allowed": true}
 dump_stacks := {"allowed": true}
+runtime_logging := {"allowed": true}

--- a/pkg/securitypolicy/policy.rego
+++ b/pkg/securitypolicy/policy.rego
@@ -1,6 +1,6 @@
 package policy
 
-api_svn := "0.7.0"
+api_svn := "0.8.0"
 
 import future.keywords.every
 import future.keywords.in
@@ -20,4 +20,5 @@ plan9_mount := data.framework.plan9_mount
 plan9_unmount := data.framework.plan9_unmount
 get_properties := data.framework.get_properties
 dump_stacks := data.framework.dump_stacks
+runtime_logging := data.framework.runtime_logging
 reason := {"errors": data.framework.errors}

--- a/pkg/securitypolicy/securitypolicy.go
+++ b/pkg/securitypolicy/securitypolicy.go
@@ -30,6 +30,7 @@ type PolicyConfig struct {
 	ExternalProcesses     []ExternalProcessConfig `json:"external_processes" toml:"external_process"`
 	AllowPropertiesAccess bool                    `json:"allow_properties_access" toml:"allow_properties_access"`
 	AllowDumpStacks       bool                    `json:"allow_dump_stacks" toml:"allow_dump_stacks"`
+	AllowRuntimeLogging   bool                    `json:"allow_runtime_logging" toml:"allow_runtime_logging"`
 }
 
 // ExternalProcessConfig contains toml or JSON config for running external processes in the UVM.

--- a/pkg/securitypolicy/securitypolicy_internal.go
+++ b/pkg/securitypolicy/securitypolicy_internal.go
@@ -12,6 +12,7 @@ type securityPolicyInternal struct {
 	ExternalProcesses     []*externalProcess
 	AllowPropertiesAccess bool
 	AllowDumpStacks       bool
+	AllowRuntimeLogging   bool
 }
 
 // Internal version of Container

--- a/pkg/securitypolicy/securitypolicy_test.go
+++ b/pkg/securitypolicy/securitypolicy_test.go
@@ -911,10 +911,11 @@ func generateConstraints(r *rand.Rand, maxContainers int32, maxExternalProcesses
 	}
 
 	return &generatedConstraints{
-		containers:         containers,
-		externalProcesses:  externalProcesses,
-		allowGetProperties: randBool(r),
-		allowDumpStacks:    randBool(r),
+		containers:          containers,
+		externalProcesses:   externalProcesses,
+		allowGetProperties:  randBool(r),
+		allowDumpStacks:     randBool(r),
+		allowRuntimeLogging: false,
 	}
 }
 
@@ -1317,10 +1318,11 @@ func atMost(r *rand.Rand, most int32) int32 {
 }
 
 type generatedConstraints struct {
-	containers         []*securityPolicyContainer
-	externalProcesses  []*externalProcess
-	allowGetProperties bool
-	allowDumpStacks    bool
+	containers          []*securityPolicyContainer
+	externalProcesses   []*externalProcess
+	allowGetProperties  bool
+	allowDumpStacks     bool
+	allowRuntimeLogging bool
 }
 
 type containerInitProcess struct {

--- a/pkg/securitypolicy/securitypolicyenforcer.go
+++ b/pkg/securitypolicy/securitypolicyenforcer.go
@@ -54,6 +54,7 @@ type SecurityPolicyEnforcer interface {
 	EnforcePlan9UnmountPolicy(target string) (err error)
 	EnforceGetPropertiesPolicy() error
 	EnforceDumpStacksPolicy() error
+	EnforceRuntimeLoggingPolicy() (err error)
 }
 
 func newSecurityPolicyFromBase64JSON(base64EncodedPolicy string) (*SecurityPolicy, error) {
@@ -505,6 +506,12 @@ func (*StandardSecurityPolicyEnforcer) EnforceDumpStacksPolicy() error {
 	return nil
 }
 
+// Stub. We are deprecating the standard enforcer. Newly added enforcement
+// points are simply allowed.
+func (*StandardSecurityPolicyEnforcer) EnforceRuntimeLoggingPolicy() error {
+	return nil
+}
+
 func (pe *StandardSecurityPolicyEnforcer) enforceCommandPolicy(containerID string, argList []string) (err error) {
 	// Get a list of all the indexes into our security policy's list of
 	// containers that are possible matches for this containerID based
@@ -834,6 +841,10 @@ func (OpenDoorSecurityPolicyEnforcer) ExtendDefaultMounts(_ []oci.Mount) error {
 	return nil
 }
 
+func (OpenDoorSecurityPolicyEnforcer) EnforceRuntimeLoggingPolicy() error {
+	return nil
+}
+
 func (oe *OpenDoorSecurityPolicyEnforcer) EncodedSecurityPolicy() string {
 	return oe.encodedSecurityPolicy
 }
@@ -898,6 +909,10 @@ func (ClosedDoorSecurityPolicyEnforcer) EnforceDumpStacksPolicy() error {
 
 func (ClosedDoorSecurityPolicyEnforcer) ExtendDefaultMounts(_ []oci.Mount) error {
 	return nil
+}
+
+func (ClosedDoorSecurityPolicyEnforcer) EnforceRuntimeLoggingPolicy() error {
+	return errors.New("runtime logging is denied by policy")
 }
 
 func (ClosedDoorSecurityPolicyEnforcer) EncodedSecurityPolicy() string {

--- a/pkg/securitypolicy/securitypolicyenforcer_rego.go
+++ b/pkg/securitypolicy/securitypolicyenforcer_rego.go
@@ -111,7 +111,7 @@ func createRegoEnforcer(base64EncodedPolicy string,
 			return createOpenDoorEnforcer(base64EncodedPolicy, defaultMounts, privilegedMounts)
 		}
 
-		code, err = marshalRego(securityPolicy.AllowAll, containers, []ExternalProcessConfig{}, true, true)
+		code, err = marshalRego(securityPolicy.AllowAll, containers, []ExternalProcessConfig{}, true, true, true)
 		if err != nil {
 			return nil, fmt.Errorf("error marshaling the policy to Rego: %w", err)
 		}
@@ -678,4 +678,10 @@ func (policy *regoEnforcer) EnforceDumpStacksPolicy() error {
 	input := make(map[string]interface{})
 
 	return policy.enforce("dump_stacks", input)
+}
+
+func (policy *regoEnforcer) EnforceRuntimeLoggingPolicy() error {
+	input := map[string]interface{}{}
+
+	return policy.enforce("runtime_logging", input)
 }

--- a/test/cri-containerd/policy_test.go
+++ b/test/cri-containerd/policy_test.go
@@ -28,7 +28,14 @@ func securityPolicyFromContainers(policyType string, containers []securitypolicy
 	if err != nil {
 		return "", err
 	}
-	policyString, err := securitypolicy.MarshalPolicy(policyType, false, pc, []securitypolicy.ExternalProcessConfig{}, true, true)
+	policyString, err := securitypolicy.MarshalPolicy(
+		policyType,
+		false,
+		pc,
+		[]securitypolicy.ExternalProcessConfig{},
+		true,
+		true,
+		true)
 	if err != nil {
 		return "", err
 	}

--- a/test/gcs/main_test.go
+++ b/test/gcs/main_test.go
@@ -133,7 +133,7 @@ func getHost(_ context.Context, tb testing.TB, rt runtime.Runtime) *hcsv2.Host {
 }
 
 func getHostErr(rt runtime.Runtime, tp transport.Transport) (*hcsv2.Host, error) {
-	h := hcsv2.NewHost(rt, tp)
+	h := hcsv2.NewHost(rt, tp, &securitypolicy.ClosedDoorSecurityPolicyEnforcer{}, os.Stdout)
 	cOpts := &guestresource.LCOWConfidentialOptions{
 		EncodedSecurityPolicy: securityPolicy,
 	}


### PR DESCRIPTION
In order to provide a confidential environment for confidential containers, we need to provide a means for customers to control information that will leave the UVM running their code. A key means for information to leave the UVM is via logging.

There's no guarantee that logging will leak information that the customer considers confidential. There's no guarantee that it won't. To address this issue, we are adding 2 additional enforcement points for policy related to logging.

The first, which is this commit, is to allow control over logging coming from GCS itself. The second which will come in another commit is to allow control over logging from containers.

For GCS logging, we have exposed it in policy as the name "runtime logging" as we don't feel that "GCS" will be particularly meaningful to the average policy writer.

The new enforcement point is used to decide if logging is allowed at all. Once we receive a policy, we check to see if GCS logging is allowed or denied. If denied, then we set the logging output for the logrus object used by GCS to be a blackhole. Otherwise, we set it to either stdout or a file depending on the options that GCS was started with.

Logging before we receive policy is controlled via a flag that is set on GCS startup for what our default policy position should be before a policy arrives, either "allow" or "deny". This initial policy stance flag is used to set the initial logrus output target and to create the "default" policy enforcer used until a policy arrives over the standard GCS API.

In GCS's main method, we do not use the enforcer but instead select an enforcer and the logging target based on the flag. We made this design decision as Maksim felt strongly that the ideal goal for policy is as "middleware" that operates only at the bridge/host level of GCS and not elsewhere including not prior to the bridge and host objects being created.

Signed-off-by: Sean T. Allen <seanallen@microsoft.com>