### PR TITLE
osversion: add "Unmanifested" const

### DIFF
--- a/osversion/windowsbuilds.go
+++ b/osversion/windowsbuilds.go
@@ -1,6 +1,18 @@
 package osversion
 
 const (
+	// Unmanifested is the build number that is returned if the binary
+	// is unmanifested. Unmanifested binaries do not return their actual version
+	// number, so the OSVersion does not contain correct versions, and should
+	// not be used.
+	//
+	// Note that 9200 was also the build number for Windows Server 2012,
+	// Windows RT, Windows RT 8.1, and Windows 8. These versions are obsolete,
+	// so should no longer be expected (but if you do, don't use this const).
+	//
+	// This const can be used to check if a binary is manifested.
+	Unmanifested = 9200
+
 	// RS1 (version 1607, codename "Redstone 1") corresponds to Windows Server
 	// 2016 (ltsc2016) and Windows 10 (Anniversary Update).
 	RS1 = 14393


### PR DESCRIPTION
- relates to https://github.com/microsoft/hcsshim/issues/1080

This const can (in most situations, unless you're expecting obsolete versions of Windows) used to check if a binary hasn't been manifested, so the OSVersion cannot be used.
