### PR TITLE
osversion: implement stringer interface, deprecate ToString()

### DIFF
--- a/osversion/osversion_windows.go
+++ b/osversion/osversion_windows.go
@@ -1,5 +1,3 @@
-//go:build windows
-
 package osversion
 
 import (
@@ -47,6 +45,15 @@ func Build() uint16 {
 	return Get().Build
 }
 
-func (osv OSVersion) ToString() string {
+// String returns the OSVersion formatted as a string. It implements the
+// [fmt.Stringer] interface.
+func (osv OSVersion) String() string {
 	return fmt.Sprintf("%d.%d.%d", osv.MajorVersion, osv.MinorVersion, osv.Build)
+}
+
+// ToString returns the OSVersion formatted as a string.
+//
+// Deprecated: use [OSVersion.String].
+func (osv OSVersion) ToString() string {
+	return osv.String()
 }

--- a/osversion/osversion_windows_test.go
+++ b/osversion/osversion_windows_test.go
@@ -1,0 +1,20 @@
+package osversion
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestOSVersionString(t *testing.T) {
+	v := OSVersion{
+		Version:      809042555,
+		MajorVersion: 123,
+		MinorVersion: 2,
+		Build:        12345,
+	}
+	expected := "the version is: 123.2.12345"
+	actual := fmt.Sprintf("the version is: %s", v)
+	if actual != expected {
+		t.Errorf("expected: %q, got: %q", expected, actual)
+	}
+}


### PR DESCRIPTION
This allows the type to be used with fm.Sprintf() and similar uses.


To preview the GoDoc (pkg.go.dev);

```bash
GOOS=windows pkgsite -http=:6060 .
```


<img width="1158" alt="Screenshot 2022-10-18 at 15 21 14" src="https://user-images.githubusercontent.com/1804568/196441535-f6792d83-8743-43fb-93b1-174df760fa54.png">
