### PR TITLE
plumb AMD certs to workload containers

### DIFF
--- a/internal/guest/runtime/hcsv2/uvm.go
+++ b/internal/guest/runtime/hcsv2/uvm.go
@@ -343,8 +343,10 @@ func (h *Host) CreateContainer(ctx context.Context, id string, settings *prot.VM
 	// construction time.
 	if oci.ParseAnnotationsBool(ctx, settings.OCISpecification.Annotations, annotations.UVMSecurityPolicyEnv, false) {
 		secPolicyEnv := fmt.Sprintf("UVM_SECURITY_POLICY=%s", h.securityPolicyEnforcer.EncodedSecurityPolicy())
-		uvmReferenceInfo := fmt.Sprintf("UVM_REFERENCE_INFO=%s", h.uvmReferenceInfo)
-		settings.OCISpecification.Process.Env = append(settings.OCISpecification.Process.Env, secPolicyEnv, uvmReferenceInfo)
+		uvmReferenceInfoEnv := fmt.Sprintf("UVM_REFERENCE_INFO=%s", h.uvmReferenceInfo)
+		amdCertEnv := fmt.Sprintf("UVM_HOST_AMD_CERTIFICATE=%s", settings.OCISpecification.Annotations[annotations.HostAMDCertificate])
+		settings.OCISpecification.Process.Env = append(settings.OCISpecification.Process.Env,
+			secPolicyEnv, uvmReferenceInfoEnv, amdCertEnv)
 	}
 
 	// Create the BundlePath

--- a/internal/oci/annotations.go
+++ b/internal/oci/annotations.go
@@ -20,7 +20,7 @@ func ProcessAnnotations(ctx context.Context, s *specs.Spec) (err error) {
 	// Named `Process` and not `Expand` since this function may be expanded (pun intended) to
 	// deal with other annotation issues and validation.
 
-	// Rathen than give up part of the way through on error, this just emits a warning (similar
+	// Rather than give up part of the way through on error, this just emits a warning (similar
 	// to the `parseAnnotation*` functions) and continues through, so the spec is not left in a
 	// (partially) unusable form.
 	// If multiple different errors are to be raised, they should be combined or, if they

--- a/internal/uvm/security_policy.go
+++ b/internal/uvm/security_policy.go
@@ -42,6 +42,17 @@ func WithSecurityPolicyEnforcer(enforcer string) ConfidentialUVMOpt {
 	}
 }
 
+func base64EncodeContent(filePath string) (string, error) {
+	if filePath == "" {
+		return "", nil
+	}
+	content, err := os.ReadFile(filePath)
+	if err != nil && !os.IsNotExist(err) {
+		return "", err
+	}
+	return base64.StdEncoding.EncodeToString(content), nil
+}
+
 // WithUVMReferenceInfo reads UVM reference info file and base64 encodes the
 // content before setting it for the resource. This is no-op if the
 // `referenceName` is empty or the file doesn't exist.
@@ -50,11 +61,11 @@ func WithUVMReferenceInfo(referenceRoot string, referenceName string) Confidenti
 		if referenceName == "" {
 			return nil
 		}
-		content, err := os.ReadFile(filepath.Join(referenceRoot, referenceName))
-		if err != nil && !os.IsNotExist(err) {
+		encoded, err := base64EncodeContent(filepath.Join(referenceRoot, referenceName))
+		if err != nil {
 			return err
 		}
-		r.EncodedUVMReference = base64.StdEncoding.EncodeToString(content)
+		r.EncodedUVMReference = encoded
 		return nil
 	}
 }

--- a/internal/uvm/start.go
+++ b/internal/uvm/start.go
@@ -282,11 +282,12 @@ func (uvm *UtilityVM) Start(ctx context.Context) (err error) {
 	}
 
 	if uvm.confidentialUVMOptions != nil && uvm.OS() == "linux" {
-		if err := uvm.SetConfidentialUVMOptions(ctx,
+		copts := []ConfidentialUVMOpt{
 			WithSecurityPolicy(uvm.confidentialUVMOptions.SecurityPolicy),
 			WithSecurityPolicyEnforcer(uvm.confidentialUVMOptions.SecurityPolicyEnforcer),
 			WithUVMReferenceInfo(defaultLCOWOSBootFilesPath(), uvm.confidentialUVMOptions.UVMReferenceInfoFile),
-		); err != nil {
+		}
+		if err := uvm.SetConfidentialUVMOptions(ctx, copts...); err != nil {
 			return err
 		}
 	}

--- a/pkg/annotations/annotations.go
+++ b/pkg/annotations/annotations.go
@@ -271,12 +271,16 @@ const (
 	// GuestStateFile specifies the path of the vmgs file to use if required. Only applies in SNP mode.
 	GuestStateFile = "io.microsoft.virtualmachine.lcow.gueststatefile"
 
-	// UVMSecurityPolicyEnv specifies if UVM_SECURITY_POLICY and
-	// UVM_REFERENCE_INFO variables should be injected for a container.
+	// UVMSecurityPolicyEnv specifies if UVM_SECURITY_POLICY, UVM_REFERENCE_INFO
+	// and UVM_HOST_AMD_CERTIFICATE variables should be injected for a container.
 	UVMSecurityPolicyEnv = "io.microsoft.virtualmachine.lcow.securitypolicy.env"
 
 	// UVMReferenceInfoFile specifies the filename of a signed UVM reference file to be passed to UVM.
 	UVMReferenceInfoFile = "io.microsoft.virtualmachine.lcow.uvm-reference-info-file"
+
+	// HostAMDCertificate specifies the filename of the AMD certificates to be passed to UVM.
+	// The certificate is expected to be located in the same directory as the shim executable.
+	HostAMDCertificate = "io.microsoft.virtualmachine.lcow.amd-certificate"
 
 	// DisableLCOWTimeSyncService is used to disable the chronyd time
 	// synchronization service inside the LCOW UVM.


### PR DESCRIPTION
Add logic to plumb AMD certificates to workload containers. The
assumption is that the certificates will be "fresh enough" for
necessary attestation and key release by the workflow and third
party services.

Signed-off-by: Maksim An <maksiman@microsoft.com>