### PR TITLE
Pass ipv6 address information to Linux GCS

### DIFF
--- a/internal/guest/network/netns.go
+++ b/internal/guest/network/netns.go
@@ -9,11 +9,13 @@ import (
 	"net"
 	"os/exec"
 	"runtime"
+	"strconv"
 	"time"
 
 	"github.com/Microsoft/hcsshim/internal/guest/prot"
 	"github.com/Microsoft/hcsshim/internal/log"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
 	"github.com/vishvananda/netns"
 )
@@ -66,29 +68,24 @@ func DoInNetNS(ns netns.NsHandle, run func() error) error {
 // This function MUST be used in tandem with `DoInNetNS` or some other means that ensures that the goroutine
 // executing this code stays on the same thread.
 func NetNSConfig(ctx context.Context, ifStr string, nsPid int, adapter *prot.NetworkAdapter) error {
+	ctx, entry := log.S(ctx, logrus.Fields{
+		"ifname": ifStr,
+		"pid":    nsPid,
+	})
 	if ifStr == "" || nsPid == -1 || adapter == nil {
 		return errors.New("All three arguments must be specified")
 	}
 
-	if adapter.NatEnabled {
-		log.G(ctx).Debugf("Configure %s in %d with: %s/%d gw=%s",
-			ifStr, nsPid, adapter.AllocatedIPAddress,
-			adapter.HostIPPrefixLength, adapter.HostIPAddress)
-	} else {
-		log.G(ctx).Debugf("Configure %s in %d with DHCP", ifStr, nsPid)
-	}
-
-	log.G(ctx).Debug("Obtaining current namespace")
+	entry.Trace("Obtaining current namespace")
 	ns, err := netns.Get()
 	if err != nil {
 		return errors.Wrap(err, "netns.Get() failed")
 	}
 	defer ns.Close()
-
-	log.G(ctx).Debugf("New network namespace from PID %d is %v", nsPid, ns)
+	entry.WithField("namespace", ns).Debug("New network namespace from PID")
 
 	// Re-Get a reference to the interface (it may be a different ID in the new namespace)
-	log.G(ctx).Debug("Getting reference to interface")
+	entry.Trace("Getting reference to interface")
 	link, err := netlink.LinkByName(ifStr)
 	if err != nil {
 		return errors.Wrapf(err, "netlink.LinkByName(%s) failed", ifStr)
@@ -96,9 +93,8 @@ func NetNSConfig(ctx context.Context, ifStr string, nsPid int, adapter *prot.Net
 
 	// User requested non-default MTU size
 	if adapter.EncapOverhead != 0 {
-		log.G(ctx).Debug("EncapOverhead non-zero, will set MTU")
 		mtu := link.Attrs().MTU - int(adapter.EncapOverhead)
-		log.G(ctx).Debugf("mtu %d", mtu)
+		entry.WithField("mtu", mtu).Debug("EncapOverhead non-zero, will set MTU")
 		if err = netlink.LinkSetMTU(link, mtu); err != nil {
 			return errors.Wrapf(err, "netlink.LinkSetMTU(%#v, %d) failed", link, mtu)
 		}
@@ -106,7 +102,9 @@ func NetNSConfig(ctx context.Context, ifStr string, nsPid int, adapter *prot.Net
 
 	// Configure the interface
 	if adapter.NatEnabled {
-		log.G(ctx).Debug("Nat enabled - configuring interface")
+		entry.Tracef("Configuring interface with NAT: %s/%d gw=%s",
+			adapter.AllocatedIPAddress,
+			adapter.HostIPPrefixLength, adapter.HostIPAddress)
 		metric := 1
 		if adapter.EnableLowMetric {
 			metric = 500
@@ -116,72 +114,22 @@ func NetNSConfig(ctx context.Context, ifStr string, nsPid int, adapter *prot.Net
 		if err := netlink.LinkSetUp(link); err != nil {
 			return errors.Wrapf(err, "netlink.LinkSetUp(%#v) failed", link)
 		}
-		// Set IP address
-		addr := &net.IPNet{
-			IP: net.ParseIP(adapter.AllocatedIPAddress),
-			// TODO(rn): This assumes/hardcodes IPv4
-			Mask: net.CIDRMask(int(adapter.HostIPPrefixLength), 32)}
-		ipAddr := &netlink.Addr{IPNet: addr, Label: ""}
-		if err := netlink.AddrAdd(link, ipAddr); err != nil {
-			return errors.Wrapf(err, "netlink.AddrAdd(%#v, %#v) failed", link, ipAddr)
+		if err := assignIPToLink(ctx, ifStr, nsPid, link,
+			adapter.AllocatedIPAddress, adapter.HostIPAddress, adapter.HostIPPrefixLength,
+			adapter.EnableLowMetric, metric,
+		); err != nil {
+			return err
 		}
-		// Set gateway
-		if adapter.HostIPAddress != "" {
-			gw := net.ParseIP(adapter.HostIPAddress)
-
-			if !addr.Contains(gw) {
-				// In the case that a gw is not part of the subnet we are setting gw for,
-				// a new addr containing this gw address need to be added into the link to avoid getting
-				// unreachable error when adding this out-of-subnet gw route
-				log.G(ctx).Debugf("gw is outside of the subnet: Configure %s in %d with: %s/%d gw=%s\n",
-					ifStr, nsPid, adapter.AllocatedIPAddress, adapter.HostIPPrefixLength, adapter.HostIPAddress)
-				addr2 := &net.IPNet{
-					IP:   net.ParseIP(adapter.HostIPAddress),
-					Mask: net.CIDRMask(32, 32)} // This assumes/hardcodes IPv4
-				ipAddr2 := &netlink.Addr{IPNet: addr2, Label: ""}
-				if err := netlink.AddrAdd(link, ipAddr2); err != nil {
-					return errors.Wrapf(err, "netlink.AddrAdd(%#v, %#v) failed", link, ipAddr2)
-				}
-			}
-
-			if !adapter.EnableLowMetric {
-				route := netlink.Route{
-					Scope:     netlink.SCOPE_UNIVERSE,
-					LinkIndex: link.Attrs().Index,
-					Gw:        gw,
-					Priority:  metric, // This is what ip route add does
-				}
-				if err := netlink.RouteAdd(&route); err != nil {
-					return errors.Wrapf(err, "netlink.RouteAdd(%#v) failed", route)
-				}
-			} else {
-				// add a route rule for the new interface so packets coming on this interface
-				// always go out the same interface
-				srcNet := &net.IPNet{IP: net.ParseIP(adapter.AllocatedIPAddress), Mask: net.CIDRMask(32, 32)}
-				rule := netlink.NewRule()
-				rule.Table = 101
-				rule.Src = srcNet
-				rule.Priority = 5
-
-				if err := netlink.RuleAdd(rule); err != nil {
-					return errors.Wrapf(err, "netlink.RuleAdd(%#v) failed", rule)
-				}
-
-				// add the default route in that interface specific table
-				route := netlink.Route{
-					Scope:     netlink.SCOPE_UNIVERSE,
-					LinkIndex: link.Attrs().Index,
-					Gw:        gw,
-					Table:     rule.Table,
-					Priority:  metric,
-				}
-				if err := netlink.RouteAdd(&route); err != nil {
-					return errors.Wrapf(err, "netlink.RouteAdd(%#v) failed", route)
-				}
-			}
+		if err := assignIPToLink(ctx, ifStr, nsPid, link,
+			adapter.AllocatedIPv6Address, adapter.HostIPv6Address, adapter.HostIPv6PrefixLength,
+			adapter.EnableLowMetric, metric,
+		); err != nil {
+			return err
 		}
 	} else {
-		log.G(ctx).Debug("Execing udhcpc with timeout...")
+		timeout := 30 * time.Second
+		entry.Trace("Configure with DHCP")
+		entry.WithField("timeout", timeout.String()).Debug("Execing udhcpc with timeout...")
 		cmd := exec.Command("udhcpc", "-q", "-i", ifStr, "-s", "/sbin/udhcpc_config.script")
 
 		done := make(chan error)
@@ -191,14 +139,14 @@ func NetNSConfig(ctx context.Context, ifStr string, nsPid int, adapter *prot.Net
 		defer close(done)
 
 		select {
-		case <-time.After(30 * time.Second):
+		case <-time.After(timeout):
 			var cos string
 			co, err := cmd.CombinedOutput() // In case it has written something
 			if err != nil {
 				cos = string(co)
 			}
 			_ = cmd.Process.Kill()
-			log.G(ctx).Debugf("udhcpc timed out [%s]", cos)
+			entry.WithField("timeout", timeout.String()).Warningf("udhcpc timed out [%s]", cos)
 			return fmt.Errorf("udhcpc timed out. Failed to get DHCP address: %s", cos)
 		case <-done:
 			var cos string
@@ -207,7 +155,7 @@ func NetNSConfig(ctx context.Context, ifStr string, nsPid int, adapter *prot.Net
 				cos = string(co)
 			}
 			if err != nil {
-				log.G(ctx).WithError(err).Debugf("udhcpc failed [%s]", cos)
+				entry.WithError(err).Debugf("udhcpc failed [%s]", cos)
 				return errors.Wrapf(err, "process failed (%s)", cos)
 			}
 		}
@@ -216,20 +164,117 @@ func NetNSConfig(ctx context.Context, ifStr string, nsPid int, adapter *prot.Net
 		if err != nil {
 			cos = string(co)
 		}
-		log.G(ctx).Debugf("udhcpc succeeded: %s", cos)
+		entry.Debugf("udhcpc succeeded: %s", cos)
 	}
 
 	// Add some debug logging
-	curNS, _ := netns.Get()
-	// Refresh link attributes/state
-	link, _ = netlink.LinkByIndex(link.Attrs().Index)
-	attr := link.Attrs()
-	addrs, _ := netlink.AddrList(link, 0)
+	if entry.Logger.GetLevel() >= logrus.DebugLevel {
+		curNS, _ := netns.Get()
+		// Refresh link attributes/state
+		link, _ = netlink.LinkByIndex(link.Attrs().Index)
+		attr := link.Attrs()
+		addrs, _ := netlink.AddrList(link, 0)
+		addrsStr := make([]string, 0, len(addrs))
+		for _, addr := range addrs {
+			addrsStr = append(addrsStr, fmt.Sprintf("%v", addr))
+		}
 
-	log.G(ctx).Debugf("%v: %s[idx=%d,type=%s] is %v", curNS, attr.Name, attr.Index, link.Type(), attr.OperState)
-	for _, addr := range addrs {
-		log.G(ctx).Debugf("  %v", addr)
+		entry.WithField("addresses", addrsStr).Debugf("%v: %s[idx=%d,type=%s] is %v",
+			curNS, attr.Name, attr.Index, link.Type(), attr.OperState)
 	}
 
+	return nil
+}
+
+func assignIPToLink(ctx context.Context,
+	ifStr string,
+	nsPid int,
+	link netlink.Link,
+	allocatedIP string,
+	gatewayIP string,
+	prefixLen uint8,
+	enableLowMetric bool,
+	metric int,
+) error {
+	entry := log.G(ctx)
+	entry.WithFields(logrus.Fields{
+		"link":      link.Attrs().Name,
+		"IP":        allocatedIP,
+		"prefixLen": prefixLen,
+		"gateway":   gatewayIP,
+		"metric":    metric,
+	}).Trace("assigning IP address")
+	if allocatedIP == "" {
+		return nil
+	}
+	// Set IP address
+	ip, addr, err := net.ParseCIDR(allocatedIP + "/" + strconv.FormatUint(uint64(prefixLen), 10))
+	if err != nil {
+		return errors.Wrapf(err, "parsing address %s/%d failed", allocatedIP, prefixLen)
+	}
+	// the IP address field in addr is masked, so replace it with the original ip address
+	addr.IP = ip
+	entry.WithFields(logrus.Fields{
+		"allocatedIP": ip,
+		"IP":          addr,
+	}).Debugf("parsed ip address %s/%d", allocatedIP, prefixLen)
+	ipAddr := &netlink.Addr{IPNet: addr, Label: ""}
+	if err := netlink.AddrAdd(link, ipAddr); err != nil {
+		return errors.Wrapf(err, "netlink.AddrAdd(%#v, %#v) failed", link, ipAddr)
+	}
+	if gatewayIP == "" {
+		return nil
+	}
+	// Set gateway
+	gw := net.ParseIP(gatewayIP)
+	if gw == nil {
+		return errors.Wrapf(err, "parsing gateway address %s failed", gatewayIP)
+	}
+
+	if !addr.Contains(gw) {
+		// In the case that a gw is not part of the subnet we are setting gw for,
+		// a new addr containing this gw address need to be added into the link to avoid getting
+		// unreachable error when adding this out-of-subnet gw route
+		entry.Debugf("gw is outside of the subnet: Configure %s in %d with: %s/%d gw=%s\n",
+			ifStr, nsPid, allocatedIP, prefixLen, gatewayIP)
+		addr2 := &net.IPNet{
+			IP:   net.ParseIP(gatewayIP),
+			Mask: net.CIDRMask(32, 32)} // This assumes/hardcodes IPv4
+		ipAddr2 := &netlink.Addr{IPNet: addr2, Label: ""}
+		if err := netlink.AddrAdd(link, ipAddr2); err != nil {
+			return errors.Wrapf(err, "netlink.AddrAdd(%#v, %#v) failed", link, ipAddr2)
+		}
+	}
+
+	var table int
+	if enableLowMetric {
+		// add a route rule for the new interface so packets coming on this interface
+		// always go out the same interface
+		_, ml := addr.Mask.Size()
+		srcNet := &net.IPNet{
+			IP:   net.ParseIP(allocatedIP),
+			Mask: net.CIDRMask(ml, ml),
+		}
+		rule := netlink.NewRule()
+		rule.Table = 101
+		rule.Src = srcNet
+		rule.Priority = 5
+
+		if err := netlink.RuleAdd(rule); err != nil {
+			return errors.Wrapf(err, "netlink.RuleAdd(%#v) failed", rule)
+		}
+		table = rule.Table
+	}
+	// add the default route in that interface specific table
+	route := netlink.Route{
+		Scope:     netlink.SCOPE_UNIVERSE,
+		LinkIndex: link.Attrs().Index,
+		Gw:        gw,
+		Table:     table,
+		Priority:  metric,
+	}
+	if err := netlink.RouteAdd(&route); err != nil {
+		return errors.Wrapf(err, "netlink.RouteAdd(%#v) failed", route)
+	}
 	return nil
 }

--- a/internal/guest/network/netns.go
+++ b/internal/guest/network/netns.go
@@ -237,9 +237,10 @@ func assignIPToLink(ctx context.Context,
 		// unreachable error when adding this out-of-subnet gw route
 		entry.Debugf("gw is outside of the subnet: Configure %s in %d with: %s/%d gw=%s\n",
 			ifStr, nsPid, allocatedIP, prefixLen, gatewayIP)
+		ml := len(gw) * 8
 		addr2 := &net.IPNet{
-			IP:   net.ParseIP(gatewayIP),
-			Mask: net.CIDRMask(32, 32)} // This assumes/hardcodes IPv4
+			IP:   gw,
+			Mask: net.CIDRMask(ml, ml)}
 		ipAddr2 := &netlink.Addr{IPNet: addr2, Label: ""}
 		if err := netlink.AddrAdd(link, ipAddr2); err != nil {
 			return errors.Wrapf(err, "netlink.AddrAdd(%#v, %#v) failed", link, ipAddr2)

--- a/internal/guest/prot/protocol.go
+++ b/internal/guest/prot/protocol.go
@@ -674,17 +674,20 @@ type ContainerGetPropertiesResponse struct {
 // NetworkAdapter represents a network interface and its associated
 // configuration.
 type NetworkAdapter struct {
-	AdapterInstanceID  string `json:"AdapterInstanceId"`
-	FirewallEnabled    bool
-	NatEnabled         bool
-	MacAddress         string `json:",omitempty"`
-	AllocatedIPAddress string `json:"AllocatedIpAddress,omitempty"`
-	HostIPAddress      string `json:"HostIpAddress,omitempty"`
-	HostIPPrefixLength uint8  `json:"HostIpPrefixLength,omitempty"`
-	HostDNSServerList  string `json:"HostDnsServerList,omitempty"`
-	HostDNSSuffix      string `json:"HostDnsSuffix,omitempty"`
-	EnableLowMetric    bool   `json:",omitempty"`
-	EncapOverhead      uint16 `json:",omitempty"`
+	AdapterInstanceID    string `json:"AdapterInstanceId"`
+	FirewallEnabled      bool
+	NatEnabled           bool
+	MacAddress           string `json:",omitempty"`
+	AllocatedIPAddress   string `json:"AllocatedIpAddress,omitempty"`
+	HostIPAddress        string `json:"HostIpAddress,omitempty"`
+	HostIPPrefixLength   uint8  `json:"HostIpPrefixLength,omitempty"`
+	AllocatedIPv6Address string `json:"AllocatedIpv6Address,omitempty"`
+	HostIPv6Address      string `json:"HostIpv6Address,omitempty"`
+	HostIPv6PrefixLength uint8  `json:"HostIpv6PrefixLength,omitempty"`
+	HostDNSServerList    string `json:"HostDnsServerList,omitempty"`
+	HostDNSSuffix        string `json:"HostDnsSuffix,omitempty"`
+	EnableLowMetric      bool   `json:",omitempty"`
+	EncapOverhead        uint16 `json:",omitempty"`
 }
 
 // MappedVirtualDisk represents a disk on the host which is mapped into a

--- a/internal/guest/runtime/hcsv2/network.go
+++ b/internal/guest/runtime/hcsv2/network.go
@@ -253,12 +253,15 @@ func (nin *nicInNamespace) assignToPid(ctx context.Context, pid int) (err error)
 		trace.Int64Attribute("pid", int64(pid)))
 
 	v1Adapter := &prot.NetworkAdapter{
-		NatEnabled:         nin.adapter.IPAddress != "",
-		AllocatedIPAddress: nin.adapter.IPAddress,
-		HostIPAddress:      nin.adapter.GatewayAddress,
-		HostIPPrefixLength: nin.adapter.PrefixLength,
-		EnableLowMetric:    nin.adapter.EnableLowMetric,
-		EncapOverhead:      nin.adapter.EncapOverhead,
+		NatEnabled:           (nin.adapter.IPAddress != "") || (nin.adapter.IPv6Address != ""),
+		AllocatedIPAddress:   nin.adapter.IPAddress,
+		HostIPAddress:        nin.adapter.GatewayAddress,
+		HostIPPrefixLength:   nin.adapter.PrefixLength,
+		AllocatedIPv6Address: nin.adapter.IPv6Address,
+		HostIPv6Address:      nin.adapter.IPv6GatewayAddress,
+		HostIPv6PrefixLength: nin.adapter.IPv6PrefixLength,
+		EnableLowMetric:      nin.adapter.EnableLowMetric,
+		EncapOverhead:        nin.adapter.EncapOverhead,
 	}
 
 	if err := network.MoveInterfaceToNS(nin.ifname, pid); err != nil {

--- a/internal/protocol/guestresource/resources.go
+++ b/internal/protocol/guestresource/resources.go
@@ -132,17 +132,20 @@ type LCOWMappedVPCIDevice struct {
 // LCOWNetworkAdapter represents a network interface and its associated
 // configuration in a namespace.
 type LCOWNetworkAdapter struct {
-	NamespaceID     string `json:",omitempty"`
-	ID              string `json:",omitempty"`
-	MacAddress      string `json:",omitempty"`
-	IPAddress       string `json:",omitempty"`
-	PrefixLength    uint8  `json:",omitempty"`
-	GatewayAddress  string `json:",omitempty"`
-	DNSSuffix       string `json:",omitempty"`
-	DNSServerList   string `json:",omitempty"`
-	EnableLowMetric bool   `json:",omitempty"`
-	EncapOverhead   uint16 `json:",omitempty"`
-	VPCIAssigned    bool   `json:",omitempty"`
+	NamespaceID        string `json:",omitempty"`
+	ID                 string `json:",omitempty"`
+	MacAddress         string `json:",omitempty"`
+	IPAddress          string `json:",omitempty"`
+	PrefixLength       uint8  `json:",omitempty"`
+	GatewayAddress     string `json:",omitempty"`
+	IPv6Address        string `json:",omitempty"`
+	IPv6PrefixLength   uint8  `json:",omitempty"`
+	IPv6GatewayAddress string `json:",omitempty"`
+	DNSSuffix          string `json:",omitempty"`
+	DNSServerList      string `json:",omitempty"`
+	EnableLowMetric    bool   `json:",omitempty"`
+	EncapOverhead      uint16 `json:",omitempty"`
+	VPCIAssigned       bool   `json:",omitempty"`
 }
 
 type LCOWContainerConstraints struct {

--- a/internal/uvm/network.go
+++ b/internal/uvm/network.go
@@ -592,22 +592,30 @@ func (uvm *UtilityVM) addNIC(ctx context.Context, id string, endpoint *hns.HNSEn
 		}
 	} else {
 		// Verify this version of LCOW supports Network HotAdd
+		s := &guestresource.LCOWNetworkAdapter{
+			NamespaceID:     endpoint.Namespace.ID,
+			ID:              id,
+			MacAddress:      endpoint.MacAddress,
+			IPAddress:       endpoint.IPAddress.String(),
+			PrefixLength:    endpoint.PrefixLength,
+			GatewayAddress:  endpoint.GatewayAddress,
+			DNSSuffix:       endpoint.DNSSuffix,
+			DNSServerList:   endpoint.DNSServerList,
+			EnableLowMetric: endpoint.EnableLowMetric,
+			EncapOverhead:   endpoint.EncapOverhead,
+		}
+		if v6 := endpoint.IPv6Address.To16(); v6 != nil && !v6.IsUnspecified() {
+			// if the address is empty or invalid, endpoint.IPv6Address.String will be "<nil>"
+			// since we should be guranteed an IPv4, but not a v6, skip invalid v6 address
+			s.IPv6Address = v6.String()
+			s.IPv6PrefixLength = endpoint.IPv6PrefixLength
+			s.IPv6GatewayAddress = endpoint.GatewayAddressV6
+		}
 		if uvm.isNetworkNamespaceSupported() {
 			request.GuestRequest = guestrequest.ModificationRequest{
 				ResourceType: guestresource.ResourceTypeNetwork,
 				RequestType:  guestrequest.RequestTypeAdd,
-				Settings: &guestresource.LCOWNetworkAdapter{
-					NamespaceID:     endpoint.Namespace.ID,
-					ID:              id,
-					MacAddress:      endpoint.MacAddress,
-					IPAddress:       endpoint.IPAddress.String(),
-					PrefixLength:    endpoint.PrefixLength,
-					GatewayAddress:  endpoint.GatewayAddress,
-					DNSSuffix:       endpoint.DNSSuffix,
-					DNSServerList:   endpoint.DNSServerList,
-					EnableLowMetric: endpoint.EnableLowMetric,
-					EncapOverhead:   endpoint.EncapOverhead,
-				},
+				Settings:     s,
 			}
 		}
 	}
@@ -694,6 +702,15 @@ func (uvm *UtilityVM) AddNICInGuest(ctx context.Context, cfg *guestresource.LCOW
 
 	return uvm.modify(ctx, &request)
 }
+
+// request := hcsschema.ModifySettingRequest{
+// 		RequestType:  guestrequest.RequestTypeAdd,
+// 		ResourcePath: fmt.Sprintf(resourcepaths.NetworkResourceFormat, id),
+// 		Settings: hcsschema.NetworkAdapter{
+// 			EndpointId: endpoint.Id,
+// 			MacAddress: endpoint.MacAddress,
+// 		},
+// 	}
 
 // RemoveNICInGuest makes a request to remove a network interface inside the lcow guest.
 // This is primarily used for removing NICs in the guest that were VPCI assigned.

--- a/internal/uvm/network.go
+++ b/internal/uvm/network.go
@@ -610,6 +610,11 @@ func (uvm *UtilityVM) addNIC(ctx context.Context, id string, endpoint *hns.HNSEn
 			s.IPv6Address = v6.String()
 			s.IPv6PrefixLength = endpoint.IPv6PrefixLength
 			s.IPv6GatewayAddress = endpoint.GatewayAddressV6
+			log.G(ctx).WithFields(logrus.Fields{
+				"ip":           s.IPAddress,
+				"prefixLength": s.IPv6PrefixLength,
+				"gateway":      s.IPv6GatewayAddress,
+			}).Debug("adding IPv6 settings")
 		}
 		if uvm.isNetworkNamespaceSupported() {
 			request.GuestRequest = guestrequest.ModificationRequest{
@@ -702,15 +707,6 @@ func (uvm *UtilityVM) AddNICInGuest(ctx context.Context, cfg *guestresource.LCOW
 
 	return uvm.modify(ctx, &request)
 }
-
-// request := hcsschema.ModifySettingRequest{
-// 		RequestType:  guestrequest.RequestTypeAdd,
-// 		ResourcePath: fmt.Sprintf(resourcepaths.NetworkResourceFormat, id),
-// 		Settings: hcsschema.NetworkAdapter{
-// 			EndpointId: endpoint.Id,
-// 			MacAddress: endpoint.MacAddress,
-// 		},
-// 	}
 
 // RemoveNICInGuest makes a request to remove a network interface inside the lcow guest.
 // This is primarily used for removing NICs in the guest that were VPCI assigned.

--- a/test/functional/lcow_networking_test.go
+++ b/test/functional/lcow_networking_test.go
@@ -1,0 +1,186 @@
+//go:build windows && functional
+// +build windows,functional
+
+package functional
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	ctrdoci "github.com/containerd/containerd/oci"
+
+	"github.com/Microsoft/hcsshim/hcn"
+	"github.com/Microsoft/hcsshim/osversion"
+
+	"github.com/Microsoft/hcsshim/test/internal/cmd"
+	"github.com/Microsoft/hcsshim/test/internal/constants"
+	"github.com/Microsoft/hcsshim/test/internal/container"
+	"github.com/Microsoft/hcsshim/test/internal/layers"
+	"github.com/Microsoft/hcsshim/test/internal/oci"
+	"github.com/Microsoft/hcsshim/test/internal/require"
+	"github.com/Microsoft/hcsshim/test/internal/uvm"
+)
+
+func TestLCOW_IPv6_Assignment(t *testing.T) {
+	requireFeatures(t, featureLCOW)
+	require.Build(t, osversion.RS5)
+
+	ns, err := newNetworkNamespace()
+	if err != nil {
+		t.Fatalf("namespace creation: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := ns.Delete(); err != nil {
+			t.Errorf("namespace delete: %v", err)
+		}
+	})
+	t.Logf("created namespace %s", ns.Id)
+
+	// create network and endpoint
+	ntwk, err := (&hcn.HostComputeNetwork{
+		Name: hcsOwner + "network",
+		Type: hcn.NAT,
+		Ipams: []hcn.Ipam{
+			{
+				Type: "Static",
+				Subnets: []hcn.Subnet{
+					{
+						IpAddressPrefix: "192.168.128.0/20",
+						Routes: []hcn.Route{
+							{
+								NextHop:           "192.168.128.1",
+								DestinationPrefix: "0.0.0.0/0",
+							},
+						},
+					},
+					{
+						IpAddressPrefix: "fd00::100/120",
+						Routes: []hcn.Route{
+							{
+								NextHop:           "fd00::101",
+								DestinationPrefix: "::/0",
+							},
+						},
+					},
+				},
+			},
+		},
+		SchemaVersion: hcn.Version{Major: 2, Minor: 2},
+	}).Create()
+	if err != nil {
+		t.Fatalf("network creation: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := ntwk.Delete(); err != nil {
+			t.Errorf("network delete: %v", err)
+		}
+	})
+	t.Logf("created network %s (%s)", ntwk.Name, ntwk.Id)
+
+	ip4Want := hcn.IpConfig{
+		IpAddress:    "192.168.128.4",
+		PrefixLength: 20,
+	}
+	ip6Want := hcn.IpConfig{
+		IpAddress:    "fd00::106",
+		PrefixLength: 120,
+	}
+
+	rts := []hcn.Route{}
+	for _, ipam := range ntwk.Ipams {
+		for _, sb := range ipam.Subnets {
+			rts = append(rts, sb.Routes...)
+			t.Logf("%s subnet %s (gw: %s)", ipam.Type, sb.IpAddressPrefix, sb.Routes[0].NextHop)
+		}
+	}
+	ep, err := (&hcn.HostComputeEndpoint{
+		Name:               ntwk.Name + "endpoint",
+		HostComputeNetwork: ntwk.Id,
+		Routes:             rts,
+		IpConfigurations:   []hcn.IpConfig{ip4Want, ip6Want},
+		SchemaVersion:      hcn.Version{Major: 2, Minor: 2},
+	}).Create()
+	if err != nil {
+		t.Fatalf("endpoint creation: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := ep.Delete(); err != nil {
+			t.Errorf("endpoint delete: %v", err)
+		}
+	})
+	t.Logf("created endpoint %s", ep.Id)
+
+	for _, ip := range ep.IpConfigurations {
+		if ip != ip4Want && ip != ip6Want {
+			t.Fatalf("endpoint address (%v) != %v or %v", ip, ip4Want, ip6Want)
+		}
+		t.Logf("ip %s/%d", ip.IpAddress, ip.PrefixLength)
+	}
+
+	if err := ep.NamespaceAttach(ns.Id); err != nil {
+		t.Fatalf("network attachment: %v", err)
+	}
+
+	ctx, _, client := newContainerdClient(context.Background(), t)
+	ls := layers.FromImage(ctx, t, client, constants.ImageLinuxAlpineLatest,
+		constants.PlatformLinux, constants.SnapshotterLinux)
+
+	opts := defaultLCOWOptions(t)
+	vm := uvm.CreateAndStartLCOWFromOpts(ctx, t, opts)
+
+	if err := vm.CreateAndAssignNetworkSetup(ctx, "", ""); err != nil {
+		t.Fatalf("setting up network: %v", err)
+	}
+	if err := vm.ConfigureNetworking(ctx, ns.Id); err != nil {
+		t.Fatalf("adding network to vm: %v", err)
+	}
+
+	cID := strings.ReplaceAll(t.Name(), "/", "")
+	scratch, _ := layers.ScratchSpace(ctx, t, vm, "", "", "")
+	spec := oci.CreateLinuxSpec(ctx, t, cID,
+		oci.DefaultLinuxSpecOpts(ns.Id,
+			ctrdoci.WithProcessArgs("/bin/sh", "-c", oci.TailNullArgs),
+			oci.WithWindowsNetworkNamespace(ns.Id),
+			oci.WithWindowsLayerFolders(append(ls, scratch)))...)
+
+	c, _, cleanup := container.Create(ctx, t, vm, spec, cID, hcsOwner)
+	t.Logf("created container %s", cID)
+	t.Cleanup(cleanup)
+	init := container.Start(ctx, t, c, nil)
+	t.Cleanup(func() {
+		cmd.Kill(ctx, t, init)
+		cmd.Wait(ctx, t, init)
+		container.Kill(ctx, t, c)
+		container.Wait(ctx, t, c)
+	})
+
+	ps := oci.CreateLinuxSpec(ctx, t, cID,
+		oci.DefaultLinuxSpecOpts(ns.Id,
+			ctrdoci.WithDefaultPathEnv,
+			ctrdoci.WithProcessArgs("/bin/sh", "-c", `ip -o address show dev eth0 scope global`),
+		)...,
+	).Process
+	io := cmd.NewBufferedIO()
+	p := cmd.Create(ctx, t, c, ps, io)
+	cmd.Start(ctx, t, p)
+
+	e := cmd.Wait(ctx, t, p)
+	out, err := io.Output()
+	t.Logf("cmd output:\n%s", out)
+	if e != 0 || err != nil {
+		t.Fatalf("exit code %d and error %v", e, err)
+	}
+
+	for _, ipc := range ep.IpConfigurations {
+		ip := fmt.Sprintf("%s/%d", ipc.IpAddress, ipc.PrefixLength)
+		if !strings.Contains(out, ip) {
+			t.Errorf("missing ip address %s", ip)
+		}
+	}
+}
+
+func newNetworkNamespace() (*hcn.HostComputeNamespace, error) {
+	return (&hcn.HostComputeNamespace{}).Create()
+}


### PR DESCRIPTION
Currently, HCN endpoint IPv6 settings are not passed into the Linux guest, so containers will not be assigned the v6 addresses that the host endpoint has.

This PR updates the shim to forward IPv6 information to the guest, updates the guest to assign both v4 and v6 addresses, if they are present, and adds tests for ipv6 functionality.

Signed-off-by: Hamza El-Saawy <hamzaelsaawy@microsoft.com>