### PR TITLE
[release/0.9] Call container.Terminate() on shutdown timeouts

### DIFF
--- a/cmd/containerd-shim-runhcs-v1/task_hcs.go
+++ b/cmd/containerd-shim-runhcs-v1/task_hcs.go
@@ -778,7 +778,8 @@ func (ht *hcsTask) close(ctx context.Context) {
 						log.G(ctx).WithError(err).Error("failed to wait for container shutdown")
 					}
 				case <-t.C:
-					log.G(ctx).WithError(hcs.ErrTimeout).Error("failed to wait for container shutdown")
+					err = hcs.ErrTimeout
+					log.G(ctx).WithError(err).Error("failed to wait for container shutdown")
 				}
 			}
 


### PR DESCRIPTION
Call container.Terminate() on shutdown timeouts

(cherry picked from commit cae120b42536adea72101e6a358183c74a0bdac5)
Signed-off-by: Kirtana Ashok <Kirtana.Ashok@microsoft.com>