### PR TITLE
Fix all go installations in the CI to the same version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
 env:
   GOFLAGS: -mod=vendor
   GOPROXY: off
+  GO_VERSION: '1.18.x'
 
 jobs:
   lint:
@@ -14,7 +15,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.17.8'
+          go-version: ${{ env.GO_VERSION }}
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
@@ -32,7 +33,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '^1.15.0'
+          go-version: ${{ env.GO_VERSION }}
       - name: Validate main modules
         shell: powershell
         run: |
@@ -51,7 +52,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '^1.15.0'
+          go-version: ${{ env.GO_VERSION }}
       - name: Validate test modules
         shell: powershell
         run: |
@@ -71,7 +72,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '^1.15.0'
+          go-version: ${{ env.GO_VERSION }}
 
       - run: go test -gcflags=all=-d=checkptr -v ./... -tags admin
       - run: go test -gcflags=all=-d=checkptr -v ./internal -tags admin
@@ -103,7 +104,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '^1.15.0'
+          go-version: ${{ env.GO_VERSION }}
 
       - run: go build ./cmd/containerd-shim-runhcs-v1
       - run: go build ./cmd/runhcs
@@ -140,7 +141,7 @@ jobs:
       - name: Install go
         uses: actions/setup-go@v2
         with:
-          go-version: '^1.15.0'
+          go-version: ${{ env.GO_VERSION }}
 
       - name: Pull busybox image
         run: docker pull busybox

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.42.1 # Has fixes for stylecheck configuration https://github.com/golangci/golangci-lint/pull/2017/files
+          version: v1.48
           args: --timeout=5m -v
           skip-go-installation: true
           only-new-issues: true

--- a/internal/hcs/errors.go
+++ b/internal/hcs/errors.go
@@ -154,7 +154,7 @@ func (e *HcsError) Error() string {
 
 func (e *HcsError) Temporary() bool {
 	err, ok := e.Err.(net.Error)
-	return ok && err.Temporary()
+	return ok && err.Temporary() //nolint:staticcheck
 }
 
 func (e *HcsError) Timeout() bool {
@@ -193,7 +193,7 @@ func (e *SystemError) Error() string {
 
 func (e *SystemError) Temporary() bool {
 	err, ok := e.Err.(net.Error)
-	return ok && err.Temporary()
+	return ok && err.Temporary() //nolint:staticcheck
 }
 
 func (e *SystemError) Timeout() bool {
@@ -224,7 +224,7 @@ func (e *ProcessError) Error() string {
 
 func (e *ProcessError) Temporary() bool {
 	err, ok := e.Err.(net.Error)
-	return ok && err.Temporary()
+	return ok && err.Temporary() //nolint:staticcheck
 }
 
 func (e *ProcessError) Timeout() bool {

--- a/test/vendor/github.com/Microsoft/hcsshim/internal/hcs/errors.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/internal/hcs/errors.go
@@ -154,7 +154,7 @@ func (e *HcsError) Error() string {
 
 func (e *HcsError) Temporary() bool {
 	err, ok := e.Err.(net.Error)
-	return ok && err.Temporary()
+	return ok && err.Temporary() //nolint:staticcheck
 }
 
 func (e *HcsError) Timeout() bool {
@@ -193,7 +193,7 @@ func (e *SystemError) Error() string {
 
 func (e *SystemError) Temporary() bool {
 	err, ok := e.Err.(net.Error)
-	return ok && err.Temporary()
+	return ok && err.Temporary() //nolint:staticcheck
 }
 
 func (e *SystemError) Timeout() bool {
@@ -224,7 +224,7 @@ func (e *ProcessError) Error() string {
 
 func (e *ProcessError) Temporary() bool {
 	err, ok := e.Err.(net.Error)
-	return ok && err.Temporary()
+	return ok && err.Temporary() //nolint:staticcheck
 }
 
 func (e *ProcessError) Timeout() bool {


### PR DESCRIPTION
Addresses CI build break in https://github.com/microsoft/hcsshim/pull/1554 that was caused by the pipeline automatically choosing golang 1.19. Instead, use golang 1.18.x.

Signed-off-by: Kathryn Baldauf <kabaldau@microsoft.com>