### PR TITLE
uVM timeout handling and logging improvement

### DIFF
--- a/internal/hcs/system.go
+++ b/internal/hcs/system.go
@@ -91,7 +91,8 @@ func CreateComputeSystem(ctx context.Context, id string, hcsDocumentInterface in
 		}
 	}
 
-	events, err := processAsyncHcsResult(ctx, createError, resultJSON, computeSystem.callbackNumber, hcsNotificationSystemCreateCompleted, &timeout.SystemCreate)
+	events, err := processAsyncHcsResult(ctx, createError, resultJSON, computeSystem.callbackNumber,
+		hcsNotificationSystemCreateCompleted, &timeout.SystemCreate)
 	if err != nil {
 		if err == ErrTimeout {
 			// Terminate the compute system if it still exists. We're okay to
@@ -205,7 +206,8 @@ func (computeSystem *System) Start(ctx context.Context) (err error) {
 	}
 
 	resultJSON, err := vmcompute.HcsStartComputeSystem(ctx, computeSystem.handle, "")
-	events, err := processAsyncHcsResult(ctx, err, resultJSON, computeSystem.callbackNumber, hcsNotificationSystemStartCompleted, &timeout.SystemStart)
+	events, err := processAsyncHcsResult(ctx, err, resultJSON, computeSystem.callbackNumber,
+		hcsNotificationSystemStartCompleted, &timeout.SystemStart)
 	if err != nil {
 		return makeSystemError(computeSystem, operation, err, events)
 	}
@@ -347,7 +349,11 @@ func (computeSystem *System) Properties(ctx context.Context, types ...schema1.Pr
 // failed to be queried they will be tallied up and returned in as the first return value. Failures on
 // query are NOT considered errors; the only failure case for this method is if the containers job object
 // cannot be opened.
-func (computeSystem *System) queryInProc(ctx context.Context, props *hcsschema.Properties, types []hcsschema.PropertyType) ([]hcsschema.PropertyType, error) {
+func (computeSystem *System) queryInProc(
+	ctx context.Context,
+	props *hcsschema.Properties,
+	types []hcsschema.PropertyType,
+) ([]hcsschema.PropertyType, error) {
 	// In the future we can make use of some new functionality in the HCS that allows you
 	// to pass a job object for HCS to use for the container. Currently, the only way we'll
 	// be able to open the job/silo is if we're running as SYSTEM.
@@ -552,7 +558,8 @@ func (computeSystem *System) Pause(ctx context.Context) (err error) {
 	}
 
 	resultJSON, err := vmcompute.HcsPauseComputeSystem(ctx, computeSystem.handle, "")
-	events, err := processAsyncHcsResult(ctx, err, resultJSON, computeSystem.callbackNumber, hcsNotificationSystemPauseCompleted, &timeout.SystemPause)
+	events, err := processAsyncHcsResult(ctx, err, resultJSON, computeSystem.callbackNumber,
+		hcsNotificationSystemPauseCompleted, &timeout.SystemPause)
 	if err != nil {
 		return makeSystemError(computeSystem, operation, err, events)
 	}
@@ -579,7 +586,8 @@ func (computeSystem *System) Resume(ctx context.Context) (err error) {
 	}
 
 	resultJSON, err := vmcompute.HcsResumeComputeSystem(ctx, computeSystem.handle, "")
-	events, err := processAsyncHcsResult(ctx, err, resultJSON, computeSystem.callbackNumber, hcsNotificationSystemResumeCompleted, &timeout.SystemResume)
+	events, err := processAsyncHcsResult(ctx, err, resultJSON, computeSystem.callbackNumber,
+		hcsNotificationSystemResumeCompleted, &timeout.SystemResume)
 	if err != nil {
 		return makeSystemError(computeSystem, operation, err, events)
 	}
@@ -611,7 +619,8 @@ func (computeSystem *System) Save(ctx context.Context, options interface{}) (err
 	}
 
 	result, err := vmcompute.HcsSaveComputeSystem(ctx, computeSystem.handle, string(saveOptions))
-	events, err := processAsyncHcsResult(ctx, err, result, computeSystem.callbackNumber, hcsNotificationSystemSaveCompleted, &timeout.SystemSave)
+	events, err := processAsyncHcsResult(ctx, err, result, computeSystem.callbackNumber,
+		hcsNotificationSystemSaveCompleted, &timeout.SystemSave)
 	if err != nil {
 		return makeSystemError(computeSystem, operation, err, events)
 	}
@@ -750,7 +759,8 @@ func (computeSystem *System) registerCallback(ctx context.Context) error {
 	callbackMap[callbackNumber] = callbackContext
 	callbackMapLock.Unlock()
 
-	callbackHandle, err := vmcompute.HcsRegisterComputeSystemCallback(ctx, computeSystem.handle, notificationWatcherCallback, callbackNumber)
+	callbackHandle, err := vmcompute.HcsRegisterComputeSystemCallback(ctx, computeSystem.handle,
+		notificationWatcherCallback, callbackNumber)
 	if err != nil {
 		return err
 	}

--- a/internal/hcs/waithelper.go
+++ b/internal/hcs/waithelper.go
@@ -9,7 +9,14 @@ import (
 	"github.com/Microsoft/hcsshim/internal/log"
 )
 
-func processAsyncHcsResult(ctx context.Context, err error, resultJSON string, callbackNumber uintptr, expectedNotification hcsNotification, timeout *time.Duration) ([]ErrorEvent, error) {
+func processAsyncHcsResult(
+	ctx context.Context,
+	err error,
+	resultJSON string,
+	callbackNumber uintptr,
+	expectedNotification hcsNotification,
+	timeout *time.Duration,
+) ([]ErrorEvent, error) {
 	events := processHcsResult(ctx, resultJSON)
 	if IsPending(err) {
 		return nil, waitForNotification(ctx, callbackNumber, expectedNotification, timeout)
@@ -18,7 +25,12 @@ func processAsyncHcsResult(ctx context.Context, err error, resultJSON string, ca
 	return events, err
 }
 
-func waitForNotification(ctx context.Context, callbackNumber uintptr, expectedNotification hcsNotification, timeout *time.Duration) error {
+func waitForNotification(
+	ctx context.Context,
+	callbackNumber uintptr,
+	expectedNotification hcsNotification,
+	timeout *time.Duration,
+) error {
 	callbackMapLock.RLock()
 	if _, ok := callbackMap[callbackNumber]; !ok {
 		callbackMapLock.RUnlock()

--- a/internal/hcsoci/resources.go
+++ b/internal/hcsoci/resources.go
@@ -14,7 +14,7 @@ func NormalizeProcessorCount(ctx context.Context, cid string, requestedCount, ho
 			"id":              cid,
 			"requested count": requestedCount,
 			"assigned count":  hostCount,
-		}).Warn("Changing user requested  cpu count to current number of processors on the host")
+		}).Warn("Changing user requested cpu count to current number of processors on the host")
 		return hostCount
 	} else {
 		return requestedCount

--- a/internal/uvm/create_lcow.go
+++ b/internal/uvm/create_lcow.go
@@ -786,15 +786,12 @@ func CreateLCOW(ctx context.Context, opts *OptionsLCOW) (_ *UtilityVM, err error
 		return nil, err
 	}
 
-	err = uvm.create(ctx, doc)
-
-	log.G(ctx).Tracef("create_lcow::CreateLCOW uvm.create result uvm: %v err %v", uvm, err)
-
-	if err != nil {
-		return nil, fmt.Errorf("error while creating the compute system: %s", err)
+	if err = uvm.create(ctx, doc); err != nil {
+		return nil, fmt.Errorf("error while creating the compute system: %w", err)
 	}
+	log.G(ctx).WithField("uvm", uvm).Trace("create_lcow::CreateLCOW uvm.create result")
 
-	// Cerate a socket to inject entropy during boot.
+	// Create a socket to inject entropy during boot.
 	uvm.entropyListener, err = uvm.listenVsock(entropyVsockPort)
 	if err != nil {
 		return nil, err

--- a/internal/vmcompute/vmcompute.go
+++ b/internal/vmcompute/vmcompute.go
@@ -7,6 +7,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/sirupsen/logrus"
 	"go.opencensus.io/trace"
 
 	"github.com/Microsoft/hcsshim/internal/interop"
@@ -65,7 +66,7 @@ type HcsCallback syscall.Handle
 type HcsProcessInformation struct {
 	// ProcessId is the pid of the created process.
 	ProcessId uint32
-	reserved  uint32 //nolint:structcheck
+	_         uint32 // reserved padding
 	// StdInput is the handle associated with the stdin of the process.
 	StdInput syscall.Handle
 	// StdOutput is the handle associated with the stdout of the process.
@@ -75,10 +76,26 @@ type HcsProcessInformation struct {
 }
 
 func execute(ctx gcontext.Context, timeout time.Duration, f func() error) error {
+	now := time.Now()
 	if timeout > 0 {
 		var cancel gcontext.CancelFunc
 		ctx, cancel = gcontext.WithTimeout(ctx, timeout)
 		defer cancel()
+	}
+
+	// if ctx already has prior deadlines, the shortest timeout takes precedence and is used.
+	// find the true timeout for reporting
+	//
+	// this is mostly an issue with (*UtilityVM).Start(context.Context), which sets its
+	// own (2 minute) timeout.
+	deadline, ok := ctx.Deadline()
+	trueTimeout := timeout
+	if ok {
+		trueTimeout = deadline.Sub(now)
+		log.G(ctx).WithFields(logrus.Fields{
+			logfields.Timeout: trueTimeout,
+			"desiredTimeout":  timeout,
+		}).Trace("Executing syscall with deadline")
 	}
 
 	done := make(chan error, 1)
@@ -88,8 +105,10 @@ func execute(ctx gcontext.Context, timeout time.Duration, f func() error) error 
 	select {
 	case <-ctx.Done():
 		if ctx.Err() == gcontext.DeadlineExceeded {
-			log.G(ctx).WithField(logfields.Timeout, timeout).
-				Warning("Syscall did not complete within operation timeout. This may indicate a platform issue. If it appears to be making no forward progress, obtain the stacks and see if there is a syscall stuck in the platform API for a significant length of time.")
+			log.G(ctx).WithField(logfields.Timeout, trueTimeout).
+				Warning("Syscall did not complete within operation timeout. This may indicate a platform issue. " +
+					"If it appears to be making no forward progress, obtain the stacks and see if there is a syscall " +
+					"stuck in the platform API for a significant length of time.")
 		}
 		return ctx.Err()
 	case err := <-done:


### PR DESCRIPTION
`(*UtilityVM).Start` was using a potentially timed-out context for its terminate, which can cause the terminate to immediately error and not log the correct status of the operation.

Additionally `(*UtilityVM).Start` sets a 2 minute timeout on the context it ultimately passes to `"vmcompute".execute`, which silently overrides the timeout `execute` uses.
Improved logs to report correct timeout.

Spelling fix.
Shortened long lines.

Signed-off-by: Hamza El-Saawy <hamzaelsaawy@microsoft.com>