### PR TITLE
[test]logging and tracing to stdout

### DIFF
--- a/test/functional/uvm_update_test.go
+++ b/test/functional/uvm_update_test.go
@@ -10,12 +10,17 @@ import (
 	"github.com/opencontainers/runtime-spec/specs-go"
 
 	"github.com/Microsoft/hcsshim/internal/protocol/guestrequest"
+	"github.com/Microsoft/hcsshim/osversion"
 	"github.com/Microsoft/hcsshim/pkg/ctrdtaskapi"
 
+	"github.com/Microsoft/hcsshim/test/internal/require"
 	"github.com/Microsoft/hcsshim/test/internal/uvm"
 )
 
 func Test_LCOW_Update_Resources(t *testing.T) {
+	requireFeatures(t, featureLCOW)
+	require.Build(t, osversion.RS5)
+
 	for _, config := range []struct {
 		name     string
 		resource interface{}

--- a/test/go.mod
+++ b/test/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.9.0
 	github.com/stretchr/testify v1.8.0
+	go.opencensus.io v0.23.0
 	golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4
 	golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f
 	google.golang.org/grpc v1.47.0
@@ -77,7 +78,6 @@ require (
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/xeipuuv/gojsonschema v1.2.0 // indirect
 	github.com/yashtewari/glob-intersection v0.1.0 // indirect
-	go.opencensus.io v0.23.0 // indirect
 	golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 // indirect
 	golang.org/x/net v0.0.0-20220722155237-a158d28d115b // indirect
 	golang.org/x/text v0.3.7 // indirect

--- a/test/internal/flag/flag.go
+++ b/test/internal/flag/flag.go
@@ -6,6 +6,8 @@ package flag
 import (
 	"flag"
 	"strings"
+
+	"github.com/sirupsen/logrus"
 )
 
 const FeatureFlagName = "feature"
@@ -73,4 +75,41 @@ func (ss StringSet) String() string {
 // Standardize formats the feature flag s to be consistent (ie, trim and to lowercase)
 func Standardize(s string) string {
 	return strings.ToLower(strings.TrimSpace(s))
+}
+
+// LogrusLevel is a flag that accepts logrus logging levels, as strings.
+type LogrusLevel struct {
+	Level logrus.Level
+}
+
+var _ flag.Value = &LogrusLevel{}
+
+func NewLogrusLevel(name, value, usage string) *LogrusLevel {
+	l := &LogrusLevel{}
+	if lvl, err := logrus.ParseLevel(value); err == nil {
+		l.Level = lvl
+	} else {
+		l.Level = logrus.StandardLogger().Level
+	}
+	flag.Var(l, name, usage)
+	return l
+}
+
+func (l *LogrusLevel) String() string {
+	// may be called ona nil receiver
+	// return default level
+	if l == nil {
+		return logrus.StandardLogger().Level.String()
+	}
+
+	return l.Level.String()
+}
+
+func (l *LogrusLevel) Set(s string) error {
+	lvl, err := logrus.ParseLevel(s)
+	if err != nil {
+		return err
+	}
+	l.Level = lvl
+	return nil
 }


### PR DESCRIPTION
Add flag to control logging level in functional and gcs tests (since they do not get forwarded to ETW automatically), and enable collecting spans.

Output logs to std out, so it is combined with logs and output from `testing` framework, and also consumed by `test2json` in CI pipeline. Otherwise, the output would be split in two, if the stdout and stderr of the process are not sent to the same destination (eg, if the stdout is written to a file or captured by a variable).

Additionally, redirecting stderr in powershell throws an error since powershell pipes and redirections are byte-oriented.
That is, from within powershell:
```powershell
> cmd /c "cmd /c `"echo hi >&2`" 2>&1"
hi
```

However, whenever powershell encounters data on stderr, it always raises an error:
```powershell
> powershell -Command "(cmd /c \`"echo hi >&2\`") 2>&1"
cmd : hi
At line:1 char:2
+ (cmd /c "echo hi >&2") 2>&1
+  ~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (hi :String) [], RemoteException
    + FullyQualifiedErrorId : NativeCommandError
```