### PR TITLE
Prevent operations on exited HCS objects.

### DIFF
--- a/internal/hcs/process.go
+++ b/internal/hcs/process.go
@@ -12,6 +12,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/Microsoft/hcsshim/internal/cow"
 	"github.com/Microsoft/hcsshim/internal/log"
 	"github.com/Microsoft/hcsshim/internal/oc"
 	"github.com/Microsoft/hcsshim/internal/vmcompute"
@@ -37,6 +38,8 @@ type Process struct {
 	exitCode       int
 	waitError      error
 }
+
+var _ cow.Process = &Process{}
 
 func newProcess(process vmcompute.HcsProcess, processID int, computeSystem *System) *Process {
 	return &Process{
@@ -91,10 +94,7 @@ func (process *Process) processSignalResult(ctx context.Context, err error) (boo
 	case nil:
 		return true, nil
 	case ErrVmcomputeOperationInvalidState, ErrComputeSystemDoesNotExist, ErrElementNotFound:
-		select {
-		case <-process.waitBlock:
-			// The process exit notification has already arrived.
-		default:
+		if !process.stopped() {
 			// The process should be gone, but we have not received the notification.
 			// After a second, force unblock the process wait to work around a possible
 			// deadlock in the HCS.
@@ -152,6 +152,10 @@ func (process *Process) Kill(ctx context.Context) (bool, error) {
 
 	if process.handle == 0 {
 		return false, makeProcessError(process, operation, ErrAlreadyClosed, nil)
+	}
+
+	if process.stopped() {
+		return false, makeProcessError(process, operation, ErrProcessAlreadyStopped, nil)
 	}
 
 	if process.killSignalDelivered {
@@ -262,6 +266,16 @@ func (process *Process) Wait() error {
 	return process.waitError
 }
 
+// Exited returns if the process has stopped
+func (process *Process) stopped() bool {
+	select {
+	case <-process.waitBlock:
+		return true
+	default:
+		return false
+	}
+}
+
 // ResizeConsole resizes the console of the process.
 func (process *Process) ResizeConsole(ctx context.Context, width, height uint16) error {
 	process.handleLock.RLock()
@@ -298,15 +312,13 @@ func (process *Process) ResizeConsole(ctx context.Context, width, height uint16)
 // ExitCode returns the exit code of the process. The process must have
 // already terminated.
 func (process *Process) ExitCode() (int, error) {
-	select {
-	case <-process.waitBlock:
-		if process.waitError != nil {
-			return -1, process.waitError
-		}
-		return process.exitCode, nil
-	default:
+	if !process.stopped() {
 		return -1, makeProcessError(process, "hcs::Process::ExitCode", ErrInvalidProcessState, nil)
 	}
+	if process.waitError != nil {
+		return -1, process.waitError
+	}
+	return process.exitCode, nil
 }
 
 // StdioLegacy returns the stdin, stdout, and stderr pipes, respectively. Closing
@@ -352,7 +364,7 @@ func (process *Process) StdioLegacy() (_ io.WriteCloser, _ io.ReadCloser, _ io.R
 }
 
 // Stdio returns the stdin, stdout, and stderr pipes, respectively.
-// To close them, close the process handle.
+// To close them, close the process handle, or use the `CloseStd*` functions.
 func (process *Process) Stdio() (stdin io.Writer, stdout, stderr io.Reader) {
 	process.stdioLock.Lock()
 	defer process.stdioLock.Unlock()
@@ -361,40 +373,51 @@ func (process *Process) Stdio() (stdin io.Writer, stdout, stderr io.Reader) {
 
 // CloseStdin closes the write side of the stdin pipe so that the process is
 // notified on the read side that there is no more data in stdin.
-func (process *Process) CloseStdin(ctx context.Context) error {
+func (process *Process) CloseStdin(ctx context.Context) (err error) {
+	operation := "hcs::Process::CloseStdin"
+	ctx, span := trace.StartSpan(ctx, operation)
+	defer span.End()
+	defer func() { oc.SetSpanStatus(span, err) }()
+	span.AddAttributes(
+		trace.StringAttribute("cid", process.SystemID()),
+		trace.Int64Attribute("pid", int64(process.processID)))
+
 	process.handleLock.RLock()
 	defer process.handleLock.RUnlock()
-
-	operation := "hcs::Process::CloseStdin"
 
 	if process.handle == 0 {
 		return makeProcessError(process, operation, ErrAlreadyClosed, nil)
 	}
 
-	modifyRequest := processModifyRequest{
-		Operation: modifyCloseHandle,
-		CloseHandle: &closeHandle{
-			Handle: stdIn,
-		},
-	}
-
-	modifyRequestb, err := json.Marshal(modifyRequest)
-	if err != nil {
-		return err
-	}
-
-	resultJSON, err := vmcompute.HcsModifyProcess(ctx, process.handle, string(modifyRequestb))
-	events := processHcsResult(ctx, resultJSON)
-	if err != nil {
-		return makeProcessError(process, operation, err, events)
-	}
-
 	process.stdioLock.Lock()
-	if process.stdin != nil {
-		process.stdin.Close()
-		process.stdin = nil
+	defer process.stdioLock.Unlock()
+	if process.stdin == nil {
+		return nil
 	}
-	process.stdioLock.Unlock()
+
+	//HcsModifyProcess request to close stdin will fail if the process has already exited
+	if !process.stopped() {
+		modifyRequest := processModifyRequest{
+			Operation: modifyCloseHandle,
+			CloseHandle: &closeHandle{
+				Handle: stdIn,
+			},
+		}
+
+		modifyRequestb, err := json.Marshal(modifyRequest)
+		if err != nil {
+			return err
+		}
+
+		resultJSON, err := vmcompute.HcsModifyProcess(ctx, process.handle, string(modifyRequestb))
+		events := processHcsResult(ctx, resultJSON)
+		if err != nil {
+			return makeProcessError(process, operation, err, events)
+		}
+	}
+
+	process.stdin.Close()
+	process.stdin = nil
 
 	return nil
 }

--- a/internal/hcs/system.go
+++ b/internal/hcs/system.go
@@ -39,6 +39,9 @@ type System struct {
 	startTime      time.Time
 }
 
+var _ cow.Container = &System{}
+var _ cow.ProcessHost = &System{}
+
 func newSystem(id string) *System {
 	return &System{
 		id:        id,
@@ -201,6 +204,8 @@ func (computeSystem *System) Start(ctx context.Context) (err error) {
 	computeSystem.handleLock.RLock()
 	defer computeSystem.handleLock.RUnlock()
 
+	// prevent starting an exited system because waitblock we do not recreate waitBlock
+	// or rerun waitBackground, so we have no way to be notified of it closing again
 	if computeSystem.handle == 0 {
 		return makeSystemError(computeSystem, operation, ErrAlreadyClosed, nil)
 	}
@@ -227,7 +232,7 @@ func (computeSystem *System) Shutdown(ctx context.Context) error {
 
 	operation := "hcs::System::Shutdown"
 
-	if computeSystem.handle == 0 {
+	if computeSystem.handle == 0 || computeSystem.stopped() {
 		return nil
 	}
 
@@ -248,7 +253,7 @@ func (computeSystem *System) Terminate(ctx context.Context) error {
 
 	operation := "hcs::System::Terminate"
 
-	if computeSystem.handle == 0 {
+	if computeSystem.handle == 0 || computeSystem.stopped() {
 		return nil
 	}
 
@@ -298,17 +303,25 @@ func (computeSystem *System) Wait() error {
 	return computeSystem.waitError
 }
 
-// ExitError returns an error describing the reason the compute system terminated.
-func (computeSystem *System) ExitError() error {
+// stopped returns true if the compute system stopped.
+func (computeSystem *System) stopped() bool {
 	select {
 	case <-computeSystem.waitBlock:
-		if computeSystem.waitError != nil {
-			return computeSystem.waitError
-		}
-		return computeSystem.exitError
+		return true
 	default:
+	}
+	return false
+}
+
+// ExitError returns an error describing the reason the compute system terminated.
+func (computeSystem *System) ExitError() error {
+	if !computeSystem.stopped() {
 		return errors.New("container not exited")
 	}
+	if computeSystem.waitError != nil {
+		return computeSystem.waitError
+	}
+	return computeSystem.exitError
 }
 
 // Properties returns the requested container properties targeting a V1 schema container.
@@ -543,7 +556,7 @@ func (computeSystem *System) PropertiesV2(ctx context.Context, types ...hcsschem
 func (computeSystem *System) Pause(ctx context.Context) (err error) {
 	operation := "hcs::System::Pause"
 
-	// hcsPauseComputeSystemContext is an async peration. Start the outer span
+	// hcsPauseComputeSystemContext is an async operation. Start the outer span
 	// here to measure the full pause time.
 	ctx, span := oc.StartSpan(ctx, operation)
 	defer span.End()


### PR DESCRIPTION
Add checks to `hcs.System` to prevent attempting to shutdown or terminate a compute system that has already been stopped.
The same checks could be added to other operations (eg, pause, start, resume) but it is unclear what error should be returned in those situations, so those operations are left untouched.

Add checks to `hcs.Process` to prevent attempting to kill a stopped process. 
Although `hcs.Process` differs from `hcs.System` in that the latter returns an error if the system is already stopped or closed, but the former does not.
Therefore, `(*Process).Kill` returns `ErrProcessAlreadyStopped`, which is the expected error in `(*hcsExec).Kill`.

Finally, an additional check is added to `(*Process).CloseStdin` to skip sending a modify request to the process to close stdin if the process has already been stopped. 
(And `(*Process).CloseStdin` now creates a span, similar to `(*Process).CloseStd(out|err)`).

The motivation for this came from `(*UtilityVM).Close()` calling `Terminate` on the compute system, even if `(*UtilityVM).Terminate()` was already called.

Signed-off-by: Hamza El-Saawy <hamzaelsaawy@microsoft.com>