### PR TITLE
create-scratch: Allow scratch creation through VMGS boot.

### DIFF
--- a/internal/uvm/create_lcow.go
+++ b/internal/uvm/create_lcow.go
@@ -119,11 +119,11 @@ type OptionsLCOW struct {
 	DisableTimeSyncService  bool                // Disables the time synchronization service
 }
 
-// defaultLCOWOSBootFilesPath returns the default path used to locate the LCOW
+// DefaultLCOWOSBootFilesPath returns the default path used to locate the LCOW
 // OS kernel and root FS files. This default is the subdirectory
 // `LinuxBootFiles` in the directory of the executable that started the current
 // process; or, if it does not exist, `%ProgramFiles%\Linux Containers`.
-func defaultLCOWOSBootFilesPath() string {
+func DefaultLCOWOSBootFilesPath() string {
 	localDirPath := filepath.Join(filepath.Dir(os.Args[0]), "LinuxBootFiles")
 	if _, err := os.Stat(localDirPath); err == nil {
 		return localDirPath
@@ -143,7 +143,7 @@ func NewDefaultOptionsLCOW(id, owner string) *OptionsLCOW {
 	kernelDirectSupported := osversion.Build() >= 18286
 	opts := &OptionsLCOW{
 		Options:                 newDefaultOptions(id, owner),
-		BootFilesPath:           defaultLCOWOSBootFilesPath(),
+		BootFilesPath:           DefaultLCOWOSBootFilesPath(),
 		KernelFile:              KernelFile,
 		KernelDirect:            kernelDirectSupported,
 		RootFSFile:              InitrdFile,
@@ -387,7 +387,6 @@ func makeLCOWVMGSDoc(ctx context.Context, opts *OptionsLCOW, uvm *UtilityVM) (_ 
 	doc.VirtualMachine.Chipset.Uefi = &hcsschema.Uefi{
 		ApplySecureBootTemplate: "Apply",
 		SecureBootTemplateId:    "1734c6e8-3154-4dda-ba5f-a874cc483422", // aka MicrosoftWindowsSecureBootTemplateGUID equivalent to "Microsoft Windows" template from Get-VMHost | select SecureBootTemplates,
-
 	}
 
 	// Point at the file that contains the linux kernel and initrd images.

--- a/internal/uvm/security_policy.go
+++ b/internal/uvm/security_policy.go
@@ -13,7 +13,6 @@ import (
 	"github.com/Microsoft/hcsshim/internal/protocol/guestrequest"
 	"github.com/Microsoft/hcsshim/internal/protocol/guestresource"
 	"github.com/Microsoft/hcsshim/pkg/ctrdtaskapi"
-	"github.com/Microsoft/hcsshim/pkg/securitypolicy"
 )
 
 type ConfidentialUVMOpt func(ctx context.Context, r *guestresource.LCOWConfidentialOptions) error
@@ -21,14 +20,6 @@ type ConfidentialUVMOpt func(ctx context.Context, r *guestresource.LCOWConfident
 // WithSecurityPolicy sets the desired security policy for the resource.
 func WithSecurityPolicy(policy string) ConfidentialUVMOpt {
 	return func(ctx context.Context, r *guestresource.LCOWConfidentialOptions) error {
-		if policy == "" {
-			openDoorPolicy := securitypolicy.NewOpenDoorPolicy()
-			policyString, err := openDoorPolicy.EncodeToString()
-			if err != nil {
-				return err
-			}
-			policy = policyString
-		}
 		r.EncodedSecurityPolicy = policy
 		return nil
 	}

--- a/internal/uvm/start.go
+++ b/internal/uvm/start.go
@@ -285,7 +285,7 @@ func (uvm *UtilityVM) Start(ctx context.Context) (err error) {
 		if err := uvm.SetConfidentialUVMOptions(ctx,
 			WithSecurityPolicy(uvm.confidentialUVMOptions.SecurityPolicy),
 			WithSecurityPolicyEnforcer(uvm.confidentialUVMOptions.SecurityPolicyEnforcer),
-			WithUVMReferenceInfo(defaultLCOWOSBootFilesPath(), uvm.confidentialUVMOptions.UVMReferenceInfoFile),
+			WithUVMReferenceInfo(DefaultLCOWOSBootFilesPath(), uvm.confidentialUVMOptions.UVMReferenceInfoFile),
 		); err != nil {
 			return err
 		}


### PR DESCRIPTION
In confidential scenario the UVM is booted from a VMGS file, which means that we might not have the compressed/uncompressed kernels or initramfs.
This PR udpates `create-scratch` to allow VMGS boot. We do this via checking the existence of kernelinitrd.vmgs file under LinuxBootFiles.

Additionally, change the behavior of `WithSecurityPolicy`, since empty security policy should be handled in the guest. The issue with the current approach is that the hash of security policy is used as host data to allow attestation later. However, when no security policy is provided, the hash is computed over an empty string, whereas `WithSecurityPolicy` sets it to an `allow_all` one, when no policy is present. This results in further validation failure, because the host data at init time won't match the hash over `allow_all` policy.

Signed-off-by: Maksim An <maksiman@microsoft.com>