### PR TITLE
Adding some missing policy elements from the templates.

### DIFF
--- a/pkg/securitypolicy/api.rego
+++ b/pkg/securitypolicy/api.rego
@@ -1,6 +1,6 @@
 package api
 
-svn := "0.9.0"
+svn := "0.10.0"
 
 enforcement_points := {
     "mount_device": {"introducedVersion": "0.1.0", "allowedByDefault": false},

--- a/pkg/securitypolicy/open_door.rego
+++ b/pkg/securitypolicy/open_door.rego
@@ -1,6 +1,6 @@
 package policy
 
-api_svn := "0.9.0"
+api_svn := "0.10.0"
 
 mount_device := {"allowed": true}
 mount_overlay := {"allowed": true}
@@ -17,3 +17,5 @@ get_properties := {"allowed": true}
 dump_stacks := {"allowed": true}
 runtime_logging := {"allowed": true}
 load_fragment := {"allowed": true}
+scratch_mount := {"allowed": true}
+scratch_unmount := {"allowed": true}

--- a/pkg/securitypolicy/policy.rego
+++ b/pkg/securitypolicy/policy.rego
@@ -1,9 +1,6 @@
 package policy
 
-api_svn := "0.9.0"
-
-import future.keywords.every
-import future.keywords.in
+api_svn := "0.10.0"
 
 ##OBJECTS##
 


### PR DESCRIPTION
When encrypted scratch was added the policy and open door templates were not updated properly, i.e. the SVN was not incremented and `scratch_mount` and `scratch_unmount` were not added to the open door template. I've added a test which will keep this from happening in the future.
