### PR TITLE
policy: do not set policy to open door if none is provided

### DIFF
--- a/internal/uvm/security_policy.go
+++ b/internal/uvm/security_policy.go
@@ -13,7 +13,6 @@ import (
 	"github.com/Microsoft/hcsshim/internal/protocol/guestrequest"
 	"github.com/Microsoft/hcsshim/internal/protocol/guestresource"
 	"github.com/Microsoft/hcsshim/pkg/ctrdtaskapi"
-	"github.com/Microsoft/hcsshim/pkg/securitypolicy"
 )
 
 type ConfidentialUVMOpt func(ctx context.Context, r *guestresource.LCOWConfidentialOptions) error
@@ -21,14 +20,6 @@ type ConfidentialUVMOpt func(ctx context.Context, r *guestresource.LCOWConfident
 // WithSecurityPolicy sets the desired security policy for the resource.
 func WithSecurityPolicy(policy string) ConfidentialUVMOpt {
 	return func(ctx context.Context, r *guestresource.LCOWConfidentialOptions) error {
-		if policy == "" {
-			openDoorPolicy := securitypolicy.NewOpenDoorPolicy()
-			policyString, err := openDoorPolicy.EncodeToString()
-			if err != nil {
-				return err
-			}
-			policy = policyString
-		}
 		r.EncodedSecurityPolicy = policy
 		return nil
 	}


### PR DESCRIPTION
Currently hcsshim is setting an allow all open door policy if no security policy has been provided.
On the host side, the security policy is hashed and used as HostData when starting an SNP-uVM. However, guest receives the aforementioned "open_door" policy and computes hash over it. As a result, this has doesn't match the LaunchData which is returned by the attestation report and rightfully so, GCS rejects the security policy.

Fix this by not special handling empty security policy on the host side and let the guest decide what to do with it, thus ensuring that both host and guest compute the hash over the same thing.

Signed-off-by: Maksim An <maksiman@microsoft.com>