### PR TITLE
Reduce dependabot update schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,16 +1,26 @@
-# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 
 version: 2
 updates:
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "sunday"
+    # ignore patch version increment updates (will not affect security updates)
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
 
   - package-ecosystem: "gomod"
     directory: "/test"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "sunday"
+    # ignore patch version increment updates (will not affect security updates)
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
Change dependebot to only check for updates on Sundays, and to ignore patch version updates (ie, `a.b.c` -> `a.b.d` will not trigger a PR).

Signed-off-by: Hamza El-Saawy <hamzaelsaawy@microsoft.com>