### PR TITLE
Add logic to cleanup the oci bundle root dir on container delete

### DIFF
--- a/internal/guest/runtime/hcsv2/container.go
+++ b/internal/guest/runtime/hcsv2/container.go
@@ -48,8 +48,9 @@ type Container struct {
 	id    string
 	vsock transport.Transport
 
-	spec      *oci.Spec
-	isSandbox bool
+	spec          *oci.Spec
+	ociBundlePath string
+	isSandbox     bool
 
 	container   runtime.Container
 	initProcess *containerProcess
@@ -206,6 +207,14 @@ func (c *Container) Delete(ctx context.Context) error {
 	if err := os.RemoveAll(c.scratchDirPath); err != nil {
 		if retErr != nil {
 			retErr = fmt.Errorf("errors deleting container state, %s & %s", retErr, err)
+		} else {
+			retErr = err
+		}
+	}
+
+	if err := os.RemoveAll(c.ociBundlePath); err != nil {
+		if retErr != nil {
+			retErr = fmt.Errorf("errors deleting container oci bundle dir, %s & %s", retErr, err)
 		} else {
 			retErr = err
 		}

--- a/internal/guest/runtime/hcsv2/uvm.go
+++ b/internal/guest/runtime/hcsv2/uvm.go
@@ -230,6 +230,7 @@ func (h *Host) CreateContainer(ctx context.Context, id string, settings *prot.VM
 		id:             id,
 		vsock:          h.vsock,
 		spec:           settings.OCISpecification,
+		ociBundlePath:  settings.OCIBundlePath,
 		isSandbox:      criType == "sandbox",
 		exitType:       prot.NtUnexpectedExit,
 		processes:      make(map[uint32]*containerProcess),
@@ -267,7 +268,7 @@ func (h *Host) CreateContainer(ctx context.Context, id string, settings *prot.VM
 			}
 			defer func() {
 				if err != nil {
-					_ = os.RemoveAll(spec.SandboxRootDir(id))
+					_ = os.RemoveAll(settings.OCIBundlePath)
 				}
 			}()
 
@@ -293,7 +294,7 @@ func (h *Host) CreateContainer(ctx context.Context, id string, settings *prot.VM
 			}
 			defer func() {
 				if err != nil {
-					_ = os.RemoveAll(getWorkloadRootDir(id))
+					_ = os.RemoveAll(settings.OCIBundlePath)
 				}
 			}()
 			if err := policy.ExtendPolicyWithNetworkingMounts(sandboxID, h.securityPolicyEnforcer, settings.OCISpecification); err != nil {
@@ -310,7 +311,7 @@ func (h *Host) CreateContainer(ctx context.Context, id string, settings *prot.VM
 		}
 		defer func() {
 			if err != nil {
-				_ = os.RemoveAll(getStandaloneRootDir(id))
+				_ = os.RemoveAll(settings.OCIBundlePath)
 			}
 		}()
 	}

--- a/internal/guest/runtime/hcsv2/workload_container.go
+++ b/internal/guest/runtime/hcsv2/workload_container.go
@@ -21,10 +21,6 @@ import (
 	"github.com/Microsoft/hcsshim/pkg/annotations"
 )
 
-func getWorkloadRootDir(id string) string {
-	return filepath.Join(guestpath.LCOWRootPrefixInUVM, id)
-}
-
 // os.MkdirAll combines the given permissions with the running process's
 // umask. By default this causes 0777 to become 0755.
 // Temporarily set the umask of this process to 0 so that we can actually


### PR DESCRIPTION
This PR fixes a shared scratch scenario where the scratch directory is cleaned up on container delete, but since the container's root directory is in a different location, the root directory is never cleaned up. Be sure to clean up both the scratch and root directories regardless of whether shared scratch is set. 

Signed-off-by: Kathryn Baldauf <kabaldau@microsoft.com>