### PR TITLE
adding tarball support for generating root layer hashes

### DIFF
--- a/cmd/dmverity-vhd/README.md
+++ b/cmd/dmverity-vhd/README.md
@@ -23,11 +23,19 @@ generator.
 ## Example usage
 
 Create VHDs:
+
 ```bash
 dmverity-vhd create -i alpine:3.12 -o alpine_3_12_layers
 ```
 
 Compute root hashes:
+
 ```bash
 dmverity-vhd --docker roothash -i alpine:3.12
+```
+
+Compute root hashes with tarball:
+
+```bash
+dmverity-vhd --tarball /path/to/tarball.tar roothash -i alpine:3.12
 ```


### PR DESCRIPTION
This will be used in a "clean-room" scenario for use to security policy generation. Clean-room in this instance is for generating a security policy on computers without internet access or the docker daemon (or similar) running.

The `&tag` passed in defaults to "latest" if only the image name is passed in. If the value of the tag is `nil`, the tarball must only have one image in it. Otherwise, many images can be stored in the tarball and be searched by their image name and tag.