### PR TITLE
Add 20H2 container image to test constants

### DIFF
--- a/internal/hcsoci/devices.go
+++ b/internal/hcsoci/devices.go
@@ -69,8 +69,8 @@ func getDeviceUtilHostPath() string {
 }
 
 func isDeviceExtensionsSupported() bool {
-	// device extensions support was added from 20348 onwards.
-	return osversion.Build() >= 20348
+	// device extensions support was added from LTSC2022 (20348) onwards.
+	return osversion.Build() >= osversion.LTSC2022
 }
 
 // getDeviceExtensions is a helper function to read the files at `extensionPaths` and unmarshal the contents

--- a/internal/schemaversion/schemaversion.go
+++ b/internal/schemaversion/schemaversion.go
@@ -40,7 +40,7 @@ func IsSupported(sv *hcsschema.Version) error {
 	}
 
 	if IsV25(sv) {
-		if osversion.Build() < 20348 { // pending solution to quuestion over version numbers re osversion.V21H2
+		if osversion.Build() < osversion.LTSC2022 { // pending solution to question over version numbers re osversion.V21H2
 			return fmt.Errorf("unsupported on this Windows build")
 		}
 		return nil

--- a/osversion/windowsbuilds.go
+++ b/osversion/windowsbuilds.go
@@ -1,37 +1,63 @@
 package osversion
 
+// Windows Client and Server build numbers.
+//
+// See:
+// https://learn.microsoft.com/en-us/windows/release-health/release-information
+// https://learn.microsoft.com/en-us/windows/release-health/windows-server-release-info
+// https://learn.microsoft.com/en-us/windows/release-health/windows11-release-information
 const (
 	// RS1 (version 1607, codename "Redstone 1") corresponds to Windows Server
 	// 2016 (ltsc2016) and Windows 10 (Anniversary Update).
 	RS1 = 14393
+	// V1607 (version 1607, codename "Redstone 1") is an alias for [RS1].
+	V1607 = RS1
+	// LTSC2016 (Windows Server 2016) is an alias for [RS1].
+	LTSC2016 = RS1
 
 	// RS2 (version 1703, codename "Redstone 2") was a client-only update, and
 	// corresponds to Windows 10 (Creators Update).
 	RS2 = 15063
+	// V1703 (version 1703, codename "Redstone 2") is an alias for [RS2].
+	V1703 = RS2
 
 	// RS3 (version 1709, codename "Redstone 3") corresponds to Windows Server
 	// 1709 (Semi-Annual Channel (SAC)), and Windows 10 (Fall Creators Update).
 	RS3 = 16299
+	// V1709 (version 1709, codename "Redstone 3") is an alias for [RS3].
+	V1709 = RS3
 
 	// RS4 (version 1803, codename "Redstone 4") corresponds to Windows Server
 	// 1803 (Semi-Annual Channel (SAC)), and Windows 10 (April 2018 Update).
 	RS4 = 17134
+	// V1803 (version 1803, codename "Redstone 4") is an alias for [RS4].
+	V1803 = RS4
 
 	// RS5 (version 1809, codename "Redstone 5") corresponds to Windows Server
 	// 2019 (ltsc2019), and Windows 10 (October 2018 Update).
 	RS5 = 17763
+	// V1809 (version 1809, codename "Redstone 5") is an alias for [RS5].
+	V1809 = RS5
+	// LTSC2019 (Windows Server 2019) is an alias for [RS5].
+	LTSC2019 = RS5
 
-	// V19H1 (version 1903) corresponds to Windows Server 1903 (semi-annual
+	// V19H1 (version 1903, codename 19H1) corresponds to Windows Server 1903 (semi-annual
 	// channel).
 	V19H1 = 18362
+	// V1903 (version 1903) is an alias for [V19H1].
+	V1903 = V19H1
 
-	// V19H2 (version 1909) corresponds to Windows Server 1909 (semi-annual
+	// V19H2 (version 1909, codename 19H2) corresponds to Windows Server 1909 (semi-annual
 	// channel).
 	V19H2 = 18363
+	// V1909 (version 1909) is an alias for [V19H2].
+	V1909 = V19H2
 
-	// V20H1 (version 2004) corresponds to Windows Server 2004 (semi-annual
+	// V20H1 (version 2004, codename 20H1) corresponds to Windows Server 2004 (semi-annual
 	// channel).
 	V20H1 = 19041
+	// V2004 (version 2004) is an alias for [V20H1].
+	V2004 = V20H1
 
 	// V20H2 corresponds to Windows Server 20H2 (semi-annual channel).
 	V20H2 = 19042
@@ -44,7 +70,15 @@ const (
 
 	// V21H2Server corresponds to Windows Server 2022 (ltsc2022).
 	V21H2Server = 20348
+	// LTSC2022 (Windows Server 2022) is an alias for [V21H2Server]
+	LTSC2022 = V21H2Server
 
 	// V21H2Win11 corresponds to Windows 11 (original release).
 	V21H2Win11 = 22000
+
+	// V22H2Win10 corresponds to Windows 10 (2022 Update).
+	V22H2Win10 = 19045
+
+	// V22H2Win11 corresponds to Windows 11 (2022 Update).
+	V22H2Win11 = 22621
 )

--- a/test/internal/constants/images.go
+++ b/test/internal/constants/images.go
@@ -11,31 +11,52 @@ import (
 
 const (
 	DockerImageRepo     = "docker.io/library"
-	McrWindowsImageRepo = "mcr.microsoft.com/windows"
+	MCRWindowsImageRepo = "mcr.microsoft.com/windows"
 
 	ImageLinuxAlpineLatest = "docker.io/library/alpine:latest"
 	ImageLinuxPause31      = "k8s.gcr.io/pause:3.1"
+	ImageMCRLinuxPause     = "mcr.microsoft.com/oss/kubernetes/pause:3.1"
 )
 
 var ErrUnsupportedBuild = errors.New("unsupported build")
 
 var (
-	ImageWindowsNanoserver1709     = NanoserverImage("1709")
-	ImageWindowsNanoserver1803     = NanoserverImage("1803")
-	ImageWindowsNanoserver1809     = NanoserverImage("1809")
-	ImageWindowsNanoserver1903     = NanoserverImage("1903")
-	ImageWindowsNanoserver1909     = NanoserverImage("1909")
-	ImageWindowsNanoserver2004     = NanoserverImage("2004")
-	ImageWindowsNanoserver2009     = NanoserverImage("2009")
+	ImageWindowsNanoserver1709 = NanoserverImage("1709")
+	ImageWindowsNanoserver1803 = NanoserverImage("1803")
+	ImageWindowsNanoserver1809 = NanoserverImage("1809")
+	ImageWindowsNanoserver1903 = NanoserverImage("1903")
+	ImageWindowsNanoserver1909 = NanoserverImage("1909")
+	ImageWindowsNanoserver2004 = NanoserverImage("2004")
+	ImageWindowsNanoserver2009 = NanoserverImage("2009")
+
+	ImageWindowsNanoserverRS3  = ImageWindowsNanoserver1709
+	ImageWindowsNanoserverRS4  = ImageWindowsNanoserver1803
+	ImageWindowsNanoserverRS5  = ImageWindowsNanoserver1809
+	ImageWindowsNanoserver19H1 = ImageWindowsNanoserver1903
+	ImageWindowsNanoserver19H2 = ImageWindowsNanoserver1909
+	ImageWindowsNanoserver20H1 = ImageWindowsNanoserver2004
+	ImageWindowsNanoserver20H2 = NanoserverImage("20H2")
+
+	ImageWindowsNanoserverLTSC2019 = ImageWindowsNanoserver1809
 	ImageWindowsNanoserverLTSC2022 = NanoserverImage("ltsc2022")
 
-	ImageWindowsServercore1709     = ServercoreImage("1709")
-	ImageWindowsServercore1803     = ServercoreImage("1803")
-	ImageWindowsServercore1809     = ServercoreImage("1809")
-	ImageWindowsServercore1903     = ServercoreImage("1903")
-	ImageWindowsServercore1909     = ServercoreImage("1909")
-	ImageWindowsServercore2004     = ServercoreImage("2004")
-	ImageWindowsServercore2009     = ServercoreImage("2009")
+	ImageWindowsServercore1709 = ServercoreImage("1709")
+	ImageWindowsServercore1803 = ServercoreImage("1803")
+	ImageWindowsServercore1809 = ServercoreImage("1809")
+	ImageWindowsServercore1903 = ServercoreImage("1903")
+	ImageWindowsServercore1909 = ServercoreImage("1909")
+	ImageWindowsServercore2004 = ServercoreImage("2004")
+	ImageWindowsServercore2009 = ServercoreImage("2009")
+
+	ImageWindowsServercoreRS3  = ImageWindowsServercore1709
+	ImageWindowsServercoreRS4  = ImageWindowsServercore1803
+	ImageWindowsServercoreRS5  = ImageWindowsServercore1809
+	ImageWindowsServercore19H1 = ImageWindowsServercore1903
+	ImageWindowsServercore19H2 = ImageWindowsServercore1909
+	ImageWindowsServercore20H1 = ImageWindowsServercore2004
+	ImageWindowsServercore20H2 = ServercoreImage("20H2")
+
+	ImageWindowsServercoreLTSC2019 = ImageWindowsServercore1809
 	ImageWindowsServercoreLTSC2022 = ServercoreImage("ltsc2022")
 )
 
@@ -51,23 +72,24 @@ func makeImageURL(repo, image, tag string) string {
 }
 
 func NanoserverImage(tag string) string {
-	return makeImageURL(McrWindowsImageRepo, "nanoserver", tag)
+	return makeImageURL(MCRWindowsImageRepo, "nanoserver", tag)
 }
 
 func ServercoreImage(tag string) string {
-	return makeImageURL(McrWindowsImageRepo, "servercore", tag)
+	return makeImageURL(MCRWindowsImageRepo, "servercore", tag)
 }
 
 var _buildToTag = map[uint16]string{
-	osversion.RS1:         "1607",
-	osversion.RS2:         "1703",
-	osversion.RS3:         "1709",
-	osversion.RS4:         "1803",
-	osversion.RS5:         "1809",
-	osversion.V19H1:       "1903",
-	osversion.V19H2:       "1909",
-	osversion.V20H1:       "2004",
-	osversion.V21H2Server: "ltsc2022",
+	osversion.RS1:      "1607",
+	osversion.RS2:      "1703",
+	osversion.RS3:      "1709",
+	osversion.RS4:      "1803",
+	osversion.RS5:      "1809",
+	osversion.V19H1:    "1903",
+	osversion.V19H2:    "1909",
+	osversion.V20H1:    "2004",
+	osversion.V20H2:    "20H2",
+	osversion.LTSC2022: "ltsc2022",
 }
 
 func ImageFromBuild(build uint16) (string, error) {
@@ -79,7 +101,7 @@ func ImageFromBuild(build uint16) (string, error) {
 	// https://techcommunity.microsoft.com/t5/containers/windows-server-2022-and-beyond-for-containers/ba-p/2712487)
 	// the ltsc2022 image should continue to work on builds ws2022 and onwards. With this in mind,
 	// if there's no mapping for the host build, just use the Windows Server 2022 image.
-	if build > osversion.V21H2Server {
+	if build > osversion.LTSC2022 {
 		return "ltsc2022", nil
 	}
 	return "", ErrUnsupportedBuild


### PR DESCRIPTION
Add 20H2 container to testing constants for completeness, since mcr has corresponding nanoserver and servercore images.

Add test constants with codenames (RS5, 20H1, etc.) and server LTSC builds to make selection easier.

Update `"osversion"` constants with 22H2 for Windows 10 & 11.

Add aliases in `"osversion"` for version numbers and LTSC server builds to ease confusion between build code names and versions.

Signed-off-by: Hamza El-Saawy <hamzaelsaawy@microsoft.com>