### PR TITLE
fix snp-report: fake-report flag is now correctly parsed

### DIFF
--- a/internal/tools/snp-report/main.go
+++ b/internal/tools/snp-report/main.go
@@ -84,7 +84,7 @@ func main() {
 	if *binaryFmtFlag {
 		var binaryReport []byte
 		var err error
-		if !*fakeReportFlag {
+		if *fakeReportFlag {
 			binaryReport, err = fake.FetchRawSNPReport()
 		} else {
 			binaryReport, err = amdsevsnp.FetchRawSNPReport(reportBytes)


### PR DESCRIPTION
Previously `fake-report` flag of `snp-report` binary was incorrectly handled when report was requested in `binary` format. This PR fixes the logic.

Signed-off-by: Maksim An <maksiman@microsoft.com>