### PR TITLE
tests: rego policy exec in container tests

### DIFF
--- a/pkg/securitypolicy/opts.go
+++ b/pkg/securitypolicy/opts.go
@@ -1,6 +1,8 @@
 package securitypolicy
 
-type ContainerConfigOpt func(*ContainerConfig) error
+type ContainerConfigOpt func(config *ContainerConfig) error
+
+type PolicyConfigOpt func(config *PolicyConfig) error
 
 // WithEnvVarRules adds environment variable constraints to container policy config.
 func WithEnvVarRules(envs []EnvRuleConfig) ContainerConfigOpt {
@@ -47,6 +49,64 @@ func WithCommand(cmd []string) ContainerConfigOpt {
 func WithAllowStdioAccess(stdio bool) ContainerConfigOpt {
 	return func(c *ContainerConfig) error {
 		c.AllowStdioAccess = stdio
+		return nil
+	}
+}
+
+// WithExecProcesses allows specified exec processes.
+func WithExecProcesses(execs []ExecProcessConfig) ContainerConfigOpt {
+	return func(c *ContainerConfig) error {
+		c.ExecProcesses = append(c.ExecProcesses, execs...)
+		return nil
+	}
+}
+
+// WithContainers adds containers to security policy.
+func WithContainers(containers []ContainerConfig) PolicyConfigOpt {
+	return func(config *PolicyConfig) error {
+		config.Containers = append(config.Containers, containers...)
+		return nil
+	}
+}
+
+func WithAllowUnencryptedScratch(allow bool) PolicyConfigOpt {
+	return func(config *PolicyConfig) error {
+		config.AllowUnencryptedScratch = allow
+		return nil
+	}
+}
+
+func WithAllowEnvVarDropping(allow bool) PolicyConfigOpt {
+	return func(config *PolicyConfig) error {
+		config.AllowEnvironmentVariableDropping = allow
+		return nil
+	}
+}
+
+func WithAllowRuntimeLogging(allow bool) PolicyConfigOpt {
+	return func(config *PolicyConfig) error {
+		config.AllowRuntimeLogging = allow
+		return nil
+	}
+}
+
+func WithExternalProcesses(processes []ExternalProcessConfig) PolicyConfigOpt {
+	return func(config *PolicyConfig) error {
+		config.ExternalProcesses = append(config.ExternalProcesses, processes...)
+		return nil
+	}
+}
+
+func WithAllowPropertiesAccess(allow bool) PolicyConfigOpt {
+	return func(config *PolicyConfig) error {
+		config.AllowPropertiesAccess = allow
+		return nil
+	}
+}
+
+func WithAllowDumpStacks(allow bool) PolicyConfigOpt {
+	return func(config *PolicyConfig) error {
+		config.AllowDumpStacks = allow
 		return nil
 	}
 }

--- a/pkg/securitypolicy/securitypolicy.go
+++ b/pkg/securitypolicy/securitypolicy.go
@@ -52,6 +52,16 @@ type PolicyConfig struct {
 	AllowUnencryptedScratch bool `json:"allow_unencrypted_scratch" toml:"allow_unencrypted_scratch"`
 }
 
+func NewPolicyConfig(opts ...PolicyConfigOpt) (*PolicyConfig, error) {
+	p := &PolicyConfig{}
+	for _, o := range opts {
+		if err := o(p); err != nil {
+			return nil, err
+		}
+	}
+	return p, nil
+}
+
 // ExternalProcessConfig contains toml or JSON config for running external processes in the UVM.
 type ExternalProcessConfig struct {
 	Command          []string `json:"command" toml:"command"`

--- a/test/cri-containerd/main_test.go
+++ b/test/cri-containerd/main_test.go
@@ -99,6 +99,7 @@ var (
 	flagVirtstack             = flag.String("virtstack", "", "Virtstack to use for hypervisor isolated containers")
 	flagVMServiceBinary       = flag.String("vmservice-binary", "", "Path to a binary implementing the vmservice ttrpc service")
 	flagContainerdServiceName = flag.String("containerd-service-name", "containerd", "Name of the containerd Windows service")
+	flagSevSnp                = flag.Bool("sev-snp", false, "Indicates that the tests are running on hardware with SEV-SNP support")
 )
 
 // Features

--- a/test/cri-containerd/policy_test.go
+++ b/test/cri-containerd/policy_test.go
@@ -23,56 +23,55 @@ var validPolicyAlpineCommand = []string{"ash", "-c", "echo 'Hello'"}
 
 type configSideEffect func(*runtime.CreateContainerRequest) error
 
-func securityPolicyFromContainers(
-	policyType string,
-	unencryptedScratch bool,
-	containers []securitypolicy.ContainerConfig,
-	allowEnvironmentVariableDropping bool,
-) (string, error) {
-	pc, err := helpers.PolicyContainersFromConfigs(containers)
-	if err != nil {
-		return "", err
-	}
-	policyString, err := securitypolicy.MarshalPolicy(policyType, false, pc,
-		[]securitypolicy.ExternalProcessConfig{
-			{
-				Command:          []string{"ls", "-l", "/dev/mapper"},
-				WorkingDir:       "/",
-				AllowStdioAccess: true,
-			},
-			{
-				Command:          []string{"bash"},
-				WorkingDir:       "/",
-				AllowStdioAccess: true,
-			},
-		},
-		[]securitypolicy.FragmentConfig{},
-		true,
-		true,
-		true,
-		allowEnvironmentVariableDropping,
-		unencryptedScratch,
-	)
-	if err != nil {
-		return "", err
-	}
-	return base64.StdEncoding.EncodeToString([]byte(policyString)), nil
+var defaultExternalProcesses = []securitypolicy.ExternalProcessConfig{
+	{
+		Command:          []string{"ls", "-l", "/dev/mapper"},
+		WorkingDir:       "/",
+		AllowStdioAccess: true,
+	},
+	{
+		Command:          []string{"bash"},
+		WorkingDir:       "/",
+		AllowStdioAccess: true,
+	},
 }
 
-func sandboxSecurityPolicy(t *testing.T, policyType string, unencryptedOk bool, dropEnvOk bool) string {
+func policyFromOpts(t *testing.T, policyType string, opts ...securitypolicy.PolicyConfigOpt) string {
 	t.Helper()
-	defaultContainers := helpers.DefaultContainerConfigs()
-	policyString, err := securityPolicyFromContainers(policyType, unencryptedOk, defaultContainers, dropEnvOk)
-	if err != nil {
-		t.Fatalf("failed to create security policy string: %s", err)
+	defaultOpts := []securitypolicy.PolicyConfigOpt{
+		securitypolicy.WithContainers(helpers.DefaultContainerConfigs()),
 	}
-	return policyString
+
+	defaultOpts = append(defaultOpts, opts...)
+	config, err := securitypolicy.NewPolicyConfig(defaultOpts...)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pc, err := helpers.PolicyContainersFromConfigs(config.Containers)
+	if err != nil {
+		t.Fatal(err)
+	}
+	policyString, err := securitypolicy.MarshalPolicy(
+		policyType,
+		false,
+		pc,
+		config.ExternalProcesses,
+		config.Fragments,
+		config.AllowPropertiesAccess,
+		config.AllowDumpStacks,
+		config.AllowRuntimeLogging,
+		config.AllowEnvironmentVariableDropping,
+		config.AllowUnencryptedScratch,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return base64.StdEncoding.EncodeToString([]byte(policyString))
 }
 
 func alpineSecurityPolicy(t *testing.T, policyType string, allowEnvironmentVariableDropping bool, opts ...securitypolicy.ContainerConfigOpt) string {
 	t.Helper()
-	defaultContainers := helpers.DefaultContainerConfigs()
-
 	alpineContainer := securitypolicy.ContainerConfig{
 		ImageName: imageLcowAlpine,
 		Command:   validPolicyAlpineCommand,
@@ -84,22 +83,32 @@ func alpineSecurityPolicy(t *testing.T, policyType string, allowEnvironmentVaria
 		}
 	}
 
-	containers := append(defaultContainers, alpineContainer)
-	policyString, err := securityPolicyFromContainers(policyType, true, containers, allowEnvironmentVariableDropping)
-	if err != nil {
-		t.Fatalf("failed to create security policy string: %s", err)
-	}
-	return policyString
+	containers := append(helpers.DefaultContainerConfigs(), alpineContainer)
+	return policyFromOpts(
+		t,
+		policyType,
+		securitypolicy.WithContainers(containers),
+		securitypolicy.WithExternalProcesses(defaultExternalProcesses),
+		securitypolicy.WithAllowUnencryptedScratch(true),
+		securitypolicy.WithAllowEnvVarDropping(allowEnvironmentVariableDropping),
+		securitypolicy.WithAllowRuntimeLogging(true),
+		securitypolicy.WithAllowPropertiesAccess(true),
+		securitypolicy.WithAllowDumpStacks(true),
+	)
 }
 
 func sandboxRequestWithPolicy(t *testing.T, policy string) *runtime.RunPodSandboxRequest {
 	t.Helper()
+	securityHardware := false
+	if *flagSevSnp {
+		securityHardware = true
+	}
 	return getRunPodSandboxRequest(
 		t,
 		lcowRuntimeHandler,
 		WithSandboxAnnotations(
 			map[string]string{
-				annotations.NoSecurityHardware:  "true",
+				annotations.NoSecurityHardware:  fmt.Sprintf("%t", !securityHardware),
 				annotations.SecurityPolicy:      policy,
 				annotations.VPMemNoMultiMapping: "true",
 			},
@@ -137,7 +146,12 @@ func Test_RunPodSandbox_WithPolicy_Allowed(t *testing.T) {
 
 	for _, pc := range policyTestMatrix {
 		t.Run(t.Name()+fmt.Sprintf("_Enforcer_%s_Input_%s", pc.enforcer, pc.input), func(t *testing.T) {
-			sandboxPolicy := sandboxSecurityPolicy(t, pc.input, true, true)
+			sandboxPolicy := policyFromOpts(
+				t,
+				pc.input,
+				securitypolicy.WithAllowUnencryptedScratch(true),
+				securitypolicy.WithAllowEnvVarDropping(true),
+			)
 			sandboxRequest := sandboxRequestWithPolicy(t, sandboxPolicy)
 			sandboxRequest.Config.Annotations[annotations.SecurityPolicyEnforcer] = pc.enforcer
 
@@ -801,7 +815,12 @@ func Test_RunContainer_WithPolicy_And_SecurityPolicyEnv_Annotation(t *testing.T)
 						annotations.UVMSecurityPolicyEnv: "true",
 						annotations.HostAMDCertificate:   certValue,
 					}
+				} else {
+					containerRequest.Config.Annotations = map[string]string{
+						annotations.UVMSecurityPolicyEnv: "false",
+					}
 				}
+
 				// setup logfile to capture stdout
 				logPath := filepath.Join(t.TempDir(), "log.txt")
 				containerRequest.Config.LogPath = logPath
@@ -967,7 +986,13 @@ func Test_RunPodSandboxAllowed_WithPolicy_EncryptedScratchPolicy(t *testing.T) {
 		},
 	} {
 		t.Run(fmt.Sprintf("AllowUnencrypted_%t_EncryptionEnabled_%t", tc.allowUnencrypted, tc.encryptAnnotation), func(t *testing.T) {
-			policy := sandboxSecurityPolicy(t, "rego", tc.allowUnencrypted, true)
+			policy := policyFromOpts(
+				t,
+				"rego",
+				securitypolicy.WithExternalProcesses(defaultExternalProcesses),
+				securitypolicy.WithAllowUnencryptedScratch(tc.allowUnencrypted),
+				securitypolicy.WithAllowEnvVarDropping(true),
+			)
 			sandboxRequest := sandboxRequestWithPolicy(t, policy)
 			// sandboxRequestWithPolicy sets security policy annotation, so we
 			// won't get a nil point deref here.
@@ -997,8 +1022,15 @@ func Test_RunPodSandboxNotAllowed_WithPolicy_EncryptedScratchPolicy(t *testing.T
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	policy := sandboxSecurityPolicy(t, "rego", false, true)
+	policy := policyFromOpts(
+		t,
+		"rego",
+		securitypolicy.WithExternalProcesses(defaultExternalProcesses),
+		securitypolicy.WithAllowUnencryptedScratch(false),
+		securitypolicy.WithAllowEnvVarDropping(true),
+	)
 	sandboxRequest := sandboxRequestWithPolicy(t, policy)
+	sandboxRequest.Config.Annotations[annotations.EncryptedScratchDisk] = "false"
 
 	// we didn't pass encrypt scratch annotation and policy should reject pod creation
 	response, err := client.RunPodSandbox(ctx, sandboxRequest)
@@ -1083,6 +1115,85 @@ func Test_RunContainer_WithPolicy_And_Binary_Logger_Without_Stdio(t *testing.T) 
 			}
 			if tc.expectedOutput != string(content) {
 				t.Fatalf("expected output %q, got %q", tc.expectedOutput, string(content))
+			}
+		})
+	}
+}
+
+func Test_ExecInContainer_WithPolicy(t *testing.T) {
+	requireFeatures(t, featureLCOWIntegrity)
+
+	client := newTestRuntimeClient(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	for _, tc := range []struct {
+		execProcessConfig  securitypolicy.ExecProcessConfig
+		execProcessRequest []string
+		shouldFail         bool
+	}{
+		{
+			execProcessConfig: securitypolicy.ExecProcessConfig{
+				Command: []string{"ls"},
+			},
+			execProcessRequest: []string{"ls"},
+			shouldFail:         false,
+		},
+		{
+			execProcessConfig: securitypolicy.ExecProcessConfig{
+				Command: []string{"ls"},
+			},
+			execProcessRequest: []string{"ls", "-l"},
+			shouldFail:         true,
+		},
+	} {
+		t.Run(fmt.Sprintf("ExecInContainer_ShouldFail_%t", tc.shouldFail), func(t *testing.T) {
+			cmd := []string{"ash", "-c", "while true; do sleep 1; done"}
+			policy := alpineSecurityPolicy(
+				t,
+				"rego",
+				true,
+				securitypolicy.WithExecProcesses([]securitypolicy.ExecProcessConfig{tc.execProcessConfig}),
+				securitypolicy.WithCommand(cmd),
+			)
+			sandboxRequest := sandboxRequestWithPolicy(t, policy)
+			podID := runPodSandbox(t, client, ctx, sandboxRequest)
+			defer removePodSandbox(t, client, ctx, podID)
+			defer stopPodSandbox(t, client, ctx, podID)
+
+			conReq := getCreateContainerRequest(
+				podID,
+				fmt.Sprintf("alpine-exec-not-allowed-%t", tc.shouldFail),
+				imageLcowAlpine,
+				cmd,
+				sandboxRequest.Config,
+			)
+
+			containerID := createContainer(t, client, ctx, conReq)
+			defer removeContainer(t, client, ctx, containerID)
+
+			startContainer(t, client, ctx, containerID)
+			defer stopContainer(t, client, ctx, containerID)
+
+			requireContainerState(ctx, t, client, containerID, runtime.ContainerState_CONTAINER_RUNNING)
+
+			execReq := &runtime.ExecSyncRequest{
+				ContainerId: containerID,
+				Cmd:         tc.execProcessRequest,
+				Timeout:     20,
+			}
+			_, err := client.ExecSync(ctx, execReq)
+			if err == nil {
+				if tc.shouldFail {
+					t.Fatal("exec should've been denied by policy")
+				}
+			} else {
+				if !tc.shouldFail {
+					t.Fatalf("unexpected exec failure: %s", err)
+				}
+				if !strings.Contains(err.Error(), "invalid command") {
+					t.Fatalf("expected 'invalid command' error, got '%s' instead", err)
+				}
 			}
 		})
 	}

--- a/test/cri-containerd/policy_test.go
+++ b/test/cri-containerd/policy_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -99,16 +100,12 @@ func alpineSecurityPolicy(t *testing.T, policyType string, allowEnvironmentVaria
 
 func sandboxRequestWithPolicy(t *testing.T, policy string) *runtime.RunPodSandboxRequest {
 	t.Helper()
-	securityHardware := false
-	if *flagSevSnp {
-		securityHardware = true
-	}
 	return getRunPodSandboxRequest(
 		t,
 		lcowRuntimeHandler,
 		WithSandboxAnnotations(
 			map[string]string{
-				annotations.NoSecurityHardware:  fmt.Sprintf("%t", !securityHardware),
+				annotations.NoSecurityHardware:  strconv.FormatBool(!*flagSevSnp),
 				annotations.SecurityPolicy:      policy,
 				annotations.VPMemNoMultiMapping: "true",
 			},


### PR DESCRIPTION
Add CRI integration tests to validate rego policy enforcement around container execs.
Additionally introduce new `PolicyConfigOpt` type for easier policy config generation, update policy tests to use the opts.

Signed-off-by: Maksim An <maksiman@microsoft.com>