### PR TITLE
Add retry to install mingw

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,7 +168,7 @@ jobs:
 
       - name: Test rego security policy
         run: go test --tags=rego -timeout=30m -mod=mod -gcflags=all=-d=checkptr -v ./pkg/securitypolicy
-    
+
       - name: Test rego policy interpreter
         run: go test -mod=mod -gcflags=all=-d=checkptr -v ./internal/regopolicyinterpreter
 
@@ -243,12 +243,72 @@ jobs:
         with:
           path: src/github.com/Microsoft/hcsshim
 
+      - name: Install crictl
+        shell: powershell
+        run: |
+          $VerbosePreference = 'Continue'
+          $ErrorActionPreference = 'Stop'
+
+          $crictlVersion = 'v1.24.2'
+          $url = "https://github.com/kubernetes-sigs/cri-tools/releases/download/${crictlVersion}/crictl-${crictlVersion}-windows-amd64.tar.gz"
+          curl.exe -L --no-progress-meter -o c:\crictl.tar.gz $url
+          tar.exe xf c:\crictl.tar.gz -C "${{ github.workspace }}/bin"
+
+          if ( $LASTEXITCODE ) {
+            Write-Output '::error::Could not install crictl.'
+            exit $LASTEXITCODE
+          }
+
+      - name: Install mingw
+        shell: powershell
+        run: |
+          $VerbosePreference = 'Continue'
+          # dont set $ErrorActionPreference since we want to allow choco install to fail later on
+
+          Write-Output '::group::Update chocolaty'
+          choco upgrade -y chocolatey
+          Write-Output '::endgroup::'
+
+          if ( $LASTEXITCODE ) {
+            Write-Output '::error::Could not update chocolatey.'
+            exit $LASTEXITCODE
+          }
+
+          Write-Output 'Install mingw'
+          # Install sometimes fails when downloading mingw zip from source-forge with:
+          #  "ERROR: The remote file either doesn't exist, is unauthorized, or is forbidden for url"
+          # Issue is with accessing from source-forge, which version 10.3+ do not use, but cannot upgrade versions.
+
+          # Add retry and backoff
+          foreach ( $i in 1..3 ) {
+            Write-Output "::group::Attempt $i"
+            if ( $i -gt 1 ) {
+              # remove any left-over state
+              choco uninstall -y --no-progress --force mingw
+
+              Write-Output 'Sleeping for 2 seconds'
+              Sleep -Seconds 2
+            }
+
+            choco install -y --no-progress --stop-on-first-failure --force mingw --allow-downgrade --version 10.2.0
+            Write-Output '::endgroup::'
+            if ( -not $LASTEXITCODE ) {
+              Write-Output "Attempt $i succeeded (exit code: $LASTEXITCODE)"
+              break
+            }
+            Write-Output "::warning title=mingw::Attempt $i failed (exit code: $LASTEXITCODE)"
+          }
+
+          if ( $LASTEXITCODE ) {
+            Write-Output "::error::Could not install mingw after $i attempts."
+            exit $LASTEXITCODE
+          }
+
       - name: Build binaries
         shell: bash
         working-directory: src/github.com/containerd/containerd
         run: |
           set -o xtrace
-          choco install mingw --version 10.2.0 --allow-downgrade
           mingw32-make.exe binaries
           script/setup/install-cni-windows
 
@@ -257,12 +317,6 @@ jobs:
         shell: powershell
         run: |
           go build -mod vendor -o "${{ github.workspace }}/src/github.com/containerd/containerd/bin/containerd-shim-runhcs-v1.exe" .\cmd\containerd-shim-runhcs-v1
-
-      - name: Get crictl tool
-        shell: powershell
-        run: |
-          curl.exe -L "https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.24.2/crictl-v1.24.2-windows-amd64.tar.gz" -o c:\crictl.tar.gz
-          tar xf c:\crictl.tar.gz -C "${{ github.workspace }}/bin"
 
       - name: Run containerd integration tests
         shell: bash


### PR DESCRIPTION
Integration test often fails because of mingw installation failure, which in turn appears to be a web-request issues.
Adding rety and backoff/sleep to resolve issue.

Signed-off-by: Hamza El-Saawy <hamzaelsaawy@microsoft.com>