### PR TITLE
Adding the commandextractor tool.

### DIFF
--- a/internal/tools/commandextractor/README.md
+++ b/internal/tools/commandextractor/README.md
@@ -1,0 +1,66 @@
+# Command Extractor
+
+This tool extracts a list of commands as a JSON file which fully exercise a Rego policy.
+The input to the tool is a TOML policy config file, like the following:
+
+``` toml
+allow_properties_access = true
+allow_runtime_logging = true
+
+[[container]]
+image_name = "contoso.azurecr.io/main:latest"
+command = ["python3","server.py"]
+allow_elevated = true
+allow_stdio_access = true
+
+[[container.exec_process]]
+command = ["/bin/bash"]
+allow_stdio_access = true
+
+[[external_process]]
+command = ["/bin/bash"]
+allow_stdio_access = true
+```
+
+(this is identical to the input format for the [security policy tool](../securitypolicy/))
+
+The resulting commands can then be used by the [policy engine simulator](../policyenginesimulator/).
+
+## Getting Started
+
+The usage for the tool is:
+
+    ./commandextractor -h
+    Usage of commandextractor:
+      -fragments string
+          path to one or more fragment configuration TOML files
+      -policy string
+          path policy configuration TOML
+    
+    Example:
+
+    ./commandextractor -policy policy.toml -fragments fragment0.toml fragment1.toml
+
+
+As an example, say that you had two files: `policy.toml`, which contains the policy configuration,
+and `fragment.toml`, which contains the fragment configuration. One can set up an experiment to test
+a policy in the following way:
+
+    securitypolicytool -c policy.toml -t rego -r > policy.rego
+    securitypolicytool -c fragment.rego -t fragment -n demo -v 1.0.0 -r > fragment.rego
+    commandextractor -policy policy.toml -fragments fragment.toml > commands.json
+    policyenginesimulator -commands commands.json -policy policy.rego
+
+The example above assumes that you want to use a framework-based policy of the kind produced
+by securitypolicytool. If you had a custom policy (*e.g.* one written by hand) you would
+still need to produce a `policy.toml` in the same format as above, but otherwise everything
+is the same:
+
+    commandextractor -policy custom_container_info.toml
+    policyenginesimulator -commands custom_container_info.toml -policy policy.rego
+
+
+> **Note**
+>
+> The policy engine simulator loads fragment code from local files. The commands produced
+> by commandextractor will contain a placeholder which must be replaced with the actual path.

--- a/internal/tools/commandextractor/main.go
+++ b/internal/tools/commandextractor/main.go
@@ -1,0 +1,417 @@
+package main
+
+/*
+This executable creates JSON command files that are compatible with the
+`policyenginesimulator` tool. It does that by reading a TOML configuration
+file in the same format as the TOML configuration files used by
+`securitypolicytool`. The program process that configuration and then extracts
+container information by inspecting the referenced images directly (downloading
+them if necessary, which can create a delay) to extract layer information,
+environment variables, and so forth. It shares this code with the
+`securitypolicytool`.
+
+It then uses that information to construct the input
+objects and enforcement points which would be the result of HCS/GCS exercising
+that configuration. This means:
+
+1. Loading all fragments (using paths to local copies of the Rego)
+2. Executing all external processes
+3. Grabbing debug information from the UVM
+4. For each container:
+   a. Mount all layers
+   b. Mount an overlay
+   c. Mount a scratch volume
+   d. Mount all plan9s
+   e. Create a container
+   f. Run all container processes
+   g. Shutdown a container
+   h. Unmount plan9s
+   i. Unmount scratch
+   j. Unmount an overlay
+   k. Unmount all layers
+
+And writes all of these to the output as JSON commands.
+*/
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/Microsoft/hcsshim/internal/guest/spec"
+	"github.com/Microsoft/hcsshim/internal/guestpath"
+	"github.com/Microsoft/hcsshim/internal/tools/securitypolicy/helpers"
+	sp "github.com/Microsoft/hcsshim/pkg/securitypolicy"
+	"github.com/pelletier/go-toml"
+)
+
+type command struct {
+	Name  string                 `json:"name"`
+	Input map[string]interface{} `json:"input"`
+}
+
+var (
+	policyPath    = flag.String("policy", "", "path policy configuration TOML")
+	fragmentsPath = flag.String("fragments", "", "path to one or more fragment configuration TOML files")
+)
+
+var numContainers int = 0
+
+func generateContainerID() string {
+	id := fmt.Sprintf("container%d", numContainers)
+	numContainers += 1
+	return id
+}
+
+var numLayers int = 0
+
+func generateLayerID() string {
+	id := fmt.Sprintf("layer%d", numLayers)
+	numLayers += 1
+	return id
+}
+
+var numPlan9 int = 0
+
+func generatePlan9Source(containerID string) string {
+	source := fmt.Sprintf(
+		"%s/%s%s",
+		guestpath.LCOWRootPrefixInUVM, containerID,
+		fmt.Sprintf(guestpath.LCOWMountPathPrefixFmt, numPlan9),
+	)
+	numPlan9 += 1
+	return source
+}
+
+var numSandboxes int = 0
+
+func generateSandboxID() string {
+	id := fmt.Sprintf("sandbox%d", numSandboxes)
+	numSandboxes += 1
+	return id
+}
+
+func fragmentToCommand(fragment sp.FragmentConfig) command {
+	return command{
+		Name: "load_fragment",
+		Input: map[string]interface{}{
+			"issuer":     fragment.Issuer,
+			"feed":       fragment.Feed,
+			"local_path": "relative/path/to/local/fragment.rego",
+		},
+	}
+}
+
+func externalProcessToCommand(process sp.ExternalProcessConfig) command {
+	return command{
+		Name: "exec_external",
+		Input: map[string]interface{}{
+			"argList":    process.Command,
+			"workingDir": process.WorkingDir,
+			"envList":    []string{"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"},
+		},
+	}
+}
+
+func toArray(array sp.StringArrayMap) []string {
+	numElements := len(array.Elements)
+	elements := make([]string, 0, numElements)
+	for i := 0; i < numElements; i++ {
+		elements = append(elements, array.Elements[strconv.Itoa(i)])
+	}
+	return elements
+}
+
+func containerToCommands(container *sp.Container) []command {
+	commands := make([]command, 0)
+	numLayers := len(container.Layers.Elements)
+	layerPaths := make([]string, numLayers)
+	for layer := 0; layer < numLayers; layer++ {
+		layerTarget := fmt.Sprintf("/mnt/%s", generateLayerID())
+		layerPaths[layer] = layerTarget
+		deviceHash := container.Layers.Elements[strconv.Itoa(numLayers-layer-1)]
+		commands = append(commands, command{
+			Name: "mount_device",
+			Input: map[string]interface{}{
+				"deviceHash": deviceHash,
+				"target":     layerTarget,
+			},
+		})
+	}
+
+	containerID := generateContainerID()
+	sandboxID := generateSandboxID()
+	overlayTarget := fmt.Sprintf("/mnt/%s", generateLayerID())
+	commands = append(commands, command{
+		Name: "mount_overlay",
+		Input: map[string]interface{}{
+			"containerID": containerID,
+			"layerPaths":  layerPaths,
+			"target":      overlayTarget,
+		},
+	})
+
+	// mount scratch
+	scratchTarget := fmt.Sprintf("/mnt/%s", generateLayerID())
+	commands = append(commands, command{
+		Name: "scratch_mount",
+		Input: map[string]interface{}{
+			"target":    scratchTarget,
+			"encrypted": true,
+		},
+	})
+
+	envList := make([]string, 0, container.EnvRules.Length)
+	for _, env := range container.EnvRules.Elements {
+		if env.Strategy == "string" {
+			envList = append(envList, env.Rule)
+		}
+	}
+
+	mountPathPrefix := strings.Replace(guestpath.LCOWMountPathPrefixFmt, "%d", "[0-9]+", 1)
+	plan9Sources := []string{}
+	mounts := make([]interface{}, 0, container.Mounts.Length)
+	for _, mount := range container.Mounts.Elements {
+		source := mount.Source
+		if strings.HasPrefix(mount.Source, "plan9://") {
+			source = generatePlan9Source(containerID)
+			plan9Sources = append(plan9Sources, source)
+			commands = append(commands, command{
+				Name: "plan9_mount",
+				Input: map[string]interface{}{
+					"rootPrefix":      guestpath.LCOWRootPrefixInUVM,
+					"mountPathPrefix": mountPathPrefix,
+					"target":          source,
+				},
+			})
+		} else if strings.HasPrefix(source, guestpath.SandboxMountPrefix) {
+			source = spec.SandboxMountSource(sandboxID, source)
+		} else if strings.HasPrefix(source, guestpath.HugePagesMountPrefix) {
+			source = spec.HugePagesMountSource(sandboxID, source)
+		}
+
+		mounts = append(mounts, map[string]interface{}{
+			"destination": mount.Destination,
+			"source":      source,
+			"options":     toArray(sp.StringArrayMap(mount.Options)),
+			"type":        mount.Type,
+		})
+	}
+
+	argList := toArray(sp.StringArrayMap(container.Command))
+
+	commands = append(commands, command{
+		Name: "create_container",
+		Input: map[string]interface{}{
+			"containerID":  containerID,
+			"argList":      argList,
+			"envList":      envList,
+			"workingDir":   container.WorkingDir,
+			"sandboxDir":   spec.SandboxMountsDir(sandboxID),
+			"hugePagesDir": spec.HugePagesMountsDir(sandboxID),
+			"mounts":       mounts,
+		},
+	})
+
+	for _, signal := range container.Signals {
+		commands = append(commands, command{
+			Name: "signal_container_process",
+			Input: map[string]interface{}{
+				"containerID":   containerID,
+				"signal":        signal,
+				"isInitProcess": true,
+				"argList":       argList,
+			},
+		})
+	}
+
+	for _, process := range container.ExecProcesses {
+		commands = append(commands, command{
+			Name: "exec_in_container",
+			Input: map[string]interface{}{
+				"containerID": containerID,
+				"argList":     process.Command,
+				"envList":     envList,
+				"workingDir":  container.WorkingDir,
+			},
+		})
+
+		for _, signal := range process.Signals {
+			commands = append(commands, command{
+				Name: "signal_container_process",
+				Input: map[string]interface{}{
+					"containerID":   containerID,
+					"signal":        signal,
+					"isInitProcess": false,
+					"argList":       process.Command,
+				},
+			})
+		}
+	}
+
+	commands = append(commands, command{
+		Name: "shutdown_container",
+		Input: map[string]interface{}{
+			"containerID": containerID,
+		},
+	})
+
+	for _, plan9Target := range plan9Sources {
+		commands = append(commands, command{
+			Name: "plan9_unmount",
+			Input: map[string]interface{}{
+				"unmountTarget": plan9Target,
+			},
+		})
+	}
+
+	commands = append(commands, command{
+		Name: "scratch_unmount",
+		Input: map[string]interface{}{
+			"unmountTarget": scratchTarget,
+		},
+	})
+
+	commands = append(commands, command{
+		Name: "unmount_overlay",
+		Input: map[string]interface{}{
+			"unmountTarget": overlayTarget,
+		},
+	})
+
+	for _, unmountTarget := range layerPaths {
+		commands = append(commands, command{
+			Name: "unmount_device",
+			Input: map[string]interface{}{
+				"unmountTarget": unmountTarget,
+			},
+		})
+	}
+
+	return commands
+}
+
+func policyConfigToCommands(path string) []command {
+	configData, err := os.ReadFile(path)
+	if err != nil {
+		log.Fatalf("error reading policy TOML: %v", err)
+	}
+
+	config := &sp.PolicyConfig{}
+
+	err = toml.Unmarshal(configData, config)
+	if err != nil {
+		log.Fatalf("error reading policy TOML: %v", err)
+	}
+
+	defaultContainers := helpers.DefaultContainerConfigs()
+	config.Containers = append(config.Containers, defaultContainers...)
+	policyContainers, err := helpers.PolicyContainersFromConfigs(config.Containers)
+	if err != nil {
+		log.Fatalf("error reading containers from images: %v", err)
+	}
+
+	commands := []command{}
+
+	// load all fragments first
+	for _, fragment := range config.Fragments {
+		commands = append(commands, fragmentToCommand(fragment))
+	}
+
+	// run all external processes
+	for _, process := range config.ExternalProcesses {
+		commands = append(commands, externalProcessToCommand(process))
+	}
+
+	// debugging methods
+	if config.AllowPropertiesAccess {
+		commands = append(commands, command{
+			Name:  "get_properties",
+			Input: map[string]interface{}{},
+		})
+	}
+
+	if config.AllowDumpStacks {
+		commands = append(commands, command{
+			Name:  "dump_stacks",
+			Input: map[string]interface{}{},
+		})
+	}
+
+	if config.AllowRuntimeLogging {
+		commands = append(commands, command{
+			Name:  "runtime_logging",
+			Input: map[string]interface{}{},
+		})
+	}
+
+	// create all containers and run their processes
+	for _, container := range policyContainers {
+		commands = append(commands, containerToCommands(container)...)
+	}
+
+	return commands
+}
+
+func fragmentConfigToCommands(path string) []command {
+	configData, err := os.ReadFile(path)
+	if err != nil {
+		log.Fatalf("error reading fragment TOML: %v", err)
+	}
+
+	config := &sp.PolicyConfig{}
+
+	err = toml.Unmarshal(configData, config)
+	if err != nil {
+		log.Fatalf("error reading fragment TOML: %v", err)
+	}
+
+	policyContainers, err := helpers.PolicyContainersFromConfigs(config.Containers)
+	if err != nil {
+		log.Fatalf("error reading containers from images: %v", err)
+	}
+
+	commands := []command{}
+
+	// load all fragments first
+	for _, fragment := range config.Fragments {
+		commands = append(commands, fragmentToCommand(fragment))
+	}
+
+	// run all external processes
+	for _, process := range config.ExternalProcesses {
+		commands = append(commands, externalProcessToCommand(process))
+	}
+
+	// create all containers and run their processes
+	for _, container := range policyContainers {
+		commands = append(commands, containerToCommands(container)...)
+	}
+
+	return commands
+}
+
+func main() {
+	flag.Parse()
+	if flag.NArg() != 0 || len(*policyPath) == 0 {
+		flag.Usage()
+		os.Exit(1)
+	}
+
+	commands := policyConfigToCommands(*policyPath)
+	fragments := strings.Split(*fragmentsPath, " ")
+	for _, fragment := range fragments {
+		commands = append(commands, fragmentConfigToCommands(fragment)...)
+	}
+
+	contents, err := json.MarshalIndent(commands, "", "    ")
+	if err != nil {
+		log.Fatalf("error when serializing commands: %v", err)
+	}
+
+	fmt.Printf("%s\n", string(contents[:]))
+}

--- a/internal/tools/policyenginesimulator/samples/simple_custom/commands.json
+++ b/internal/tools/policyenginesimulator/samples/simple_custom/commands.json
@@ -4,7 +4,6 @@
         "input": {
             "issuer": "did:web:contoso.github.io",
             "feed": "contoso.azurecr.io/custom",
-            "namespace": "custom",
             "local_path": "custom.rego"
         }
     },

--- a/internal/tools/policyenginesimulator/samples/simple_framework/commands.json
+++ b/internal/tools/policyenginesimulator/samples/simple_framework/commands.json
@@ -4,7 +4,6 @@
         "input": {
             "issuer": "did:web:contoso.github.io",
             "feed": "contoso.azurecr.io/fragment",
-            "namespace": "fragment",
             "local_path": "fragment.rego"
         }
     },

--- a/internal/tools/securitypolicy/main.go
+++ b/internal/tools/securitypolicy/main.go
@@ -40,8 +40,11 @@ func main() {
 			return err
 		}
 
-		defaultContainers := helpers.DefaultContainerConfigs()
-		config.Containers = append(config.Containers, defaultContainers...)
+		if *outputType != "fragment" {
+			defaultContainers := helpers.DefaultContainerConfigs()
+			config.Containers = append(config.Containers, defaultContainers...)
+		}
+
 		policyContainers, err := helpers.PolicyContainersFromConfigs(config.Containers)
 		if err != nil {
 			return err

--- a/pkg/securitypolicy/framework.rego
+++ b/pkg/securitypolicy/framework.rego
@@ -529,15 +529,12 @@ default exec_external := {"allowed": false}
 exec_external := {"allowed": true,
                   "allow_stdio_access": allow_stdio_access,
                   "env_list": env_list} {
-    print(count(candidate_external_processes))
-
     possible_processes := [process |
         process := candidate_external_processes[_]
         workingDirectory_ok(process.working_dir)
         command_ok(process.command)
     ]
 
-    print(count(possible_processes))
     # check to see if the environment variables match, dropping
     # them if allowed (and necessary)
     env_list := valid_envs_for_all(possible_processes)
@@ -592,7 +589,6 @@ apply_defaults(name, raw_values, framework_svn) := values {
 apply_defaults(name, raw_values, framework_svn) := values {
     semver.compare(framework_svn, svn) < 0
     template := load_defaults(name, framework_svn)
-    print(template)
     values := [updated | 
         raw := raw_values[_]
         flat := object.union(template, raw)


### PR DESCRIPTION
This tool extracts a list of commands as a JSON file which fully exercise a Rego policy. The input to the tool is a TOML policy config file, like the following:

``` toml
allow_properties_access = true
allow_runtime_logging = true

[[container]]
image_name = "contoso.azurecr.io/main:latest"
command = ["python3","server.py"]
allow_elevated = true
allow_stdio_access = true

[[container.exec_process]]
command = ["/bin/bash"]
allow_stdio_access = true

[[external_process]]
command = ["/bin/bash"]
allow_stdio_access = true
```

(this is identical to the input format for the securitypolicy tool)

The resulting commands can then be used by the policyenginesimulator.
