### PR TITLE
fix: temp file leak during hash computation

### DIFF
--- a/ext4/tar2ext4/tar2ext4.go
+++ b/ext4/tar2ext4/tar2ext4.go
@@ -249,6 +249,7 @@ func ConvertAndComputeRootDigest(r io.Reader) (string, error) {
 	defer func() {
 		_ = os.Remove(out.Name())
 	}()
+	defer out.Close()
 
 	options := []Option{
 		ConvertWhiteout,


### PR DESCRIPTION
Fix a temp file leak when computing dmverity root hash. This mainly 
affects `dmverity-vhd` tool and users may see their temp storage filling up.

Signed-off-by: Maksim An <maksiman@microsoft.com>