### PR TITLE
Add test for commands which contain quotes

### DIFF
--- a/internal/cmd/cmd_test.go
+++ b/internal/cmd/cmd_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"os/exec"
@@ -154,6 +155,15 @@ func TestCmdExitCode(t *testing.T) {
 	err := cmd.Run()
 	if e, ok := err.(*ExitError); !ok || e.ExitCode() != 64 {
 		t.Fatal("expected exit code 64, got ", err)
+	}
+}
+
+func TestCmdQuotesInCommand(t *testing.T) {
+	tempDir := t.TempDir()
+	cmd := Command(&localProcessHost{}, "cmd", "/S", "/C", fmt.Sprintf(`mkdir %s\test_dir && icacls %s\test_dir /grant "CREATOR OWNER":(OI)(CI)(IO)F /T`, tempDir, tempDir))
+	err := cmd.Run()
+	if err != nil {
+		t.Fatal(err)
 	}
 }
 


### PR DESCRIPTION
This adds a new test which verifies if a command containing parameters with quotes will work correctly.

I stumbled across this when I tried to create a Dockerfile with the following command:

```Dockerfile
RUN mkdir C:\test_dir && \
    icacls C:\test_dir /grant "CREATOR OWNER":(OI)(CI)(IO)F /T && \
    /bin/sh.exe -c "echo test_content > /test_dir/test_file"
```

It seems to fail because hcsshim escapes the command args, turning ```"CREATOR OWNER"``` into ```\"CREATOR OWNER\"``` and icacls complains with:

```
Invalid parameter ""CREATOR"
```

Notice the double quote before ```CREATOR```. Removing the call to ```windows.EscapeArg()``` and simply joining the args into a cmdline, seems to make it work. Not sure if that's right, though.

Signed-off-by: Gabriel Adrian Samfira <gsamfira@cloudbasesolutions.com>