### PR TITLE
Adding a default error message.

### DIFF
--- a/pkg/securitypolicy/securitypolicyenforcer_rego.go
+++ b/pkg/securitypolicy/securitypolicyenforcer_rego.go
@@ -307,11 +307,15 @@ func (policy *regoEnforcer) getReasonNotAllowed(enforcementPoint string, input i
 	if err == nil {
 		errors, _ := result.Value("errors")
 		if errors != nil {
-			return fmt.Errorf("%s not allowed by policy. Errors: %v.\nInput: %s", enforcementPoint, errors, string(inputJSON))
+			if len(errors.([]interface{})) > 0 {
+				return fmt.Errorf("%s not allowed by policy. Errors: %v. Input: %s", enforcementPoint, errors, string(inputJSON))
+			} else {
+				return fmt.Errorf("%s not allowed by policy. Security policy is not valid. Please check security policy or re-generate with tooling. Input: %s", enforcementPoint, string(inputJSON))
+			}
 		}
 	}
 
-	return fmt.Errorf("%s not allowed by policy.\nInput: %s", enforcementPoint, string(inputJSON))
+	return fmt.Errorf("%s not allowed by policy. Security policy is not valid. Please check security policy or re-generate with tooling. Input: %s", enforcementPoint, string(inputJSON))
 }
 
 func (policy *regoEnforcer) EnforceDeviceMountPolicy(target string, deviceHash string) error {


### PR DESCRIPTION
If the policy does not return an error, this means that an unexpected error has occurred. We want to signal this to the user by throwing a generic error which will indicate to them the general nature of what has gone wrong, i.e. that their Rego is invalid.
