### PR TITLE
SCSI package support partitioned disks

### DIFF
--- a/internal/clone/registry.go
+++ b/internal/clone/registry.go
@@ -44,7 +44,7 @@ type TemplateConfig struct {
 func init() {
 	// Register the pointer to structs because that is what is being stored.
 	gob.Register(&uvm.VSMBShare{})
-	gob.Register(&uvm.SCSIMount{})
+	gob.Register(&uvm.SCSIAttachment{})
 }
 
 func encodeTemplateConfig(templateConfig *TemplateConfig) ([]byte, error) {

--- a/internal/devices/drivers.go
+++ b/internal/devices/drivers.go
@@ -54,7 +54,7 @@ func InstallDrivers(ctx context.Context, vm *uvm.UtilityVM, share string, gpuDri
 	}
 
 	// no need to reinstall if the driver has already been added in LCOW, return early
-	if _, err := vm.GetScsiUvmPath(ctx, share); err != uvm.ErrNotAttached {
+	if _, err := vm.GetSCSIMountUVMPath(ctx, share); err != uvm.ErrNotAttached {
 		return nil, err
 	}
 

--- a/internal/guest/runtime/hcsv2/uvm.go
+++ b/internal/guest/runtime/hcsv2/uvm.go
@@ -897,7 +897,10 @@ func modifyMappedVirtualDisk(
 				return err
 			}
 		}
-		return scsi.UnplugDevice(ctx, mvd.Controller, mvd.Lun)
+		if mvd.UnplugDevice {
+			return scsi.UnplugDevice(ctx, mvd.Controller, mvd.Lun)
+		}
+		return nil
 	default:
 		return newInvalidRequestTypeError(rt)
 	}

--- a/internal/hcsoci/hcsdoc_wcow.go
+++ b/internal/hcsoci/hcsdoc_wcow.go
@@ -76,7 +76,7 @@ func createMountsConfig(ctx context.Context, coi *createOptionsInternal) (*mount
 						return nil, err
 					}
 				}
-				uvmPath, err := coi.HostingSystem.GetScsiUvmPath(ctx, mountPath)
+				uvmPath, err := coi.HostingSystem.GetSCSIMountUVMPath(ctx, mountPath)
 				if err != nil {
 					return nil, err
 				}

--- a/internal/hcsoci/resources_lcow.go
+++ b/internal/hcsoci/resources_lcow.go
@@ -30,12 +30,12 @@ func allocateLinuxResources(ctx context.Context, coi *createOptionsInternal, r *
 	containerRootInUVM := r.ContainerRootInUVM()
 	if coi.Spec.Windows != nil && len(coi.Spec.Windows.LayerFolders) > 0 {
 		log.G(ctx).Debug("hcsshim::allocateLinuxResources mounting storage")
-		rootPath, scratchPath, err := layers.MountLCOWLayers(ctx, coi.actualID, coi.Spec.Windows.LayerFolders, containerRootInUVM, "", coi.HostingSystem)
+		rootPath, scratchPath, layersMounts, err := layers.MountLCOWLayers(ctx, coi.actualID, coi.Spec.Windows.LayerFolders, containerRootInUVM, "", coi.HostingSystem)
 		if err != nil {
 			return errors.Wrap(err, "failed to mount container storage")
 		}
 		coi.Spec.Root.Path = rootPath
-		layers := layers.NewImageLayers(coi.HostingSystem, containerRootInUVM, coi.Spec.Windows.LayerFolders, "", isSandbox)
+		layers := layers.NewImageLayers(coi.HostingSystem, containerRootInUVM, layersMounts, "", isSandbox)
 		r.SetLayers(layers)
 		r.SetLcowScratchPath(scratchPath)
 	} else if coi.Spec.Root.Path != "" {

--- a/internal/hcsoci/resources_wcow.go
+++ b/internal/hcsoci/resources_wcow.go
@@ -59,12 +59,12 @@ func allocateWindowsResources(ctx context.Context, coi *createOptionsInternal, r
 	if coi.Spec.Root.Path == "" && (coi.HostingSystem != nil || coi.Spec.Windows.HyperV == nil) {
 		log.G(ctx).Debug("hcsshim::allocateWindowsResources mounting storage")
 		containerRootInUVM := r.ContainerRootInUVM()
-		containerRootPath, err := layers.MountWCOWLayers(ctx, coi.actualID, coi.Spec.Windows.LayerFolders, containerRootInUVM, "", coi.HostingSystem)
+		containerRootPath, layerMounts, err := layers.MountWCOWLayers(ctx, coi.actualID, coi.Spec.Windows.LayerFolders, containerRootInUVM, "", coi.HostingSystem)
 		if err != nil {
 			return errors.Wrap(err, "failed to mount container storage")
 		}
 		coi.Spec.Root.Path = containerRootPath
-		layers := layers.NewImageLayers(coi.HostingSystem, containerRootInUVM, coi.Spec.Windows.LayerFolders, "", isSandbox)
+		layers := layers.NewImageLayers(coi.HostingSystem, containerRootInUVM, layerMounts, "", isSandbox)
 		r.SetLayers(layers)
 	}
 

--- a/internal/layers/layers.go
+++ b/internal/layers/layers.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"time"
 
@@ -23,19 +24,24 @@ import (
 	"github.com/Microsoft/hcsshim/internal/wclayer"
 )
 
+type LayerMount struct {
+	HostPath  string
+	GuestPath string
+}
+
 // ImageLayers contains all the layers for an image.
 type ImageLayers struct {
 	vm                 *uvm.UtilityVM
 	containerRootInUVM string
 	volumeMountPath    string
-	layers             []string
+	layers             []*LayerMount
 	// In some instances we may want to avoid cleaning up the image layers, such as when tearing
 	// down a sandbox container since the UVM will be torn down shortly after and the resources
 	// can be cleaned up on the host.
 	skipCleanup bool
 }
 
-func NewImageLayers(vm *uvm.UtilityVM, containerRootInUVM string, layers []string, volumeMountPath string, skipCleanup bool) *ImageLayers {
+func NewImageLayers(vm *uvm.UtilityVM, containerRootInUVM string, layers []*LayerMount, volumeMountPath string, skipCleanup bool) *ImageLayers {
 	return &ImageLayers{
 		vm:                 vm,
 		containerRootInUVM: containerRootInUVM,
@@ -71,16 +77,16 @@ func (layers *ImageLayers) Release(ctx context.Context, all bool) error {
 // Returns the path at which the `rootfs` of the container can be accessed. Also, returns the path inside the
 // UVM at which container scratch directory is located. Usually, this path is the path at which the container
 // scratch VHD is mounted. However, in case of scratch sharing this is a directory under the UVM scratch.
-func MountLCOWLayers(ctx context.Context, containerID string, layerFolders []string, guestRoot, volumeMountPath string, vm *uvm.UtilityVM) (_, _ string, err error) {
+func MountLCOWLayers(ctx context.Context, containerID string, layerFolders []string, guestRoot, volumeMountPath string, vm *uvm.UtilityVM) (_, _ string, _ []*LayerMount, err error) {
 	if vm.OS() != "linux" {
-		return "", "", errors.New("MountLCOWLayers should only be called for LCOW")
+		return "", "", nil, errors.New("MountLCOWLayers should only be called for LCOW")
 	}
 
 	// V2 UVM
 	log.G(ctx).WithField("os", vm.OS()).Debug("hcsshim::MountLCOWLayers V2 UVM")
 
 	var (
-		layersAdded       []string
+		layersAdded       []*LayerMount
 		lcowUvmLayerPaths []string
 	)
 	defer func() {
@@ -95,22 +101,21 @@ func MountLCOWLayers(ctx context.Context, containerID string, layerFolders []str
 
 	for _, layerPath := range layerFolders[:len(layerFolders)-1] {
 		log.G(ctx).WithField("layerPath", layerPath).Debug("mounting layer")
-		var (
+		if path.Ext(layerPath) != ".vhd" && path.Ext(layerPath) != ".vhdx" {
 			layerPath = filepath.Join(layerPath, "layer.vhd")
-			uvmPath   string
-		)
-		uvmPath, err = addLCOWLayer(ctx, vm, layerPath)
-		if err != nil {
-			return "", "", fmt.Errorf("failed to add LCOW layer: %s", err)
 		}
-		layersAdded = append(layersAdded, layerPath)
-		lcowUvmLayerPaths = append(lcowUvmLayerPaths, uvmPath)
+		layerMount, err := addLCOWLayer(ctx, vm, layerPath)
+		if err != nil {
+			return "", "", nil, fmt.Errorf("failed to add LCOW layer: %s", err)
+		}
+		layersAdded = append(layersAdded, layerMount)
+		lcowUvmLayerPaths = append(lcowUvmLayerPaths, layerMount.GuestPath)
 	}
 
 	containerScratchPathInUVM := ospath.Join(vm.OS(), guestRoot)
-	hostPath, err := getScratchVHDPath(layerFolders)
+	hostPath, err := getScratchVHDHostPath(layerFolders)
 	if err != nil {
-		return "", "", fmt.Errorf("failed to get scratch VHD path in layer folders: %s", err)
+		return "", "", nil, fmt.Errorf("failed to get scratch VHD path in layer folders: %s", err)
 	}
 	log.G(ctx).WithField("hostPath", hostPath).Debug("mounting scratch VHD")
 
@@ -125,7 +130,7 @@ func MountLCOWLayers(ctx context.Context, containerID string, layerFolders []str
 		uvm.VMAccessTypeIndividual,
 	)
 	if err != nil {
-		return "", "", fmt.Errorf("failed to add SCSI scratch VHD: %s", err)
+		return "", "", nil, fmt.Errorf("failed to add SCSI scratch VHD: %s", err)
 	}
 
 	// handles the case where we want to share a scratch disk for multiple containers instead
@@ -138,19 +143,27 @@ func MountLCOWLayers(ctx context.Context, containerID string, layerFolders []str
 
 	defer func() {
 		if err != nil {
-			if err := vm.RemoveSCSI(ctx, hostPath); err != nil {
+			if err := vm.RemoveSCSIMount(ctx, scsiMount.HostPath, scsiMount.UVMPath); err != nil {
 				log.G(ctx).WithError(err).Warn("failed to remove scratch on cleanup")
 			}
 		}
 	}()
 
+	// add the scratch to the resulting layer mounts
+	scratchLayerMount := &LayerMount{
+		HostPath:  scsiMount.HostPath,
+		GuestPath: scsiMount.UVMPath,
+	}
+	layersAdded = append(layersAdded, scratchLayerMount)
+
+	// combine the layers
 	rootfs := ospath.Join(vm.OS(), guestRoot, guestpath.RootfsPath)
 	err = vm.CombineLayersLCOW(ctx, containerID, lcowUvmLayerPaths, containerScratchPathInUVM, rootfs)
 	if err != nil {
-		return "", "", err
+		return "", "", nil, err
 	}
 	log.G(ctx).Debug("hcsshim::MountLCOWLayers Succeeded")
-	return rootfs, containerScratchPathInUVM, nil
+	return rootfs, containerScratchPathInUVM, layersAdded, nil
 }
 
 // MountWCOWLayers is a helper for clients to hide all the complexity of layer mounting for WCOW.
@@ -164,10 +177,15 @@ func MountLCOWLayers(ctx context.Context, containerID string, layerFolders []str
 //
 //	Job container: Returns the mount path on the host as a volume guid, with the volume mounted on
 //	the host at `volumeMountPath`.
-func MountWCOWLayers(ctx context.Context, containerID string, layerFolders []string, guestRoot, volumeMountPath string, vm *uvm.UtilityVM) (_ string, err error) {
+func MountWCOWLayers(ctx context.Context, containerID string, layerFolders []string, guestRoot, volumeMountPath string, vm *uvm.UtilityVM) (_ string, _ []*LayerMount, err error) {
+	var (
+		layersAdded    []*LayerMount
+		layerHostPaths []string
+	)
+
 	if vm == nil {
 		if len(layerFolders) < 2 {
-			return "", errors.New("need at least two layers - base and scratch")
+			return "", nil, errors.New("need at least two layers - base and scratch")
 		}
 		path := layerFolders[len(layerFolders)-1]
 		rest := layerFolders[:len(layerFolders)-1]
@@ -209,7 +227,7 @@ func MountWCOWLayers(ctx context.Context, containerID string, layerFolders []str
 					}
 				}
 				// This was a failure case outside of the commonly known error conditions, don't retry here.
-				return "", lErr
+				return "", nil, lErr
 			}
 
 			// No errors in layer setup, we can leave the loop
@@ -218,7 +236,7 @@ func MountWCOWLayers(ctx context.Context, containerID string, layerFolders []str
 		// If we got unlucky and ran into one of the two errors mentioned five times in a row and left the loop, we need to check
 		// the loop error here and fail also.
 		if lErr != nil {
-			return "", errors.Wrap(lErr, "layer retry loop failed")
+			return "", nil, errors.Wrap(lErr, "layer retry loop failed")
 		}
 
 		// If any of the below fails, we want to detach the filter and unmount the disk.
@@ -231,33 +249,37 @@ func MountWCOWLayers(ctx context.Context, containerID string, layerFolders []str
 
 		mountPath, err := wclayer.GetLayerMountPath(ctx, path)
 		if err != nil {
-			return "", err
+			return "", nil, err
 		}
 
 		// Mount the volume to a directory on the host if requested. This is the case for job containers.
 		if volumeMountPath != "" {
 			if err := MountSandboxVolume(ctx, volumeMountPath, mountPath); err != nil {
-				return "", err
+				return "", nil, err
 			}
 		}
 
-		return mountPath, nil
+		// we only need to track the base path here because on unmount, that's
+		// all we need
+		layerMount := &LayerMount{
+			HostPath: path,
+		}
+		layersAdded = append(layersAdded, layerMount)
+
+		return mountPath, layersAdded, nil
 	}
 
 	if vm.OS() != "windows" {
-		return "", errors.New("MountWCOWLayers should only be called for WCOW")
+		return "", nil, errors.New("MountWCOWLayers should only be called for WCOW")
 	}
 
 	// V2 UVM
 	log.G(ctx).WithField("os", vm.OS()).Debug("hcsshim::MountWCOWLayers V2 UVM")
 
-	var (
-		layersAdded []string
-	)
 	defer func() {
 		if err != nil {
 			for _, l := range layersAdded {
-				if err := vm.RemoveVSMB(ctx, l, true); err != nil {
+				if err := vm.RemoveVSMB(ctx, l.HostPath, true); err != nil {
 					log.G(ctx).WithError(err).Warn("failed to remove wcow layer on cleanup")
 				}
 			}
@@ -271,16 +293,22 @@ func MountWCOWLayers(ctx context.Context, containerID string, layerFolders []str
 		if vm.IsTemplate {
 			vm.SetSaveableVSMBOptions(options, options.ReadOnly)
 		}
-		if _, err := vm.AddVSMB(ctx, layerPath, options); err != nil {
-			return "", fmt.Errorf("failed to add VSMB layer: %s", err)
+		vsmb, err := vm.AddVSMB(ctx, layerPath, options)
+		if err != nil {
+			return "", nil, fmt.Errorf("failed to add VSMB layer: %s", err)
 		}
-		layersAdded = append(layersAdded, layerPath)
+		layerMount := &LayerMount{
+			HostPath:  layerPath,
+			GuestPath: vsmb.GuestPath,
+		}
+		layersAdded = append(layersAdded, layerMount)
+		layerHostPaths = append(layerHostPaths, layerPath)
 	}
 
 	containerScratchPathInUVM := ospath.Join(vm.OS(), guestRoot)
-	hostPath, err := getScratchVHDPath(layerFolders)
+	hostPath, err := getScratchVHDHostPath(layerFolders)
 	if err != nil {
-		return "", fmt.Errorf("failed to get scratch VHD path in layer folders: %s", err)
+		return "", nil, fmt.Errorf("failed to get scratch VHD path in layer folders: %s", err)
 	}
 	log.G(ctx).WithField("hostPath", hostPath).Debug("mounting scratch VHD")
 
@@ -295,77 +323,104 @@ func MountWCOWLayers(ctx context.Context, containerID string, layerFolders []str
 		uvm.VMAccessTypeIndividual,
 	)
 	if err != nil {
-		return "", fmt.Errorf("failed to add SCSI scratch VHD: %s", err)
+		return "", nil, fmt.Errorf("failed to add SCSI scratch VHD: %s", err)
 	}
 	containerScratchPathInUVM = scsiMount.UVMPath
 
 	defer func() {
 		if err != nil {
-			if err := vm.RemoveSCSI(ctx, hostPath); err != nil {
+			if err := vm.RemoveSCSIMount(ctx, scsiMount.HostPath, scsiMount.UVMPath); err != nil {
 				log.G(ctx).WithError(err).Warn("failed to remove scratch on cleanup")
 			}
 		}
 	}()
 
+	// add the scratch to the resulting layer mounts
+	scratchLayerMount := &LayerMount{
+		HostPath:  scsiMount.HostPath,
+		GuestPath: scsiMount.UVMPath,
+	}
+	layersAdded = append(layersAdded, scratchLayerMount)
+
 	// Load the filter at the C:\s<ID> location calculated above. We pass into this
 	// request each of the read-only layer folders.
 	var layers []hcsschema.Layer
-	layers, err = GetHCSLayers(ctx, vm, layersAdded)
+	layers, err = GetHCSLayers(ctx, vm, layerHostPaths)
 	if err != nil {
-		return "", err
+		return "", nil, err
 	}
 	err = vm.CombineLayersWCOW(ctx, layers, containerScratchPathInUVM)
 	if err != nil {
-		return "", err
+		return "", nil, err
 	}
 	log.G(ctx).Debug("hcsshim::MountWCOWLayers Succeeded")
-	return containerScratchPathInUVM, nil
+	return containerScratchPathInUVM, layersAdded, nil
 }
 
-func addLCOWLayer(ctx context.Context, vm *uvm.UtilityVM, layerPath string) (uvmPath string, err error) {
+func addLCOWLayer(ctx context.Context, vm *uvm.UtilityVM, layerPath string) (_ *LayerMount, err error) {
 	// don't try to add as vpmem when we want additional devices on the uvm to be fully physically backed
 	if !vm.DevicesPhysicallyBacked() {
 		// We first try vPMEM and if it is full or the file is too large we
 		// fall back to SCSI.
-		uvmPath, err = vm.AddVPMem(ctx, layerPath)
+		uvmPath, err := vm.AddVPMem(ctx, layerPath)
 		if err == nil {
 			log.G(ctx).WithFields(logrus.Fields{
 				"layerPath": layerPath,
 				"layerType": "vpmem",
 			}).Debug("Added LCOW layer")
-			return uvmPath, nil
+			layerMount := &LayerMount{
+				HostPath:  layerPath,
+				GuestPath: uvmPath,
+			}
+			return layerMount, nil
 		} else if err != uvm.ErrNoAvailableLocation && err != uvm.ErrMaxVPMemLayerSize {
-			return "", fmt.Errorf("failed to add VPMEM layer: %s", err)
+			return nil, fmt.Errorf("failed to add VPMEM layer: %s", err)
 		}
 	}
 
+	// TODO katiewasnothere: parse the string to see if we have a partition
 	options := []string{"ro"}
-	uvmPath = fmt.Sprintf(guestpath.LCOWGlobalMountPrefixFmt, vm.UVMMountCounter())
-	sm, err := vm.AddSCSI(ctx, layerPath, uvmPath, true, false, options, uvm.VMAccessTypeNoop)
+	uvmPath := fmt.Sprintf(guestpath.LCOWGlobalMountPrefixFmt, vm.UVMMountCounter())
+	sm, err := vm.AddSCSILayer(
+		ctx,
+		layerPath,
+		uvmPath,
+		0,
+		true,
+		false,
+		options,
+		uvm.VMAccessTypeNoop,
+	)
 	if err != nil {
-		return "", fmt.Errorf("failed to add SCSI layer: %s", err)
+		return nil, fmt.Errorf("failed to add SCSI layer: %s", err)
 	}
+
+	layerMount := &LayerMount{
+		HostPath:  layerPath,
+		GuestPath: sm.UVMPath,
+	}
+
 	log.G(ctx).WithFields(logrus.Fields{
 		"layerPath": layerPath,
 		"layerType": "scsi",
 	}).Debug("Added LCOW layer")
-	return sm.UVMPath, nil
+	return layerMount, nil
 }
 
-func removeLCOWLayer(ctx context.Context, vm *uvm.UtilityVM, layerPath string) error {
+func removeLCOWLayer(ctx context.Context, vm *uvm.UtilityVM, layer *LayerMount) error {
 	// Assume it was added to vPMEM and fall back to SCSI
-	err := vm.RemoveVPMem(ctx, layerPath)
+	err := vm.RemoveVPMem(ctx, layer.HostPath)
 	if err == nil {
 		log.G(ctx).WithFields(logrus.Fields{
-			"layerPath": layerPath,
+			"layerPath": layer.HostPath,
 			"layerType": "vpmem",
 		}).Debug("Removed LCOW layer")
 		return nil
 	} else if err == uvm.ErrNotAttached {
-		err = vm.RemoveSCSI(ctx, layerPath)
+		err = vm.RemoveSCSIMount(ctx, layer.HostPath, layer.GuestPath)
 		if err == nil {
 			log.G(ctx).WithFields(logrus.Fields{
-				"layerPath": layerPath,
+				"layerPath": layer.HostPath,
 				"layerType": "scsi",
 			}).Debug("Removed LCOW layer")
 			return nil
@@ -391,14 +446,14 @@ const (
 )
 
 // UnmountContainerLayers is a helper for clients to hide all the complexity of layer unmounting
-func UnmountContainerLayers(ctx context.Context, layerFolders []string, containerRootPath, volumeMountPath string, vm *uvm.UtilityVM, op UnmountOperation) error {
-	log.G(ctx).WithField("layerFolders", layerFolders).Debug("hcsshim::unmountContainerLayers")
+func UnmountContainerLayers(ctx context.Context, layerMounts []*LayerMount, containerRootPath, volumeMountPath string, vm *uvm.UtilityVM, op UnmountOperation) error {
+	log.G(ctx).WithField("layerMounts", layerMounts).Debug("hcsshim::unmountContainerLayers")
 	if vm == nil {
 		// Must be an argon - folders are mounted on the host
 		if op != UnmountOperationAll {
 			return errors.New("only operation supported for host-mounted folders is unmountOperationAll")
 		}
-		if len(layerFolders) < 1 {
+		if len(layerMounts) < 1 {
 			return errors.New("need at least one layer for Unmount")
 		}
 
@@ -410,17 +465,17 @@ func UnmountContainerLayers(ctx context.Context, layerFolders []string, containe
 			}
 		}
 
-		path := layerFolders[len(layerFolders)-1]
-		if err := wclayer.UnprepareLayer(ctx, path); err != nil {
+		baseLayer := layerMounts[len(layerMounts)-1]
+		if err := wclayer.UnprepareLayer(ctx, baseLayer.HostPath); err != nil {
 			return err
 		}
-		return wclayer.DeactivateLayer(ctx, path)
+		return wclayer.DeactivateLayer(ctx, baseLayer.HostPath)
 	}
 
 	// V2 Xenon
 
 	// Base+Scratch as a minimum. This is different to v1 which only requires the scratch
-	if len(layerFolders) < 2 {
+	if len(layerMounts) < 2 {
 		return errors.New("at least two layers are required for unmount")
 	}
 
@@ -442,11 +497,10 @@ func UnmountContainerLayers(ctx context.Context, layerFolders []string, containe
 
 	// Unload the SCSI scratch path
 	if (op & UnmountOperationSCSI) == UnmountOperationSCSI {
-		hostScratchFile, err := getScratchVHDPath(layerFolders)
-		if err != nil {
-			return errors.Wrap(err, "failed to get scratch VHD path in layer folders")
-		}
-		if err := vm.RemoveSCSI(ctx, hostScratchFile); err != nil {
+		// TODO katiewasnothere: make sure that there is a scratch layer mount
+		scratchFile := getScratchVHDMount(layerMounts)
+		// TODO katiewasnothere: make sure scratch has a uvm path
+		if err := vm.RemoveSCSIMount(ctx, scratchFile.HostPath, scratchFile.GuestPath); err != nil {
 			log.G(ctx).WithError(err).Warn("failed to remove scratch")
 			if retError == nil {
 				retError = err
@@ -460,8 +514,8 @@ func UnmountContainerLayers(ctx context.Context, layerFolders []string, containe
 	// only removed once the count drops to zero. This allows multiple containers
 	// to share layers.
 	if vm.OS() == "windows" && (op&UnmountOperationVSMB) == UnmountOperationVSMB {
-		for _, layerPath := range layerFolders[:len(layerFolders)-1] {
-			if e := vm.RemoveVSMB(ctx, layerPath, true); e != nil {
+		for _, layer := range layerMounts[:len(layerMounts)-1] {
+			if e := vm.RemoveVSMB(ctx, layer.HostPath, true); e != nil {
 				log.G(ctx).WithError(e).Warn("remove VSMB failed")
 				if retError == nil {
 					retError = e
@@ -476,9 +530,9 @@ func UnmountContainerLayers(ctx context.Context, layerFolders []string, containe
 	// and only removed once the count drops to zero. This allows multiple containers to
 	// share layers. Note that SCSI is used on large layers.
 	if vm.OS() == "linux" && (op&UnmountOperationVPMEM) == UnmountOperationVPMEM {
-		for _, layerPath := range layerFolders[:len(layerFolders)-1] {
-			hostPath := filepath.Join(layerPath, "layer.vhd")
-			if err := removeLCOWLayer(ctx, vm, hostPath); err != nil {
+		for _, layer := range layerMounts[:len(layerMounts)-1] {
+			// TODO katiewasnothere: make sure the hostpath has the vhdx ext
+			if err := removeLCOWLayer(ctx, vm, layer); err != nil {
 				log.G(ctx).WithError(err).Warn("remove layer failed")
 				if retError == nil {
 					retError = err
@@ -515,7 +569,7 @@ func containerRootfsPath(vm *uvm.UtilityVM, rootPath string) string {
 	return ospath.Join(vm.OS(), rootPath, guestpath.RootfsPath)
 }
 
-func getScratchVHDPath(layerFolders []string) (string, error) {
+func getScratchVHDHostPath(layerFolders []string) (string, error) {
 	hostPath := filepath.Join(layerFolders[len(layerFolders)-1], "sandbox.vhdx")
 	// For LCOW, we can reuse another container's scratch space (usually the sandbox container's).
 	//
@@ -528,6 +582,12 @@ func getScratchVHDPath(layerFolders []string) (string, error) {
 		return "", errors.Wrap(err, "failed to eval symlinks")
 	}
 	return hostPath, nil
+}
+
+// TODO katiewasnothere: this should already have the vhdx at the end
+func getScratchVHDMount(layerMounts []*LayerMount) *LayerMount {
+	scratchMount := layerMounts[len(layerMounts)-1]
+	return scratchMount
 }
 
 // Mount the sandbox vhd to a user friendly path.

--- a/internal/lcow/disk.go
+++ b/internal/lcow/disk.go
@@ -40,13 +40,18 @@ func FormatDisk(ctx context.Context, lcowUVM *uvm.UtilityVM, destPath string) er
 		_ = scsi.Release(ctx)
 	}()
 
+	scsiAttachment, err := lcowUVM.GetSCSIAttachment(ctx, destPath)
+	if err != nil {
+		return err
+	}
+
 	log.G(ctx).WithFields(logrus.Fields{
 		"dest":       destPath,
-		"controller": scsi.Controller,
-		"lun":        scsi.LUN,
+		"controller": scsiAttachment.Controller,
+		"lun":        scsiAttachment.LUN,
 	}).Debug("lcow::FormatDisk device attached")
 
-	if err := formatDiskUvm(ctx, lcowUVM, scsi.Controller, scsi.LUN, destPath); err != nil {
+	if err := formatDiskUvm(ctx, lcowUVM, scsiAttachment.Controller, scsiAttachment.LUN, destPath); err != nil {
 		return err
 	}
 	log.G(ctx).WithField("dest", destPath).Debug("lcow::FormatDisk complete")

--- a/internal/protocol/guestresource/resources.go
+++ b/internal/protocol/guestresource/resources.go
@@ -67,13 +67,14 @@ type WCOWCombinedLayers struct {
 // LCOWMappedVirtualDisk represents a disk on the host which is mapped into a
 // directory in the guest in the V2 schema.
 type LCOWMappedVirtualDisk struct {
-	MountPath  string            `json:"MountPath,omitempty"`
-	Lun        uint8             `json:"Lun,omitempty"`
-	Controller uint8             `json:"Controller,omitempty"`
-	ReadOnly   bool              `json:"ReadOnly,omitempty"`
-	Encrypted  bool              `json:"Encrypted,omitempty"`
-	Options    []string          `json:"Options,omitempty"`
-	VerityInfo *DeviceVerityInfo `json:"VerityInfo,omitempty"`
+	MountPath    string            `json:"MountPath,omitempty"`
+	Lun          uint8             `json:"Lun,omitempty"`
+	Controller   uint8             `json:"Controller,omitempty"`
+	ReadOnly     bool              `json:"ReadOnly,omitempty"`
+	Encrypted    bool              `json:"Encrypted,omitempty"`
+	Options      []string          `json:"Options,omitempty"`
+	VerityInfo   *DeviceVerityInfo `json:"VerityInfo,omitempty"`
+	UnplugDevice bool              `json:"UnplugDevice,omitempty"`
 }
 
 type WCOWMappedVirtualDisk struct {

--- a/internal/uvm/create_lcow.go
+++ b/internal/uvm/create_lcow.go
@@ -643,7 +643,7 @@ func makeLCOWDoc(ctx context.Context, opts *OptionsLCOW, uvm *UtilityVM) (_ *hcs
 				Path:     rootfsFullPath,
 				ReadOnly: true,
 			}
-			uvm.scsiLocations[0][0] = newSCSIMount(uvm, rootfsFullPath, "/", "VirtualDisk", "", 1, 0, 0, true, false)
+			uvm.scsiLocations[0][0] = newSCSIAttachment(rootfsFullPath, "VirtualDisk", "", 1, 0, 0, true, false, false)
 		}
 	}
 

--- a/internal/uvm/create_wcow.go
+++ b/internal/uvm/create_wcow.go
@@ -343,14 +343,14 @@ func CreateWCOW(ctx context.Context, opts *OptionsWCOW) (_ *UtilityVM, err error
 			Type_: "VirtualDisk",
 		}
 
-		uvm.scsiLocations[0][0] = newSCSIMount(uvm,
+		uvm.scsiLocations[0][0] = newSCSIAttachment(
 			doc.VirtualMachine.Devices.Scsi[guestrequest.ScsiControllerGuids[0]].Attachments["0"].Path,
-			"",
 			doc.VirtualMachine.Devices.Scsi[guestrequest.ScsiControllerGuids[0]].Attachments["0"].Type_,
 			"",
 			1,
 			0,
 			0,
+			false,
 			false,
 			false)
 	} else {

--- a/internal/uvm/scsi.go
+++ b/internal/uvm/scsi.go
@@ -44,39 +44,37 @@ const (
 const scsiCurrentSerialVersionID = 2
 
 var (
-	ErrNoAvailableLocation      = fmt.Errorf("no available location")
-	ErrNotAttached              = fmt.Errorf("not attached")
-	ErrAlreadyAttached          = fmt.Errorf("already attached")
-	ErrNoSCSIControllers        = fmt.Errorf("no SCSI controllers configured for this utility VM")
-	ErrTooManyAttachments       = fmt.Errorf("too many SCSI attachments")
-	ErrSCSILayerWCOWUnsupported = fmt.Errorf("SCSI attached layers are not supported for WCOW")
+	ErrNoAvailableLocation         = fmt.Errorf("no available location")
+	ErrNotAttached                 = fmt.Errorf("not attached")
+	ErrAlreadyAttached             = fmt.Errorf("already attached")
+	ErrNoSCSIControllers           = fmt.Errorf("no SCSI controllers configured for this utility VM")
+	ErrTooManyAttachments          = fmt.Errorf("too many SCSI attachments")
+	ErrSCSILayerWCOWUnsupported    = fmt.Errorf("SCSI attached layers are not supported for WCOW")
+	ErrAttachmentHasMultipleMounts = fmt.Errorf("SCSI attachment has multipl mounts")
 )
 
-// Release frees the resources of the corresponding Scsi Mount
-func (sm *SCSIMount) Release(ctx context.Context) error {
-	if err := sm.vm.RemoveSCSI(ctx, sm.HostPath); err != nil {
+func (gm *SCSIMount) Release(ctx context.Context) error {
+	if err := gm.vm.RemoveSCSIMount(ctx, gm.HostPath, gm.UVMPath); err != nil {
 		return fmt.Errorf("failed to remove SCSI device: %s", err)
 	}
 	return nil
 }
 
-// SCSIMount struct representing a SCSI mount point and the UVM
+// SCSIAttachment struct representing a SCSI mount point and the UVM
 // it belongs to.
-type SCSIMount struct {
-	// Utility VM the scsi mount belongs to
-	vm *UtilityVM
+type SCSIAttachment struct {
 	// path is the host path to the vhd that is mounted.
 	HostPath string
-	// path for the uvm
-	UVMPath string
+	mounts   map[string]*SCSIMount
 	// scsi controller
 	Controller int
 	// scsi logical unit number
 	LUN int32
 	// While most VHDs attached to SCSI are scratch spaces, in the case of LCOW
 	// when the size is over the size possible to attach to PMEM, we use SCSI for
-	// read-only layers. As RO layers are shared, we perform ref-counting.
-	isLayer  bool
+	// read-only layers.
+	isLayer bool
+	// ref count the attachment so we know when to remove it
 	refCount uint32
 	// specifies if this is an encrypted VHD
 	encrypted bool
@@ -92,6 +90,18 @@ type SCSIMount struct {
 	serialVersionID uint32
 	// Make sure that serialVersionID is always the last field and its value is
 	// incremented every time this structure is updated
+}
+
+// SCSIMount
+// all UVMPaths must be unique in the uvm
+type SCSIMount struct {
+	HostPath string // used for finding the scsi attachment
+	vm       *UtilityVM
+
+	UVMPath   string
+	partition uint8
+
+	refCount uint32
 
 	// A channel to wait on while mount of this SCSI disk is in progress.
 	waitCh chan struct{}
@@ -100,13 +110,24 @@ type SCSIMount struct {
 	waitErr error
 }
 
+func (gm *SCSIMount) logFormat() logrus.Fields {
+	return logrus.Fields{
+		"HostPath":  gm.HostPath,
+		"UVMPath":   gm.UVMPath,
+		"Partition": gm.partition,
+		"refCount":  gm.refCount,
+	}
+}
+
 // addSCSIRequest is an internal struct used to hold all the parameters that are sent to
 // the addSCSIActual method.
 type addSCSIRequest struct {
 	// host path to the disk that should be added as a SCSI disk.
 	hostPath string
 	// the path inside the uvm at which this disk should show up. Can be empty.
-	uvmPath string
+	uvmPath   string
+	partition uint8
+	isLayer   bool
 	// attachmentType is required and `must` be `VirtualDisk` for vhd/vhdx
 	// attachments, `PassThru` for physical disk and `ExtensibleVirtualDisk` for
 	// Extensible virtual disks.
@@ -131,23 +152,25 @@ func (sm *SCSIMount) RefCount() uint32 {
 	return sm.refCount
 }
 
-func (sm *SCSIMount) logFormat() logrus.Fields {
-	return logrus.Fields{
-		"HostPath":                  sm.HostPath,
-		"UVMPath":                   sm.UVMPath,
-		"isLayer":                   sm.isLayer,
-		"refCount":                  sm.refCount,
-		"Controller":                sm.Controller,
-		"LUN":                       sm.LUN,
-		"ExtensibleVirtualDiskType": sm.extensibleVirtualDiskType,
-		"SerialVersionID":           sm.serialVersionID,
-	}
-}
-
 func newSCSIMount(
 	uvm *UtilityVM,
 	hostPath string,
 	uvmPath string,
+	partition uint8,
+	refCount uint32,
+) *SCSIMount {
+	return &SCSIMount{
+		vm:        uvm,
+		HostPath:  hostPath,
+		UVMPath:   uvmPath,
+		partition: partition,
+		refCount:  refCount,
+		waitCh:    make(chan struct{}),
+	}
+}
+
+func newSCSIAttachment(
+	hostPath string,
 	attachmentType string,
 	evdType string,
 	refCount uint32,
@@ -155,132 +178,33 @@ func newSCSIMount(
 	lun int32,
 	readOnly bool,
 	encrypted bool,
-) *SCSIMount {
-	return &SCSIMount{
-		vm:                        uvm,
+	isLayer bool,
+) *SCSIAttachment {
+	return &SCSIAttachment{
 		HostPath:                  hostPath,
-		UVMPath:                   uvmPath,
+		mounts:                    make(map[string]*SCSIMount),
 		refCount:                  refCount,
 		Controller:                controller,
 		LUN:                       int32(lun),
+		isLayer:                   isLayer,
 		encrypted:                 encrypted,
 		readOnly:                  readOnly,
 		attachmentType:            attachmentType,
 		extensibleVirtualDiskType: evdType,
 		serialVersionID:           scsiCurrentSerialVersionID,
-		waitCh:                    make(chan struct{}),
 	}
 }
 
-// allocateSCSISlot finds the next available slot on the
-// SCSI controllers associated with a utility VM to use.
-// Lock must be held when calling this function
-func (uvm *UtilityVM) allocateSCSISlot(ctx context.Context) (int, int, error) {
-	for controller := 0; controller < int(uvm.scsiControllerCount); controller++ {
-		for lun, sm := range uvm.scsiLocations[controller] {
-			// If sm is nil, we have found an open slot so we allocate a new SCSIMount
-			if sm == nil {
-				return controller, lun, nil
-			}
-		}
+func (sm *SCSIAttachment) logFormat() logrus.Fields {
+	return logrus.Fields{
+		"HostPath":                  sm.HostPath,
+		"isLayer":                   sm.isLayer,
+		"refCount":                  sm.refCount,
+		"Controller":                sm.Controller,
+		"LUN":                       sm.LUN,
+		"ExtensibleVirtualDiskType": sm.extensibleVirtualDiskType,
+		"SerialVersionID":           sm.serialVersionID,
 	}
-	return -1, -1, ErrNoAvailableLocation
-}
-
-func (uvm *UtilityVM) deallocateSCSIMount(ctx context.Context, sm *SCSIMount) {
-	uvm.m.Lock()
-	defer uvm.m.Unlock()
-	if sm != nil {
-		log.G(ctx).WithFields(sm.logFormat()).Debug("removed SCSI location")
-		uvm.scsiLocations[sm.Controller][sm.LUN] = nil
-	}
-}
-
-// Lock must be held when calling this function.
-func (uvm *UtilityVM) findSCSIAttachment(ctx context.Context, findThisHostPath string) (*SCSIMount, error) {
-	for _, luns := range uvm.scsiLocations {
-		for _, sm := range luns {
-			if sm != nil && sm.HostPath == findThisHostPath {
-				log.G(ctx).WithFields(sm.logFormat()).Debug("found SCSI location")
-				return sm, nil
-			}
-		}
-	}
-	return nil, ErrNotAttached
-}
-
-// RemoveSCSI removes a SCSI disk from a utility VM.
-func (uvm *UtilityVM) RemoveSCSI(ctx context.Context, hostPath string) error {
-	uvm.m.Lock()
-	defer uvm.m.Unlock()
-
-	if uvm.scsiControllerCount == 0 {
-		return ErrNoSCSIControllers
-	}
-
-	// Make sure it is actually attached
-	sm, err := uvm.findSCSIAttachment(ctx, hostPath)
-	if err != nil {
-		return err
-	}
-
-	sm.refCount--
-	if sm.refCount > 0 {
-		return nil
-	}
-
-	scsiModification := &hcsschema.ModifySettingRequest{
-		RequestType:  guestrequest.RequestTypeRemove,
-		ResourcePath: fmt.Sprintf(resourcepaths.SCSIResourceFormat, guestrequest.ScsiControllerGuids[sm.Controller], sm.LUN),
-	}
-
-	var verity *guestresource.DeviceVerityInfo
-	if v, iErr := readVeritySuperBlock(ctx, hostPath); iErr != nil {
-		log.G(ctx).WithError(iErr).WithField("hostPath", sm.HostPath).Debug("unable to read dm-verity information from VHD")
-	} else {
-		if v != nil {
-			log.G(ctx).WithFields(logrus.Fields{
-				"hostPath":   hostPath,
-				"rootDigest": v.RootDigest,
-			}).Debug("removing SCSI with dm-verity")
-		}
-		verity = v
-	}
-
-	// Include the GuestRequest so that the GCS ejects the disk cleanly if the
-	// disk was attached/mounted
-	//
-	// Note: We always send a guest eject even if there is no UVM path in lcow
-	// so that we synchronize the guest state. This seems to always avoid SCSI
-	// related errors if this index quickly reused by another container.
-	if uvm.operatingSystem == "windows" && sm.UVMPath != "" {
-		scsiModification.GuestRequest = guestrequest.ModificationRequest{
-			ResourceType: guestresource.ResourceTypeMappedVirtualDisk,
-			RequestType:  guestrequest.RequestTypeRemove,
-			Settings: guestresource.WCOWMappedVirtualDisk{
-				ContainerPath: sm.UVMPath,
-				Lun:           sm.LUN,
-			},
-		}
-	} else {
-		scsiModification.GuestRequest = guestrequest.ModificationRequest{
-			ResourceType: guestresource.ResourceTypeMappedVirtualDisk,
-			RequestType:  guestrequest.RequestTypeRemove,
-			Settings: guestresource.LCOWMappedVirtualDisk{
-				MountPath:  sm.UVMPath, // May be blank in attach-only
-				Lun:        uint8(sm.LUN),
-				Controller: uint8(sm.Controller),
-				VerityInfo: verity,
-			},
-		}
-	}
-
-	if err := uvm.modify(ctx, scsiModification); err != nil {
-		return fmt.Errorf("failed to remove SCSI disk %s from container %s: %s", hostPath, uvm.id, err)
-	}
-	log.G(ctx).WithFields(sm.logFormat()).Debug("removed SCSI location")
-	uvm.scsiLocations[sm.Controller][sm.LUN] = nil
-	return nil
 }
 
 // AddSCSI adds a SCSI disk to a utility VM at the next available location. This
@@ -379,118 +303,20 @@ func (uvm *UtilityVM) AddSCSIExtensibleVirtualDisk(ctx context.Context, hostPath
 	return uvm.addSCSIActual(ctx, addReq)
 }
 
-// addSCSIActual is the implementation behind the external functions AddSCSI,
-// AddSCSIPhysicalDisk, AddSCSIExtensibleVirtualDisk.
-//
-// We are in control of everything ourselves. Hence we have ref- counting and
-// so-on tracking what SCSI locations are available or used.
-//
-// Returns result from calling modify with the given scsi mount
-func (uvm *UtilityVM) addSCSIActual(ctx context.Context, addReq *addSCSIRequest) (_ *SCSIMount, err error) {
-	sm, existed, err := uvm.allocateSCSIMount(
-		ctx,
-		addReq.readOnly,
-		addReq.encrypted,
-		addReq.hostPath,
-		addReq.uvmPath,
-		addReq.attachmentType,
-		addReq.evdType,
-		addReq.vmAccess,
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	if existed {
-		// another mount request might be in progress, wait for it to finish and if that operation
-		// fails return that error.
-		<-sm.waitCh
-		if sm.waitErr != nil {
-			return nil, sm.waitErr
-		}
-		return sm, nil
-	}
-
-	// This is the first goroutine to add this disk, close the waitCh after we are done.
-	defer func() {
-		if err != nil {
-			uvm.deallocateSCSIMount(ctx, sm)
-		}
-
-		// error must be set _before_ the channel is closed.
-		sm.waitErr = err
-		close(sm.waitCh)
-	}()
-
-	SCSIModification := &hcsschema.ModifySettingRequest{
-		RequestType: guestrequest.RequestTypeAdd,
-		Settings: hcsschema.Attachment{
-			Path:                      sm.HostPath,
-			Type_:                     addReq.attachmentType,
-			ReadOnly:                  addReq.readOnly,
-			ExtensibleVirtualDiskType: addReq.evdType,
-		},
-		ResourcePath: fmt.Sprintf(resourcepaths.SCSIResourceFormat, guestrequest.ScsiControllerGuids[sm.Controller], sm.LUN),
-	}
-
-	if sm.UVMPath != "" {
-		guestReq := guestrequest.ModificationRequest{
-			ResourceType: guestresource.ResourceTypeMappedVirtualDisk,
-			RequestType:  guestrequest.RequestTypeAdd,
-		}
-
-		if uvm.operatingSystem == "windows" {
-			guestReq.Settings = guestresource.WCOWMappedVirtualDisk{
-				ContainerPath: sm.UVMPath,
-				Lun:           sm.LUN,
-			}
-		} else {
-			var verity *guestresource.DeviceVerityInfo
-			if v, iErr := readVeritySuperBlock(ctx, sm.HostPath); iErr != nil {
-				log.G(ctx).WithError(iErr).WithField("hostPath", sm.HostPath).Debug("unable to read dm-verity information from VHD")
-			} else {
-				if v != nil {
-					log.G(ctx).WithFields(logrus.Fields{
-						"hostPath":   sm.HostPath,
-						"rootDigest": v.RootDigest,
-					}).Debug("adding SCSI with dm-verity")
-				}
-				verity = v
-			}
-
-			guestReq.Settings = guestresource.LCOWMappedVirtualDisk{
-				MountPath:  sm.UVMPath,
-				Lun:        uint8(sm.LUN),
-				Controller: uint8(sm.Controller),
-				ReadOnly:   addReq.readOnly,
-				Encrypted:  addReq.encrypted,
-				Options:    addReq.guestOptions,
-				VerityInfo: verity,
-			}
-		}
-		SCSIModification.GuestRequest = guestReq
-	}
-
-	if err := uvm.modify(ctx, SCSIModification); err != nil {
-		return nil, fmt.Errorf("failed to modify UVM with new SCSI mount: %s", err)
-	}
-	return sm, nil
-}
-
 // allocateSCSIMount grants vm access to hostpath and increments the ref count of an existing scsi
 // device or allocates a new one if not already present.
 // Returns the resulting *SCSIMount, a bool indicating if the scsi device was already present,
 // and error if any.
-func (uvm *UtilityVM) allocateSCSIMount(
+func (uvm *UtilityVM) allocateSCSIAttachment(
 	ctx context.Context,
 	readOnly bool,
 	encrypted bool,
 	hostPath string,
-	uvmPath string,
 	attachmentType string,
 	evdType string,
 	vmAccess VMAccessType,
-) (*SCSIMount, bool, error) {
+	isLayer bool,
+) (*SCSIAttachment, bool, error) {
 	if attachmentType != "ExtensibleVirtualDisk" {
 		// Ensure the utility VM has access
 		err := grantAccess(ctx, uvm.id, hostPath, vmAccess)
@@ -514,10 +340,8 @@ func (uvm *UtilityVM) allocateSCSIMount(
 		return nil, false, err
 	}
 
-	uvm.scsiLocations[controller][lun] = newSCSIMount(
-		uvm,
+	uvm.scsiLocations[controller][lun] = newSCSIAttachment(
 		hostPath,
-		uvmPath,
 		attachmentType,
 		evdType,
 		1,
@@ -525,24 +349,31 @@ func (uvm *UtilityVM) allocateSCSIMount(
 		int32(lun),
 		readOnly,
 		encrypted,
+		isLayer,
 	)
 
-	log.G(ctx).WithFields(uvm.scsiLocations[controller][lun].logFormat()).Debug("allocated SCSI mount")
+	log.G(ctx).WithFields(uvm.scsiLocations[controller][lun].logFormat()).Debug("allocated SCSI attachment")
 
 	return uvm.scsiLocations[controller][lun], false, nil
 }
 
-// GetScsiUvmPath returns the guest mounted path of a SCSI drive.
+// GetFirstSCSIMountUVMPath returns the guest mounted path of a SCSI drive.
 //
 // If `hostPath` is not mounted returns `ErrNotAttached`.
-func (uvm *UtilityVM) GetScsiUvmPath(ctx context.Context, hostPath string) (string, error) {
+func (uvm *UtilityVM) GetFirstSCSIMountUVMPath(ctx context.Context, hostPath string) (string, error) {
 	uvm.m.Lock()
 	defer uvm.m.Unlock()
+	// make sure it's attached
 	sm, err := uvm.findSCSIAttachment(ctx, hostPath)
 	if err != nil {
 		return "", err
 	}
-	return sm.UVMPath, err
+
+	gm, err := sm.findFirstSCSIMount(ctx)
+	if err != nil {
+		return "", err
+	}
+	return gm.UVMPath, nil
 }
 
 // ScratchEncryptionEnabled is a getter for `uvm.encryptScratch`.
@@ -564,10 +395,396 @@ func grantAccess(ctx context.Context, uvmID string, hostPath string, vmAccess VM
 	return nil
 }
 
-var _ = (Cloneable)(&SCSIMount{})
+func (sm *SCSIAttachment) GetSerialVersionID() uint32 {
+	return scsiCurrentSerialVersionID
+}
+
+// ParseExtensibleVirtualDiskPath parses the evd path provided in the config.
+// extensible virtual disk path has format "evd://<evdType>/<evd-mount-path>"
+// this function parses that and returns the `evdType` and `evd-mount-path`.
+func ParseExtensibleVirtualDiskPath(hostPath string) (evdType, mountPath string, err error) {
+	trimmedPath := strings.TrimPrefix(hostPath, "evd://")
+	separatorIndex := strings.Index(trimmedPath, "/")
+	if separatorIndex <= 0 {
+		return "", "", errors.Errorf("invalid extensible vhd path: %s", hostPath)
+	}
+	return trimmedPath[:separatorIndex], trimmedPath[separatorIndex+1:], nil
+}
+
+// allocateSCSISlot finds the next available slot on the
+// SCSI controllers associated with a utility VM to use.
+// Lock must be held when calling this function
+func (uvm *UtilityVM) allocateSCSISlot(ctx context.Context) (int, int, error) {
+	for controller := 0; controller < int(uvm.scsiControllerCount); controller++ {
+		for lun, sm := range uvm.scsiLocations[controller] {
+			// If sm is nil, we have found an open slot so we allocate a new SCSIMount
+			if sm == nil {
+				return controller, lun, nil
+			}
+		}
+	}
+	return -1, -1, ErrNoAvailableLocation
+}
+
+func (uvm *UtilityVM) deallocateSCSIAttachment(ctx context.Context, sm *SCSIAttachment) {
+	uvm.m.Lock()
+	defer uvm.m.Unlock()
+	if sm != nil {
+		log.G(ctx).WithFields(sm.logFormat()).Debug("removed SCSI location")
+		uvm.scsiLocations[sm.Controller][sm.LUN] = nil
+	}
+}
+
+// Lock must be held when calling this function.
+func (uvm *UtilityVM) findSCSIAttachment(ctx context.Context, findThisHostPath string) (*SCSIAttachment, error) {
+	for _, luns := range uvm.scsiLocations {
+		for _, sm := range luns {
+			if sm != nil && sm.HostPath == findThisHostPath {
+				log.G(ctx).WithFields(sm.logFormat()).Debug("found SCSI location")
+				return sm, nil
+			}
+		}
+	}
+	return nil, ErrNotAttached
+}
+
+func (sm *SCSIAttachment) findSCSIMount(ctx context.Context, findThisUVMPath string) (*SCSIMount, error) {
+	for _, gm := range sm.mounts {
+		if gm != nil && gm.UVMPath == findThisUVMPath {
+			// TODO katiewasnothere: check if this still works when we don't have
+			// a uvm path
+			log.G(ctx).WithFields(gm.logFormat()).Debug("found SCSI mount")
+			return gm, nil
+		}
+	}
+	return nil, ErrNotAttached
+}
+
+// this is similar to findSCSIMount except that it finds the first mount with the host path
+// and does not account for uvm path
+func (sm *SCSIAttachment) findFirstSCSIMount(ctx context.Context) (*SCSIMount, error) {
+	for _, gm := range sm.mounts {
+		log.G(ctx).WithFields(gm.logFormat()).Debug("found SCSI mount")
+		return gm, nil
+	}
+	return nil, ErrNotAttached
+}
+
+// allocateSCSIMount grants vm access to hostpath and increments the ref count of an existing scsi
+// device or allocates a new one if not already present.
+// Returns the resulting *SCSIMount, a bool indicating if the scsi device was already present,
+// and error if any.
+func (uvm *UtilityVM) allocateSCSIMount(
+	ctx context.Context,
+	sm *SCSIAttachment,
+	hostPath string,
+	uvmPath string,
+	partition uint8,
+	allowMultipleGuestMounts bool,
+) (_ *SCSIMount, _ bool, err error) {
+	// TODO katiewasnothere: do we need to hold the lock here?
+	uvm.m.Lock()
+	defer uvm.m.Unlock()
+	var gm *SCSIMount
+	if allowMultipleGuestMounts {
+		// if we allow multiple scsi mounts for a given hostPath, then we should
+		// search by both the hostPath and uvmPath
+		if gm, err = sm.findSCSIMount(ctx, uvmPath); err == nil {
+			gm.refCount++
+			return gm, true, nil
+		}
+	} else {
+		// else just check if a scsi mount exists only by the hostPath
+		if gm, err = sm.findFirstSCSIMount(ctx); err == nil {
+			gm.refCount++
+			return gm, true, nil
+		}
+	}
+
+	scsiMount := newSCSIMount(
+		uvm,
+		hostPath,
+		uvmPath,
+		partition,
+		1,
+	)
+	sm.mounts[uvmPath] = scsiMount
+
+	log.G(ctx).WithFields(scsiMount.logFormat()).Debug("allocated SCSI mount")
+
+	return scsiMount, false, nil
+}
+
+func (uvm *UtilityVM) deallocateSCSIMount(ctx context.Context, sm *SCSIAttachment, gm *SCSIMount) {
+	uvm.m.Lock()
+	defer uvm.m.Unlock()
+	if sm != nil && gm != nil {
+		log.G(ctx).WithFields(gm.logFormat()).Debug("removed SCSI mount")
+		sm.mounts[gm.UVMPath] = nil
+	}
+}
+
+// addSCSIActual is the implementation behind the external functions AddSCSI,
+// AddSCSIPhysicalDisk, AddSCSIExtensibleVirtualDisk.
+//
+// We are in control of everything ourselves. Hence we have ref- counting and
+// so-on tracking what SCSI locations are available or used.
+//
+// Returns result from calling modify with the given scsi mount
+func (uvm *UtilityVM) addSCSIActual(ctx context.Context, addReq *addSCSIRequest) (_ *SCSIMount, err error) {
+	sm, attachmentExisted, err := uvm.allocateSCSIAttachment(
+		ctx,
+		addReq.readOnly,
+		addReq.encrypted,
+		addReq.hostPath,
+		addReq.attachmentType,
+		addReq.evdType,
+		addReq.vmAccess,
+		addReq.isLayer,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	// continue even if the attachment already exists
+	// TODO TODO TODO katiewasnothere: only allocate new SCSIMount if it either
+	// doesn't exist OR this is a layer
+	allowMultipleGuestMounts := addReq.isLayer && uvm.operatingSystem != "windows"
+	gm, mountExisted, err := uvm.allocateSCSIMount(
+		ctx,
+		sm,
+		addReq.hostPath,
+		addReq.uvmPath,
+		addReq.partition,
+		allowMultipleGuestMounts,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	if mountExisted {
+		// another mount request might be in progress, wait for it to finish and if that operation
+		// fails return that error.
+		<-gm.waitCh
+		if gm.waitErr != nil {
+			return nil, gm.waitErr
+		}
+		return gm, nil
+	}
+
+	// This is the first goroutine to add this disk, close the waitCh after we are done.
+	defer func() {
+		if err != nil {
+			// TODO katiewasnothere: only deallocate scsi attachment if it didn't already exist
+			if !attachmentExisted {
+				uvm.deallocateSCSIAttachment(ctx, sm)
+			}
+			uvm.deallocateSCSIMount(ctx, sm, gm)
+		}
+
+		// error must be set _before_ the channel is closed.
+		gm.waitErr = err
+		close(gm.waitCh)
+	}()
+
+	SCSIModification := &hcsschema.ModifySettingRequest{}
+
+	if !attachmentExisted {
+		// only add the attachment request if the attachment hadn't already existed
+		SCSIModification = &hcsschema.ModifySettingRequest{
+			RequestType: guestrequest.RequestTypeAdd,
+			Settings: hcsschema.Attachment{
+				Path:                      sm.HostPath,
+				Type_:                     addReq.attachmentType,
+				ReadOnly:                  addReq.readOnly,
+				ExtensibleVirtualDiskType: addReq.evdType,
+			},
+			ResourcePath: fmt.Sprintf(resourcepaths.SCSIResourceFormat, guestrequest.ScsiControllerGuids[sm.Controller], sm.LUN),
+		}
+	}
+
+	if gm.UVMPath != "" {
+		guestReq := guestrequest.ModificationRequest{
+			ResourceType: guestresource.ResourceTypeMappedVirtualDisk,
+			RequestType:  guestrequest.RequestTypeAdd,
+		}
+
+		if uvm.operatingSystem == "windows" {
+			guestReq.Settings = guestresource.WCOWMappedVirtualDisk{
+				ContainerPath: gm.UVMPath,
+				Lun:           sm.LUN,
+			}
+		} else {
+			var verity *guestresource.DeviceVerityInfo
+			if v, iErr := readVeritySuperBlock(ctx, gm.HostPath); iErr != nil {
+				log.G(ctx).WithError(iErr).WithField("hostPath", gm.HostPath).Debug("unable to read dm-verity information from VHD")
+			} else {
+				if v != nil {
+					log.G(ctx).WithFields(logrus.Fields{
+						"hostPath":   gm.HostPath,
+						"rootDigest": v.RootDigest,
+					}).Debug("adding SCSI with dm-verity")
+				}
+				verity = v
+			}
+
+			guestReq.Settings = guestresource.LCOWMappedVirtualDisk{
+				MountPath:  gm.UVMPath,
+				Lun:        uint8(sm.LUN),
+				Controller: uint8(sm.Controller),
+				ReadOnly:   addReq.readOnly,
+				Encrypted:  addReq.encrypted,
+				Options:    addReq.guestOptions,
+				VerityInfo: verity,
+			}
+		}
+		SCSIModification.GuestRequest = guestReq
+	}
+
+	if err := uvm.modify(ctx, SCSIModification); err != nil {
+		return nil, fmt.Errorf("failed to modify UVM with new SCSI mount: %s", err)
+	}
+	return gm, nil
+}
+
+// RemoveSCSI removes a SCSI disk from a utility VM.
+func (uvm *UtilityVM) RemoveSCSIMount(ctx context.Context, hostPath, uvmPath string) error {
+	uvm.m.Lock()
+	defer uvm.m.Unlock()
+
+	if uvm.scsiControllerCount == 0 {
+		return ErrNoSCSIControllers
+	}
+
+	// Make sure it is actually attached
+	sm, err := uvm.findSCSIAttachment(ctx, hostPath)
+	if err != nil {
+		return err
+	}
+
+	// get the mount
+	gm, err := sm.findSCSIMount(ctx, uvmPath)
+	if err != nil {
+		return err
+	}
+
+	sm.refCount--
+	gm.refCount--
+	if gm.refCount > 0 {
+		return nil
+	}
+
+	removeAttachment := (sm.refCount <= 0)
+	scsiModification := &hcsschema.ModifySettingRequest{}
+
+	if removeAttachment {
+		scsiModification = &hcsschema.ModifySettingRequest{
+			RequestType:  guestrequest.RequestTypeRemove,
+			ResourcePath: fmt.Sprintf(resourcepaths.SCSIResourceFormat, guestrequest.ScsiControllerGuids[sm.Controller], sm.LUN),
+		}
+	}
+
+	var verity *guestresource.DeviceVerityInfo
+	if v, iErr := readVeritySuperBlock(ctx, hostPath); iErr != nil {
+		log.G(ctx).WithError(iErr).WithField("hostPath", sm.HostPath).Debug("unable to read dm-verity information from VHD")
+	} else {
+		if v != nil {
+			log.G(ctx).WithFields(logrus.Fields{
+				"hostPath":   hostPath,
+				"rootDigest": v.RootDigest,
+			}).Debug("removing SCSI with dm-verity")
+		}
+		verity = v
+	}
+
+	// Include the GuestRequest so that the GCS ejects the disk cleanly if the
+	// disk was attached/mounted
+	//
+	// Note: We always send a guest eject even if there is no UVM path in lcow
+	// so that we synchronize the guest state. This seems to always avoid SCSI
+	// related errors if this index quickly reused by another container.
+	if uvm.operatingSystem == "windows" && gm.UVMPath != "" {
+		scsiModification.GuestRequest = guestrequest.ModificationRequest{
+			ResourceType: guestresource.ResourceTypeMappedVirtualDisk,
+			RequestType:  guestrequest.RequestTypeRemove,
+			Settings: guestresource.WCOWMappedVirtualDisk{
+				ContainerPath: gm.UVMPath,
+				Lun:           sm.LUN,
+			},
+		}
+	} else {
+		scsiModification.GuestRequest = guestrequest.ModificationRequest{
+			ResourceType: guestresource.ResourceTypeMappedVirtualDisk,
+			RequestType:  guestrequest.RequestTypeRemove,
+			Settings: guestresource.LCOWMappedVirtualDisk{
+				MountPath:  gm.UVMPath, // May be blank in attach-only
+				Lun:        uint8(sm.LUN),
+				Controller: uint8(sm.Controller),
+				VerityInfo: verity,
+			},
+		}
+	}
+
+	if err := uvm.modify(ctx, scsiModification); err != nil {
+		return fmt.Errorf("failed to remove SCSI disk %s from container %s: %s", hostPath, uvm.id, err)
+	}
+
+	if removeAttachment {
+		uvm.scsiLocations[sm.Controller][sm.LUN] = nil
+		log.G(ctx).WithFields(sm.logFormat()).Debug("removed SCSI attachment")
+	}
+	sm.mounts[gm.UVMPath] = nil
+	log.G(ctx).WithFields(gm.logFormat()).Debug("removed SCSI mount")
+
+	return nil
+}
+
+// AddSCSILayer  adds a SCSI disk to a utility VM at the next available location. This
+// function should be called for adding a scratch layer, a read-only layer as an
+// alternative to VPMEM, or for other VHD mounts.
+//
+// `hostPath` is required and must point to a vhd/vhdx path.
+//
+// `uvmPath` is optional. If not provided, no guest request will be made
+//
+// `readOnly` set to `true` if the vhd/vhdx should be attached read only.
+//
+// `encrypted` set to `true` if the vhd/vhdx should be attached in encrypted mode.
+// The device will be formatted, so this option must be used only when creating
+// scratch vhd/vhdx.
+//
+// `guestOptions` is a slice that contains optional information to pass
+// to the guest service
+//
+// `vmAccess` indicates what access to grant the vm for the hostpath
+func (uvm *UtilityVM) AddSCSILayer(
+	ctx context.Context,
+	hostPath string,
+	uvmPath string,
+	partition uint8,
+	readOnly bool,
+	encrypted bool,
+	guestOptions []string,
+	vmAccess VMAccessType,
+) (*SCSIMount, error) {
+	addReq := &addSCSIRequest{
+		hostPath:       hostPath,
+		uvmPath:        uvmPath,
+		partition:      partition,
+		attachmentType: "VirtualDisk",
+		isLayer:        true,
+		readOnly:       readOnly,
+		encrypted:      encrypted,
+		guestOptions:   guestOptions,
+		vmAccess:       vmAccess,
+	}
+	return uvm.addSCSIActual(ctx, addReq)
+}
+
+var _ = (Cloneable)(&SCSIAttachment{})
 
 // GobEncode serializes the SCSIMount struct
-func (sm *SCSIMount) GobEncode() ([]byte, error) {
+func (sm *SCSIAttachment) GobEncode() ([]byte, error) {
 	var buf bytes.Buffer
 	encoder := gob.NewEncoder(&buf)
 	errMsgFmt := "failed to encode SCSIMount: %s"
@@ -578,7 +795,7 @@ func (sm *SCSIMount) GobEncode() ([]byte, error) {
 	if err := encoder.Encode(sm.HostPath); err != nil {
 		return nil, fmt.Errorf(errMsgFmt, err)
 	}
-	if err := encoder.Encode(sm.UVMPath); err != nil {
+	if err := encoder.Encode(sm.mounts); err != nil {
 		return nil, fmt.Errorf(errMsgFmt, err)
 	}
 	if err := encoder.Encode(sm.Controller); err != nil {
@@ -596,12 +813,15 @@ func (sm *SCSIMount) GobEncode() ([]byte, error) {
 	if err := encoder.Encode(sm.extensibleVirtualDiskType); err != nil {
 		return nil, fmt.Errorf(errMsgFmt, err)
 	}
+	if err := encoder.Encode(sm.isLayer); err != nil {
+		return nil, fmt.Errorf(errMsgFmt, err)
+	}
 	return buf.Bytes(), nil
 }
 
 // GobDecode deserializes the SCSIMount struct into the struct on which this is called
 // (i.e the sm pointer)
-func (sm *SCSIMount) GobDecode(data []byte) error {
+func (sm *SCSIAttachment) GobDecode(data []byte) error {
 	buf := bytes.NewBuffer(data)
 	decoder := gob.NewDecoder(buf)
 	errMsgFmt := "failed to decode SCSIMount: %s"
@@ -615,7 +835,7 @@ func (sm *SCSIMount) GobDecode(data []byte) error {
 	if err := decoder.Decode(&sm.HostPath); err != nil {
 		return fmt.Errorf(errMsgFmt, err)
 	}
-	if err := decoder.Decode(&sm.UVMPath); err != nil {
+	if err := decoder.Decode(&sm.mounts); err != nil {
 		return fmt.Errorf(errMsgFmt, err)
 	}
 	if err := decoder.Decode(&sm.Controller); err != nil {
@@ -633,14 +853,17 @@ func (sm *SCSIMount) GobDecode(data []byte) error {
 	if err := decoder.Decode(&sm.extensibleVirtualDiskType); err != nil {
 		return fmt.Errorf(errMsgFmt, err)
 	}
+	if err := decoder.Decode(&sm.isLayer); err != nil {
+		return fmt.Errorf(errMsgFmt, err)
+	}
 	return nil
 }
 
-// Clone function creates a clone of the SCSIMount `sm` and adds the cloned SCSIMount to
+// Clone function creates a clone of the SCSIAttachment `sm` and adds the cloned SCSIAttachment to
 // the uvm `vm`. If `sm` is read only then it is simply added to the `vm`. But if it is a
 // writable mount(e.g a scratch layer) then a copy of it is made and that copy is added
 // to the `vm`.
-func (sm *SCSIMount) Clone(ctx context.Context, vm *UtilityVM, cd *cloneData) error {
+func (sm *SCSIAttachment) Clone(ctx context.Context, vm *UtilityVM, cd *cloneData) error {
 	var (
 		dstVhdPath string = sm.HostPath
 		err        error
@@ -710,10 +933,8 @@ func (sm *SCSIMount) Clone(ctx context.Context, vm *UtilityVM, cd *cloneData) er
 		Type_: sm.attachmentType,
 	}
 
-	clonedScsiMount := newSCSIMount(
-		vm,
+	clonedSCSIAttachment := newSCSIAttachment(
 		dstVhdPath,
-		sm.UVMPath,
 		sm.attachmentType,
 		sm.extensibleVirtualDiskType,
 		1,
@@ -721,25 +942,21 @@ func (sm *SCSIMount) Clone(ctx context.Context, vm *UtilityVM, cd *cloneData) er
 		sm.LUN,
 		sm.readOnly,
 		sm.encrypted,
+		sm.isLayer,
 	)
 
-	vm.scsiLocations[sm.Controller][sm.LUN] = clonedScsiMount
+	for _, gm := range sm.mounts {
+		clonedSCSIMount := newSCSIMount(
+			gm.vm,
+			dstVhdPath,
+			gm.UVMPath,
+			gm.partition,
+			1,
+		)
+		clonedSCSIAttachment.mounts[gm.UVMPath] = clonedSCSIMount
+	}
+
+	vm.scsiLocations[sm.Controller][sm.LUN] = clonedSCSIAttachment
 
 	return nil
-}
-
-func (sm *SCSIMount) GetSerialVersionID() uint32 {
-	return scsiCurrentSerialVersionID
-}
-
-// ParseExtensibleVirtualDiskPath parses the evd path provided in the config.
-// extensible virtual disk path has format "evd://<evdType>/<evd-mount-path>"
-// this function parses that and returns the `evdType` and `evd-mount-path`.
-func ParseExtensibleVirtualDiskPath(hostPath string) (evdType, mountPath string, err error) {
-	trimmedPath := strings.TrimPrefix(hostPath, "evd://")
-	separatorIndex := strings.Index(trimmedPath, "/")
-	if separatorIndex <= 0 {
-		return "", "", errors.Errorf("invalid extensible vhd path: %s", hostPath)
-	}
-	return trimmedPath[:separatorIndex], trimmedPath[separatorIndex+1:], nil
 }

--- a/internal/uvm/types.go
+++ b/internal/uvm/types.go
@@ -87,9 +87,9 @@ type UtilityVM struct {
 	vpmemDevicesMultiMapped [MaxVPMEMCount]*vPMemInfoMulti
 
 	// SCSI devices that are mapped into a Windows or Linux utility VM
-	scsiLocations       [4][64]*SCSIMount // Hyper-V supports 4 controllers, 64 slots per controller. Limited to 1 controller for now though.
-	scsiControllerCount uint32            // Number of SCSI controllers in the utility VM
-	encryptScratch      bool              // Enable scratch encryption
+	scsiLocations       [4][64]*SCSIAttachment // Hyper-V supports 4 controllers, 64 slots per controller. Limited to 1 controller for now though.
+	scsiControllerCount uint32                 // Number of SCSI controllers in the utility VM
+	encryptScratch      bool                   // Enable scratch encryption
 
 	vpciDevices map[VPCIDeviceKey]*VPCIDevice // map of device instance id to vpci device
 

--- a/internal/uvm/vsmb.go
+++ b/internal/uvm/vsmb.go
@@ -37,7 +37,7 @@ type VSMBShare struct {
 	refCount        uint32
 	name            string
 	allowedFiles    []string
-	guestPath       string
+	GuestPath       string
 	options         hcsschema.VirtualSmbShareOptions
 	serialVersionID uint32
 }
@@ -214,7 +214,7 @@ func (uvm *UtilityVM) AddVSMB(ctx context.Context, hostPath string, options *hcs
 		share = &VSMBShare{
 			vm:              uvm,
 			name:            shareName,
-			guestPath:       vsmbSharePrefix + shareName,
+			GuestPath:       vsmbSharePrefix + shareName,
 			HostPath:        hostPath,
 			serialVersionID: vsmbCurrentSerialVersionID,
 		}
@@ -326,7 +326,7 @@ func (uvm *UtilityVM) GetVSMBUvmPath(ctx context.Context, hostPath string, readO
 	if err != nil {
 		return "", err
 	}
-	return filepath.Join(share.guestPath, f), nil
+	return filepath.Join(share.GuestPath, f), nil
 }
 
 var _ = (Cloneable)(&VSMBShare{})
@@ -351,7 +351,7 @@ func (vsmb *VSMBShare) GobEncode() ([]byte, error) {
 	if err := encoder.Encode(vsmb.allowedFiles); err != nil {
 		return nil, fmt.Errorf(errMsgFmt, err)
 	}
-	if err := encoder.Encode(vsmb.guestPath); err != nil {
+	if err := encoder.Encode(vsmb.GuestPath); err != nil {
 		return nil, fmt.Errorf(errMsgFmt, err)
 	}
 	if err := encoder.Encode(vsmb.options); err != nil {
@@ -383,7 +383,7 @@ func (vsmb *VSMBShare) GobDecode(data []byte) error {
 	if err := decoder.Decode(&vsmb.allowedFiles); err != nil {
 		return fmt.Errorf(errMsgFmt, err)
 	}
-	if err := decoder.Decode(&vsmb.guestPath); err != nil {
+	if err := decoder.Decode(&vsmb.GuestPath); err != nil {
 		return fmt.Errorf(errMsgFmt, err)
 	}
 	if err := decoder.Decode(&vsmb.options); err != nil {
@@ -411,7 +411,7 @@ func (vsmb *VSMBShare) Clone(ctx context.Context, vm *UtilityVM, cd *cloneData) 
 		name:            vsmb.name,
 		options:         vsmb.options,
 		allowedFiles:    vsmb.allowedFiles,
-		guestPath:       vsmb.guestPath,
+		GuestPath:       vsmb.GuestPath,
 		serialVersionID: vsmbCurrentSerialVersionID,
 	}
 	shareKey := getVSMBShareKey(vsmb.HostPath, vsmb.options.ReadOnly)

--- a/pkg/securitypolicy/securitypolicyenforcer.go
+++ b/pkg/securitypolicy/securitypolicyenforcer.go
@@ -87,7 +87,7 @@ func newSecurityPolicyFromBase64JSON(base64EncodedPolicy string) (*SecurityPolic
 	securityPolicy := new(SecurityPolicy)
 	err = json.Unmarshal(jsonPolicy, securityPolicy)
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to unmarshal JSON policy")
+		return nil, errors.Wrapf(err, "unable to unmarshal JSON policy: %v", jsonPolicy)
 	}
 
 	return securityPolicy, nil

--- a/test/functional/uvm_scsi_test.go
+++ b/test/functional/uvm_scsi_test.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"sync"
 	"testing"
@@ -27,9 +26,7 @@ import (
 
 // TestSCSIAddRemovev2LCOW validates adding and removing SCSI disks
 // from a utility VM in both attach-only and with a container path.
-func TestSCSIAddRemoveLCOW(t *testing.T) {
-	t.Skip("not yet updated")
-
+func TestSCSIAddRemoveMultipleLCOW(t *testing.T) {
 	require.Build(t, osversion.RS5)
 	requireFeatures(t, featureLCOW, featureSCSI)
 
@@ -39,23 +36,92 @@ func TestSCSIAddRemoveLCOW(t *testing.T) {
 	testSCSIAddRemoveMultiple(t, u, `/run/gcs/c/0/scsi`, "linux", []string{})
 }
 
+func TestSCSIAddRemoveSingleLCOW(t *testing.T) {
+	require.Build(t, osversion.RS5)
+	requireFeatures(t, featureLCOW, featureSCSI)
+
+	u := tuvm.CreateAndStartLCOWFromOpts(context.Background(), t, defaultLCOWOptions(t))
+	defer u.Close()
+
+	testSCSIAddRemoveSingle(t, u, `/run/gcs/c/0/scsi`, "linux", []string{})
+}
+
 // TestSCSIAddRemoveWCOW validates adding and removing SCSI disks
 // from a utility VM in both attach-only and with a container path.
-func TestSCSIAddRemoveWCOW(t *testing.T) {
-	t.Skip("not yet updated")
-
+func TestSCSIAddRemoveSingleWCOW(t *testing.T) {
 	require.Build(t, osversion.RS5)
 	requireFeatures(t, featureWCOW, featureSCSI)
 
 	// TODO make the image configurable to the build we're testing on
-	u, layers, _ := tuvm.CreateWCOWUVM(context.Background(), t, t.Name(), "mcr.microsoft.com/windows/nanoserver:1903")
+	u, layers, _ := tuvm.CreateWCOWUVM(context.Background(), t, t.Name(), "mcr.microsoft.com/windows/nanoserver:1909")
+	defer u.Close()
+
+	testSCSIAddRemoveMultiple(t, u, `c:\`, "windows", layers)
+}
+
+func TestSCSIAddRemoveMultipleWCOW(t *testing.T) {
+	require.Build(t, osversion.RS5)
+	requireFeatures(t, featureWCOW, featureSCSI)
+
+	// TODO make the image configurable to the build we're testing on
+	u, layers, _ := tuvm.CreateWCOWUVM(context.Background(), t, t.Name(), "mcr.microsoft.com/windows/nanoserver:1909")
 	defer u.Close()
 
 	testSCSIAddRemoveSingle(t, u, `c:\`, "windows", layers)
 }
 
-//nolint:unused // unused since tests are skipped
-func testAddSCSI(u *uvm.UtilityVM, disks []string, pathPrefix string, usePath bool, reAdd bool) error {
+func TestSCSIWithEmptyAndNonEmptyUVMPathLCOW(t *testing.T) {
+	require.Build(t, osversion.RS5)
+	requireFeatures(t, featureLCOW, featureSCSI)
+
+	u := tuvm.CreateAndStartLCOWFromOpts(context.Background(), t, defaultLCOWOptions(t))
+	defer u.Close()
+
+	numDisks := 64
+	pathPrefix := `/run/gcs/c/0/scsi`
+	// Create a bunch of directories each containing sandbox.vhdx
+	disks := make([]string, numDisks)
+	for i := 0; i < numDisks; i++ {
+		tempDir := testutilities.CreateLCOWBlankRWLayer(context.Background(), t)
+		disks[i] = filepath.Join(tempDir, `sandbox.vhdx`)
+	}
+
+	logrus.Debugln("Adding scsi disks with empty uvmPaths")
+	useUvmPathPrefix := false
+	mounts, err := testAddSCSI(u, disks, pathPrefix, useUvmPathPrefix, false)
+	if err != nil {
+		t.Fatalf("failed to add SCSI device: %v", err)
+	}
+
+	// Try to re-add
+	logrus.Debugln("Next - try re-adding scsi disks with non-empty uvmPaths")
+	useUvmPathPrefix = true
+	reMounts, err := testAddSCSI(u, disks, pathPrefix, useUvmPathPrefix, true)
+	if err != nil {
+		t.Fatalf("failed to add SCSI device: %v", err)
+	}
+
+	// validate that all remounted scsi devices have a non empty uvm path
+	for _, m := range reMounts {
+		if m.UVMPath == "" {
+			t.Fatalf("expected uvmPath to be non-empty for scsi disk: %v", m.HostPath)
+		}
+	}
+
+	logrus.Debugln("Next - Remove emtpy uvmPath scsi mounts")
+	err = testRemoveAllSCSI(u, mounts)
+	if err != nil {
+		t.Fatalf("failed to remove SCSI disk: %v", err)
+	}
+	logrus.Debugln("Next - Remove non-emtpy uvmPath scsi mounts")
+	err = testRemoveAllSCSI(u, reMounts)
+	if err != nil {
+		t.Fatalf("failed to remove SCSI disk: %v", err)
+	}
+}
+
+func testAddSCSI(u *uvm.UtilityVM, disks []string, pathPrefix string, usePath bool, reAdd bool) ([]*uvm.SCSIMount, error) {
+	mounts := []*uvm.SCSIMount{}
 	for i := range disks {
 		uvmPath := ""
 		if usePath {
@@ -64,19 +130,19 @@ func testAddSCSI(u *uvm.UtilityVM, disks []string, pathPrefix string, usePath bo
 		var options []string
 		scsiMount, err := u.AddSCSI(context.Background(), disks[i], uvmPath, false, false, options, uvm.VMAccessTypeIndividual)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		if reAdd && scsiMount.UVMPath != uvmPath {
-			return fmt.Errorf("expecting existing path to be %s but it is %s", uvmPath, scsiMount.UVMPath)
+			return nil, fmt.Errorf("expecting existing path to be %s but it is %s", uvmPath, scsiMount.UVMPath)
 		}
+		mounts = append(mounts, scsiMount)
 	}
-	return nil
+	return mounts, nil
 }
 
-//nolint:unused // unused since tests are skipped
-func testRemoveAllSCSI(u *uvm.UtilityVM, disks []string) error {
-	for i := range disks {
-		if err := u.RemoveSCSI(context.Background(), disks[i]); err != nil {
+func testRemoveAllSCSI(u *uvm.UtilityVM, scsiMounts []*uvm.SCSIMount) error {
+	for _, m := range scsiMounts {
+		if err := u.RemoveSCSIMount(context.Background(), m.HostPath, m.UVMPath); err != nil {
 			return err
 		}
 	}
@@ -85,8 +151,6 @@ func testRemoveAllSCSI(u *uvm.UtilityVM, disks []string) error {
 
 // TODO this test is only needed until WCOW supports adding the same scsi device to
 // multiple containers
-//
-//nolint:unused // unused since tests are skipped
 func testSCSIAddRemoveSingle(t *testing.T, u *uvm.UtilityVM, pathPrefix string, operatingSystem string, wcowImageLayerFolders []string) {
 	t.Helper()
 	numDisks := 63 // Windows: 63 as the UVM scratch is at 0:0
@@ -109,14 +173,14 @@ func testSCSIAddRemoveSingle(t *testing.T, u *uvm.UtilityVM, pathPrefix string, 
 	// Add each of the disks to the utility VM. Attach-only, no container path
 	useUvmPathPrefix := false
 	logrus.Debugln("First - adding in attach-only")
-	err := testAddSCSI(u, disks, pathPrefix, useUvmPathPrefix, false)
+	mounts, err := testAddSCSI(u, disks, pathPrefix, useUvmPathPrefix, false)
 	if err != nil {
 		t.Fatalf("failed to add SCSI device: %v", err)
 	}
 
 	// Remove them all
 	logrus.Debugln("Removing them all")
-	err = testRemoveAllSCSI(u, disks)
+	err = testRemoveAllSCSI(u, mounts)
 	if err != nil {
 		t.Fatalf("failed to remove SCSI disk: %v", err)
 	}
@@ -124,13 +188,13 @@ func testSCSIAddRemoveSingle(t *testing.T, u *uvm.UtilityVM, pathPrefix string, 
 	// Now re-add but providing a container path
 	useUvmPathPrefix = true
 	logrus.Debugln("Next - re-adding with a container path")
-	err = testAddSCSI(u, disks, pathPrefix, useUvmPathPrefix, false)
+	mounts, err = testAddSCSI(u, disks, pathPrefix, useUvmPathPrefix, false)
 	if err != nil {
 		t.Fatalf("failed to add SCSI device: %v", err)
 	}
 
 	logrus.Debugln("Next - Removing them")
-	err = testRemoveAllSCSI(u, disks)
+	err = testRemoveAllSCSI(u, mounts)
 	if err != nil {
 		t.Fatalf("failed to remove SCSI disk: %v", err)
 	}
@@ -138,7 +202,6 @@ func testSCSIAddRemoveSingle(t *testing.T, u *uvm.UtilityVM, pathPrefix string, 
 	// TODO: Could extend to validate can't add a 64th disk (windows). 65th (linux).
 }
 
-//nolint:unused // unused since tests are skipped
 func testSCSIAddRemoveMultiple(t *testing.T, u *uvm.UtilityVM, pathPrefix string, operatingSystem string, wcowImageLayerFolders []string) {
 	t.Helper()
 	numDisks := 63 // Windows: 63 as the UVM scratch is at 0:0
@@ -161,7 +224,7 @@ func testSCSIAddRemoveMultiple(t *testing.T, u *uvm.UtilityVM, pathPrefix string
 	// Add each of the disks to the utility VM. Attach-only, no container path
 	useUvmPathPrefix := false
 	logrus.Debugln("First - adding in attach-only")
-	err := testAddSCSI(u, disks, pathPrefix, useUvmPathPrefix, false)
+	mounts, err := testAddSCSI(u, disks, pathPrefix, useUvmPathPrefix, false)
 	if err != nil {
 		t.Fatalf("failed to add SCSI device: %v", err)
 	}
@@ -169,7 +232,7 @@ func testSCSIAddRemoveMultiple(t *testing.T, u *uvm.UtilityVM, pathPrefix string
 	// Try to re-add.
 	// We only support re-adding the same scsi device for lcow right now
 	logrus.Debugln("Next - trying to re-add")
-	err = testAddSCSI(u, disks, pathPrefix, useUvmPathPrefix, true)
+	reMounts, err := testAddSCSI(u, disks, pathPrefix, useUvmPathPrefix, true)
 	if err != nil {
 		t.Fatalf("failed to re-add SCSI device: %v", err)
 	}
@@ -177,12 +240,12 @@ func testSCSIAddRemoveMultiple(t *testing.T, u *uvm.UtilityVM, pathPrefix string
 	// Remove them all
 	logrus.Debugln("Removing them all")
 	// first removal decrements ref count
-	err = testRemoveAllSCSI(u, disks)
+	err = testRemoveAllSCSI(u, mounts)
 	if err != nil {
 		t.Fatalf("failed to remove SCSI disk: %v", err)
 	}
 	// second removal actually removes the device
-	err = testRemoveAllSCSI(u, disks)
+	err = testRemoveAllSCSI(u, reMounts)
 	if err != nil {
 		t.Fatalf("failed to remove SCSI disk: %v", err)
 	}
@@ -190,38 +253,28 @@ func testSCSIAddRemoveMultiple(t *testing.T, u *uvm.UtilityVM, pathPrefix string
 	// Now re-add but providing a container path
 	logrus.Debugln("Next - re-adding with a container path")
 	useUvmPathPrefix = true
-	err = testAddSCSI(u, disks, pathPrefix, useUvmPathPrefix, false)
+	mounts, err = testAddSCSI(u, disks, pathPrefix, useUvmPathPrefix, false)
 	if err != nil {
 		t.Fatalf("failed to add SCSI device: %v", err)
 	}
 
 	// Try to re-add
 	logrus.Debugln("Next - trying to re-add")
-	err = testAddSCSI(u, disks, pathPrefix, useUvmPathPrefix, true)
+	reMounts, err = testAddSCSI(u, disks, pathPrefix, useUvmPathPrefix, true)
 	if err != nil {
 		t.Fatalf("failed to add SCSI device: %v", err)
 	}
 
 	logrus.Debugln("Next - Removing them")
 	// first removal decrements ref count
-	err = testRemoveAllSCSI(u, disks)
+	err = testRemoveAllSCSI(u, mounts)
 	if err != nil {
 		t.Fatalf("failed to remove SCSI disk: %v", err)
 	}
 	// second removal actually removes the device
-	err = testRemoveAllSCSI(u, disks)
+	err = testRemoveAllSCSI(u, reMounts)
 	if err != nil {
 		t.Fatalf("failed to remove SCSI disk: %v", err)
-	}
-
-	// check the devices are no longer present on the uvm
-	targetNamespace := "k8s.io"
-	for i := 0; i < numDisks; i++ {
-		uvmPath := fmt.Sprintf(`%s%d`, pathPrefix, i)
-		out, err := exec.Command(`shimdiag.exe`, `exec`, targetNamespace, `ls`, uvmPath).Output()
-		if err == nil {
-			t.Fatalf("expected to no longer have scsi device files, instead returned %s", string(out))
-		}
 	}
 
 	// TODO: Could extend to validate can't add a 64th disk (windows). 65th (linux).
@@ -287,26 +340,25 @@ func TestParallelScsiOps(t *testing.T) {
 				}
 
 				var options []string
-				_, err = u.AddSCSI(context.Background(), path, "", false, false, options, uvm.VMAccessTypeIndividual)
+				scsiMount, err := u.AddSCSI(context.Background(), path, "", false, false, options, uvm.VMAccessTypeIndividual)
 				if err != nil {
 					os.Remove(path)
 					t.Errorf("failed to AddSCSI for worker: %d, iteration: %d with err: %v", scsiIndex, iteration, err)
 					continue
 				}
-				err = u.RemoveSCSI(context.Background(), path)
+				err = u.RemoveSCSIMount(context.Background(), path, scsiMount.UVMPath)
 				if err != nil {
 					t.Errorf("failed to RemoveSCSI for worker: %d, iteration: %d with err: %v", scsiIndex, iteration, err)
 					// This worker cant continue because the index is dead. We have to stop
 					break
 				}
-
-				_, err = u.AddSCSI(context.Background(), path, fmt.Sprintf("/run/gcs/c/0/scsi/%d", iteration), false, false, options, uvm.VMAccessTypeIndividual)
+				scsiMount, err = u.AddSCSI(context.Background(), path, fmt.Sprintf("/run/gcs/c/0/scsi/%d", iteration), false, false, options, uvm.VMAccessTypeIndividual)
 				if err != nil {
 					os.Remove(path)
 					t.Errorf("failed to AddSCSI for worker: %d, iteration: %d with err: %v", scsiIndex, iteration, err)
 					continue
 				}
-				err = u.RemoveSCSI(context.Background(), path)
+				err = u.RemoveSCSIMount(context.Background(), path, scsiMount.UVMPath)
 				if err != nil {
 					t.Errorf("failed to RemoveSCSI for worker: %d, iteration: %d with err: %v", scsiIndex, iteration, err)
 					// This worker cant continue because the index is dead. We have to stop


### PR DESCRIPTION
Partitioned scsi disks in linux normally show up like the following:
```
sdd       8:48   0   271M  0 disk
├─sdd1    8:49   0  88.9M  0 part
├─sdd2    8:50   0  61.9M  0 part
├─sdd3    8:51   0    32K  0 part
```
Such that each partition has an index on the attached disk. In order to use these partitions, our package needs to support having multiple guest paths mounted in the UVM for a given scsi device. 

This PR changes how the package thinks about and handles SCSI disks to allow for future use with partitioned disks. In particular this PR updates the SCSI logic from a 1:1 mapping of an attached disk with a guest mount in the UVM to a 1:many mapping of an attached disk with many potential guest mounts. **This is only supported for layer scsi mounts on linux.** 

This PR also updates some functional tests that can be used to verify behavior. 

Future PRs will be made to use this PR's changes. This PR does NOT include the guest side changes to use partitioned disks. This will also come in a later PR. 