### PR TITLE
Fix unintended data modification when redacted environment variables

### DIFF
--- a/pkg/securitypolicy/securitypolicyenforcer_rego.go
+++ b/pkg/securitypolicy/securitypolicyenforcer_rego.go
@@ -318,6 +318,11 @@ func (policy *regoEnforcer) getReasonNotAllowed(enforcementPoint string, input i
 
 func (policy *regoEnforcer) redactSensitiveData(input inputData) inputData {
 	if v, k := input["envList"]; k {
+		newInput := make(inputData)
+		for k, v := range input {
+			newInput[k] = v
+		}
+
 		newEnvList := make([]string, 0)
 		cast, ok := v.([]string)
 		if ok {
@@ -328,7 +333,9 @@ func (policy *regoEnforcer) redactSensitiveData(input inputData) inputData {
 			}
 		}
 
-		input["envList"] = newEnvList
+		newInput["envList"] = newEnvList
+
+		return newInput
 	}
 
 	return input


### PR DESCRIPTION
When I did the change to redact environment variable values in policy engine error messages, I create a "false positive error message" bug.

If any policy check were to be denied that involved environment variables in the check, then environment variables would be listed as a cause even if they weren't. This was because the previous redacting code was changing the data object used to determine the errors.

The updated data object had the redacted environment variables which would never match so all error messages would include that the envs were invalid.

This commit fixes that issue but creating a new object when redacting, the original object is still used to data checking and if redaction has been done, the new data object is used for generating the error message.

The current test system makes this somewhat hard to test for. I will be adding tests to cover "false positive error messages" in the not so distant future. In the meantime, this commit addresses the bug before it makes to production.

Signed-off-by: Sean T. Allen <seanallen@microsoft.com>