### PR TITLE
Fix false positive error messages on exec_external policy denial

### DIFF
--- a/pkg/securitypolicy/framework.rego
+++ b/pkg/securitypolicy/framework.rego
@@ -880,7 +880,7 @@ env_matches(env) {
     input.rule in ["exec_external"]
     some process in data.policy.external_processes
     some rule in process.env_rules
-    env_ok(rule.pattern, rule.strategy, input.envList)
+    env_ok(rule.pattern, rule.strategy, env)
 }
 
 errors[envError] {
@@ -906,7 +906,7 @@ workingDirectory_matches {
 
 workingDirectory_matches {
     input.rule == "exec_external"
-    some process in data.external_processes
+    some process in data.policy.external_processes
     workingDirectory_ok(process.working_dir)
 }
 


### PR DESCRIPTION
Due to errors in the logic for detecting errors when exec_external was denied, if it was denied, env list and working directory errors would always appear because the error checks were incorrect.

This commit fixes those errors.

At the moment, checking to make sure we don't have false positives in tests is difficult. Work to add those tests is planned but will take a bit. In the meantime, this change will fix the issue that is live in production.

Signed-off-by: Sean T. Allen <seanallen@microsoft.com>