### PR TITLE
dmverity: fix padding

### DIFF
--- a/ext4/dmverity/dmverity.go
+++ b/ext4/dmverity/dmverity.go
@@ -99,8 +99,10 @@ func MerkleTree(r io.Reader) ([]byte, error) {
 			nextLevel.Write(h)
 		}
 
-		padding := bytes.Repeat([]byte{0}, blockSize-(nextLevel.Len()%blockSize))
-		nextLevel.Write(padding)
+		if nextLevel.Len()%blockSize != 0 {
+			padding := bytes.Repeat([]byte{0}, blockSize-(nextLevel.Len()%blockSize))
+			nextLevel.Write(padding)
+		}
 
 		layers = append(layers, nextLevel.Bytes())
 		currentLevel = bufio.NewReaderSize(nextLevel, MerkleTreeBufioSize)


### PR DESCRIPTION
Due to a missing check for whether padding is needed or not, for certain images we may end up with an extra 4096 zero-byte padding in the merkle tree. Fix this by checking if padding is needed.

Signed-off-by: Maksim An <maksiman@microsoft.com>