### PR TITLE
Provide error message when the lack of required environment variable causes policy denial

### DIFF
--- a/pkg/securitypolicy/securitypolicy_test.go
+++ b/pkg/securitypolicy/securitypolicy_test.go
@@ -1093,6 +1093,16 @@ func buildEnvironmentVariablesFromEnvRules(rules []EnvRuleConfig, r *rand.Rand) 
 	// variable
 	numberOfRules := int32(len(rules))
 	numberOfMatches := randMinMax(r, 1, numberOfRules)
+
+	// Build in all required rules, this isn't a setup method of "missing item"
+	// tests
+	for _, rule := range rules {
+		if rule.Required {
+			vars = append(vars, rule.Rule)
+			numberOfMatches--
+		}
+	}
+
 	usedIndexes := map[int]struct{}{}
 	for numberOfMatches > 0 {
 		anIndex := -1


### PR DESCRIPTION
This commit handles the simplest case of error reporting and doesn't inform as to the particular variables or the group them into sets based on container/process.

Signed-off-by: Sean T. Allen <seanallen@microsoft.com>
Signed-off-by: Matthew A Johnson <matjoh@microsoft.com>