### PR TITLE
Format encrypted scratch disk as xfs rather than ext4fs

### DIFF
--- a/internal/guest/storage/crypt/crypt_test.go
+++ b/internal/guest/storage/crypt/crypt_test.go
@@ -179,56 +179,6 @@ func Test_Encrypt_Get_Device_Size_Error(t *testing.T) {
 	}
 }
 
-func Test_Encrypt_Create_Sparse_File_Error(t *testing.T) {
-	clearCryptTestDependencies()
-
-	// Test what happens when it isn't possible to create a sparse file, and
-	// make sure that _createSparseEmptyFile receives the right arguments.
-
-	blockDeviceSize := int64(memory.GiB)
-
-	_generateKeyFile = func(path string, size int64) error {
-		return nil
-	}
-	_osRemoveAll = func(path string) error {
-		return nil
-	}
-	_cryptsetupFormat = func(source string, keyFilePath string) error {
-		return nil
-	}
-	_cryptsetupOpen = func(source string, deviceName string, keyFilePath string) error {
-		return nil
-	}
-	_cryptsetupClose = func(deviceName string) error {
-		return nil
-	}
-	_getBlockDeviceSize = func(ctx context.Context, path string) (int64, error) {
-		// Return a non-zero size
-		return blockDeviceSize, nil
-	}
-
-	source := "/dev/sda"
-	tempExt4File := tempDir + "ext4.img"
-
-	expectedErr := errors.New("expected error message")
-	_createSparseEmptyFile = func(ctx context.Context, path string, size int64) error {
-		// Check that the path and the size are the expected ones
-		if path != tempExt4File {
-			t.Fatalf("expected path: '%v' got: '%v'", tempExt4File, path)
-		}
-		if size != blockDeviceSize {
-			t.Fatalf("expected size: '%v' got: '%v'", blockDeviceSize, size)
-		}
-
-		return expectedErr
-	}
-
-	_, err := EncryptDevice(context.Background(), source, "dm-crypt-name")
-	if errors.Unwrap(err) != expectedErr {
-		t.Fatalf("expected err: '%v' got: '%v'", expectedErr, err)
-	}
-}
-
 func Test_Encrypt_Mkfs_Error(t *testing.T) {
 	clearCryptTestDependencies()
 
@@ -259,14 +209,20 @@ func Test_Encrypt_Mkfs_Error(t *testing.T) {
 	_createSparseEmptyFile = func(ctx context.Context, path string, size int64) error {
 		return nil
 	}
+	_mkfsXfs = func(string) error {
+		return nil
+	}
+	_zeroDevice = func(string, int64, int64) error {
+		return nil
+	}
 
 	source := "/dev/sda"
-	tempExt4File := tempDir + "ext4.img"
+	formatTarget := "/dev/mapper/dm-crypt-name"
 
 	expectedErr := errors.New("expected error message")
-	_mkfsExt4Command = func(args []string) error {
-		if args[0] != tempExt4File {
-			t.Fatalf("expected args: '%v' got: '%v'", tempExt4File, args[0])
+	_mkfsXfs = func(arg string) error {
+		if arg != formatTarget {
+			t.Fatalf("expected args: '%v' got: '%v'", formatTarget, arg)
 		}
 		return expectedErr
 	}
@@ -274,62 +230,6 @@ func Test_Encrypt_Mkfs_Error(t *testing.T) {
 	_, err := EncryptDevice(context.Background(), source, "dm-crypt-name")
 	if errors.Unwrap(err) != expectedErr {
 		t.Fatalf("expected err: '%v' got: '%v'", expectedErr, err)
-	}
-}
-
-func Test_Encrypt_Sparse_Copy_Error(t *testing.T) {
-	clearCryptTestDependencies()
-
-	// Test what happens when the sparse copy fails. Verify that the arguments
-	// passed to it are the right ones.
-
-	blockDeviceSize := int64(memory.GiB)
-
-	_generateKeyFile = func(path string, size int64) error {
-		return nil
-	}
-	_osRemoveAll = func(path string) error {
-		return nil
-	}
-	_cryptsetupFormat = func(source string, keyFilePath string) error {
-		return nil
-	}
-	_cryptsetupOpen = func(source string, deviceName string, keyFilePath string) error {
-		return nil
-	}
-	_cryptsetupClose = func(deviceName string) error {
-		return nil
-	}
-	_getBlockDeviceSize = func(ctx context.Context, path string) (int64, error) {
-		// Return a non-zero size
-		return blockDeviceSize, nil
-	}
-	_createSparseEmptyFile = func(ctx context.Context, path string, size int64) error {
-		return nil
-	}
-	_mkfsExt4Command = func(args []string) error {
-		return nil
-	}
-
-	source := "/dev/sda"
-	tempExt4File := tempDir + "ext4.img"
-	dmCryptName := "dm-crypt-target"
-	deviceNamePath := "/dev/mapper/" + dmCryptName
-
-	expectedErr := errors.New("expected error message")
-	_copyEmptySparseFilesystem = func(source string, destination string) error {
-		if source != tempExt4File {
-			t.Fatalf("expected source: '%v' got: '%v'", tempExt4File, source)
-		}
-		if destination != deviceNamePath {
-			t.Fatalf("expected destination: '%v' got: '%v'", deviceNamePath, destination)
-		}
-		return expectedErr
-	}
-
-	_, err := EncryptDevice(context.Background(), source, dmCryptName)
-	if errors.Unwrap(err) != expectedErr {
-		t.Fatalf("expected err:'%v' got: '%v'", expectedErr, err)
 	}
 }
 
@@ -360,6 +260,9 @@ func Test_Encrypt_Success(t *testing.T) {
 		return nil
 	}
 	_mkfsExt4Command = func(args []string) error {
+		return nil
+	}
+	_mkfsXfs = func(arg string) error {
 		return nil
 	}
 	_copyEmptySparseFilesystem = func(source string, destination string) error {

--- a/internal/guest/storage/crypt/crypt_test.go
+++ b/internal/guest/storage/crypt/crypt_test.go
@@ -19,14 +19,11 @@ func osMkdirTempTest(dir string, pattern string) (string, error) {
 }
 
 func clearCryptTestDependencies() {
-	_copyEmptySparseFilesystem = nil
-	_createSparseEmptyFile = nil
 	_cryptsetupClose = nil
 	_cryptsetupFormat = nil
 	_cryptsetupOpen = nil
 	_generateKeyFile = nil
 	_getBlockDeviceSize = nil
-	_mkfsExt4Command = nil
 	_osMkdirTemp = osMkdirTempTest
 	_osRemoveAll = nil
 }
@@ -206,9 +203,6 @@ func Test_Encrypt_Mkfs_Error(t *testing.T) {
 		// Return a non-zero size
 		return blockDeviceSize, nil
 	}
-	_createSparseEmptyFile = func(ctx context.Context, path string, size int64) error {
-		return nil
-	}
 	_mkfsXfs = func(string) error {
 		return nil
 	}
@@ -256,16 +250,7 @@ func Test_Encrypt_Success(t *testing.T) {
 		// Return a non-zero size
 		return blockDeviceSize, nil
 	}
-	_createSparseEmptyFile = func(ctx context.Context, path string, size int64) error {
-		return nil
-	}
-	_mkfsExt4Command = func(args []string) error {
-		return nil
-	}
 	_mkfsXfs = func(arg string) error {
-		return nil
-	}
-	_copyEmptySparseFilesystem = func(source string, destination string) error {
 		return nil
 	}
 

--- a/internal/guest/storage/crypt/utilities.go
+++ b/internal/guest/storage/crypt/utilities.go
@@ -34,115 +34,48 @@ func getBlockDeviceSize(ctx context.Context, path string) (int64, error) {
 	return pos, nil
 }
 
-// createSparseEmptyFile creates a sparse file of the specified size. The whole
-// file is empty, so the size on disk is zero, only the logical size is the
-// specified one.
-func createSparseEmptyFile(ctx context.Context, path string, size int64) (err error) {
-	f, err := os.Create(path)
+
+// In the xfs mkfs case it appears to attempt to read the first block of the device.
+// This results in an integrity error. This function zeros out the start of the device
+// so we are sure that when it is read it has already been hashed so matches.
+
+func zeroDevice(devicePath string, blockSize int64, numberOfBlocks int64) error {
+	fout, err := os.OpenFile(devicePath, os.O_WRONLY, 0)
 	if err != nil {
-		return errors.Wrapf(err, "failed to create: %s", path)
-	}
-
-	defer func() {
-		if err != nil {
-			if inErr := os.RemoveAll(path); inErr != nil {
-				log.G(ctx).WithError(inErr).Debug("failed to delete: " + path)
-			}
-		}
-	}()
-
-	defer func() {
-		if err := f.Close(); err != nil {
-			log.G(ctx).WithError(err).Debug("failed to close: " + path)
-		}
-	}()
-
-	if err := f.Truncate(size); err != nil {
-		return errors.Wrapf(err, "failed to truncate: %s", path)
-	}
-
-	return nil
-}
-
-// The following constants aren't defined in the io or os libraries.
-//
-//nolint:stylecheck // ST1003: ALL_CAPS
-const (
-	SEEK_DATA = 3
-	SEEK_HOLE = 4
-)
-
-// copyEmptySparseFilesystem copies data chunks of a sparse source file into a
-// destination file. It skips holes. Note that this is intended to copy a
-// filesystem that has just been generated, so it only contains metadata blocks.
-// Because of that, the source file must end with a hole. If it ends with data,
-// the last chunk of data won't be copied.
-func copyEmptySparseFilesystem(source string, destination string) error {
-	fin, err := os.OpenFile(source, os.O_RDONLY, 0)
-	if err != nil {
-		return errors.Wrap(err, "failed to open source file")
-	}
-	defer fin.Close()
-
-	fout, err := os.OpenFile(destination, os.O_WRONLY, 0)
-	if err != nil {
-		return errors.Wrap(err, "failed to open destination file")
+		return errors.Wrapf(err, "failed to open device file %s", devicePath)
 	}
 	defer fout.Close()
 
-	finInfo, err := fin.Stat()
-	if err != nil {
-		return errors.Wrap(err, "failed to stat source file")
+	zeros := make([]byte, blockSize)
+	for i := range zeros {
+		zeros[i] = 0
 	}
 
-	finSize := finInfo.Size()
+	// get the size so we don't overrun the end of the device
+	foutSize, err := fout.Seek(0, io.SeekEnd)
+	if err != nil {
+		return errors.Wrapf(err, "zeroDevice: failed to seek to end, device file %s", devicePath)
+	}
+
+	// move back to the front.
+	_, err = fout.Seek(0, io.SeekStart)
+	if err != nil {
+		return errors.Wrapf(err, "zeroDevice: failed to seek to start, device file %s", devicePath)
+	}
 
 	var offset int64 = 0
-	for {
+	var which int64
+	for which = 0; which < numberOfBlocks; which++ {
 		// Exit when the end of the file is reached
-		if offset >= finSize {
+		if offset >= foutSize {
 			break
 		}
-
-		// Calculate bounds of the next data chunk
-		chunkStart, err := fin.Seek(offset, SEEK_DATA)
-		if (err != nil) || (chunkStart == -1) {
-			// No more chunks left
-			break
-		}
-		chunkEnd, err := fin.Seek(chunkStart, SEEK_HOLE)
-		if (err != nil) || (chunkEnd == -1) {
-			break
-		}
-		chunkSize := chunkEnd - chunkStart
-		offset = chunkEnd
-
-		// Read contents of this data chunk
-		//nolint:staticcheck //TODO: SA1019: os.SEEK_SET has been deprecated since Go 1.7: Use io.SeekStart, io.SeekCurrent, and io.SeekEnd.
-		_, err = fin.Seek(chunkStart, os.SEEK_SET)
-		if err != nil {
-			return errors.Wrap(err, "failed to seek set in source file")
-		}
-
-		chunkData := make([]byte, chunkSize)
-		count, err := fin.Read(chunkData)
-		if err != nil {
-			return errors.Wrap(err, "failed to read source file")
-		}
-		if int64(count) != chunkSize {
-			return errors.Wrap(err, "not enough data read from source file")
-		}
-
 		// Write data to destination file
-		//nolint:staticcheck //TODO: SA1019: os.SEEK_SET has been deprecated since Go 1.7: Use io.SeekStart, io.SeekCurrent, and io.SeekEnd.
-		_, err = fout.Seek(chunkStart, os.SEEK_SET)
+		wrttten, err := fout.Write(zeros)
 		if err != nil {
-			return errors.Wrap(err, "failed to seek destination file")
+			return errors.Wrapf(err, "failed to write destination file %s offset %d", devicePath, offset)
 		}
-		_, err = fout.Write(chunkData)
-		if err != nil {
-			return errors.Wrap(err, "failed to write destination file")
-		}
+		offset += int64(wrttten)
 	}
 
 	return nil

--- a/internal/guest/storage/scsi/scsi.go
+++ b/internal/guest/storage/scsi/scsi.go
@@ -154,6 +154,8 @@ func Mount(
 		data = "noload"
 	}
 
+	var mountType = "ext4"
+
 	if encrypted {
 		cryptDeviceName := fmt.Sprintf(cryptDeviceFmt, controller, lun)
 		encryptedSource, err := encryptDevice(spnCtx, source, cryptDeviceName)
@@ -161,10 +163,11 @@ func Mount(
 			return fmt.Errorf("failed to mount encrypted device %s: %w", source, err)
 		}
 		source = encryptedSource
+		mountType = "xfs"
 	}
 
 	for {
-		if err := unixMount(source, target, "ext4", flags, data); err != nil {
+		if err := unixMount(source, target, mountType, flags, data); err != nil {
 			// The `source` found by controllerLunToName can take some time
 			// before its actually available under `/dev/sd*`. Retry while we
 			// wait for `source` to show up.

--- a/internal/guest/storage/scsi/scsi.go
+++ b/internal/guest/storage/scsi/scsi.go
@@ -154,8 +154,7 @@ func Mount(
 		data = "noload"
 	}
 
-	var mountType = "ext4"
-
+	mountType := "ext4"
 	if encrypted {
 		cryptDeviceName := fmt.Sprintf(cryptDeviceFmt, controller, lun)
 		encryptedSource, err := encryptDevice(spnCtx, source, cryptDeviceName)


### PR DESCRIPTION
To avoid the  ioerror detected by the integrity layer.