### PR TITLE
Fix compilation error caused by "PRs crossing in the night"

### DIFF
--- a/pkg/securitypolicy/regopolicy_test.go
+++ b/pkg/securitypolicy/regopolicy_test.go
@@ -4028,7 +4028,7 @@ func Test_Rego_ExecExternalProcessPolicy_ConflictingAllowStdioAccessHasErrorMess
 
 func Test_Rego_Enforce_CreateContainer_RequiredEnvMissingHasErrorMessage(t *testing.T) {
 	constraints := generateConstraints(testRand, 1)
-	container := selectContainerFromConstraints(constraints, testRand)
+	container := selectContainerFromContainerList(constraints.containers, testRand)
 	requiredRule := EnvRuleConfig{
 		Strategy: "string",
 		Rule:     randVariableString(testRand, maxGeneratedEnvironmentVariableRuleLength),
@@ -4063,7 +4063,7 @@ func Test_Rego_Enforce_CreateContainer_RequiredEnvMissingHasErrorMessage(t *test
 
 func Test_Rego_ExecInContainerPolicy_RequiredEnvMissingHasErrorMessage(t *testing.T) {
 	constraints := generateConstraints(testRand, 1)
-	container := selectContainerFromConstraints(constraints, testRand)
+	container := selectContainerFromContainerList(constraints.containers, testRand)
 	neededEnv := randVariableString(testRand, maxGeneratedEnvironmentVariableRuleLength)
 	requiredRule := EnvRuleConfig{
 		Strategy: "string",


### PR DESCRIPTION
Two recent PRs of mine had an unfortunate interaction. Both passed they should have. Bunt one was refactoring that removed a method that the second PR relied and when they were both merged to main, compilation error!

Refactor commit:

https://github.com/microsoft/hcsshim/commit/2c33d3d83a1e447e129b7487bf04c3144d14f4a9

Commit that didn't take the above changes into account:

https://github.com/microsoft/hcsshim/commit/c97246d11f19a4f178f1a82fe8b2caa0b404b472