### PR TITLE
Wait longer before trying to install mingw after failing to install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -286,8 +286,8 @@ jobs:
               # remove any left-over state
               choco uninstall -y --no-progress --force mingw
 
-              Write-Output 'Sleeping for 2 seconds'
-              Sleep -Seconds 2
+              Write-Output 'Sleeping for 60 seconds'
+              Sleep -Seconds 60
             }
 
             choco install -y --no-progress --stop-on-first-failure --force mingw --allow-downgrade --version 10.2.0


### PR DESCRIPTION
I've been watching the mingw failures I get and I've been checking "successes" to see if I can see the current 2 second back off being successful. I regularly see the short retry period not working and I've seen only once or twice that it it worked.

This commit ups the time to retry to a longer 60 seconds which should give a better chance at success.