### PR TITLE
Import base layer images

### DIFF
--- a/internal/wclayer/importlayer.go
+++ b/internal/wclayer/importlayer.go
@@ -142,6 +142,12 @@ func NewLayerWriter(ctx context.Context, path string, parentLayerPaths []string)
 		if err != nil {
 			return nil, err
 		}
+
+		// ensure the required files are present in the base layer
+		_, err = ensureBaseLayer(f)
+		if err != nil {
+			return nil, err
+		}
 		return &baseLayerWriter{
 			ctx:  ctx,
 			s:    span,


### PR DESCRIPTION
If a project creates a base layer image and wants to directly import the base then this ensure the baseline file are in place.  It is a follow up to #1637 and enables containerd with `ctr image import image.tar` of a base layer.

@gabriel-samfira @helsaawy @TBBle 

I didn't find any tests that I could run but I am happy to add something if I get a pointer in the right direction.