### PR TITLE
[release/0.9] Fix graceful termination test errors (#1687)

### DIFF
--- a/test/cri-containerd/stopcontainer_test.go
+++ b/test/cri-containerd/stopcontainer_test.go
@@ -5,9 +5,11 @@ package cri_containerd
 
 import (
 	"context"
+	"math"
 	"testing"
 	"time"
 
+	"github.com/Microsoft/hcsshim/osversion"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 )
 
@@ -186,6 +188,12 @@ func assertContainerState(t *testing.T, client runtime.RuntimeServiceClient, ctx
 // behavior and to ensure that the containers are killed only after 15 second
 // timeout specified via the stop container command.
 func Test_GracefulTermination(t *testing.T) {
+	// The test image is based on 2022 servercore and nanoserver images. Ensure
+	// that we are running on the correct OS version
+	if osversion.Build() < osversion.V21H2Server {
+		t.Skip()
+	}
+
 	for name, tc := range map[string]struct {
 		features       []string
 		runtimeHandler string
@@ -243,13 +251,13 @@ func Test_GracefulTermination(t *testing.T) {
 			startTimeOfContainer := time.Now()
 			// stop container with timeout of 15 seconds
 			stopContainerWithTimeout(t, client, ctx, containerID, 15)
-			assertContainerState(t, client, ctx, containerID, runtime.ContainerState_CONTAINER_EXITED)
 			// get time elapsed before and after container stop command was issued
-			elapsedTime := time.Since(startTimeOfContainer)
+			elapsedTime := math.Round(time.Since(startTimeOfContainer).Seconds())
+			assertContainerState(t, client, ctx, containerID, runtime.ContainerState_CONTAINER_EXITED)
 			// Ensure that the container has stopped after approx 15 seconds.
-			// We are giving it a buffer of +/- 1 second
-			if elapsedTime < 14*time.Second || elapsedTime > 16*time.Second {
-				t.Fatalf("Container did not shutdown gracefully \n")
+			// We are giving it a buffer of few seconds to account for cloud test delays
+			if elapsedTime < 14 || elapsedTime > 20 {
+				t.Fatalf("Container did not shutdown gracefully. Total elapsedTime before and after container stop command was issued is: %v", elapsedTime)
 			}
 		})
 	}


### PR DESCRIPTION
This PR ports graceful termination test fix from main.

- Loosen the time interval check that measures the time taken to
stop the container with -t command to account for cloud test delays
- Add to check that OS version is V21H2Server since the graceful
termination test images are based on servercore and nanoserver 2022.


(cherry picked from commit 5e3a6dfa5fdcb695748e19f03d5ffb5127a7588a)