### PR TITLE
Update golangci linter and clean go mod cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,9 +30,13 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
+      - name: Clean mod cache
+        shell: Powershell
+        run: |
+          go clean -modcache
       - uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.49
+          version: v1.52
           args: >-
             --verbose
             --max-issues-per-linter=0

--- a/internal/guest/prot/protocol.go
+++ b/internal/guest/prot/protocol.go
@@ -30,7 +30,6 @@ import (
 // III - 12 Bits   Message Id
 // VV  - 8 Bits    Version
 
-//nolint:deadcode,varcheck
 const (
 	messageTypeMask     = 0xF0000000
 	messageCategoryMask = 0x0FF00000

--- a/internal/guest/storage/devicemapper/devicemapper.go
+++ b/internal/guest/storage/devicemapper/devicemapper.go
@@ -29,7 +29,7 @@ var (
 	openMapperWrapper   = openMapper
 )
 
-//nolint:deadcode,varcheck,stylecheck // ST1003: ALL_CAPS
+//nolint:stylecheck // ST1003: ALL_CAPS
 const (
 	_DM_IOCTL      = 0xfd
 	_DM_IOCTL_SIZE = 312
@@ -42,7 +42,7 @@ const (
 
 const blockSize = 512
 
-//nolint:deadcode,varcheck,stylecheck // ST1003: ALL_CAPS
+//nolint:stylecheck // ST1003: ALL_CAPS
 const (
 	_DM_VERSION = iota
 	_DM_REMOVE_ALL

--- a/internal/security/grantvmgroupaccess.go
+++ b/internal/security/grantvmgroupaccess.go
@@ -23,20 +23,14 @@ type (
 )
 
 type explicitAccess struct {
-	//nolint:structcheck
 	accessPermissions accessMask
-	//nolint:structcheck
-	accessMode accessMode
-	//nolint:structcheck
-	inheritance inheritMode
-	//nolint:structcheck
-	trustee trustee
+	accessMode        accessMode
+	inheritance       inheritMode
+	trustee           trustee
 }
 
 type trustee struct {
-	//nolint:unused,structcheck
-	multipleTrustee *trustee
-	//nolint:unused,structcheck
+	multipleTrustee          *trustee
 	multipleTrusteeOperation int32
 	trusteeForm              trusteeForm
 	trusteeType              trusteeType

--- a/pkg/amdsevsnp/report.go
+++ b/pkg/amdsevsnp/report.go
@@ -16,7 +16,6 @@ import (
 	"github.com/Microsoft/hcsshim/internal/guest/linux"
 )
 
-//nolint:deadcode,varcheck // enumerate all options
 const (
 	msgTypeInvalid = iota
 	msgCPUIDRequest

--- a/test/cri-containerd/container_update_test.go
+++ b/test/cri-containerd/container_update_test.go
@@ -24,7 +24,7 @@ func calculateJobCPUWeight(processorWeight uint32) uint32 {
 	return 1 + uint32((8*processorWeight)/processorWeightMax)
 }
 
-//nolint:deadcode,unused // may be used in future tests
+//nolint:unused // may be used in future tests
 func calculateJobCPURate(hostProcs uint32, processorCount uint32) uint32 {
 	rate := (processorCount * 10000) / hostProcs
 	if rate == 0 {

--- a/test/cri-containerd/container_virtual_device_test.go
+++ b/test/cri-containerd/container_virtual_device_test.go
@@ -109,7 +109,7 @@ func findTestNvidiaGPULocationPath() (string, error) {
 
 // findTestVirtualDeviceID returns the instance ID of the first generic pcip device on the host
 //
-//nolint:deadcode,unused // may be used in future tests
+//nolint:unused // may be used in future tests
 func findTestVirtualDeviceID() (string, error) {
 	out, err := exec.Command(
 		"powershell",

--- a/test/cri-containerd/main_test.go
+++ b/test/cri-containerd/main_test.go
@@ -80,7 +80,7 @@ const (
 
 // Image definitions
 //
-//nolint:deadcode,unused,varcheck // may be used in future tests
+//nolint:unused // may be used in future tests
 var (
 	imageWindowsNanoserver      = getWindowsNanoserverImage(osversion.Build())
 	imageWindowsServercore      = getWindowsServerCoreImage(osversion.Build())
@@ -172,6 +172,7 @@ func getWindowsNanoserverImage(build uint16) string {
 	return constants.NanoserverImage(tag)
 }
 
+//nolint:unused // may be used in future tests
 func getWindowsServerCoreImage(build uint16) string {
 	tag, err := constants.ImageFromBuild(build)
 	if err != nil {

--- a/test/cri-containerd/pod_update_test.go
+++ b/test/cri-containerd/pod_update_test.go
@@ -257,7 +257,6 @@ func Test_Pod_UpdateResources_CPUGroup(t *testing.T) {
 		}
 	}()
 
-	//nolint:unused // false positive about config being unused
 	type config struct {
 		name             string
 		requiredFeatures []string

--- a/test/cri-containerd/policy_test.go
+++ b/test/cri-containerd/policy_test.go
@@ -1271,6 +1271,7 @@ func Test_RunPodSandbox_Concurrently(t *testing.T) {
 	requireFeatures(t, featureLCOWIntegrity)
 
 	for i := 0; i < 20; i++ {
+		i := i // define a local copy of loop variable that will be captured by `t.Run` closure
 		t.Run(fmt.Sprintf("ParallelPodRun_%d", i+1), func(t *testing.T) {
 			t.Parallel()
 			client := newTestRuntimeClient(t)

--- a/test/functional/lcow_test.go
+++ b/test/functional/lcow_test.go
@@ -252,8 +252,6 @@ func TestLCOWSimplePodScenario(t *testing.T) {
 
 // Helper to run the init process in an LCOW container; verify it exits with exit
 // code 0; verify stderr is empty; check output is as expected.
-//
-//nolint:unused // unused since tests are skipped
 func runInitProcess(t *testing.T, s cow.Container, expected string) {
 	t.Helper()
 	var errB bytes.Buffer

--- a/test/functional/main_test.go
+++ b/test/functional/main_test.go
@@ -191,7 +191,7 @@ func defaultLCOWOptions(tb testing.TB) *uvm.OptionsLCOW {
 	return opts
 }
 
-//nolint:deadcode,unused // will be used when WCOW tests are updated
+//nolint:unused // will be used when WCOW tests are updated
 func defaultWCOWOptions(tb testing.TB) *uvm.OptionsWCOW {
 	tb.Helper()
 	return uvm.NewDefaultOptionsWCOW(util.CleanName(tb.Name()), hcsOwner)
@@ -212,7 +212,7 @@ func linuxImageLayers(ctx context.Context, tb testing.TB) []string {
 // If layer paths were provided on the command line, they are returned.
 // Otherwise, it pulls an appropriate image.
 //
-//nolint:deadcode,unused // will be used when WCOW tests are updated
+//nolint:unused // will be used when WCOW tests are updated
 func windowsImageLayers(ctx context.Context, tb testing.TB) []string {
 	tb.Helper()
 	if ss := flagWCOWLayerPaths.Strings(); len(ss) > 0 {
@@ -224,8 +224,6 @@ func windowsImageLayers(ctx context.Context, tb testing.TB) []string {
 // windowsServercoreImageLayers returns image layer paths for Windows servercore.
 //
 // See [windowsImageLayers] for more.
-//
-//nolint:unused // will be used when WCOW tests are updated
 func windowsServercoreImageLayers(ctx context.Context, tb testing.TB) []string {
 	tb.Helper()
 	return servercoreImagePaths.Layers(ctx, tb)

--- a/test/functional/uvm_mem_backingtype_test.go
+++ b/test/functional/uvm_mem_backingtype_test.go
@@ -17,21 +17,18 @@ import (
 	tuvm "github.com/Microsoft/hcsshim/test/internal/uvm"
 )
 
-//nolint:unused // unused since tests are skipped
 func runMemStartLCOWTest(t *testing.T, opts *uvm.OptionsLCOW) {
 	t.Helper()
 	u := tuvm.CreateAndStartLCOWFromOpts(context.Background(), t, opts)
 	u.Close()
 }
 
-//nolint:unused // unused since tests are skipped
 func runMemStartWCOWTest(t *testing.T, opts *uvm.OptionsWCOW) {
 	t.Helper()
 	u, _, _ := tuvm.CreateWCOWUVMFromOptsWithImage(context.Background(), t, opts, "microsoft/nanoserver")
 	u.Close()
 }
 
-//nolint:unused // unused since tests are skipped
 func runMemTests(t *testing.T, os string) {
 	t.Helper()
 	type testCase struct {
@@ -78,7 +75,6 @@ func TestMemBackingTypeLCOW(t *testing.T) {
 	runMemTests(t, "linux")
 }
 
-//nolint:unused // unused since tests are skipped
 func runBenchMemStartTest(b *testing.B, opts *uvm.OptionsLCOW) {
 	b.Helper()
 	// Cant use testutilities here because its `testing.B` not `testing.T`
@@ -92,7 +88,6 @@ func runBenchMemStartTest(b *testing.B, opts *uvm.OptionsLCOW) {
 	}
 }
 
-//nolint:unused // unused since tests are skipped
 func runBenchMemStartLcowTest(b *testing.B, allowOvercommit bool, enableDeferredCommit bool) {
 	b.Helper()
 	for i := 0; i < b.N; i++ {

--- a/test/functional/uvm_scsi_test.go
+++ b/test/functional/uvm_scsi_test.go
@@ -54,7 +54,6 @@ func TestSCSIAddRemoveWCOW(t *testing.T) {
 	testSCSIAddRemoveSingle(t, u, `c:\`, "windows", layers)
 }
 
-//nolint:unused // unused since tests are skipped
 func testAddSCSI(u *uvm.UtilityVM, disks []string, pathPrefix string, usePath bool, reAdd bool) error {
 	for i := range disks {
 		uvmPath := ""
@@ -73,7 +72,6 @@ func testAddSCSI(u *uvm.UtilityVM, disks []string, pathPrefix string, usePath bo
 	return nil
 }
 
-//nolint:unused // unused since tests are skipped
 func testRemoveAllSCSI(u *uvm.UtilityVM, disks []string) error {
 	for i := range disks {
 		if err := u.RemoveSCSI(context.Background(), disks[i]); err != nil {
@@ -85,8 +83,6 @@ func testRemoveAllSCSI(u *uvm.UtilityVM, disks []string) error {
 
 // TODO this test is only needed until WCOW supports adding the same scsi device to
 // multiple containers
-//
-//nolint:unused // unused since tests are skipped
 func testSCSIAddRemoveSingle(t *testing.T, u *uvm.UtilityVM, pathPrefix string, operatingSystem string, wcowImageLayerFolders []string) {
 	t.Helper()
 	numDisks := 63 // Windows: 63 as the UVM scratch is at 0:0
@@ -138,7 +134,6 @@ func testSCSIAddRemoveSingle(t *testing.T, u *uvm.UtilityVM, pathPrefix string, 
 	// TODO: Could extend to validate can't add a 64th disk (windows). 65th (linux).
 }
 
-//nolint:unused // unused since tests are skipped
 func testSCSIAddRemoveMultiple(t *testing.T, u *uvm.UtilityVM, pathPrefix string, operatingSystem string, wcowImageLayerFolders []string) {
 	t.Helper()
 	numDisks := 63 // Windows: 63 as the UVM scratch is at 0:0

--- a/test/functional/uvm_virtualdevice_test.go
+++ b/test/functional/uvm_virtualdevice_test.go
@@ -19,8 +19,6 @@ import (
 const lcowGPUBootFilesPath = "C:\\ContainerPlat\\LinuxBootFiles\\nvidiagpu"
 
 // findTestDevices returns the first pcip device on the host
-//
-//nolint:unused // unused since tests are skipped
 func findTestVirtualDevice() (string, error) {
 	out, err := exec.Command(
 		"powershell",

--- a/test/functional/wcow_test.go
+++ b/test/functional/wcow_test.go
@@ -181,8 +181,6 @@ import (
 // Helper to stop a container.
 // Ones created through hcsoci methods will be of type cow.Container.
 // Ones created through hcsshim methods will be of type hcsshim.Container
-//
-//nolint:unused // unused since tests are skipped
 func stopContainer(t *testing.T, c interface{}) {
 	t.Helper()
 	switch c := c.(type) {
@@ -214,8 +212,6 @@ func stopContainer(t *testing.T, c interface{}) {
 
 // Helper to launch a process in a container created through the hcsshim methods.
 // At the point of calling, the container must have been successfully created.
-//
-//nolint:unused // unused since tests are skipped
 func runShimCommand(t *testing.T,
 	c hcsshim.Container,
 	command string,
@@ -262,7 +258,6 @@ func runShimCommand(t *testing.T,
 	}
 }
 
-//nolint:unused // unused since tests are skipped
 func runShimCommands(t *testing.T, c hcsshim.Container) {
 	t.Helper()
 	runShimCommand(t, c, `echo Hello`, `c:\`, 0, "Hello")
@@ -281,7 +276,6 @@ func runShimCommands(t *testing.T, c hcsshim.Container) {
 	runShimCommand(t, c, `ls`, `c:\mappedrw`, 0, `readwrite`)
 }
 
-//nolint:unused // unused since tests are skipped
 func runHcsCommands(t *testing.T, c cow.Container) {
 	t.Helper()
 	runHcsCommand(t, c, `echo Hello`, `c:\`, 0, "Hello")
@@ -302,8 +296,6 @@ func runHcsCommands(t *testing.T, c cow.Container) {
 
 // Helper to launch a process in a container created through the hcsshim methods.
 // At the point of calling, the container must have been successfully created.
-//
-//nolint:unused // unused since tests are skipped
 func runHcsCommand(t *testing.T,
 	c cow.Container,
 	command string,
@@ -349,8 +341,6 @@ func runHcsCommand(t *testing.T,
 }
 
 // Creates two temp folders used for the mounts/mapped directories
-//
-//nolint:unused // unused since tests are skipped
 func createTestMounts(t *testing.T) (string, string) {
 	t.Helper()
 	// Create two temp folders for mapped directories.
@@ -364,8 +354,6 @@ func createTestMounts(t *testing.T) (string, string) {
 }
 
 // For calling hcsshim interface, need hcsshim.Layer built from an images layer folders
-//
-//nolint:unused // unused since tests are skipped
 func generateShimLayersStruct(t *testing.T, imageLayers []string) []hcsshim.Layer {
 	t.Helper()
 	var layers []hcsshim.Layer
@@ -504,7 +492,6 @@ func TestWCOWXenonShim(t *testing.T) {
 	stopContainer(t, xenonShim)
 }
 
-//nolint:unused // unused since tests are skipped
 func generateWCOWOciTestSpec(t *testing.T, imageLayers []string, scratchPath, hostRWSharedDirectory, hostROSharedDirectory string) *specs.Spec {
 	t.Helper()
 	return &specs.Spec{


### PR DESCRIPTION
The goal of this PR is to fix a problem seen in https://github.com/microsoft/hcsshim/pull/1704. In that PR, it appears that the linter continuously fails with 

```
level=error msg="Running error: 1 error occurred:\n\t* can't run linter goanalysis_metalinter: buildir: failed to load package : could not load export data: no export data for \"github.com/Microsoft/hcsshim/test/internal/require\"\n\n"
```

However, in that PR that package has been removed and all references to it in the repo have been updated. 

We believe this is an issue with the linter's mod cache being out of date. This PR aims to address that by updating the linter version and adding an additional step beforehand to clean the mod cache. 