### PR TITLE
con-con: write policy, reference info and cert to container's rootfs

### DIFF
--- a/pkg/annotations/annotations.go
+++ b/pkg/annotations/annotations.go
@@ -271,8 +271,10 @@ const (
 	// GuestStateFile specifies the path of the vmgs file to use if required. Only applies in SNP mode.
 	GuestStateFile = "io.microsoft.virtualmachine.lcow.gueststatefile"
 
-	// UVMSecurityPolicyEnv specifies if UVM_SECURITY_POLICY, UVM_REFERENCE_INFO
-	// and UVM_HOST_AMD_CERTIFICATE variables should be injected for a container.
+	// UVMSecurityPolicyEnv specifies if confidential containers' related information
+	// should be written to containers' rootfs. The filenames and location are defined
+	// by securitypolicy.PolicyFilename, securitypolicy.HostAMDCertFilename and
+	// securitypolicy.ReferenceInfoFilename.
 	UVMSecurityPolicyEnv = "io.microsoft.virtualmachine.lcow.securitypolicy.env"
 
 	// UVMReferenceInfoFile specifies the filename of a signed UVM reference file to be passed to UVM.

--- a/pkg/securitypolicy/securitypolicy.go
+++ b/pkg/securitypolicy/securitypolicy.go
@@ -45,10 +45,10 @@ const (
 const plan9Prefix = "plan9://"
 
 const (
-	SecurityContextMountPath = "/tmp/security-context"
-	PolicyFilename           = "security-policy-base64"
-	HostAMDCertFilename      = "host-amd-cert-base64"
-	ReferenceInfoFilename    = "reference-info-base64"
+	SecurityContextDirTemplate = "security-context-*"
+	PolicyFilename             = "security-policy-base64"
+	HostAMDCertFilename        = "host-amd-cert-base64"
+	ReferenceInfoFilename      = "reference-info-base64"
 )
 
 // PolicyConfig contains toml or JSON config for security policy.

--- a/pkg/securitypolicy/securitypolicy.go
+++ b/pkg/securitypolicy/securitypolicy.go
@@ -44,6 +44,13 @@ const (
 
 const plan9Prefix = "plan9://"
 
+const (
+	SecurityContextMountPath = "/tmp/security-context"
+	PolicyFilename           = "security-policy-base64"
+	HostAMDCertFilename      = "host-amd-cert-base64"
+	ReferenceInfoFilename    = "reference-info-base64"
+)
+
 // PolicyConfig contains toml or JSON config for security policy.
 type PolicyConfig struct {
 	AllowAll                         bool                    `json:"allow_all" toml:"allow_all"`

--- a/test/cri-containerd/policy_test.go
+++ b/test/cri-containerd/policy_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -772,13 +773,26 @@ func Test_RunContainer_WithPolicy_And_SecurityPolicyEnv_Annotation(t *testing.T)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	// The command prints environment variables to stdout, which we can capture
-	// and validate later
-	alpineCmd := []string{"ash", "-c", "env && sleep 1"}
+	alpineCmd := []string{"ash", "-c", "sleep 10"}
 
+	listDirCmd := []string{"ls", "-l", securitypolicy.SecurityContextMountPath}
+	// Make sure these are linux paths
+	catPolicyCmd := []string{"cat", path.Join(securitypolicy.SecurityContextMountPath, securitypolicy.PolicyFilename)}
+	catCertCmd := []string{"cat", path.Join(securitypolicy.SecurityContextMountPath, securitypolicy.HostAMDCertFilename)}
 	opts := []securitypolicy.ContainerConfigOpt{
 		securitypolicy.WithCommand(alpineCmd),
 		securitypolicy.WithAllowStdioAccess(true),
+		securitypolicy.WithExecProcesses([]securitypolicy.ExecProcessConfig{
+			{
+				Command: listDirCmd,
+			},
+			{
+				Command: catPolicyCmd,
+			},
+			{
+				Command: catCertCmd,
+			},
+		}),
 	}
 	for _, config := range []struct {
 		name   string
@@ -787,10 +801,6 @@ func Test_RunContainer_WithPolicy_And_SecurityPolicyEnv_Annotation(t *testing.T)
 		{
 			name:   "OpenDoorPolicy",
 			policy: openDoorPolicy,
-		},
-		{
-			name:   "StandardPolicy",
-			policy: alpineSecurityPolicy(t, "json", false, false, opts...),
 		},
 		{
 			name:   "RegoPolicy",
@@ -825,42 +835,57 @@ func Test_RunContainer_WithPolicy_And_SecurityPolicyEnv_Annotation(t *testing.T)
 					}
 				}
 
-				// setup logfile to capture stdout
-				logPath := filepath.Join(t.TempDir(), "log.txt")
-				containerRequest.Config.LogPath = logPath
-
 				containerID := createContainer(t, client, ctx, containerRequest)
 				defer removeContainer(t, client, ctx, containerID)
 
 				startContainer(t, client, ctx, containerID)
 				requireContainerState(ctx, t, client, containerID, runtime.ContainerState_CONTAINER_RUNNING)
 
-				// no need to stop the container since it'll exit by itself
-				requireContainerState(ctx, t, client, containerID, runtime.ContainerState_CONTAINER_EXITED)
-
-				content, err := os.ReadFile(logPath)
-				if err != nil {
-					t.Fatalf("error reading log file: %s", err)
-				}
-				targetEnvs := []string{
-					fmt.Sprintf("UVM_SECURITY_POLICY=%s", config.policy),
-					"UVM_REFERENCE_INFO=",
-					fmt.Sprintf("UVM_HOST_AMD_CERTIFICATE=%s", certValue),
-				}
+				r := execSync(t, client, ctx, &runtime.ExecSyncRequest{
+					ContainerId: containerID,
+					Cmd:         listDirCmd,
+				})
 				if setPolicyEnv {
-					// make sure that the expected environment variable was set
-					for _, env := range targetEnvs {
-						if !strings.Contains(string(content), env) {
-							t.Fatalf("missing init process environment variable: %s", env)
-						}
+					if r.ExitCode != 0 {
+						t.Log(string(r.Stderr))
+						t.Fatalf("unexpected exec exit code: %d", r.ExitCode)
+					}
+
+					// validate content of the policy file
+					r2 := execSync(t, client, ctx, &runtime.ExecSyncRequest{
+						ContainerId: containerID,
+						Cmd:         catPolicyCmd,
+					})
+					r2stdout := string(r2.Stdout)
+					if r2stdout != config.policy {
+						t.Log(config.policy)
+						t.Log(r2stdout)
+						t.Fatal("supplied policy is different from the one written in file")
+					}
+
+					// validate content of AMD cert file
+					r3 := execSync(t, client, ctx, &runtime.ExecSyncRequest{
+						ContainerId: containerID,
+						Cmd:         catCertCmd,
+					})
+					r3stdout := string(r3.Stdout)
+					if r3stdout != certValue {
+						t.Log(certValue)
+						t.Log(r3stdout)
+						t.Fatal("supplied cert is different from the one written in file")
 					}
 				} else {
-					for _, env := range targetEnvs {
-						if strings.Contains(string(content), env) {
-							t.Fatalf("environment variable should not be set for init process: %s", env)
-						}
+					if r.ExitCode != 1 {
+						t.Log(string(r.Stdout))
+						t.Fatalf("unexpected exec exit code: %d", r.ExitCode)
+					}
+					if !strings.Contains(string(r.Stderr), "No such file") {
+						t.Fatalf("expected different error output, got:\n %s", string(r.Stderr))
 					}
 				}
+
+				// no need to stop the container since it'll exit by itself
+				requireContainerState(ctx, t, client, containerID, runtime.ContainerState_CONTAINER_EXITED)
 			})
 		}
 	}


### PR DESCRIPTION
Due to `execve` limitation on the size of environment variable, write the base64 encoded security policy, UVM reference info and host AMD certificate to container's rootfs.

Update existing test accordingly.