### PR TITLE
Moving to structured JSON policy decisions.

### DIFF
--- a/internal/guest/bridge/bridge_v2.go
+++ b/internal/guest/bridge/bridge_v2.go
@@ -442,11 +442,11 @@ func (b *Bridge) modifySettingsV2(r *Request) (_ RequestResponse, err error) {
 }
 
 func (b *Bridge) dumpStacksV2(r *Request) (_ RequestResponse, err error) {
-	_, span := oc.StartSpan(r.Context, "opengcs::bridge::dumpStacksV2")
+	ctx, span := oc.StartSpan(r.Context, "opengcs::bridge::dumpStacksV2")
 	defer span.End()
 	defer func() { oc.SetSpanStatus(span, err) }()
 
-	stacks, err := b.hostState.GetStacks()
+	stacks, err := b.hostState.GetStacks(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/guest/runtime/hcsv2/uvm.go
+++ b/internal/guest/runtime/hcsv2/uvm.go
@@ -125,7 +125,7 @@ func (h *Host) SetConfidentialUVMOptions(ctx context.Context, r *guestresource.L
 	// The other point is on startup where we take a flag to set the default
 	// policy enforcer to use before a policy arrives. After that flag is set,
 	// we use the enforcer in question to set up logging as well.
-	if err = p.EnforceRuntimeLoggingPolicy(); err == nil {
+	if err = p.EnforceRuntimeLoggingPolicy(ctx); err == nil {
 		logrus.SetOutput(h.logWriter)
 	} else {
 		logrus.SetOutput(io.Discard)
@@ -208,7 +208,7 @@ func (h *Host) InjectFragment(ctx context.Context, fragment *guestresource.LCOWS
 	}
 
 	// now offer the payload fragment to the policy
-	err = h.securityPolicyEnforcer.LoadFragment(issuer, feed, payloadString)
+	err = h.securityPolicyEnforcer.LoadFragment(ctx, issuer, feed, payloadString)
 	if err != nil {
 		return fmt.Errorf("InjectFragment failed policy load: %w", err)
 	}
@@ -405,6 +405,7 @@ func (h *Host) CreateContainer(ctx context.Context, id string, settings *prot.VM
 	}
 
 	envToKeep, capsToKeep, allowStdio, err := h.securityPolicyEnforcer.EnforceCreateContainerPolicy(
+		ctx,
 		sandboxID,
 		id,
 		settings.OCISpecification.Process.Args,
@@ -628,7 +629,7 @@ func (h *Host) ShutdownContainer(ctx context.Context, containerID string, gracef
 		return err
 	}
 
-	err = h.securityPolicyEnforcer.EnforceShutdownContainerPolicy(containerID)
+	err = h.securityPolicyEnforcer.EnforceShutdownContainerPolicy(ctx, containerID)
 	if err != nil {
 		return err
 	}
@@ -665,7 +666,7 @@ func (h *Host) SignalContainerProcess(ctx context.Context, containerID string, p
 	}
 
 	startupArgList := p.(*containerProcess).spec.Args
-	err = h.securityPolicyEnforcer.EnforceSignalContainerProcessPolicy(containerID, signal, signalingInitProcess, startupArgList)
+	err = h.securityPolicyEnforcer.EnforceSignalContainerProcessPolicy(ctx, containerID, signal, signalingInitProcess, startupArgList)
 	if err != nil {
 		return err
 	}
@@ -681,6 +682,7 @@ func (h *Host) ExecProcess(ctx context.Context, containerID string, params prot.
 		var envToKeep securitypolicy.EnvList
 		var allowStdioAccess bool
 		envToKeep, allowStdioAccess, err = h.securityPolicyEnforcer.EnforceExecExternalProcessPolicy(
+			ctx,
 			params.CommandArgs,
 			processParamEnvToOCIEnv(params.Environment),
 			params.WorkingDirectory,
@@ -727,6 +729,7 @@ func (h *Host) ExecProcess(ctx context.Context, containerID string, params prot.
 			}
 
 			envToKeep, capsToKeep, allowStdioAccess, err = h.securityPolicyEnforcer.EnforceExecInContainerPolicy(
+				ctx,
 				containerID,
 				params.OCIProcess.Args,
 				params.OCIProcess.Env,
@@ -774,7 +777,7 @@ func (h *Host) GetExternalProcess(pid int) (Process, error) {
 }
 
 func (h *Host) GetProperties(ctx context.Context, containerID string, query prot.PropertyQuery) (*prot.PropertiesV2, error) {
-	err := h.securityPolicyEnforcer.EnforceGetPropertiesPolicy()
+	err := h.securityPolicyEnforcer.EnforceGetPropertiesPolicy(ctx)
 	if err != nil {
 		return nil, errors.Wrapf(err, "get properties denied due to policy")
 	}
@@ -807,8 +810,8 @@ func (h *Host) GetProperties(ctx context.Context, containerID string, query prot
 	return properties, nil
 }
 
-func (h *Host) GetStacks() (string, error) {
-	err := h.securityPolicyEnforcer.EnforceDumpStacksPolicy()
+func (h *Host) GetStacks(ctx context.Context) (string, error) {
+	err := h.securityPolicyEnforcer.EnforceDumpStacksPolicy(ctx)
 	if err != nil {
 		return "", errors.Wrapf(err, "dump stacks denied due to policy")
 	}
@@ -932,7 +935,7 @@ func modifyMappedVirtualDisk(
 					deviceHash = mvd.VerityInfo.RootDigest
 				}
 
-				err = securityPolicy.EnforceDeviceMountPolicy(mvd.MountPath, deviceHash)
+				err = securityPolicy.EnforceDeviceMountPolicy(ctx, mvd.MountPath, deviceHash)
 				if err != nil {
 					return errors.Wrapf(err, "mounting scsi device controller %d lun %d onto %s denied by policy", mvd.Controller, mvd.Lun, mvd.MountPath)
 				}
@@ -945,7 +948,7 @@ func modifyMappedVirtualDisk(
 	case guestrequest.RequestTypeRemove:
 		if mvd.MountPath != "" {
 			if mvd.ReadOnly {
-				if err := securityPolicy.EnforceDeviceUnmountPolicy(mvd.MountPath); err != nil {
+				if err := securityPolicy.EnforceDeviceUnmountPolicy(ctx, mvd.MountPath); err != nil {
 					return fmt.Errorf("unmounting scsi device at %s denied by policy: %w", mvd.MountPath, err)
 				}
 			}
@@ -969,14 +972,14 @@ func modifyMappedDirectory(
 ) (err error) {
 	switch rt {
 	case guestrequest.RequestTypeAdd:
-		err = securityPolicy.EnforcePlan9MountPolicy(md.MountPath)
+		err = securityPolicy.EnforcePlan9MountPolicy(ctx, md.MountPath)
 		if err != nil {
 			return errors.Wrapf(err, "mounting plan9 device at %s denied by policy", md.MountPath)
 		}
 
 		return plan9.Mount(ctx, vsock, md.MountPath, md.ShareName, uint32(md.Port), md.ReadOnly)
 	case guestrequest.RequestTypeRemove:
-		err = securityPolicy.EnforcePlan9UnmountPolicy(md.MountPath)
+		err = securityPolicy.EnforcePlan9UnmountPolicy(ctx, md.MountPath)
 		if err != nil {
 			return errors.Wrapf(err, "unmounting plan9 device at %s denied by policy", md.MountPath)
 		}
@@ -998,14 +1001,14 @@ func modifyMappedVPMemDevice(ctx context.Context,
 		if vpd.VerityInfo != nil {
 			deviceHash = vpd.VerityInfo.RootDigest
 		}
-		err = securityPolicy.EnforceDeviceMountPolicy(vpd.MountPath, deviceHash)
+		err = securityPolicy.EnforceDeviceMountPolicy(ctx, vpd.MountPath, deviceHash)
 		if err != nil {
 			return errors.Wrapf(err, "mounting pmem device %d onto %s denied by policy", vpd.DeviceNumber, vpd.MountPath)
 		}
 
 		return pmem.Mount(ctx, vpd.DeviceNumber, vpd.MountPath, vpd.MappingInfo, vpd.VerityInfo)
 	case guestrequest.RequestTypeRemove:
-		if err := securityPolicy.EnforceDeviceUnmountPolicy(vpd.MountPath); err != nil {
+		if err := securityPolicy.EnforceDeviceUnmountPolicy(ctx, vpd.MountPath); err != nil {
 			return errors.Wrapf(err, "unmounting pmem device from %s denied by policy", vpd.MountPath)
 		}
 
@@ -1048,18 +1051,18 @@ func modifyCombinedLayers(
 			upperdirPath = filepath.Join(cl.ScratchPath, "upper")
 			workdirPath = filepath.Join(cl.ScratchPath, "work")
 
-			if err := securityPolicy.EnforceScratchMountPolicy(cl.ScratchPath, scratchEncrypted); err != nil {
+			if err := securityPolicy.EnforceScratchMountPolicy(ctx, cl.ScratchPath, scratchEncrypted); err != nil {
 				return fmt.Errorf("scratch mounting denied by policy: %w", err)
 			}
 		}
 
-		if err := securityPolicy.EnforceOverlayMountPolicy(cl.ContainerID, layerPaths, cl.ContainerRootPath); err != nil {
+		if err := securityPolicy.EnforceOverlayMountPolicy(ctx, cl.ContainerID, layerPaths, cl.ContainerRootPath); err != nil {
 			return fmt.Errorf("overlay creation denied by policy: %w", err)
 		}
 
 		return overlay.MountLayer(ctx, layerPaths, upperdirPath, workdirPath, cl.ContainerRootPath, readonly)
 	case guestrequest.RequestTypeRemove:
-		if err := securityPolicy.EnforceOverlayUnmountPolicy(cl.ContainerRootPath); err != nil {
+		if err := securityPolicy.EnforceOverlayUnmountPolicy(ctx, cl.ContainerRootPath); err != nil {
 			return errors.Wrap(err, "overlay removal denied by policy")
 		}
 

--- a/internal/regopolicyinterpreter/regopolicyinterpreter.go
+++ b/internal/regopolicyinterpreter/regopolicyinterpreter.go
@@ -590,11 +590,11 @@ func (r *RegoPolicyInterpreter) Query(rule string, input map[string]interface{})
 		return nil, err
 	}
 
-	result := make(RegoQueryResult)
 	if len(rawResult) == 0 {
-		return result, nil
+		return nil, errors.New("emtpy result from Rego query")
 	}
 
+	result := make(RegoQueryResult)
 	resultSet, ok := rawResult[0].Expressions[0].Value.(map[string]interface{})
 	if !ok {
 		return nil, errors.New("unable to load results object from Rego query")

--- a/pkg/securitypolicy/framework.rego
+++ b/pkg/securitypolicy/framework.rego
@@ -729,16 +729,20 @@ plan9_unmount := {"metadata": [removePlan9Target], "allowed": true} {
 }
 
 
-default enforcement_point_info := {"available": false, "default_results": {"allow": false}, "unknown": true, "invalid": false}
+default enforcement_point_info := {"available": false, "default_results": {"allow": false}, "unknown": true, "invalid": false, "version_missing": false}
 
-enforcement_point_info := {"available": available, "default_results": default_results, "unknown": false, "invalid": false} {
+enforcement_point_info := {"available": false, "default_results": {"allow": false}, "unknown": false, "invalid": false, "version_missing": true} {
+    policy_api_version == null
+}
+
+enforcement_point_info := {"available": available, "default_results": default_results, "unknown": false, "invalid": false, "version_missing": false} {
     enforcement_point := data.api.enforcement_points[input.name]
     semver.compare(data.api.version, enforcement_point.introducedVersion) >= 0
     available := semver.compare(policy_api_version, enforcement_point.introducedVersion) >= 0
     default_results := enforcement_point.default_results
 }
 
-enforcement_point_info := {"available": false, "default_results": {"allow": false}, "unknown": false, "invalid": true} {
+enforcement_point_info := {"available": false, "default_results": {"allow": false}, "unknown": false, "invalid": true, "version_missing": false} {
     enforcement_point := data.api.enforcement_points[input.name]
     semver.compare(data.api.version, enforcement_point.introducedVersion) < 0
 }
@@ -1385,17 +1389,19 @@ errors[framework_version_error] {
 
 errors[framework_version_error] {
     semver.compare(policy_framework_version, version) > 0
-    framework_version_error := concat(" ", ["framework_version is ahead of the current version:", policy_framework_version, ">", version])
+    framework_version_error := concat(" ", ["framework_version is ahead of the current version:", policy_framework_version, "is greater than", version])
 }
 
 errors[fragment_framework_version_error] {
+    input.namespace
     fragment_framework_version == null
     fragment_framework_version_error := concat(" ", ["fragment framework_version is missing. Current version:", version])
 }
 
 errors[fragment_framework_version_error] {
+    input.namespace
     semver.compare(fragment_framework_version, version) > 0
-    fragment_framework_version_error := concat(" ", ["fragment framework_version is ahead of the current version:", fragment_framework_version, ">", version])
+    fragment_framework_version_error := concat(" ", ["fragment framework_version is ahead of the current version:", fragment_framework_version, "is greater than", version])
 }
 
 errors["containers only distinguishable by allow_stdio_access"] {

--- a/pkg/securitypolicy/securitypolicy.go
+++ b/pkg/securitypolicy/securitypolicy.go
@@ -130,6 +130,23 @@ func MeasureSeccompProfile(seccomp *specs.LinuxSeccomp) (string, error) {
 	return fmt.Sprintf("%x", profileSHA256), nil
 }
 
+const policyDecisionPattern = `policyDecision< %s >policyDecision`
+
+func ExtractPolicyDecision(errorMessage string) (string, error) {
+	re := regexp.MustCompile(fmt.Sprintf(policyDecisionPattern, `(.*)`))
+	matches := re.FindStringSubmatch(errorMessage)
+	if len(matches) != 2 {
+		return "", errors.Errorf("unable to extract policy decision from error message: %s", errorMessage)
+	}
+
+	errorBytes, err := base64.RawURLEncoding.DecodeString(matches[1])
+	if err != nil {
+		return "", err
+	}
+
+	return string(errorBytes), nil
+}
+
 // ContainerConfig contains toml or JSON config for container described
 // in security policy.
 type ContainerConfig struct {

--- a/test/cri-containerd/policy_test.go
+++ b/test/cri-containerd/policy_test.go
@@ -124,6 +124,31 @@ func sandboxRequestWithPolicy(t *testing.T, policy string) *runtime.RunPodSandbo
 	)
 }
 
+func assertErrorContains(t *testing.T, err error, expected string) bool {
+	t.Helper()
+	if err == nil {
+		t.Error("expected error but got nil")
+		return false
+	}
+
+	if strings.Contains(err.Error(), expected) {
+		return true
+	}
+
+	policyDecisionJSON, err := securitypolicy.ExtractPolicyDecision(err.Error())
+	if err != nil {
+		t.Error(err)
+		return false
+	}
+
+	if !strings.Contains(policyDecisionJSON, expected) {
+		t.Errorf("expected policy decision JSON to contain %q", expected)
+		return false
+	}
+
+	return true
+}
+
 type policyConfig struct {
 	enforcer string
 	input    string
@@ -355,7 +380,7 @@ func Test_RunContainer_WithPolicy_And_InvalidConfigs(t *testing.T) {
 			if err == nil {
 				t.Fatal("expected container start failure")
 			}
-			if !strings.Contains(err.Error(), testConfig.expectedError) {
+			if !assertErrorContains(t, err, testConfig.expectedError) {
 				t.Fatalf("expected %q in error message, got: %q", testConfig.expectedError, err)
 			}
 		})
@@ -635,7 +660,7 @@ func Test_RunContainer_WithPolicy_And_MountConstraints_NotAllowed(t *testing.T) 
 			if err == nil {
 				t.Fatal("expected container start failure")
 			}
-			if !strings.Contains(err.Error(), testConfig.expectedError) {
+			if !assertErrorContains(t, err, testConfig.expectedError) {
 				t.Fatalf("expected %q in error message, got: %q", testConfig.expectedError, err)
 			}
 		})
@@ -728,7 +753,7 @@ func Test_RunPrivilegedContainer_WithPolicy_And_AllowElevated_NotSet(t *testing.
 		t.Fatalf("expected to fail")
 	} else {
 		expectedErrStr := "privileged escalation unmatched by policy rule"
-		if !strings.Contains(err.Error(), expectedErrStr) {
+		if !assertErrorContains(t, err, expectedErrStr) {
 			t.Fatalf("expected different error: %s", err)
 		}
 	}
@@ -759,7 +784,7 @@ func Test_RunContainer_WithPolicy_CannotSet_AllowAll_And_Containers(t *testing.T
 	if err == nil {
 		t.Fatal("expected to fail")
 	}
-	if !strings.Contains(err.Error(), securitypolicy.ErrInvalidOpenDoorPolicy.Error()) {
+	if !assertErrorContains(t, err, securitypolicy.ErrInvalidOpenDoorPolicy.Error()) {
 		t.Fatalf("expected error %s, got %s", securitypolicy.ErrInvalidOpenDoorPolicy, err)
 	}
 }
@@ -1057,7 +1082,7 @@ func Test_RunPodSandboxNotAllowed_WithPolicy_EncryptedScratchPolicy(t *testing.T
 		t.Fatalf("expected to fail")
 	}
 	expectedError := "unencrypted scratch not allowed"
-	if !strings.Contains(err.Error(), expectedError) {
+	if !assertErrorContains(t, err, expectedError) {
 		t.Fatalf("expected '%s' error, got '%s'", expectedError, err)
 	}
 }
@@ -1205,7 +1230,7 @@ func Test_ExecInContainer_WithPolicy(t *testing.T) {
 				if !tc.shouldFail {
 					t.Fatalf("unexpected exec failure: %s", err)
 				}
-				if !strings.Contains(err.Error(), "invalid command") {
+				if !assertErrorContains(t, err, "invalid command") {
 					t.Fatalf("expected 'invalid command' error, got '%s' instead", err)
 				}
 			}
@@ -1297,7 +1322,7 @@ func Test_ExecInContainer_WithPolicy_Privileged(t *testing.T) {
 				if !tc.shouldFail {
 					t.Fatalf("unexpected exec failure: %s", err)
 				}
-				if !strings.Contains(err.Error(), "invalid command") {
+				if !assertErrorContains(t, err, "invalid command") {
 					t.Fatalf("expected 'invalid command' error, got '%s' instead", err)
 				}
 			}
@@ -1352,7 +1377,7 @@ func Test_ExecInUVM_WithPolicy(t *testing.T) {
 				if !tc.shouldFail {
 					t.Fatalf("external process exec should succeed, got error instead: %s", err)
 				}
-				if !strings.Contains(err.Error(), "invalid command") {
+				if !assertErrorContains(t, err, "invalid command") {
 					t.Fatalf("expected invalid command error, got %s", err)
 				}
 			} else {


### PR DESCRIPTION
This PR makes two major changes:

1. All policy enforcement points now receive a context objects and use it to log policy errors and denial decisions.
2. Policy denials are now conveyed as structured JSON objects.

Whereas previously policy denial was surfaced as a text error message, the policy now generates a bracketed base64 encoded string:

`policydecision< (base64) >policydecision`

When decoded, this will be a JSON object with the following structure:

```javascript
{
  "input": {/*redacted input object*/},
  "decision": "deny",
  "reason": {/*reason object explaining decision*/},
  "policyError": "optional error field"
}
```

NB: the `"policyError"` field above is only present if the denial was triggered by an actual error in the Rego policy.