### PR TITLE
tests: fix error assertion and container layer sha256

### DIFF
--- a/test/cri-containerd/policy-v0.1.0.rego
+++ b/test/cri-containerd/policy-v0.1.0.rego
@@ -18,7 +18,7 @@ containers := [
     {
         "command": ["ash","-c","echo 'Hello'"],
         "env_rules": [{"pattern": `PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin`, "strategy": "string", "required": true},{"pattern": `TERM=xterm`, "strategy": "string", "required": false}],
-        "layers": ["0196c8ecca6c885a250b186ed8449cf42d737b8551b8d0839381461d95461802"],
+        "layers": ["ebac866d4031abdde44160431606f4b4d75db0b0c675e9e4f46244dd5f3e81e2"],
         "mounts": [],
         "exec_processes": [],
         "signals": [],

--- a/test/cri-containerd/policy_test.go
+++ b/test/cri-containerd/policy_test.go
@@ -751,7 +751,7 @@ func Test_RunPrivilegedContainer_WithPolicy_And_AllowElevated_NotSet(t *testing.
 	); err == nil {
 		t.Fatalf("expected to fail")
 	} else {
-		expectedErrStr := "privileged escalation unmatched by policy rule"
+		expectedErrStr := "privileged escalation not allowed"
 		if !assertErrorContains(t, err, expectedErrStr) {
 			t.Fatalf("expected different error: %s", err)
 		}
@@ -1021,6 +1021,9 @@ func Test_RunPodSandboxAllowed_WithPolicy_EncryptedScratchPolicy(t *testing.T) {
 		},
 	} {
 		t.Run(fmt.Sprintf("AllowUnencrypted_%t_EncryptionEnabled_%t", tc.allowUnencrypted, tc.encryptAnnotation), func(t *testing.T) {
+			if tc.encryptAnnotation && !*flagSevSnp {
+				t.Skip("not running on SNP hardware, dm-crypt not supported")
+			}
 			policy := policyFromOpts(
 				t,
 				"rego",
@@ -1954,7 +1957,7 @@ func Test_Plan9Mount_WithPolicy(t *testing.T) {
 					t.Fatalf("container creation should have succeeded: %s", err)
 				}
 				expectedErrStr := "invalid mount list: /mounts/p9"
-				if !strings.Contains(err.Error(), expectedErrStr) {
+				if !assertErrorContains(t, err, expectedErrStr) {
 					t.Fatalf("expected '%s' policy error, got: %s", expectedErrStr, err)
 				}
 			}


### PR DESCRIPTION
Rego error messages are now returned base64 encoded, so direct error message assertions don't work and we need to decode the policy decision string first. One of the tests was missing this.

Additionally alpine container has been updated and the layer digest has changed, so the policy used to check backward compat is now broken. Update it to have a valid digest.