### PR TITLE
Add test for support of NFS mount

### DIFF
--- a/test/cri-containerd/main_test.go
+++ b/test/cri-containerd/main_test.go
@@ -56,6 +56,7 @@ const (
 	imageLcowAlpineCoreDump = "cplatpublic.azurecr.io/stackoverflow-alpine:latest"
 	imageLcowCosmos         = "cosmosarno/spark-master:2.4.1_2019-04-18_8e864ce"
 	imageLcowCustomUser     = "cplatpublic.azurecr.io/linux_custom_user:latest"
+	imageLcowUbuntu         = "ubuntu:latest"
 	alpineAspNet            = "mcr.microsoft.com/dotnet/core/aspnet:3.1-alpine3.11"
 	alpineAspnetUpgrade     = "mcr.microsoft.com/dotnet/core/aspnet:3.1.2-alpine3.11"
 


### PR DESCRIPTION
LCOW kernel needs to be built with certain config options(`CONFIG_NFS_FS=y`, `CONFIG_NFS_V4=y` & `CONFIG_NFS_V4_1=y`)_in order to be able to successfully run a NFS client and mount a NFS inside a container. This test attempts to mount a (fake) NFS server to ensure that the kernel has the capabilities of running a NFS client.

We don't mount a real NFS server because creating a real NFS server that will work in all kinds of test environments is not simple. Instead, we look at the error returned by the NFS mount operation and decide if the failure is because the server wasn't available (i.e a `Connection refused` error) or because the kernel doesn't support NFS clients (`No Device` error).

Limitations on different approaches of starting a real NFS server:
1. Starting another LCOW container that runs a NFS server: By default on Linux the NFS server runs in the kernel and to enable that the kernel must be built with `NFSD_*` config options (note that the config options for running NFS server are different than the config options required for NFS client), which we don't currently do and it doesn't make sense to just enable these options for a test.
2. Running a userspace NFS server: There are a few userspace NFS server projects but getting them to run inside the UtilityVM wasn't very easy. We didn't want to spend a lot of time on this test.
3. Running NFS server on the windows host: Not all builds of windows support this so the test won't run in all environments.