### PR TITLE
gcs: Support routing container stdio to sidecar

### DIFF
--- a/internal/guest/runtime/runc/container.go
+++ b/internal/guest/runtime/runc/container.go
@@ -5,6 +5,7 @@ package runc
 
 import (
 	"encoding/json"
+	"fmt"
 	"net"
 	"os"
 	"path/filepath"
@@ -326,7 +327,7 @@ func (c *container) runExecCommand(processDef *oci.Process, stdioSet *stdio.Conn
 
 	args := []string{"exec"}
 	args = append(args, "-d", "--process", filepath.Join(tempProcessDir, "process.json"))
-	return c.startProcess(tempProcessDir, processDef.Terminal, stdioSet, args...)
+	return c.startProcess(tempProcessDir, processDef.Terminal, stdioSet, nil, args...)
 }
 
 // startProcess performs the operations necessary to start a container process
@@ -337,7 +338,9 @@ func (c *container) runExecCommand(processDef *oci.Process, stdioSet *stdio.Conn
 func (c *container) startProcess(
 	tempProcessDir string,
 	hasTerminal bool,
-	stdioSet *stdio.ConnectionSet, initialArgs ...string,
+	stdioSet *stdio.ConnectionSet,
+	annotations map[string]string,
+	initialArgs ...string,
 ) (p *process, err error) {
 	args := initialArgs
 
@@ -386,6 +389,70 @@ func (c *container) startProcess(
 		}
 		if fileSet.Err != nil {
 			cmd.Stderr = fileSet.Err
+		}
+	}
+
+	// This is for enabling container logging via side car feature. This is in experimental stage now and need to be revisited.
+	var stdoutFifoPipe, stderrFifoPipe *os.File
+	if annotations != nil {
+		pipeNameSuffix, exists := annotations["io.microsoft.bmc.logging.pipelocation"]
+		if exists {
+			if hasTerminal {
+				return nil, fmt.Errorf("logging via side car and TTY are not supported together")
+			}
+			pipeDirectory := "/run/gcs/containerlogs/"
+			stdoutPipeName := pipeDirectory + pipeNameSuffix + "-stdout"
+			stderrPipeName := pipeDirectory + pipeNameSuffix + "-stderr"
+			err = os.MkdirAll(pipeDirectory, 0755)
+			if err != nil {
+				return nil, fmt.Errorf("error creating log directory %s for logging pipe fifo: %w", pipeDirectory, err)
+			}
+
+			_, err = os.Stat(stdoutPipeName)
+			if err != nil {
+				// fifo pipe does not exist, create one
+				err = syscall.Mkfifo(stdoutPipeName, 0666)
+				if err != nil {
+					return nil, fmt.Errorf("error creating fifo %s: %w", stdoutPipeName, err)
+				}
+			}
+
+			_, err = os.Stat(stderrPipeName)
+			if err != nil {
+				// fifo pipe does not exist, create one
+				err = syscall.Mkfifo(stderrPipeName, 0666)
+				if err != nil {
+					return nil, fmt.Errorf("error creating fifo %s: %w", stderrPipeName, err)
+				}
+			}
+
+			// pipe either exist before hand or we have created one above
+			stdoutFifoPipe, err = os.OpenFile(stdoutPipeName, os.O_RDWR|os.O_APPEND, os.ModeNamedPipe)
+			if err != nil {
+				return nil, fmt.Errorf("error opening fifo %s: %w", stdoutPipeName, err)
+			}
+
+			stderrFifoPipe, err = os.OpenFile(stderrPipeName, os.O_RDWR|os.O_APPEND, os.ModeNamedPipe)
+			if err != nil {
+				return nil, fmt.Errorf("error opening fifo %s: %w", stderrPipeName, err)
+			}
+		}
+
+		isLoggingSideCarContainerStr, exists := annotations["io.microsoft.bmc.logging.isLoggingSideCarContainer"]
+		if exists {
+			isLoggingSideCarContainer, err := strconv.ParseBool(isLoggingSideCarContainerStr)
+			if err != nil {
+				return nil, fmt.Errorf("error parsing flag isLoggingSideCarContainer: %w", err)
+			}
+			if !isLoggingSideCarContainer {
+				// workload container needs to redirect stdout and stderr to fifo pipe.
+				cmd.Stdout = stdoutFifoPipe
+				cmd.Stderr = stderrFifoPipe
+			} else {
+				// logging side car container needs to know the pipe fd.
+				cmd.Args = append(cmd.Args, "--preserve-fds", "2")
+				cmd.ExtraFiles = []*os.File{stdoutFifoPipe, stderrFifoPipe}
+			}
 		}
 	}
 

--- a/internal/guest/runtime/runc/runc.go
+++ b/internal/guest/runtime/runc/runc.go
@@ -193,7 +193,8 @@ func (r *runcRuntime) runCreateCommand(id string, bundlePath string, stdioSet *s
 	}
 
 	args := []string{"create", "-b", bundlePath, "--no-pivot"}
-	p, err := c.startProcess(tempProcessDir, spec.Process.Terminal, stdioSet, args...)
+
+	p, err := c.startProcess(tempProcessDir, spec.Process.Terminal, stdioSet, spec.Annotations, args...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The PR aims to add support for redirecting container stdout and stderr statements to a another container(logging container) via named pipes. 
This is controlled by set of annotations being passed in the spec. 
When the annotation is set, the named pipe is created in the UVM. The workload container will start to redirect stdout and stderr statements to this named pipe and logging container will use the pipe file descriptor passed to it to read data coming through pipe.