### PR TITLE
Make sure that security context files are readable by all

### DIFF
--- a/internal/guest/runtime/hcsv2/uvm.go
+++ b/internal/guest/runtime/hcsv2/uvm.go
@@ -455,7 +455,7 @@ func (h *Host) CreateContainer(ctx context.Context, id string, settings *prot.VM
 				return nil, fmt.Errorf("failed to create security context directory: %w", err)
 			}
 			// Make sure that files inside directory are readable
-			if err := os.Chmod(securityContextDir, 0745); err != nil {
+			if err := os.Chmod(securityContextDir, 0755); err != nil {
 				return nil, fmt.Errorf("failed to chmod security context directory: %w", err)
 			}
 

--- a/internal/guest/runtime/hcsv2/uvm.go
+++ b/internal/guest/runtime/hcsv2/uvm.go
@@ -454,8 +454,8 @@ func (h *Host) CreateContainer(ctx context.Context, id string, settings *prot.VM
 			if err != nil {
 				return nil, fmt.Errorf("failed to create security context directory: %w", err)
 			}
-			// Make sure it's readable
-			if err := os.Chmod(securityContextDir, 0744); err != nil {
+			// Make sure that files inside directory are readable
+			if err := os.Chmod(securityContextDir, 0745); err != nil {
 				return nil, fmt.Errorf("failed to chmod security context directory: %w", err)
 			}
 


### PR DESCRIPTION
The recent changes to store the UVM security context in files rather than envvars prevents other processes running in the container from reading these as the parent `/security-context-*` directory doesn't allow for these files to be read. 

```
$ sudo ls -la /security-context-2100795932/
total 32
drwxr--r-- 2 root root    93 Apr 13 10:23 .    << Missing x for others
drwxr-xr-x 1 root root   148 Apr 13 14:30 ..
-rwxr--r-- 1 root root  8924 Apr 13 10:23 host-amd-cert-base64
-rwxr--r-- 1 root root 14524 Apr 13 10:23 reference-info-base64
-rwxr--r-- 1 root root   988 Apr 13 10:23 security-policy-base64
$ cat /security-context-2100795932/host-amd-cert-base64
cat: /security-context-2100795932/host-amd-cert-base64: Permission denied

$ sudo chmod 745 /security-context-2100795932/
$ cat /security-context-2100795932/host-amd-cert-base64
eyJ2Y2VrQ2VydCI6Ii0tLS0tQkVHSU4gQ0VSVElGSUNBVEUtLS0...
```

This PR fixes it by setting the appropriate permissions when creating the `/security-context-*` directory. 