### PR TITLE
Policy decision truncation.

### DIFF
--- a/internal/guest/runtime/hcsv2/uvm.go
+++ b/internal/guest/runtime/hcsv2/uvm.go
@@ -107,6 +107,10 @@ func (h *Host) SetConfidentialUVMOptions(ctx context.Context, r *guestresource.L
 		return errors.New("security policy has already been set")
 	}
 
+	// this limit ensures messages are below the character truncation limit that
+	// can be imposed by an orchestrator
+	maxErrorMessageLength := 3 * 1024
+
 	// Initialize security policy enforcer for a given enforcer type and
 	// encoded security policy.
 	p, err := securitypolicy.CreateSecurityPolicyEnforcer(
@@ -114,6 +118,7 @@ func (h *Host) SetConfidentialUVMOptions(ctx context.Context, r *guestresource.L
 		r.EncodedSecurityPolicy,
 		policy.DefaultCRIMounts(),
 		policy.DefaultCRIPrivilegedMounts(),
+		maxErrorMessageLength,
 	)
 	if err != nil {
 		return err

--- a/internal/regopolicyinterpreter/regopolicyinterpreter.go
+++ b/internal/regopolicyinterpreter/regopolicyinterpreter.go
@@ -237,7 +237,7 @@ func newRegoMetadataOperation(operation interface{}) (*regoMetadataOperation, er
 	}
 	metadataOp.Name, ok = data["name"].(string)
 	if !ok {
-		return nil, errors.New("uanble to load metadata name")
+		return nil, errors.New("unable to load metadata name")
 	}
 	action, ok := data["action"].(string)
 	if !ok {
@@ -591,7 +591,7 @@ func (r *RegoPolicyInterpreter) Query(rule string, input map[string]interface{})
 	}
 
 	if len(rawResult) == 0 {
-		return nil, errors.New("emtpy result from Rego query")
+		return nil, errors.New("empty result from Rego query")
 	}
 
 	result := make(RegoQueryResult)

--- a/pkg/securitypolicy/framework.rego
+++ b/pkg/securitypolicy/framework.rego
@@ -1020,6 +1020,11 @@ scratch_unmount := {"metadata": [remove_scratch_mount], "allowed": true} {
     }
 }
 
+reason := {
+    "errors": errors,
+    "error_objects": error_objects
+}
+
 ################################################################
 # Error messages
 ################################################################

--- a/pkg/securitypolicy/policy.rego
+++ b/pkg/securitypolicy/policy.rego
@@ -22,7 +22,4 @@ runtime_logging := data.framework.runtime_logging
 load_fragment := data.framework.load_fragment
 scratch_mount := data.framework.scratch_mount
 scratch_unmount := data.framework.scratch_unmount
-reason := {
-    "errors": data.framework.errors,
-    "error_objects": data.framework.error_objects,
-}
+reason := data.framework.reason

--- a/test/cri-containerd/policy-v0.1.0.rego
+++ b/test/cri-containerd/policy-v0.1.0.rego
@@ -57,5 +57,5 @@ scratch_mount := data.framework.scratch_mount
 scratch_unmount := data.framework.scratch_unmount
 reason := {
     "errors": data.framework.errors,
-    "matches": data.framework.matches,
+    "error_objects": data.framework.error_objects,
 }


### PR DESCRIPTION
In some circumstances, the policy decision object returned from a policy denial causes the resulting error message to exceed the maximum error length imposed by Service Fabric. This PR adds some truncation logic to reduce the size of the decision object so it first into the limit. Firstly, all standard capability sets (privileged and unprivileged) are replaced with a placeholder. Then, if the message is above the length limit the following things are truncated until the message is below the threshold:

1. `reason.error_objects`
2. `input`
3. `reason` (the rest of the reason object returned from the policy)