### PR TITLE
Fixing the errors for missing enforcement points

### DIFF
--- a/internal/regopolicyinterpreter/regopolicyinterpreter.go
+++ b/internal/regopolicyinterpreter/regopolicyinterpreter.go
@@ -590,11 +590,11 @@ func (r *RegoPolicyInterpreter) Query(rule string, input map[string]interface{})
 		return nil, err
 	}
 
+	result := make(RegoQueryResult)
 	if len(rawResult) == 0 {
-		return nil, errors.New("empty result from Rego query")
+		return result, nil
 	}
 
-	result := make(RegoQueryResult)
 	resultSet, ok := rawResult[0].Expressions[0].Value.(map[string]interface{})
 	if !ok {
 		return nil, errors.New("unable to load results object from Rego query")

--- a/pkg/securitypolicy/securitypolicyenforcer_rego.go
+++ b/pkg/securitypolicy/securitypolicyenforcer_rego.go
@@ -408,7 +408,11 @@ func (policy *regoEnforcer) denyWithReason(ctx context.Context, enforcementPoint
 
 	result, err := policy.rego.Query("data.policy.reason", input)
 	if err == nil {
-		policyDecision["reason"] = replaceCapabilitiesWithPlaceholdersInReason(result)
+		if result.IsEmpty() {
+			policyDecision["reason"] = noReasonMessage
+		} else {
+			policyDecision["reason"] = replaceCapabilitiesWithPlaceholdersInReason(result)
+		}
 	} else {
 		log.G(ctx).WithError(err).Warn("unable to obtain reason for policy decision")
 		policyDecision["reason"] = noReasonMessage


### PR DESCRIPTION
Due to a change made during the switch to structured JSON policy decisions, the path that was previously
followed to produce the errors for missing enforcement points was broken. This commit fixes that change and adds a test to protect against regression on these error messages in the future.