### PR TITLE
Adding padding to base64 encoded policy decisions

### DIFF
--- a/pkg/securitypolicy/securitypolicy.go
+++ b/pkg/securitypolicy/securitypolicy.go
@@ -146,7 +146,7 @@ func ExtractPolicyDecision(errorMessage string) (string, error) {
 		return "", errors.Errorf("unable to extract policy decision from error message: %s", errorMessage)
 	}
 
-	errorBytes, err := base64.RawURLEncoding.DecodeString(matches[1])
+	errorBytes, err := base64.URLEncoding.DecodeString(matches[1])
 	if err != nil {
 		return "", err
 	}

--- a/pkg/securitypolicy/securitypolicy.go
+++ b/pkg/securitypolicy/securitypolicy.go
@@ -146,7 +146,7 @@ func ExtractPolicyDecision(errorMessage string) (string, error) {
 		return "", errors.Errorf("unable to extract policy decision from error message: %s", errorMessage)
 	}
 
-	errorBytes, err := base64.URLEncoding.DecodeString(matches[1])
+	errorBytes, err := base64.StdEncoding.DecodeString(matches[1])
 	if err != nil {
 		return "", err
 	}

--- a/pkg/securitypolicy/securitypolicyenforcer_rego.go
+++ b/pkg/securitypolicy/securitypolicyenforcer_rego.go
@@ -352,7 +352,7 @@ func (policy *regoEnforcer) policyDecisionToError(ctx context.Context, decision 
 
 	log.G(ctx).WithField("policyDecision", string(decisionJSON))
 
-	base64EncodedDecisionJSON := base64.URLEncoding.EncodeToString(decisionJSON)
+	base64EncodedDecisionJSON := base64.StdEncoding.EncodeToString(decisionJSON)
 	errorMessage := fmt.Errorf(policyDecisionPattern, base64EncodedDecisionJSON)
 	if policy.maxErrorMessageLength == 0 {
 		// indicates no message truncation
@@ -373,7 +373,7 @@ func (policy *regoEnforcer) policyDecisionToError(ctx context.Context, decision 
 			log.G(ctx).WithError(err).Error("unable to marshal error object")
 			decisionJSON = []byte(`"Unable to marshal error object"`)
 		}
-		base64EncodedDecisionJSON = base64.URLEncoding.EncodeToString(decisionJSON)
+		base64EncodedDecisionJSON = base64.StdEncoding.EncodeToString(decisionJSON)
 		errorMessage = fmt.Errorf(policyDecisionPattern, base64EncodedDecisionJSON)
 
 		if len(errorMessage.Error()) <= policy.maxErrorMessageLength {

--- a/pkg/securitypolicy/securitypolicyenforcer_rego.go
+++ b/pkg/securitypolicy/securitypolicyenforcer_rego.go
@@ -352,7 +352,7 @@ func (policy *regoEnforcer) policyDecisionToError(ctx context.Context, decision 
 
 	log.G(ctx).WithField("policyDecision", string(decisionJSON))
 
-	base64EncodedDecisionJSON := base64.RawURLEncoding.EncodeToString(decisionJSON)
+	base64EncodedDecisionJSON := base64.URLEncoding.EncodeToString(decisionJSON)
 	errorMessage := fmt.Errorf(policyDecisionPattern, base64EncodedDecisionJSON)
 	if policy.maxErrorMessageLength == 0 {
 		// indicates no message truncation
@@ -373,7 +373,7 @@ func (policy *regoEnforcer) policyDecisionToError(ctx context.Context, decision 
 			log.G(ctx).WithError(err).Error("unable to marshal error object")
 			decisionJSON = []byte(`"Unable to marshal error object"`)
 		}
-		base64EncodedDecisionJSON = base64.RawURLEncoding.EncodeToString(decisionJSON)
+		base64EncodedDecisionJSON = base64.URLEncoding.EncodeToString(decisionJSON)
 		errorMessage = fmt.Errorf(policyDecisionPattern, base64EncodedDecisionJSON)
 
 		if len(errorMessage.Error()) <= policy.maxErrorMessageLength {


### PR DESCRIPTION
This commit switches from raw encoding (no padding) to standard encoding (padding with `=`) for base64-encoded policy decisions.