### PR TITLE
gcs: Add SCSIDevice type with remove operation

### DIFF
--- a/internal/guest/prot/protocol.go
+++ b/internal/guest/prot/protocol.go
@@ -534,6 +534,12 @@ func UnmarshalContainerModifySettings(b []byte) (*ContainerModifySettings, error
 
 	// Fill in the ResourceType-specific fields.
 	switch msr.ResourceType {
+	case guestresource.ResourceTypeSCSIDevice:
+		msd := &guestresource.SCSIDevice{}
+		if err := commonutils.UnmarshalJSONWithHresult(msrRawSettings, msd); err != nil {
+			return &request, errors.Wrap(err, "failed to unmarshal settings as SCSIDevice")
+		}
+		msr.Settings = msd
 	case guestresource.ResourceTypeMappedVirtualDisk:
 		mvd := &guestresource.LCOWMappedVirtualDisk{}
 		if err := commonutils.UnmarshalJSONWithHresult(msrRawSettings, mvd); err != nil {

--- a/internal/protocol/guestresource/resources.go
+++ b/internal/protocol/guestresource/resources.go
@@ -18,6 +18,11 @@ const (
 	// ResourceTypeMappedDirectory is the modify resource type for mapped
 	// directories
 	ResourceTypeMappedDirectory guestrequest.ResourceType = "MappedDirectory"
+	// ResourceTypeSCSIDevice is the modify resources type for SCSI devices.
+	// Note this type is not related to mounting a device in the guest, only
+	// for operations on the SCSI device itself.
+	// Currently it only supports Remove, to cleanly remove a SCSI device.
+	ResourceTypeSCSIDevice guestrequest.ResourceType = "SCSIDevice"
 	// ResourceTypeMappedVirtualDisk is the modify resource type for mapped
 	// virtual disks
 	ResourceTypeMappedVirtualDisk guestrequest.ResourceType = "MappedVirtualDisk"
@@ -63,6 +68,12 @@ type WCOWCombinedLayers struct {
 }
 
 // Defines the schema for hosted settings passed to GCS and/or OpenGCS
+
+// SCSIDevice represents a SCSI device that is attached to the system.
+type SCSIDevice struct {
+	Controller uint8 `json:"Controller,omitempty"`
+	Lun        uint8 `json:"Lun,omitempty"`
+}
 
 // LCOWMappedVirtualDisk represents a disk on the host which is mapped into a
 // directory in the guest in the V2 schema.


### PR DESCRIPTION
This is commit 2/6 in a chain. Recommended to review in order. If reviewing a later PR in the chain, you can view individual commits to see just what that PR changes.
- #1740
- #1741
- #1742
- #1743
- #1744
- #1745

SCSI devices must be unplugged by the guest before removal on the host
side, to ensure smooth operation. Previously a SCSI device was unplugged
when a LCOWMappedVirtualDisk entry was removed. However, we want to
support multiple mounts per disk, which means we need to decouple unplug
from unmount.

This change introduces a new SCSIDevice resource type that has a remove
operation that can be used by the host to trigger an explicit unplug via
SCSI.

This is a breaking change to the bridge protocol:
- With new host/old guest, the host will attempt a SCSIDevice remove
  which will fail due to being unsupported by the guest.
- With old host/new guest, the host will expect the device to be
  unplugged when the disk is removed, which will no longer occur.