### PR TITLE
Remove dependence on GetScsiUvmPath function

### DIFF
--- a/cmd/gcstools/installdrivers.go
+++ b/cmd/gcstools/installdrivers.go
@@ -6,6 +6,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -26,6 +27,14 @@ func install(ctx context.Context) error {
 	}
 	targetOverlayPath := args[0]
 	driver := args[1]
+
+	if _, err := os.Lstat(targetOverlayPath); err == nil {
+		// We assume the overlay path to be unique per set of drivers. Thus, if the path
+		// exists already, we have already installed these drivers, and can quit early.
+		return nil
+	} else if !errors.Is(err, fs.ErrNotExist) {
+		return fmt.Errorf("failed to stat overlay dir: %s: %w", targetOverlayPath, err)
+	}
 
 	// create an overlay mount from the driver's UVM path so we can write to the
 	// mount path in the UVM despite having mounted in the driver originally as

--- a/internal/hcsoci/hcsdoc_wcow.go
+++ b/internal/hcsoci/hcsdoc_wcow.go
@@ -69,19 +69,9 @@ func createMountsConfig(ctx context.Context, coi *createOptionsInternal) (*mount
 				}
 				mdv2.HostPath = src
 			} else if mount.Type == "virtual-disk" || mount.Type == "physical-disk" || mount.Type == "extensible-virtual-disk" {
-				mountPath := mount.Source
-				var err error
-				if mount.Type == "extensible-virtual-disk" {
-					_, mountPath, err = uvm.ParseExtensibleVirtualDiskPath(mount.Source)
-					if err != nil {
-						return nil, err
-					}
-				}
-				uvmPath, err := coi.HostingSystem.GetScsiUvmPath(ctx, mountPath)
-				if err != nil {
-					return nil, err
-				}
-				mdv2.HostPath = uvmPath
+				// For v2 schema containers, any disk mounts will be part of coi.additionalMounts.
+				// For v1 schema containers, we don't even get here, since there is no HostingSystem.
+				continue
 			} else if strings.HasPrefix(mount.Source, guestpath.SandboxMountPrefix) {
 				// Convert to the path in the guest that was asked for.
 				mdv2.HostPath = convertToWCOWSandboxMountPath(mount.Source)
@@ -97,6 +87,7 @@ func createMountsConfig(ctx context.Context, coi *createOptionsInternal) (*mount
 			config.mdsv2 = append(config.mdsv2, mdv2)
 		}
 	}
+	config.mdsv2 = append(config.mdsv2, coi.windowsAdditionalMounts...)
 	return &config, nil
 }
 

--- a/internal/hcsoci/resources_wcow.go
+++ b/internal/hcsoci/resources_wcow.go
@@ -19,6 +19,7 @@ import (
 	"github.com/Microsoft/hcsshim/internal/cmd"
 	"github.com/Microsoft/hcsshim/internal/credentials"
 	"github.com/Microsoft/hcsshim/internal/guestpath"
+	hcsschema "github.com/Microsoft/hcsshim/internal/hcs/schema2"
 	"github.com/Microsoft/hcsshim/internal/layers"
 	"github.com/Microsoft/hcsshim/internal/log"
 	"github.com/Microsoft/hcsshim/internal/resources"
@@ -151,35 +152,52 @@ func setupMounts(ctx context.Context, coi *createOptionsInternal, r *resources.R
 				}
 			}
 			l := log.G(ctx).WithField("mount", fmt.Sprintf("%+v", mount))
-			if mount.Type == "physical-disk" {
-				l.Debug("hcsshim::allocateWindowsResources Hot-adding SCSI physical disk for OCI mount")
-				scsiMount, err := coi.HostingSystem.AddSCSIPhysicalDisk(ctx, mount.Source, uvmPath, readOnly, mount.Options)
-				if err != nil {
-					return errors.Wrapf(err, "adding SCSI physical disk mount %+v", mount)
-				}
-				r.Add(scsiMount)
-			} else if mount.Type == "virtual-disk" {
-				l.Debug("hcsshim::allocateWindowsResources Hot-adding SCSI virtual disk for OCI mount")
-				scsiMount, err := coi.HostingSystem.AddSCSI(
-					ctx,
-					mount.Source,
-					uvmPath,
-					readOnly,
-					false,
-					mount.Options,
-					uvm.VMAccessTypeIndividual,
+			if mount.Type == "physical-disk" || mount.Type == "virtual-disk" || mount.Type == "extensible-virtual-disk" {
+				var (
+					scsiMount *uvm.SCSIMount
+					err       error
 				)
+				switch mount.Type {
+				case "physical-disk":
+					l.Debug("hcsshim::allocateWindowsResources Hot-adding SCSI physical disk for OCI mount")
+					scsiMount, err = coi.HostingSystem.AddSCSIPhysicalDisk(
+						ctx,
+						mount.Source,
+						uvmPath,
+						readOnly,
+						mount.Options,
+					)
+				case "virtual-disk":
+					l.Debug("hcsshim::allocateWindowsResources Hot-adding SCSI virtual disk for OCI mount")
+					scsiMount, err = coi.HostingSystem.AddSCSI(
+						ctx,
+						mount.Source,
+						uvmPath,
+						readOnly,
+						false,
+						mount.Options,
+						uvm.VMAccessTypeIndividual,
+					)
+				case "extensible-virtual-disk":
+					l.Debug("hcsshim::allocateWindowsResource Hot-adding ExtensibleVirtualDisk")
+					scsiMount, err = coi.HostingSystem.AddSCSIExtensibleVirtualDisk(
+						ctx,
+						mount.Source,
+						uvmPath,
+						readOnly,
+					)
+				}
 				if err != nil {
-					return errors.Wrapf(err, "adding SCSI virtual disk mount %+v", mount)
+					return fmt.Errorf("adding SCSI mount %+v: %w", mount, err)
 				}
 				r.Add(scsiMount)
-			} else if mount.Type == "extensible-virtual-disk" {
-				l.Debug("hcsshim::allocateWindowsResource Hot-adding ExtensibleVirtualDisk")
-				scsiMount, err := coi.HostingSystem.AddSCSIExtensibleVirtualDisk(ctx, mount.Source, uvmPath, readOnly)
-				if err != nil {
-					return errors.Wrapf(err, "adding SCSI EVD mount failed %+v", mount)
-				}
-				r.Add(scsiMount)
+				// Compute guest mounts now, and store them, so they can be added to the container doc later.
+				// We do this now because we have access to the guest path through the returned mount object.
+				coi.windowsAdditionalMounts = append(coi.windowsAdditionalMounts, hcsschema.MappedDirectory{
+					HostPath:      scsiMount.UVMPath,
+					ContainerPath: mount.Destination,
+					ReadOnly:      readOnly,
+				})
 			} else if strings.HasPrefix(mount.Source, guestpath.SandboxMountPrefix) {
 				// Mounts that map to a path in the UVM are specified with a 'sandbox://' prefix.
 				//

--- a/internal/uvm/scsi.go
+++ b/internal/uvm/scsi.go
@@ -519,19 +519,6 @@ func (uvm *UtilityVM) allocateSCSIMount(
 	return uvm.scsiLocations[controller][lun], false, nil
 }
 
-// GetScsiUvmPath returns the guest mounted path of a SCSI drive.
-//
-// If `hostPath` is not mounted returns `ErrNotAttached`.
-func (uvm *UtilityVM) GetScsiUvmPath(ctx context.Context, hostPath string) (string, error) {
-	uvm.m.Lock()
-	defer uvm.m.Unlock()
-	sm, err := uvm.findSCSIAttachment(ctx, hostPath)
-	if err != nil {
-		return "", err
-	}
-	return sm.UVMPath, err
-}
-
 // ScratchEncryptionEnabled is a getter for `uvm.encryptScratch`.
 //
 // Returns true if the scratch disks should be encrypted, false otherwise.


### PR DESCRIPTION
This is commit 3/6 in a chain. Recommended to review in order. If reviewing a later PR in the chain, you can view individual commits to see just what that PR changes.
- #1740
- #1741
- #1742
- #1743
- #1744
- #1745

`GetScsiUvmPath` encodes the unfortunate assumption that there is a single guest mount path for each SCSI device host path. This may be correct today, but there is no good reason for it to be treated as an invariant (mounting a SCSI device gives you back an object that tells you where it was mounted) and needs to not be true in the future (so we can do things like mounting multiple partitions from a device).

These commits remove the usage of `GetScsiUvmPath`, and replace it with just getting the guest path directly from the returned `SCSIMount` object.

Please see individual commit messages for details.