### PR TITLE
Rework layer handling to return a ResourceCloser 

### DIFF
--- a/internal/hcsoci/resources_wcow.go
+++ b/internal/hcsoci/resources_wcow.go
@@ -60,13 +60,16 @@ func allocateWindowsResources(ctx context.Context, coi *createOptionsInternal, r
 	if coi.Spec.Root.Path == "" && (coi.HostingSystem != nil || coi.Spec.Windows.HyperV == nil) {
 		log.G(ctx).Debug("hcsshim::allocateWindowsResources mounting storage")
 		containerRootInUVM := r.ContainerRootInUVM()
-		containerRootPath, err := layers.MountWCOWLayers(ctx, coi.actualID, coi.Spec.Windows.LayerFolders, containerRootInUVM, "", coi.HostingSystem)
+		containerRootPath, closer, err := layers.MountWCOWLayers(ctx, coi.actualID, coi.Spec.Windows.LayerFolders, containerRootInUVM, "", coi.HostingSystem)
 		if err != nil {
 			return errors.Wrap(err, "failed to mount container storage")
 		}
 		coi.Spec.Root.Path = containerRootPath
-		layers := layers.NewImageLayers(coi.HostingSystem, containerRootInUVM, coi.Spec.Windows.LayerFolders, "", isSandbox)
-		r.SetLayers(layers)
+		// If this is the pause container in a hypervisor-isolated pod, we can skip cleanup of
+		// layers, as that happens automatically when the UVM is terminated.
+		if !isSandbox || coi.HostingSystem == nil {
+			r.SetLayers(closer)
+		}
 	}
 
 	if err := setupMounts(ctx, coi, r); err != nil {

--- a/test/functional/uvm_vpmem_test.go
+++ b/test/functional/uvm_vpmem_test.go
@@ -37,11 +37,11 @@ func TestVPMEM(t *testing.T) {
 	}
 
 	for i := 0; i < int(iterations); i++ {
-		uvmPath, err := u.AddVPMem(ctx, filepath.Join(tempDir, "layer.vhd"))
+		mount, err := u.AddVPMem(ctx, filepath.Join(tempDir, "layer.vhd"))
 		if err != nil {
 			t.Fatalf("AddVPMEM failed: %s", err)
 		}
-		t.Logf("exposed as %s", uvmPath)
+		t.Logf("exposed as %s", mount.GuestPath)
 	}
 
 	// Remove them all


### PR DESCRIPTION
This is commit 4/6 in a chain. Recommended to review in order. If reviewing a later PR in the chain, you can view individual commits to see just what that PR changes.
- #1740
- #1741
- #1742
- #1743
- #1744
- #1745

Currently, the layers package relies on the caller of Mount*COWLayers to
subsequently call NewImageLayers, which constructs a special ImageLayers
object that can be used to later clean up the layer mounts. However,
this requires the caller to know too much about the internals of the
layer mounting process.

A cleaner approach, which I take here, is to instead return a standard
ResourceCloser from Mount*COWLayers which then knows how to clean up
whatever mounts were done. I have also changed the layers code to use
ResourceCloser in more places internally.

There is a new check in resources_*cow.go, such that the layers closer
is only stored if the container is not a hypervisor-isolated sandbox
container. This duplicates the logic that was previously in
(*ImageLayers).Release.