### PR TITLE
Support flexible LCOW layer parsing and partitioned layers

### DIFF
--- a/cmd/containerd-shim-runhcs-v1/rootfs.go
+++ b/cmd/containerd-shim-runhcs-v1/rootfs.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/Microsoft/hcsshim/internal/layers"
+	"github.com/containerd/containerd/api/types"
+	"github.com/containerd/containerd/errdefs"
+	"github.com/containerd/containerd/mount"
+)
+
+// validateRootfsAndLayers checks to ensure we have appropriate information
+// for setting up the container's root filesystem. It ensures the following:
+// - One and only one of Rootfs or LayerFolders can be provided.
+// - If LayerFolders are provided, there are at least two entries.
+// - If Rootfs is provided, there is a single entry and it does not have a Target set.
+func validateRootfsAndLayers(rootfs []*types.Mount, layerFolders []string) error {
+	if len(rootfs) > 0 && len(layerFolders) > 0 {
+		return fmt.Errorf("cannot pass both a rootfs mount and Windows.LayerFolders: %w", errdefs.ErrFailedPrecondition)
+	}
+	if len(rootfs) == 0 && len(layerFolders) == 0 {
+		return fmt.Errorf("must pass either a rootfs mount or Windows.LayerFolders: %w", errdefs.ErrFailedPrecondition)
+	}
+	if len(rootfs) > 0 {
+		// We have a rootfs.
+
+		if len(rootfs) > 1 {
+			return fmt.Errorf("expected a single rootfs mount: %w", errdefs.ErrFailedPrecondition)
+		}
+		if rootfs[0].Target != "" {
+			return fmt.Errorf("rootfs mount is missing Target path: %w", errdefs.ErrFailedPrecondition)
+		}
+	} else {
+		// We have layerFolders.
+
+		if len(layerFolders) < 2 {
+			return fmt.Errorf("must pass at least two Windows.LayerFolders: %w", errdefs.ErrFailedPrecondition)
+		}
+	}
+
+	return nil
+}
+
+// parseLegacyRootfsMount parses the rootfs mount format that we have traditionally
+// used for both Linux and Windows containers.
+// The mount format consists of:
+//   - The scratch folder path in m.Source, which contains sandbox.vhdx.
+//   - A mount option in the form parentLayerPaths=<JSON>, where JSON is an array of
+//     string paths to read-only layer directories. The exact contents of these layer
+//     directories are intepreteted differently for Linux and Windows containers.
+func parseLegacyRootfsMount(m *types.Mount) (string, []string, error) {
+	// parentLayerPaths are passed in layerN, layerN-1, ..., layer 0
+	//
+	// The OCI spec expects:
+	//   layerN, layerN-1, ..., layer0, scratch
+	var parentLayerPaths []string
+	for _, option := range m.Options {
+		if strings.HasPrefix(option, mount.ParentLayerPathsFlag) {
+			err := json.Unmarshal([]byte(option[len(mount.ParentLayerPathsFlag):]), &parentLayerPaths)
+			if err != nil {
+				return "", nil, fmt.Errorf("unmarshal parent layer paths from mount: %v: %w", err, errdefs.ErrFailedPrecondition)
+			}
+			// Would perhaps be worthwhile to check for unrecognized options and return an error,
+			// but since this is a legacy layer mount we don't do that to avoid breaking anyone.
+			break
+		}
+	}
+	return m.Source, parentLayerPaths, nil
+}
+
+// getLCOWLayers returns a layers.LCOWLayers describing the rootfs that should be set up
+// for an LCOW container. It takes as input the set of rootfs mounts and the layer folders
+// from the OCI spec, it is assumed that these were previously checked with validateRootfsAndLayers
+// such that only one of them is populated.
+func getLCOWLayers(rootfs []*types.Mount, layerFolders []string) (*layers.LCOWLayers, error) {
+	legacyLayer := func(scratchLayer string, parentLayers []string) *layers.LCOWLayers {
+		// Each read-only layer should have a layer.vhd, and the scratch layer should have a sandbox.vhdx.
+		roLayers := make([]*layers.LCOWLayer, 0, len(parentLayers))
+		for _, parentLayer := range parentLayers {
+			roLayers = append(roLayers, &layers.LCOWLayer{VHDPath: filepath.Join(parentLayer, "layer.vhd")})
+		}
+		return &layers.LCOWLayers{
+			Layers:         roLayers,
+			ScratchVHDPath: filepath.Join(scratchLayer, "sandbox.vhdx"),
+		}
+	}
+	// Due to previous validation, we know that for a Linux container we either have LayerFolders, or
+	// a single rootfs mount.
+	if len(layerFolders) > 0 {
+		return legacyLayer(layerFolders[len(layerFolders)-1], layerFolders[:len(layerFolders)-1]), nil
+	}
+	m := rootfs[0]
+	switch m.Type {
+	case "lcow-layer":
+		scratchLayer, parentLayers, err := parseLegacyRootfsMount(rootfs[0])
+		if err != nil {
+			return nil, err
+		}
+		return legacyLayer(scratchLayer, parentLayers), nil
+	default:
+		return nil, fmt.Errorf("unrecognized rootfs mount type: %s", m.Type)
+	}
+}

--- a/internal/hcsoci/create.go
+++ b/internal/hcsoci/create.go
@@ -16,6 +16,7 @@ import (
 	"github.com/Microsoft/hcsshim/internal/guestpath"
 	"github.com/Microsoft/hcsshim/internal/hcs"
 	hcsschema "github.com/Microsoft/hcsshim/internal/hcs/schema2"
+	"github.com/Microsoft/hcsshim/internal/layers"
 	"github.com/Microsoft/hcsshim/internal/log"
 	"github.com/Microsoft/hcsshim/internal/oci"
 	"github.com/Microsoft/hcsshim/internal/resources"
@@ -43,6 +44,7 @@ type CreateOptions struct {
 	SchemaVersion    *hcsschema.Version // Requested Schema Version. Defaults to v2 for RS5, v1 for RS1..RS4
 	HostingSystem    *uvm.UtilityVM     // Utility or service VM in which the container is to be created.
 	NetworkNamespace string             // Host network namespace to use (overrides anything in the spec)
+	LCOWLayers       *layers.LCOWLayers
 
 	// This is an advanced debugging parameter. It allows for diagnosability by leaving a containers
 	// resources allocated in case of a failure. Thus you would be able to use tools such as hcsdiag

--- a/internal/hcsoci/resources_lcow.go
+++ b/internal/hcsoci/resources_lcow.go
@@ -28,9 +28,9 @@ func allocateLinuxResources(ctx context.Context, coi *createOptionsInternal, r *
 		coi.Spec.Root = &specs.Root{}
 	}
 	containerRootInUVM := r.ContainerRootInUVM()
-	if coi.Spec.Windows != nil && len(coi.Spec.Windows.LayerFolders) > 0 {
+	if coi.LCOWLayers != nil {
 		log.G(ctx).Debug("hcsshim::allocateLinuxResources mounting storage")
-		rootPath, scratchPath, closer, err := layers.MountLCOWLayers(ctx, coi.actualID, coi.Spec.Windows.LayerFolders, containerRootInUVM, coi.HostingSystem)
+		rootPath, scratchPath, closer, err := layers.MountLCOWLayers(ctx, coi.actualID, coi.LCOWLayers, containerRootInUVM, coi.HostingSystem)
 		if err != nil {
 			return errors.Wrap(err, "failed to mount container storage")
 		}

--- a/internal/protocol/guestresource/resources.go
+++ b/internal/protocol/guestresource/resources.go
@@ -81,6 +81,7 @@ type LCOWMappedVirtualDisk struct {
 	MountPath  string            `json:"MountPath,omitempty"`
 	Lun        uint8             `json:"Lun,omitempty"`
 	Controller uint8             `json:"Controller,omitempty"`
+	Partition  uint64            `json:"Partition,omitempty"`
 	ReadOnly   bool              `json:"ReadOnly,omitempty"`
 	Encrypted  bool              `json:"Encrypted,omitempty"`
 	Options    []string          `json:"Options,omitempty"`

--- a/internal/uvm/scsi/backend.go
+++ b/internal/uvm/scsi/backend.go
@@ -186,6 +186,7 @@ func mountRequest(controller, lun uint, path string, config *mountConfig, osType
 			MountPath:  path,
 			Controller: uint8(controller),
 			Lun:        uint8(lun),
+			Partition:  config.partition,
 			ReadOnly:   config.readOnly,
 			Encrypted:  config.encrypted,
 			Options:    config.options,
@@ -212,6 +213,7 @@ func unmountRequest(controller, lun uint, path string, config *mountConfig, osTy
 		req.Settings = guestresource.LCOWMappedVirtualDisk{
 			MountPath:  path,
 			Lun:        uint8(lun),
+			Partition:  config.partition,
 			Controller: uint8(controller),
 			VerityInfo: config.verity,
 		}

--- a/internal/uvm/scsi/manager.go
+++ b/internal/uvm/scsi/manager.go
@@ -66,6 +66,7 @@ func NewManager(
 // MountConfig specifies the options to apply for mounting a SCSI device in
 // the guest OS.
 type MountConfig struct {
+	Partition uint64
 	Encrypted bool
 	Options   []string
 }
@@ -136,6 +137,7 @@ func (m *Manager) AddVirtualDisk(
 	var mcInternal *mountConfig
 	if mc != nil {
 		mcInternal = &mountConfig{
+			partition: mc.Partition,
 			readOnly:  readOnly,
 			encrypted: mc.Encrypted,
 			options:   mc.Options,
@@ -179,6 +181,7 @@ func (m *Manager) AddPhysicalDisk(
 	var mcInternal *mountConfig
 	if mc != nil {
 		mcInternal = &mountConfig{
+			partition: mc.Partition,
 			readOnly:  readOnly,
 			encrypted: mc.Encrypted,
 			options:   mc.Options,
@@ -221,6 +224,7 @@ func (m *Manager) AddExtensibleVirtualDisk(
 	var mcInternal *mountConfig
 	if mc != nil {
 		mcInternal = &mountConfig{
+			partition: mc.Partition,
 			readOnly:  readOnly,
 			encrypted: mc.Encrypted,
 			options:   mc.Options,

--- a/internal/uvm/scsi/mount.go
+++ b/internal/uvm/scsi/mount.go
@@ -38,6 +38,7 @@ type mount struct {
 }
 
 type mountConfig struct {
+	partition uint64
 	readOnly  bool
 	encrypted bool
 	verity    *guestresource.DeviceVerityInfo


### PR DESCRIPTION
This is commit 6/6 in a chain. Recommended to review in order. If reviewing a later PR in the chain, you can view individual commits to see just what that PR changes.
- #1740
- #1741
- #1742
- #1743
- #1744
- #1745

This PR increases the flexibility of how we handle LCOW layers. This gives us greater ability to represent layers differently. For example, this PR also adds a new `lcow-partitioned-layer` type which consists of a VHD path and a partition index on that VHD for each read-only layer.

Please see individual commits for details.