### PR TITLE
Guest agent support for partitions on SCSI devices

### DIFF
--- a/internal/guest/runtime/hcsv2/uvm.go
+++ b/internal/guest/runtime/hcsv2/uvm.go
@@ -555,8 +555,7 @@ func (h *Host) modifyHostSettings(ctx context.Context, containerID string, req *
 		if !mvd.ReadOnly {
 			localCtx, cancel := context.WithTimeout(ctx, time.Second*5)
 			defer cancel()
-			var source string
-			source, err = scsi.ControllerLunToName(localCtx, mvd.Controller, mvd.Lun)
+			source, err := scsi.GetDevicePath(localCtx, mvd.Controller, mvd.Lun, mvd.Partition)
 			if err != nil {
 				return err
 			}
@@ -982,7 +981,7 @@ func modifyMappedVirtualDisk(
 				}
 			}
 
-			return scsi.Mount(mountCtx, mvd.Controller, mvd.Lun, mvd.MountPath,
+			return scsi.Mount(mountCtx, mvd.Controller, mvd.Lun, mvd.Partition, mvd.MountPath,
 				mvd.ReadOnly, mvd.Encrypted, mvd.Options, mvd.VerityInfo)
 		}
 		return nil
@@ -994,7 +993,8 @@ func modifyMappedVirtualDisk(
 				}
 			}
 
-			if err := scsi.Unmount(ctx, mvd.Controller, mvd.Lun, mvd.MountPath, mvd.Encrypted, mvd.VerityInfo); err != nil {
+			if err := scsi.Unmount(ctx, mvd.Controller, mvd.Lun, mvd.Partition,
+				mvd.MountPath, mvd.Encrypted, mvd.VerityInfo); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
This PR is based on Kevin's recent PRs to clean up our package, refactor our SCSI package, and refactor how we handle layers. You can find those PRs here:
* https://github.com/microsoft/hcsshim/pull/1740
* https://github.com/microsoft/hcsshim/pull/1741
* https://github.com/microsoft/hcsshim/pull/1742
* https://github.com/microsoft/hcsshim/pull/1743
* https://github.com/microsoft/hcsshim/pull/1744
* https://github.com/microsoft/hcsshim/pull/1745

This PR does the following:
* Update `ControllerLunToName` to `GetDevicePath` and take in partition as an additional param
* Wait for partition subdirectory to appear for the devices
* Update device encryption and verity device names with partition index
* Update device encryption and verity device tests
* Add new unit tests for `GetDevicePath`

When Kevin's above PRs are in their final state and merged, this PR will be rebased to contain only the last commit containing the changes I outlined above. 

To view the contents of this PR, I recommend viewing only the last commit so that github doesn't freak out.