### PR TITLE
Allow patch dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,17 +7,13 @@ updates:
     schedule:
       interval: "weekly"
       day: "sunday"
-    # ignore patch version increment updates (will not affect security updates)
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-patch"]
 
   - package-ecosystem: "gomod"
     directory: "/test"
     schedule:
       interval: "weekly"
       day: "sunday"
-    # ignore patch version increment updates (will not affect security updates)
+    # ignore patch version increment updates in test, since shouldn't be critical
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-patch"]


### PR DESCRIPTION
Patch updates can be disabled for most dependencies, but ignoring all patch-fixes has caused errors (notably containerd).
Individual dependecies can have their patch updates ignored if they are too noisy