### PR TITLE
SCSI ensure filesystem

### DIFF
--- a/internal/guest/runtime/hcsv2/uvm.go
+++ b/internal/guest/runtime/hcsv2/uvm.go
@@ -980,9 +980,14 @@ func modifyMappedVirtualDisk(
 					return errors.Wrapf(err, "mounting scsi device controller %d lun %d onto %s denied by policy", mvd.Controller, mvd.Lun, mvd.MountPath)
 				}
 			}
-
+			config := &scsi.Config{
+				Encrypted:        mvd.Encrypted,
+				VerityInfo:       mvd.VerityInfo,
+				EnsureFilesystem: mvd.EnsureFilesystem,
+				Filesystem:       mvd.Filesystem,
+			}
 			return scsi.Mount(mountCtx, mvd.Controller, mvd.Lun, mvd.Partition, mvd.MountPath,
-				mvd.ReadOnly, mvd.Encrypted, mvd.Options, mvd.VerityInfo)
+				mvd.ReadOnly, mvd.Options, config)
 		}
 		return nil
 	case guestrequest.RequestTypeRemove:
@@ -992,9 +997,14 @@ func modifyMappedVirtualDisk(
 					return fmt.Errorf("unmounting scsi device at %s denied by policy: %w", mvd.MountPath, err)
 				}
 			}
-
+			config := &scsi.Config{
+				Encrypted:        mvd.Encrypted,
+				VerityInfo:       mvd.VerityInfo,
+				EnsureFilesystem: mvd.EnsureFilesystem,
+				Filesystem:       mvd.Filesystem,
+			}
 			if err := scsi.Unmount(ctx, mvd.Controller, mvd.Lun, mvd.Partition,
-				mvd.MountPath, mvd.Encrypted, mvd.VerityInfo); err != nil {
+				mvd.MountPath, config); err != nil {
 				return err
 			}
 		}

--- a/internal/guest/storage/crypt/crypt_test.go
+++ b/internal/guest/storage/crypt/crypt_test.go
@@ -125,46 +125,6 @@ func Test_Encrypt_Cryptsetup_Open_Error(t *testing.T) {
 	}
 }
 
-func Test_Encrypt_Mkfs_Error(t *testing.T) {
-	clearCryptTestDependencies()
-
-	// Test what happens when mkfs fails to format the unencrypted device.
-	// Verify that the arguments passed to it are the right ones.
-	_generateKeyFile = func(path string, size int64) error {
-		return nil
-	}
-	_osRemoveAll = func(path string) error {
-		return nil
-	}
-	_cryptsetupFormat = func(source string, keyFilePath string) error {
-		return nil
-	}
-	_cryptsetupOpen = func(source string, deviceName string, keyFilePath string) error {
-		return nil
-	}
-	_cryptsetupClose = func(deviceName string) error {
-		return nil
-	}
-	_zeroFirstBlock = func(_ string, _ int) error {
-		return nil
-	}
-
-	source := "/dev/sda"
-	formatTarget := "/dev/mapper/dm-crypt-name"
-
-	expectedErr := errors.New("expected error message")
-	_mkfsXfs = func(arg string) error {
-		if arg != formatTarget {
-			t.Fatalf("expected args: '%v' got: '%v'", formatTarget, arg)
-		}
-		return expectedErr
-	}
-
-	if _, err := EncryptDevice(context.Background(), source, "dm-crypt-name"); errors.Unwrap(err) != expectedErr {
-		t.Fatalf("expected err: '%v' got: '%v'", expectedErr, err)
-	}
-}
-
 func Test_Encrypt_Success(t *testing.T) {
 	clearCryptTestDependencies()
 
@@ -182,9 +142,6 @@ func Test_Encrypt_Success(t *testing.T) {
 		return nil
 	}
 	_zeroFirstBlock = func(_ string, _ int) error {
-		return nil
-	}
-	_mkfsXfs = func(arg string) error {
 		return nil
 	}
 

--- a/internal/guest/storage/ext4/format.go
+++ b/internal/guest/storage/ext4/format.go
@@ -18,7 +18,7 @@ func mkfsExt4Command(args []string) error {
 	}
 	return nil
 }
-func FormatExt4(ctx context.Context, source string) error {
+func Format(ctx context.Context, source string) error {
 	// Format source as ext4
 	if err := mkfsExt4Command([]string{source}); err != nil {
 		return fmt.Errorf("mkfs.ext4 failed to format %s: %w", source, err)

--- a/internal/guest/storage/xfs/format.go
+++ b/internal/guest/storage/xfs/format.go
@@ -1,0 +1,17 @@
+package xfs
+
+import (
+	"fmt"
+	"os/exec"
+)
+
+// Format formats `source` by invoking mkfs.xfs.
+func Format(devicePath string) error {
+	args := []string{"-f", devicePath}
+	cmd := exec.Command("mkfs.xfs", args...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("mkfs.xfs failed with %s: %w", string(output), err)
+	}
+	return nil
+}

--- a/internal/protocol/guestresource/resources.go
+++ b/internal/protocol/guestresource/resources.go
@@ -78,14 +78,16 @@ type SCSIDevice struct {
 // LCOWMappedVirtualDisk represents a disk on the host which is mapped into a
 // directory in the guest in the V2 schema.
 type LCOWMappedVirtualDisk struct {
-	MountPath  string            `json:"MountPath,omitempty"`
-	Lun        uint8             `json:"Lun,omitempty"`
-	Controller uint8             `json:"Controller,omitempty"`
-	Partition  uint64            `json:"Partition,omitempty"`
-	ReadOnly   bool              `json:"ReadOnly,omitempty"`
-	Encrypted  bool              `json:"Encrypted,omitempty"`
-	Options    []string          `json:"Options,omitempty"`
-	VerityInfo *DeviceVerityInfo `json:"VerityInfo,omitempty"`
+	MountPath        string            `json:"MountPath,omitempty"`
+	Lun              uint8             `json:"Lun,omitempty"`
+	Controller       uint8             `json:"Controller,omitempty"`
+	Partition        uint64            `json:"Partition,omitempty"`
+	ReadOnly         bool              `json:"ReadOnly,omitempty"`
+	Encrypted        bool              `json:"Encrypted,omitempty"`
+	Options          []string          `json:"Options,omitempty"`
+	VerityInfo       *DeviceVerityInfo `json:"VerityInfo,omitempty"`
+	EnsureFilesystem bool              `json:"EnsureFilesystem,omitempty"`
+	Filesystem       string            `json:"Filesystem,omitempty"`
 }
 
 type WCOWMappedVirtualDisk struct {

--- a/internal/uvm/scsi/manager.go
+++ b/internal/uvm/scsi/manager.go
@@ -66,9 +66,25 @@ func NewManager(
 // MountConfig specifies the options to apply for mounting a SCSI device in
 // the guest OS.
 type MountConfig struct {
+	// Partition is the target partition index on a partitioned device to
+	// mount. Partitions are 1-based indexed.
+	// This is only supported for LCOW.
 	Partition uint64
+	// Encrypted indicates if we should encrypt the device with dm-crypt.
+	// This is only supported for LCOW.
 	Encrypted bool
-	Options   []string
+	// Options are options such as propagation options, flags, or data to
+	// pass to the mount call.
+	// This is only supported for LCOW.
+	Options []string
+	// EnsureFilesystem indicates to format the mount as `Filesystem`
+	// if it is not already formatted with that fs type.
+	// This is only supported for LCOW.
+	EnsureFileystem bool
+	// Filesystem is the target filesystem that a device will be
+	// mounted as.
+	// This is only supported for LCOW.
+	Filesystem string
 }
 
 // Mount represents a SCSI device that has been attached to a VM, and potentially
@@ -137,11 +153,13 @@ func (m *Manager) AddVirtualDisk(
 	var mcInternal *mountConfig
 	if mc != nil {
 		mcInternal = &mountConfig{
-			partition: mc.Partition,
-			readOnly:  readOnly,
-			encrypted: mc.Encrypted,
-			options:   mc.Options,
-			verity:    readVerityInfo(ctx, hostPath),
+			partition:       mc.Partition,
+			readOnly:        readOnly,
+			encrypted:       mc.Encrypted,
+			options:         mc.Options,
+			verity:          readVerityInfo(ctx, hostPath),
+			ensureFileystem: mc.EnsureFileystem,
+			filesystem:      mc.Filesystem,
 		}
 	}
 	return m.add(ctx,
@@ -181,11 +199,13 @@ func (m *Manager) AddPhysicalDisk(
 	var mcInternal *mountConfig
 	if mc != nil {
 		mcInternal = &mountConfig{
-			partition: mc.Partition,
-			readOnly:  readOnly,
-			encrypted: mc.Encrypted,
-			options:   mc.Options,
-			verity:    readVerityInfo(ctx, hostPath),
+			partition:       mc.Partition,
+			readOnly:        readOnly,
+			encrypted:       mc.Encrypted,
+			options:         mc.Options,
+			verity:          readVerityInfo(ctx, hostPath),
+			ensureFileystem: mc.EnsureFileystem,
+			filesystem:      mc.Filesystem,
 		}
 	}
 	return m.add(ctx,
@@ -224,10 +244,12 @@ func (m *Manager) AddExtensibleVirtualDisk(
 	var mcInternal *mountConfig
 	if mc != nil {
 		mcInternal = &mountConfig{
-			partition: mc.Partition,
-			readOnly:  readOnly,
-			encrypted: mc.Encrypted,
-			options:   mc.Options,
+			partition:       mc.Partition,
+			readOnly:        readOnly,
+			encrypted:       mc.Encrypted,
+			options:         mc.Options,
+			ensureFileystem: mc.EnsureFileystem,
+			filesystem:      mc.Filesystem,
 		}
 	}
 	return m.add(ctx,

--- a/internal/uvm/scsi/mount.go
+++ b/internal/uvm/scsi/mount.go
@@ -38,11 +38,13 @@ type mount struct {
 }
 
 type mountConfig struct {
-	partition uint64
-	readOnly  bool
-	encrypted bool
-	verity    *guestresource.DeviceVerityInfo
-	options   []string
+	partition       uint64
+	readOnly        bool
+	encrypted       bool
+	verity          *guestresource.DeviceVerityInfo
+	options         []string
+	ensureFileystem bool
+	filesystem      string
 }
 
 func (mm *mountManager) mount(ctx context.Context, controller, lun uint, c *mountConfig) (_ string, err error) {


### PR DESCRIPTION
This PR is based on https://github.com/microsoft/hcsshim/pull/1747, which is in turn based on the below PRs:
* https://github.com/microsoft/hcsshim/pull/1740
* https://github.com/microsoft/hcsshim/pull/1741
* https://github.com/microsoft/hcsshim/pull/1742
* https://github.com/microsoft/hcsshim/pull/1743
* https://github.com/microsoft/hcsshim/pull/1744
* https://github.com/microsoft/hcsshim/pull/1745

This PR additionally has one temporary commit that was used for testing. When the PRs that this PR is based on are updated, this PR will also need to be updated and will likely have some rebase conflicts. You can find the target code changes in the last commit on this PR.

The main work in this PR is the creation of two new options on an LCOW scsi mount `EnsureFilesystem` and `Filesystem`. These options are added to light up the ability to optionally ensure that a disk has a specific filesystem configured on it in the guest. 

This PR does the following: 
* Add new `EnsureFilesystem` and `Filesystem` options on LCOWMappedVirtualDisk 
* Add matching `EnsureFilesystem` and `Filesystem` options on scsi MountConfig 
* Set `EnsureFilesystem` and `Filesystem` when attaching scratch devices 
* New package for formatting using xfs 
* Add plumbing in guest scsi package to support `EnsureFilesystem` and `Filesystem`. 
* Create new `Config` type in guest scsi package for passing in setup/cleanup configuration settings 
* Move wait for scsi /dev device before other actions are taken during mount. 
* Add new call to get a device's filesystem by reading its superblock
* Add new scsi unit tests for new features and update existing tests

Note: it is expected that this PR does not currently pass the linter or integration tests in the CI.