### PR TITLE
Enable guest agent unit tests in the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,6 +200,9 @@ jobs:
       - name: Test rego policy interpreter
         run: gotestsum --format standard-verbose --debug -- -mod=mod -gcflags=all=-d=checkptr ./internal/regopolicyinterpreter
 
+      - name: Run guest code unit tests
+        run: gotestsum --format standard-verbose --debug -- -mod=mod -gcflags=all=-d=checkptr ./internal/guest/...
+      
       - name: Build gcs Testing Binary
         run: go test -mod=mod -gcflags=all=-d=checkptr -c -tags functional ./gcs
         working-directory: test


### PR DESCRIPTION
This PR enables the guest agent unit tests as part of the CI's linux testing. This includes unit tests for everything under internal/guest, such as scsi mounting, pmem mounting, etc. 