### PR TITLE
Use vm ID when adding LCOW SCSI layers

### DIFF
--- a/internal/layers/layers.go
+++ b/internal/layers/layers.go
@@ -420,7 +420,7 @@ func addLCOWLayer(ctx context.Context, vm *uvm.UtilityVM, layer *LCOWLayer) (uvm
 		}
 	}
 
-	sm, err := vm.SCSIManager.AddVirtualDisk(ctx, layer.VHDPath, true, "", &scsi.MountConfig{Partition: layer.Partition, Options: []string{"ro"}})
+	sm, err := vm.SCSIManager.AddVirtualDisk(ctx, layer.VHDPath, true, vm.ID(), &scsi.MountConfig{Partition: layer.Partition, Options: []string{"ro"}})
 	if err != nil {
 		return "", nil, fmt.Errorf("failed to add SCSI layer: %s", err)
 	}


### PR DESCRIPTION
This PR fixes a bug where we weren't passing in the vm ID when adding scsi layers. This causes us to fail to mount scsi layers since the VMs do not have permission to use the disks. 