### PR TITLE
[gcs.test] update scratch space cleanup order

### DIFF
--- a/scripts/Test-LCOW-UVM.ps1
+++ b/scripts/Test-LCOW-UVM.ps1
@@ -51,8 +51,10 @@ param (
 
     # gcs test/container options
 
+    # we can no longer specify the guest/destination path for SCSI mounts, so hope the rootfs is the first
+    # path to be SCSI-mounted
     [string]
-    $ContainerRootFSMount = '/run/rootfs',
+    $ContainerRootFSMount = '/run/mounts/scsi/m0',
 
     [string]
     $ContainerRootFSPath = (Join-Path $BootFilesPath 'rootfs.vhd'),
@@ -79,10 +81,10 @@ $UVMBootPath = Resolve-Path $UVMBootPath
 
 $shell = ( $Action -eq 'Shell' )
 
+$date = Get-Date
 if ( $shell ) {
     $cmd = 'ash'
 } else {
-    $date = Get-Date
     $waitfiles = "$ContainerRootFSMount"
     $gcspath = 'gcs.test'
     if ( -not $SkipGCSTestMount ) {
@@ -124,7 +126,7 @@ $boot = "$UVMBootPath -gcs lcow " + `
     "-boot-files-path $BootFilesPath " + `
     "-root-fs-type $BootFSType " + `
     '-kernel-file vmlinux ' + `
-    "-mount-scsi `"$ContainerRootFSPath,$ContainerRootFSMount`" "
+    "-mount-scsi `"$ContainerRootFSPath`" "
 
 if ( -not $SkipGCSTestMount ) {
     $boot += "-share `"$GCSTestPath,$GCSTestMount`" "

--- a/test/gcs/container_bench_test.go
+++ b/test/gcs/container_bench_test.go
@@ -45,9 +45,7 @@ func BenchmarkContainerCreate(b *testing.B) {
 		// create launches background go-routines
 		// so kill container to end those and avoid future perf hits
 		killContainer(ctx, b, c)
-		deleteContainer(ctx, b, c)
-		removeContainer(ctx, b, host, id)
-		unmountRootfs(ctx, b, scratch)
+		cleanupContainer(ctx, b, host, c)
 	}
 }
 


### PR DESCRIPTION
Can no longer specify guest path for SCSI mounts, so update gcs test script.
Additionally, now need to unmount scratch space before deleting the container, so update gcs tests.