### PR TITLE
Minor fixes to SCSI mount operation

### DIFF
--- a/ext4/tar2ext4/tar2ext4.go
+++ b/ext4/tar2ext4/tar2ext4.go
@@ -13,6 +13,7 @@ import (
 	"github.com/Microsoft/hcsshim/ext4/dmverity"
 	"github.com/Microsoft/hcsshim/ext4/internal/compactext4"
 	"github.com/Microsoft/hcsshim/ext4/internal/format"
+	"github.com/Microsoft/hcsshim/internal/log"
 	"github.com/pkg/errors"
 )
 
@@ -259,6 +260,9 @@ func IsDeviceExt4(devicePath string) bool {
 	// ReadExt4SuperBlock will check the superblock magic number for us,
 	// so we know if no error is returned, this is an ext4 device.
 	_, err := ReadExt4SuperBlock(devicePath)
+	if err != nil {
+		log.L.Warnf("failed to read Ext4 superblock: %s", err)
+	}
 	return err == nil
 }
 

--- a/test/cri-containerd/container_test.go
+++ b/test/cri-containerd/container_test.go
@@ -916,9 +916,9 @@ func Test_Container_NFSMount_LCOW(t *testing.T) {
 	defer stopContainer(t, client, ctx, containerID)
 
 	execHelper := func(ctrID string, cmd []string) {
+		t.Helper()
 		stdout, stderr, errcode := execContainer(t, client, ctx, ctrID, cmd)
 		if errcode != 0 {
-			t.Helper()
 			t.Logf("stdout: %s \n\n stderr: %s\n\n", stdout, stderr)
 			t.Fatalf("failed to run '%v'\n: errcode: %d", cmd, errcode)
 		}

--- a/test/cri-containerd/main_test.go
+++ b/test/cri-containerd/main_test.go
@@ -62,7 +62,7 @@ const (
 	alpineAspnetUpgrade     = "mcr.microsoft.com/dotnet/core/aspnet:3.1.2-alpine3.11"
 
 	imageWindowsProcessDump = "cplatpublic.azurecr.io/crashdump:latest"
-	imageWindowsArgsEscaped = "cplatpublic.azurecr.io/argsescaped:latest"
+	imageWindowsArgsEscaped = "cplatpublic.azurecr.io/args-escaped-test-image-ns:latest"
 	imageWindowsTimezone    = "cplatpublic.azurecr.io/timezone:latest"
 
 	imageJobContainerHNS     = "cplatpublic.azurecr.io/jobcontainer_hns:latest"


### PR DESCRIPTION
During a recent refactor SCSI mount operation code removed a retry logic that is needed when examining the filesystem type on a SCSI device. Retry is needed because sometimes attempting to open a SCSI devices immediately after attaching it results in ENXIO/ENOENT errors. This adds the retry logic back.

Names of some images used in the tests had changed, this commit updates those names too.