### PR TITLE
[ci] Fix integration test failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -373,20 +373,17 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      # needs to be a separate step since terminal reload is required to bring in new env variables and PATH
+      - name: Upgrade Chocolaty
+        shell: powershell
+        run: |
+          choco upgrade -y chocolatey 2>&1
+
       - name: Install mingw
         shell: powershell
         run: |
           $VerbosePreference = 'Continue'
           # dont set $ErrorActionPreference since we want to allow choco install to fail later on
-
-          Write-Output '::group::Update chocolaty'
-          choco upgrade -y chocolatey
-          Write-Output '::endgroup::'
-
-          if ( $LASTEXITCODE ) {
-            Write-Output '::error::Could not update chocolatey.'
-            exit $LASTEXITCODE
-          }
 
           Write-Output 'Install mingw'
           # Install sometimes fails when downloading mingw zip from source-forge with:
@@ -404,7 +401,7 @@ jobs:
               Sleep -Seconds 60
             }
 
-            choco install -y --no-progress --stop-on-first-failure --force mingw --allow-downgrade --version 10.2.0
+            choco install -y --no-progress --stop-on-first-failure --force mingw --allow-downgrade --version 10.3.0
             Write-Output '::endgroup::'
             if ( -not $LASTEXITCODE ) {
               Write-Output "Attempt $i succeeded (exit code: $LASTEXITCODE)"
@@ -417,6 +414,9 @@ jobs:
             Write-Output "::error::Could not install mingw after $i attempts."
             exit $LASTEXITCODE
           }
+
+          # verify mingw32-make was installed
+          Get-Command -CommandType Application -ErrorAction Stop mingw32-make.exe
 
       - name: Build binaries
         shell: bash


### PR DESCRIPTION
containerd integration tests have been failing to build since mingw `10.2` appears to no install `mingw32-make.exe` anymore.
upgrading to `10.3` appears to fix this. 

add dedicated check for `mingw32-make.exe` instead of relying on build stage to fail

also, move `choco upgrade` command to dedicated step to allow environment variables to be reloaded.