### PR TITLE
Update CI to use golang 1.20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   - pull_request
 
 env:
-  GO_VERSION: "1.19.x"
+  GO_VERSION: "1.20.x"
   GOTESTSUM_VERSION: "latest"
 
 jobs:

--- a/ext4/tar2ext4/tar2ext4.go
+++ b/ext4/tar2ext4/tar2ext4.go
@@ -149,7 +149,7 @@ func ConvertTarToExt4(r io.Reader, w io.ReadWriteSeeker, options ...Option) erro
 
 			var typ uint16
 			switch hdr.Typeflag {
-			case tar.TypeReg, tar.TypeRegA:
+			case tar.TypeReg:
 				typ = compactext4.S_IFREG
 			case tar.TypeSymlink:
 				typ = compactext4.S_IFLNK


### PR DESCRIPTION
This PR updates the CI to use golang 1.20. 

During this update, we get a new deprecated error in the linter due to [tar.TypeRegA](https://pkg.go.dev/archive/tar#pkg-constants) in our tar2ext4 code. The archive/tar code will automatically convert any use of tar.TypeRegA to tar.TypeReg, therefore, we should be safe to remove the reference to that constant in our code.