### PR TITLE
tests: rego `get_properties` functional test

### DIFF
--- a/test/functional/lcow_policy_test.go
+++ b/test/functional/lcow_policy_test.go
@@ -1,0 +1,107 @@
+//go:build windows && functional
+
+package functional
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	ctrdoci "github.com/containerd/containerd/oci"
+
+	"github.com/Microsoft/hcsshim/internal/uvm"
+	"github.com/Microsoft/hcsshim/pkg/securitypolicy"
+	"github.com/Microsoft/hcsshim/test/internal/cmd"
+	"github.com/Microsoft/hcsshim/test/internal/container"
+	"github.com/Microsoft/hcsshim/test/internal/layers"
+	"github.com/Microsoft/hcsshim/test/internal/oci"
+	"github.com/Microsoft/hcsshim/test/internal/util"
+	"github.com/Microsoft/hcsshim/test/pkg/images"
+	policytest "github.com/Microsoft/hcsshim/test/pkg/securitypolicy"
+	uvmtest "github.com/Microsoft/hcsshim/test/pkg/uvm"
+)
+
+func setupScratchTemplate(ctx context.Context, tb testing.TB) string {
+	tb.Helper()
+	opts := defaultLCOWOptions(tb)
+	vm, err := uvm.CreateLCOW(ctx, opts)
+	if err != nil {
+		tb.Fatalf("failed to create scratch formatting uVM: %s", err)
+	}
+	if err := vm.Start(ctx); err != nil {
+		tb.Fatalf("failed to start scratch formatting uVM: %s", err)
+	}
+	defer vm.Close()
+	scratch, _ := layers.ScratchSpace(ctx, tb, vm, "", "", "")
+	return scratch
+}
+
+func Test_GetProperties_WithPolicy(t *testing.T) {
+	requireFeatures(t, featureLCOWIntegrity)
+
+	ctx := namespacedContext()
+	scratchPath := setupScratchTemplate(ctx, t)
+
+	ls := linuxImageLayers(ctx, t)
+	for _, allowProperties := range []bool{true, false} {
+		t.Run(fmt.Sprintf("AllowPropertiesAccess_%t", allowProperties), func(t *testing.T) {
+			opts := defaultLCOWOptions(t)
+			policy := policytest.PolicyFromImageWithOpts(
+				t,
+				images.ImageLinuxAlpineLatest,
+				"rego",
+				[]securitypolicy.ContainerConfigOpt{
+					securitypolicy.WithCommand([]string{"/bin/sh", "-c", oci.TailNullArgs}),
+				},
+				[]securitypolicy.PolicyConfigOpt{
+					securitypolicy.WithAllowPropertiesAccess(allowProperties),
+					securitypolicy.WithAllowUnencryptedScratch(true),
+				},
+			)
+			opts.SecurityPolicyEnforcer = "rego"
+			opts.SecurityPolicy = policy
+
+			cleanName := util.CleanName(t.Name())
+			vm := uvmtest.CreateAndStartLCOWFromOpts(ctx, t, opts)
+			spec := oci.CreateLinuxSpec(
+				ctx,
+				t,
+				cleanName,
+				oci.DefaultLinuxSpecOpts(
+					"",
+					ctrdoci.WithProcessArgs("/bin/sh", "-c", oci.TailNullArgs),
+					oci.WithWindowsLayerFolders(append(ls, scratchPath)),
+				)...,
+			)
+
+			c, _, cleanup := container.Create(ctx, t, vm, spec, cleanName, hcsOwner)
+			t.Cleanup(cleanup)
+
+			init := container.Start(ctx, t, c, nil)
+			t.Cleanup(func() {
+				container.Kill(ctx, t, c)
+				container.Wait(ctx, t, c)
+			})
+
+			_, err := c.Properties(ctx)
+			if err != nil {
+				if allowProperties {
+					t.Fatalf("get properties should have been allowed: %s", err)
+				}
+				if !(policytest.AssertErrorContains(t, err, "deny") &&
+					policytest.AssertErrorContains(t, err, "get_properties")) {
+					t.Fatalf("get properties denial error, got: %s", err)
+				}
+			} else {
+				if !allowProperties {
+					t.Fatal("get properties should have failed")
+				}
+			}
+
+			cmd.Kill(ctx, t, init)
+			if e := cmd.Wait(ctx, t, init); e != 137 {
+				t.Errorf("got exit code %d, wanted %d", e, 137)
+			}
+		})
+	}
+}

--- a/test/functional/main_test.go
+++ b/test/functional/main_test.go
@@ -58,20 +58,22 @@ var (
 )
 
 const (
-	featureLCOW        = "LCOW"
-	featureWCOW        = "WCOW"
-	featureContainer   = "container"
-	featureHostProcess = "HostProcess"
-	featureUVMMem      = "UVMMem"
-	featurePlan9       = "Plan9"
-	featureSCSI        = "SCSI"
-	featureScratch     = "Scratch"
-	featureVSMB        = "vSMB"
-	featureVPMEM       = "vPMEM"
+	featureLCOW          = "LCOW"
+	featureLCOWIntegrity = "LCOWIntegrity"
+	featureWCOW          = "WCOW"
+	featureContainer     = "container"
+	featureHostProcess   = "HostProcess"
+	featureUVMMem        = "UVMMem"
+	featurePlan9         = "Plan9"
+	featureSCSI          = "SCSI"
+	featureScratch       = "Scratch"
+	featureVSMB          = "vSMB"
+	featureVPMEM         = "vPMEM"
 )
 
 var allFeatures = []string{
 	featureLCOW,
+	featureLCOWIntegrity,
 	featureWCOW,
 	featureHostProcess,
 	featureContainer,
@@ -204,6 +206,14 @@ func linuxImageLayers(ctx context.Context, tb testing.TB) []string {
 	tb.Helper()
 	if ss := flagLCOWLayerPaths.Strings(); len(ss) > 0 {
 		return ss
+	}
+	if flagFeatures.IsSet(featureLCOWIntegrity) {
+		alpineWithVerity := &layers.LazyImageLayers{
+			Image:        images.ImageLinuxAlpineLatest,
+			Platform:     images.PlatformLinux,
+			AppendVerity: true,
+		}
+		return alpineWithVerity.Layers(ctx, tb)
 	}
 	return alpineImagePaths.Layers(ctx, tb)
 }

--- a/test/internal/layers/lazy.go
+++ b/test/internal/layers/lazy.go
@@ -13,13 +13,13 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/Microsoft/go-winio"
+	"github.com/Microsoft/hcsshim/ext4/dmverity"
+	"github.com/Microsoft/hcsshim/internal/security"
 	"github.com/google/go-containerregistry/pkg/crane"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 
 	"github.com/Microsoft/hcsshim/ext4/tar2ext4"
 	"github.com/Microsoft/hcsshim/internal/log"
-	"github.com/Microsoft/hcsshim/internal/security"
 	"github.com/Microsoft/hcsshim/internal/wclayer"
 	"github.com/Microsoft/hcsshim/pkg/ociwclayer"
 
@@ -30,8 +30,9 @@ import (
 // helper utilities for dealing with images
 
 type LazyImageLayers struct {
-	Image    string
-	Platform string
+	Image        string
+	Platform     string
+	AppendVerity bool
 	// TempPath is the path to create a temporary directory in.
 	// Defaults to [os.TempDir] if left empty.
 	TempPath string
@@ -40,6 +41,8 @@ type LazyImageLayers struct {
 	once   sync.Once
 	layers []string
 }
+
+type extractHandler func(ctx context.Context, rc io.ReadCloser, dir string, parents []string) error
 
 // Close removes the downloaded image layers.
 //
@@ -93,17 +96,9 @@ func (x *LazyImageLayers) extractLayers(ctx context.Context) (err error) {
 		}
 	}
 
-	var extract func(context.Context, io.ReadCloser, string, []string) error
-	switch x.Platform {
-	case images.PlatformLinux:
-		extract = linuxImage
-	case images.PlatformWindows:
-		if err = winio.EnableProcessPrivileges([]string{winio.SeBackupPrivilege, winio.SeRestorePrivilege}); err != nil {
-			return err
-		}
-		extract = windowsImage
-	default:
-		return fmt.Errorf("unsupported platform %q", x.Platform)
+	extract, err := extractImageHandler(x.Platform, x.AppendVerity)
+	if err != nil {
+		return err
 	}
 
 	img, err := crane.Pull(x.Image, crane.WithPlatform(&v1.Platform{OS: x.Platform, Architecture: runtime.GOARCH}))
@@ -135,27 +130,85 @@ func (x *LazyImageLayers) extractLayers(ctx context.Context) (err error) {
 	return nil
 }
 
-func linuxImage(ctx context.Context, rc io.ReadCloser, dir string, _ []string) error {
-	f, err := os.Create(filepath.Join(dir, "layer.vhd"))
-	if err != nil {
-		return fmt.Errorf("create layer vhd: %w", err)
+func extractImageHandler(platform string, appendVerity bool) (extractHandler, error) {
+	var extract extractHandler
+	if platform == images.PlatformLinux {
+		extract = linuxExt4LayerExtractHandler()
+		if appendVerity {
+			extract = withAppendVerity(extract)
+		}
+		extract = withVhdFooter(extract)
+		return extract, nil
+	} else if platform == images.PlatformWindows {
+		return windowsImage, nil
 	}
-	// in case we fail before granting access; double close on file will no-op
-	defer f.Close()
+	return nil, fmt.Errorf("unsupported platform %q", platform)
+}
 
-	if err := tar2ext4.Convert(rc, f, tar2ext4.AppendVhdFooter, tar2ext4.ConvertWhiteout); err != nil {
-		return fmt.Errorf("convert to vhd %s: %w", f.Name(), err)
-	}
-	if err := f.Sync(); err != nil {
-		return fmt.Errorf("sync vhd %s to disk: %w", f.Name(), err)
-	}
-	f.Close()
+func linuxExt4LayerExtractHandler() extractHandler {
+	return func(_ context.Context, rc io.ReadCloser, dir string, _ []string) error {
+		f, err := os.Create(filepath.Join(dir, "layer.vhd"))
+		if err != nil {
+			return fmt.Errorf("create layer vhd: %w", err)
+		}
+		defer f.Close()
 
-	if err = security.GrantVmGroupAccess(f.Name()); err != nil {
-		return fmt.Errorf("grant vm group access to %s: %w", f.Name(), err)
+		convertOpts := []tar2ext4.Option{
+			tar2ext4.ConvertWhiteout,
+			tar2ext4.MaximumDiskSize(dmverity.RecommendedVHDSizeGB),
+		}
+		if err := tar2ext4.Convert(rc, f, convertOpts...); err != nil {
+			return fmt.Errorf("convert to ext4 %s: %w", f.Name(), err)
+		}
+		if err := f.Sync(); err != nil {
+			return fmt.Errorf("sync ext4 file %s to disk: %w", f.Name(), err)
+		}
+		return nil
 	}
+}
 
-	return nil
+func withAppendVerity(fn extractHandler) extractHandler {
+	return func(ctx context.Context, rc io.ReadCloser, dir string, parents []string) error {
+		if err := fn(ctx, rc, dir, parents); err != nil {
+			return err
+		}
+		f, err := os.OpenFile(filepath.Join(dir, "layer.vhd"), os.O_RDWR, 0)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+
+		if _, err := f.Seek(0, io.SeekEnd); err != nil {
+			return fmt.Errorf("unable to prepare file to append verity: %w", err)
+		}
+
+		if err := dmverity.ComputeAndWriteHashDevice(f, f); err != nil {
+			return fmt.Errorf("unable to compute and append hash device: %w", err)
+		}
+		return nil
+	}
+}
+
+func withVhdFooter(fn extractHandler) extractHandler {
+	return func(ctx context.Context, rc io.ReadCloser, dir string, parents []string) error {
+		if err := fn(ctx, rc, dir, parents); err != nil {
+			return err
+		}
+		f, err := os.OpenFile(filepath.Join(dir, "layer.vhd"), os.O_RDWR, 0)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+
+		if err := tar2ext4.ConvertToVhd(f); err != nil {
+			return fmt.Errorf("unable to convert file to VHD: %w", err)
+		}
+
+		if err = security.GrantVmGroupAccess(f.Name()); err != nil {
+			return fmt.Errorf("grant vm group access to %s: %w", f.Name(), err)
+		}
+		return nil
+	}
 }
 
 func windowsImage(ctx context.Context, rc io.ReadCloser, dir string, parents []string) error {

--- a/test/internal/layers/scratch.go
+++ b/test/internal/layers/scratch.go
@@ -4,6 +4,7 @@ package layers
 
 import (
 	"context"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -21,6 +22,9 @@ func CacheFile(_ context.Context, tb testing.TB, dir string) string {
 	tb.Helper()
 	if dir == "" {
 		dir = tb.TempDir()
+		tb.Cleanup(func() {
+			os.RemoveAll(dir)
+		})
 	}
 	cache := filepath.Join(dir, CacheFileName)
 	return cache
@@ -33,6 +37,9 @@ func ScratchSpace(ctx context.Context, tb testing.TB, vm *uvm.UtilityVM, name, d
 	tb.Helper()
 	if dir == "" {
 		dir = tb.TempDir()
+		tb.Cleanup(func() {
+			os.RemoveAll(dir)
+		})
 	}
 	if cache == "" {
 		cache = CacheFile(ctx, tb, dir)

--- a/test/pkg/securitypolicy/policy.go
+++ b/test/pkg/securitypolicy/policy.go
@@ -1,0 +1,98 @@
+package securitypolicy
+
+import (
+	"encoding/base64"
+	"strings"
+	"testing"
+
+	"github.com/Microsoft/hcsshim/internal/tools/securitypolicy/helpers"
+	"github.com/Microsoft/hcsshim/pkg/securitypolicy"
+)
+
+func PolicyFromImageWithOpts(
+	tb testing.TB,
+	imageName string,
+	policyType string,
+	cOpts []securitypolicy.ContainerConfigOpt,
+	pOpts []securitypolicy.PolicyConfigOpt,
+) string {
+	tb.Helper()
+	containerConfig := securitypolicy.ContainerConfig{
+		ImageName: imageName,
+	}
+	for _, co := range cOpts {
+		if err := co(&containerConfig); err != nil {
+			tb.Fatal(err)
+		}
+	}
+
+	policyOpts := []securitypolicy.PolicyConfigOpt{
+		securitypolicy.WithContainers([]securitypolicy.ContainerConfig{
+			containerConfig,
+		}),
+	}
+	policyOpts = append(policyOpts, pOpts...)
+
+	return PolicyWithOpts(tb, policyType, policyOpts...)
+}
+
+func PolicyWithOpts(tb testing.TB, policyType string, pOpts ...securitypolicy.PolicyConfigOpt) string {
+	tb.Helper()
+	policyOpts := []securitypolicy.PolicyConfigOpt{
+		securitypolicy.WithContainers(helpers.DefaultContainerConfigs()),
+	}
+	policyOpts = append(policyOpts, pOpts...)
+
+	config, err := securitypolicy.NewPolicyConfig(policyOpts...)
+	if err != nil {
+		tb.Fatal(err)
+	}
+
+	pc, err := helpers.PolicyContainersFromConfigs(config.Containers)
+	if err != nil {
+		tb.Fatal(err)
+	}
+	policyString, err := securitypolicy.MarshalPolicy(
+		policyType,
+		config.AllowAll,
+		pc,
+		config.ExternalProcesses,
+		config.Fragments,
+		config.AllowPropertiesAccess,
+		config.AllowDumpStacks,
+		config.AllowRuntimeLogging,
+		config.AllowEnvironmentVariableDropping,
+		config.AllowUnencryptedScratch,
+		config.AllowCapabilityDropping,
+	)
+	if err != nil {
+		tb.Fatal(err)
+	}
+	return base64.StdEncoding.EncodeToString([]byte(policyString))
+
+}
+
+func AssertErrorContains(t *testing.T, err error, expected string) bool {
+	t.Helper()
+	if err == nil {
+		t.Error("expected error but got nil")
+		return false
+	}
+
+	if strings.Contains(err.Error(), expected) {
+		return true
+	}
+
+	policyDecisionJSON, err := securitypolicy.ExtractPolicyDecision(err.Error())
+	if err != nil {
+		t.Error(err)
+		return false
+	}
+
+	if !strings.Contains(policyDecisionJSON, expected) {
+		t.Errorf("expected policy decision JSON to contain %q", expected)
+		return false
+	}
+
+	return true
+}


### PR DESCRIPTION
Update test images package to support image extract decorators as an easy way to extend the logic if we need to chain a few steps, in this case appending verity hashes to an ext4 fs.

Add default mount extension logic to standalone container path as well to enable functional tests.

Add new `securitypolicy` package under `test/pkg` to share some logic between cri-containerd and functional tests.

Add lower level `get_properties` test with rego policies.