### PR TITLE
When fetching the pid counts for the container the state can be invalid sometimes

### DIFF
--- a/cmd/containerd-shim-runhcs-v1/task_hcs.go
+++ b/cmd/containerd-shim-runhcs-v1/task_hcs.go
@@ -566,6 +566,9 @@ func (ht *hcsTask) Pids(ctx context.Context) ([]runhcsopts.ProcessDetails, error
 	// Get the guest pids
 	props, err := ht.c.Properties(ctx, schema1.PropertyTypeProcessList)
 	if err != nil {
+		if isStatsNotFound(err) {
+			return nil, errors.Wrapf(errdefs.ErrNotFound, "failed to fetch pids: %s", err)
+		}
 		return nil, err
 	}
 


### PR DESCRIPTION
This uses the same logic for pods that are in invalid states when the properties are queried.  Found this while testing https://github.com/kubernetes/kubernetes/pull/116968 and the "not found error" will allow to handle gracefully in https://github.com/containerd/containerd/pull/8671.