### PR TITLE
add support for verity checking partitioned disks

### DIFF
--- a/cmd/containerd-shim-runhcs-v1/rootfs.go
+++ b/cmd/containerd-shim-runhcs-v1/rootfs.go
@@ -75,12 +75,18 @@ func parseLegacyRootfsMount(m *types.Mount) (string, []string, error) {
 // for an LCOW container. It takes as input the set of rootfs mounts and the layer folders
 // from the OCI spec, it is assumed that these were previously checked with validateRootfsAndLayers
 // such that only one of them is populated.
-func getLCOWLayers(rootfs []*types.Mount, layerFolders []string) (*layers.LCOWLayers, error) {
+func getLCOWLayers(rootfs []*types.Mount, layerFolders []string, guestReadVerity bool) (*layers.LCOWLayers, error) {
 	legacyLayer := func(scratchLayer string, parentLayers []string) *layers.LCOWLayers {
 		// Each read-only layer should have a layer.vhd, and the scratch layer should have a sandbox.vhdx.
 		roLayers := make([]*layers.LCOWLayer, 0, len(parentLayers))
 		for _, parentLayer := range parentLayers {
-			roLayers = append(roLayers, &layers.LCOWLayer{VHDPath: filepath.Join(parentLayer, "layer.vhd")})
+			roLayers = append(
+				roLayers,
+				&layers.LCOWLayer{
+					VHDPath:         filepath.Join(parentLayer, "layer.vhd"),
+					GuestReadVerity: guestReadVerity,
+				},
+			)
 		}
 		return &layers.LCOWLayers{
 			Layers:         roLayers,
@@ -122,7 +128,14 @@ func getLCOWLayers(rootfs []*types.Mount, layerFolders []string) (*layers.LCOWLa
 		}
 		roLayers := make([]*layers.LCOWLayer, 0, len(layerData))
 		for _, layer := range layerData {
-			roLayers = append(roLayers, &layers.LCOWLayer{VHDPath: layer.Path, Partition: layer.Partition})
+			roLayers = append(
+				roLayers,
+				&layers.LCOWLayer{
+					VHDPath:         layer.Path,
+					Partition:       layer.Partition,
+					GuestReadVerity: guestReadVerity,
+				},
+			)
 		}
 		return &layers.LCOWLayers{Layers: roLayers, ScratchVHDPath: scratchPath}, nil
 	default:

--- a/cmd/containerd-shim-runhcs-v1/rootfs.go
+++ b/cmd/containerd-shim-runhcs-v1/rootfs.go
@@ -75,7 +75,7 @@ func parseLegacyRootfsMount(m *types.Mount) (string, []string, error) {
 // for an LCOW container. It takes as input the set of rootfs mounts and the layer folders
 // from the OCI spec, it is assumed that these were previously checked with validateRootfsAndLayers
 // such that only one of them is populated.
-func getLCOWLayers(rootfs []*types.Mount, layerFolders []string, guestReadVerity bool) (*layers.LCOWLayers, error) {
+func getLCOWLayers(rootfs []*types.Mount, layerFolders []string) (*layers.LCOWLayers, error) {
 	legacyLayer := func(scratchLayer string, parentLayers []string) *layers.LCOWLayers {
 		// Each read-only layer should have a layer.vhd, and the scratch layer should have a sandbox.vhdx.
 		roLayers := make([]*layers.LCOWLayer, 0, len(parentLayers))
@@ -83,8 +83,7 @@ func getLCOWLayers(rootfs []*types.Mount, layerFolders []string, guestReadVerity
 			roLayers = append(
 				roLayers,
 				&layers.LCOWLayer{
-					VHDPath:         filepath.Join(parentLayer, "layer.vhd"),
-					GuestReadVerity: guestReadVerity,
+					VHDPath: filepath.Join(parentLayer, "layer.vhd"),
 				},
 			)
 		}
@@ -131,9 +130,8 @@ func getLCOWLayers(rootfs []*types.Mount, layerFolders []string, guestReadVerity
 			roLayers = append(
 				roLayers,
 				&layers.LCOWLayer{
-					VHDPath:         layer.Path,
-					Partition:       layer.Partition,
-					GuestReadVerity: guestReadVerity,
+					VHDPath:   layer.Path,
+					Partition: layer.Partition,
 				},
 			)
 		}

--- a/cmd/containerd-shim-runhcs-v1/task_hcs.go
+++ b/cmd/containerd-shim-runhcs-v1/task_hcs.go
@@ -154,7 +154,8 @@ func createContainer(
 			if s.Windows != nil {
 				layerFolders = s.Windows.LayerFolders
 			}
-			lcowLayers, err := getLCOWLayers(rootfs, layerFolders)
+			guestReadVerity := oci.ParseAnnotationsBool(ctx, s.Annotations, annotations.GuestReadVerity, false)
+			lcowLayers, err := getLCOWLayers(rootfs, layerFolders, guestReadVerity)
 			if err != nil {
 				return nil, nil, err
 			}

--- a/cmd/containerd-shim-runhcs-v1/task_hcs.go
+++ b/cmd/containerd-shim-runhcs-v1/task_hcs.go
@@ -11,11 +11,11 @@ import (
 	"time"
 
 	eventstypes "github.com/containerd/containerd/api/events"
-	task "github.com/containerd/containerd/api/runtime/task/v2"
+	"github.com/containerd/containerd/api/runtime/task/v2"
 	"github.com/containerd/containerd/api/types"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/runtime"
-	typeurl "github.com/containerd/typeurl/v2"
+	"github.com/containerd/typeurl/v2"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -154,8 +154,7 @@ func createContainer(
 			if s.Windows != nil {
 				layerFolders = s.Windows.LayerFolders
 			}
-			guestReadVerity := oci.ParseAnnotationsBool(ctx, s.Annotations, annotations.GuestReadVerity, false)
-			lcowLayers, err := getLCOWLayers(rootfs, layerFolders, guestReadVerity)
+			lcowLayers, err := getLCOWLayers(rootfs, layerFolders)
 			if err != nil {
 				return nil, nil, err
 			}

--- a/internal/guest/runtime/hcsv2/uvm.go
+++ b/internal/guest/runtime/hcsv2/uvm.go
@@ -968,36 +968,33 @@ func modifyMappedVirtualDisk(
 	mvd *guestresource.LCOWMappedVirtualDisk,
 	securityPolicy securitypolicy.SecurityPolicyEnforcer,
 ) (err error) {
+	var verityInfo *guestresource.DeviceVerityInfo
+	if mvd.ReadOnly {
+		// The only time the policy is empty, and we want it to be empty
+		// is when no policy is provided, and we default to open door
+		// policy. In any other case, e.g. explicit open door or any
+		// other rego policy we would like to mount layers with verity.
+		if len(securityPolicy.EncodedSecurityPolicy()) > 0 {
+			devPath, err := scsi.GetDevicePath(ctx, mvd.Controller, mvd.Lun, mvd.Partition)
+			if err != nil {
+				return err
+			}
+			verityInfo, err = verity.ReadVeritySuperBlock(ctx, devPath)
+			if err != nil {
+				return err
+			}
+		}
+	}
 	switch rt {
 	case guestrequest.RequestTypeAdd:
 		mountCtx, cancel := context.WithTimeout(ctx, time.Second*5)
 		defer cancel()
 		if mvd.MountPath != "" {
-			verityInfo := mvd.VerityInfo
 			if mvd.ReadOnly {
-				// The only time the policy is empty, and we want it to be empty
-				// is when no policy is provided, and we default to open door
-				// policy. In any other case, e.g. explicit open door or any
-				// other rego policy we would like to mount layers with verity.
-				if len(securityPolicy.EncodedSecurityPolicy()) > 0 {
-					mvd.GuestReadVerity = true
-				}
-				// containers only have read-only layers so only enforce for them
 				var deviceHash string
 				if verityInfo != nil {
-					deviceHash = mvd.VerityInfo.RootDigest
-				} else if mvd.GuestReadVerity {
-					devPath, err := scsi.GetDevicePath(ctx, mvd.Controller, mvd.Lun, mvd.Partition)
-					if err != nil {
-						return err
-					}
-					verityInfo, err = verity.ReadVeritySuperBlock(ctx, devPath)
-					if err != nil {
-						return err
-					}
 					deviceHash = verityInfo.RootDigest
 				}
-
 				err = securityPolicy.EnforceDeviceMountPolicy(ctx, mvd.MountPath, deviceHash)
 				if err != nil {
 					return errors.Wrapf(err, "mounting scsi device controller %d lun %d onto %s denied by policy", mvd.Controller, mvd.Lun, mvd.MountPath)
@@ -1015,21 +1012,7 @@ func modifyMappedVirtualDisk(
 		return nil
 	case guestrequest.RequestTypeRemove:
 		if mvd.MountPath != "" {
-			verityInfo := mvd.VerityInfo
-			if len(securityPolicy.EncodedSecurityPolicy()) > 0 {
-				mvd.GuestReadVerity = true
-			}
 			if mvd.ReadOnly {
-				if mvd.GuestReadVerity {
-					devPath, err := scsi.GetDevicePath(ctx, mvd.Controller, mvd.Lun, mvd.Partition)
-					if err != nil {
-						return err
-					}
-					verityInfo, err = verity.ReadVeritySuperBlock(ctx, devPath)
-					if err != nil {
-						return err
-					}
-				}
 				if err := securityPolicy.EnforceDeviceUnmountPolicy(ctx, mvd.MountPath); err != nil {
 					return fmt.Errorf("unmounting scsi device at %s denied by policy: %w", mvd.MountPath, err)
 				}
@@ -1083,24 +1066,32 @@ func modifyMappedVPMemDevice(ctx context.Context,
 	vpd *guestresource.LCOWMappedVPMemDevice,
 	securityPolicy securitypolicy.SecurityPolicyEnforcer,
 ) (err error) {
+	var verityInfo *guestresource.DeviceVerityInfo
+	var deviceHash string
+	if len(securityPolicy.EncodedSecurityPolicy()) > 0 {
+		if vpd.MappingInfo != nil {
+			return fmt.Errorf("multi mapping is not supported with verity")
+		}
+		verityInfo, err = verity.ReadVeritySuperBlock(ctx, pmem.GetDevicePath(vpd.DeviceNumber))
+		if err != nil {
+			return err
+		}
+		deviceHash = verityInfo.RootDigest
+	}
 	switch rt {
 	case guestrequest.RequestTypeAdd:
-		var deviceHash string
-		if vpd.VerityInfo != nil {
-			deviceHash = vpd.VerityInfo.RootDigest
-		}
 		err = securityPolicy.EnforceDeviceMountPolicy(ctx, vpd.MountPath, deviceHash)
 		if err != nil {
 			return errors.Wrapf(err, "mounting pmem device %d onto %s denied by policy", vpd.DeviceNumber, vpd.MountPath)
 		}
 
-		return pmem.Mount(ctx, vpd.DeviceNumber, vpd.MountPath, vpd.MappingInfo, vpd.VerityInfo)
+		return pmem.Mount(ctx, vpd.DeviceNumber, vpd.MountPath, vpd.MappingInfo, verityInfo)
 	case guestrequest.RequestTypeRemove:
 		if err := securityPolicy.EnforceDeviceUnmountPolicy(ctx, vpd.MountPath); err != nil {
 			return errors.Wrapf(err, "unmounting pmem device from %s denied by policy", vpd.MountPath)
 		}
 
-		return pmem.Unmount(ctx, vpd.DeviceNumber, vpd.MountPath, vpd.MappingInfo, vpd.VerityInfo)
+		return pmem.Unmount(ctx, vpd.DeviceNumber, vpd.MountPath, vpd.MappingInfo, verityInfo)
 	default:
 		return newInvalidRequestTypeError(rt)
 	}

--- a/internal/guest/storage/pmem/pmem.go
+++ b/internal/guest/storage/pmem/pmem.go
@@ -56,6 +56,11 @@ func mount(ctx context.Context, source, target string) (err error) {
 	return nil
 }
 
+// GetDevicePath returns VPMem device path
+func GetDevicePath(devNumber uint32) string {
+	return fmt.Sprintf(pMemFmt, devNumber)
+}
+
 // Mount mounts the pmem device at `/dev/pmem<device>` to `target` in a basic scenario.
 // If either mappingInfo or verityInfo are non-nil, the device-mapper framework is used
 // to create linear and verity targets accordingly. If both are non-nil, the linear
@@ -84,7 +89,7 @@ func Mount(
 		trace.Int64Attribute("deviceNumber", int64(device)),
 		trace.StringAttribute("target", target))
 
-	devicePath := fmt.Sprintf(pMemFmt, device)
+	devicePath := GetDevicePath(device)
 
 	// dm-linear target has to be created first. When verity info is also present, the linear target becomes the data
 	// device instead of the original VPMem.

--- a/internal/guest/storage/scsi/scsi.go
+++ b/internal/guest/storage/scsi/scsi.go
@@ -167,12 +167,8 @@ func Mount(
 	}
 
 	if readonly {
-		var deviceHash string
 		if config.VerityInfo != nil {
-			deviceHash = config.VerityInfo.RootDigest
-		}
-
-		if config.VerityInfo != nil {
+			deviceHash := config.VerityInfo.RootDigest
 			dmVerityName := fmt.Sprintf(verityDeviceFmt, controller, lun, partition, deviceHash)
 			if source, err = createVerityTarget(spnCtx, source, dmVerityName, config.VerityInfo); err != nil {
 				return err

--- a/internal/layers/layers.go
+++ b/internal/layers/layers.go
@@ -27,12 +27,11 @@ import (
 )
 
 type LCOWLayer struct {
-	VHDPath         string
-	Partition       uint64
-	GuestReadVerity bool
+	VHDPath   string
+	Partition uint64
 }
 
-// Defines a set of LCOW layers.
+// LCOWLayers defines a set of LCOW layers.
 // For future extensibility, the LCOWLayer type could be swapped for an interface,
 // and we could either call some method on the interface to "apply" it directly to the UVM,
 // or type cast it to the various types that we support, and use the one it matches.
@@ -427,9 +426,8 @@ func addLCOWLayer(ctx context.Context, vm *uvm.UtilityVM, layer *LCOWLayer) (uvm
 		true,
 		"",
 		&scsi.MountConfig{
-			Partition:       layer.Partition,
-			Options:         []string{"ro"},
-			GuestReadVerity: layer.GuestReadVerity,
+			Partition: layer.Partition,
+			Options:   []string{"ro"},
 		},
 	)
 	if err != nil {

--- a/internal/protocol/guestresource/resources.go
+++ b/internal/protocol/guestresource/resources.go
@@ -88,6 +88,7 @@ type LCOWMappedVirtualDisk struct {
 	VerityInfo       *DeviceVerityInfo `json:"VerityInfo,omitempty"`
 	EnsureFilesystem bool              `json:"EnsureFilesystem,omitempty"`
 	Filesystem       string            `json:"Filesystem,omitempty"`
+	GuestReadVerity  bool              `json:"GuestReadVerity,omitempty"`
 }
 
 type WCOWMappedVirtualDisk struct {

--- a/internal/protocol/guestresource/resources.go
+++ b/internal/protocol/guestresource/resources.go
@@ -78,17 +78,17 @@ type SCSIDevice struct {
 // LCOWMappedVirtualDisk represents a disk on the host which is mapped into a
 // directory in the guest in the V2 schema.
 type LCOWMappedVirtualDisk struct {
-	MountPath        string            `json:"MountPath,omitempty"`
-	Lun              uint8             `json:"Lun,omitempty"`
-	Controller       uint8             `json:"Controller,omitempty"`
-	Partition        uint64            `json:"Partition,omitempty"`
-	ReadOnly         bool              `json:"ReadOnly,omitempty"`
-	Encrypted        bool              `json:"Encrypted,omitempty"`
-	Options          []string          `json:"Options,omitempty"`
+	MountPath  string   `json:"MountPath,omitempty"`
+	Lun        uint8    `json:"Lun,omitempty"`
+	Controller uint8    `json:"Controller,omitempty"`
+	Partition  uint64   `json:"Partition,omitempty"`
+	ReadOnly   bool     `json:"ReadOnly,omitempty"`
+	Encrypted  bool     `json:"Encrypted,omitempty"`
+	Options    []string `json:"Options,omitempty"`
+	// Deprecated: verity info is read by the guest
 	VerityInfo       *DeviceVerityInfo `json:"VerityInfo,omitempty"`
 	EnsureFilesystem bool              `json:"EnsureFilesystem,omitempty"`
 	Filesystem       string            `json:"Filesystem,omitempty"`
-	GuestReadVerity  bool              `json:"GuestReadVerity,omitempty"`
 }
 
 type WCOWMappedVirtualDisk struct {
@@ -113,6 +113,8 @@ type LCOWVPMemMappingInfo struct {
 
 // DeviceVerityInfo represents dm-verity metadata of a block device.
 // Most of the fields can be directly mapped to table entries https://www.kernel.org/doc/html/latest/admin-guide/device-mapper/verity.html
+// Deprecated: verity info is now read inside the guest and this message will be
+// removed.
 type DeviceVerityInfo struct {
 	// Ext4SizeInBytes is the size of ext4 file system
 	Ext4SizeInBytes int64 `json:",omitempty"`
@@ -137,6 +139,7 @@ type LCOWMappedVPMemDevice struct {
 	// MappingInfo is used when multiple devices are mapped onto a single VPMem device
 	MappingInfo *LCOWVPMemMappingInfo `json:"MappingInfo,omitempty"`
 	// VerityInfo is used when the VPMem has read-only integrity protection enabled
+	// Deprecated: verity info is now read inside the guest.
 	VerityInfo *DeviceVerityInfo `json:"VerityInfo,omitempty"`
 }
 

--- a/internal/uvm/scsi/backend.go
+++ b/internal/uvm/scsi/backend.go
@@ -174,7 +174,7 @@ func mountRequest(controller, lun uint, path string, config *mountConfig, osType
 		if controller != 0 {
 			return guestrequest.ModificationRequest{}, errors.New("WCOW only supports SCSI controller 0")
 		}
-		if config.encrypted || config.verity != nil || len(config.options) != 0 ||
+		if config.encrypted || len(config.options) != 0 ||
 			config.ensureFilesystem || config.filesystem != "" || config.partition != 0 {
 			return guestrequest.ModificationRequest{},
 				errors.New("WCOW does not support encrypted, verity, guest options, partitions, specifying mount filesystem, or ensuring filesystem on mounts")
@@ -192,10 +192,8 @@ func mountRequest(controller, lun uint, path string, config *mountConfig, osType
 			ReadOnly:         config.readOnly,
 			Encrypted:        config.encrypted,
 			Options:          config.options,
-			VerityInfo:       config.verity,
 			EnsureFilesystem: config.ensureFilesystem,
 			Filesystem:       config.filesystem,
-			GuestReadVerity:  config.guestReadVerity,
 		}
 	default:
 		return guestrequest.ModificationRequest{}, fmt.Errorf("unsupported os type: %s", osType)
@@ -216,12 +214,10 @@ func unmountRequest(controller, lun uint, path string, config *mountConfig, osTy
 		}
 	case "linux":
 		req.Settings = guestresource.LCOWMappedVirtualDisk{
-			MountPath:       path,
-			Lun:             uint8(lun),
-			Partition:       config.partition,
-			Controller:      uint8(controller),
-			VerityInfo:      config.verity,
-			GuestReadVerity: config.guestReadVerity,
+			MountPath:  path,
+			Lun:        uint8(lun),
+			Partition:  config.partition,
+			Controller: uint8(controller),
 		}
 	default:
 		return guestrequest.ModificationRequest{}, fmt.Errorf("unsupported os type: %s", osType)

--- a/internal/uvm/scsi/backend.go
+++ b/internal/uvm/scsi/backend.go
@@ -175,7 +175,7 @@ func mountRequest(controller, lun uint, path string, config *mountConfig, osType
 			return guestrequest.ModificationRequest{}, errors.New("WCOW only supports SCSI controller 0")
 		}
 		if config.encrypted || config.verity != nil || len(config.options) != 0 ||
-			config.ensureFileystem || config.filesystem != "" || config.partition != 0 {
+			config.ensureFilesystem || config.filesystem != "" || config.partition != 0 {
 			return guestrequest.ModificationRequest{},
 				errors.New("WCOW does not support encrypted, verity, guest options, partitions, specifying mount filesystem, or ensuring filesystem on mounts")
 		}
@@ -193,8 +193,9 @@ func mountRequest(controller, lun uint, path string, config *mountConfig, osType
 			Encrypted:        config.encrypted,
 			Options:          config.options,
 			VerityInfo:       config.verity,
-			EnsureFilesystem: config.ensureFileystem,
+			EnsureFilesystem: config.ensureFilesystem,
 			Filesystem:       config.filesystem,
+			GuestReadVerity:  config.guestReadVerity,
 		}
 	default:
 		return guestrequest.ModificationRequest{}, fmt.Errorf("unsupported os type: %s", osType)
@@ -215,11 +216,12 @@ func unmountRequest(controller, lun uint, path string, config *mountConfig, osTy
 		}
 	case "linux":
 		req.Settings = guestresource.LCOWMappedVirtualDisk{
-			MountPath:  path,
-			Lun:        uint8(lun),
-			Partition:  config.partition,
-			Controller: uint8(controller),
-			VerityInfo: config.verity,
+			MountPath:       path,
+			Lun:             uint8(lun),
+			Partition:       config.partition,
+			Controller:      uint8(controller),
+			VerityInfo:      config.verity,
+			GuestReadVerity: config.guestReadVerity,
 		}
 	default:
 		return guestrequest.ModificationRequest{}, fmt.Errorf("unsupported os type: %s", osType)

--- a/internal/uvm/scsi/manager.go
+++ b/internal/uvm/scsi/manager.go
@@ -80,11 +80,14 @@ type MountConfig struct {
 	// EnsureFilesystem indicates to format the mount as `Filesystem`
 	// if it is not already formatted with that fs type.
 	// This is only supported for LCOW.
-	EnsureFileystem bool
+	EnsureFilesystem bool
 	// Filesystem is the target filesystem that a device will be
 	// mounted as.
 	// This is only supported for LCOW.
 	Filesystem string
+	// GuestReadVerity indicates if the guest uVM should attempt to read verity
+	// info from mounted device.
+	GuestReadVerity bool
 }
 
 // Mount represents a SCSI device that has been attached to a VM, and potentially
@@ -152,14 +155,19 @@ func (m *Manager) AddVirtualDisk(
 	}
 	var mcInternal *mountConfig
 	if mc != nil {
+		var dmverity *guestresource.DeviceVerityInfo
+		if !mc.GuestReadVerity {
+			dmverity = readVerityInfo(ctx, hostPath)
+		}
 		mcInternal = &mountConfig{
-			partition:       mc.Partition,
-			readOnly:        readOnly,
-			encrypted:       mc.Encrypted,
-			options:         mc.Options,
-			verity:          readVerityInfo(ctx, hostPath),
-			ensureFileystem: mc.EnsureFileystem,
-			filesystem:      mc.Filesystem,
+			partition:        mc.Partition,
+			readOnly:         readOnly,
+			encrypted:        mc.Encrypted,
+			options:          mc.Options,
+			verity:           dmverity,
+			ensureFilesystem: mc.EnsureFilesystem,
+			filesystem:       mc.Filesystem,
+			guestReadVerity:  mc.GuestReadVerity,
 		}
 	}
 	return m.add(ctx,
@@ -198,14 +206,19 @@ func (m *Manager) AddPhysicalDisk(
 	}
 	var mcInternal *mountConfig
 	if mc != nil {
+		var dmverity *guestresource.DeviceVerityInfo
+		if !mc.GuestReadVerity {
+			dmverity = readVerityInfo(ctx, hostPath)
+		}
 		mcInternal = &mountConfig{
-			partition:       mc.Partition,
-			readOnly:        readOnly,
-			encrypted:       mc.Encrypted,
-			options:         mc.Options,
-			verity:          readVerityInfo(ctx, hostPath),
-			ensureFileystem: mc.EnsureFileystem,
-			filesystem:      mc.Filesystem,
+			partition:        mc.Partition,
+			readOnly:         readOnly,
+			encrypted:        mc.Encrypted,
+			options:          mc.Options,
+			verity:           dmverity,
+			ensureFilesystem: mc.EnsureFilesystem,
+			filesystem:       mc.Filesystem,
+			guestReadVerity:  mc.GuestReadVerity,
 		}
 	}
 	return m.add(ctx,
@@ -244,12 +257,13 @@ func (m *Manager) AddExtensibleVirtualDisk(
 	var mcInternal *mountConfig
 	if mc != nil {
 		mcInternal = &mountConfig{
-			partition:       mc.Partition,
-			readOnly:        readOnly,
-			encrypted:       mc.Encrypted,
-			options:         mc.Options,
-			ensureFileystem: mc.EnsureFileystem,
-			filesystem:      mc.Filesystem,
+			partition:        mc.Partition,
+			readOnly:         readOnly,
+			encrypted:        mc.Encrypted,
+			options:          mc.Options,
+			ensureFilesystem: mc.EnsureFilesystem,
+			filesystem:       mc.Filesystem,
+			guestReadVerity:  mc.GuestReadVerity,
 		}
 	}
 	return m.add(ctx,

--- a/internal/uvm/scsi/mount.go
+++ b/internal/uvm/scsi/mount.go
@@ -38,13 +38,14 @@ type mount struct {
 }
 
 type mountConfig struct {
-	partition       uint64
-	readOnly        bool
-	encrypted       bool
-	verity          *guestresource.DeviceVerityInfo
-	options         []string
-	ensureFileystem bool
-	filesystem      string
+	partition        uint64
+	readOnly         bool
+	encrypted        bool
+	verity           *guestresource.DeviceVerityInfo
+	options          []string
+	ensureFilesystem bool
+	filesystem       string
+	guestReadVerity  bool
 }
 
 func (mm *mountManager) mount(ctx context.Context, controller, lun uint, c *mountConfig) (_ string, err error) {

--- a/internal/uvm/scsi/mount.go
+++ b/internal/uvm/scsi/mount.go
@@ -6,8 +6,6 @@ import (
 	"reflect"
 	"sort"
 	"sync"
-
-	"github.com/Microsoft/hcsshim/internal/protocol/guestresource"
 )
 
 type mountManager struct {
@@ -41,11 +39,9 @@ type mountConfig struct {
 	partition        uint64
 	readOnly         bool
 	encrypted        bool
-	verity           *guestresource.DeviceVerityInfo
 	options          []string
 	ensureFilesystem bool
 	filesystem       string
-	guestReadVerity  bool
 }
 
 func (mm *mountManager) mount(ctx context.Context, controller, lun uint, c *mountConfig) (_ string, err error) {

--- a/internal/uvm/vpmem_mapped.go
+++ b/internal/uvm/vpmem_mapped.go
@@ -16,7 +16,6 @@ import (
 	"github.com/Microsoft/hcsshim/internal/memory"
 	"github.com/Microsoft/hcsshim/internal/protocol/guestrequest"
 	"github.com/Microsoft/hcsshim/internal/protocol/guestresource"
-	"github.com/Microsoft/hcsshim/internal/verity"
 )
 
 const (
@@ -83,16 +82,6 @@ func newMappedVPMemModifyRequest(
 			DeviceOffsetInBytes: md.mappedRegion.Offset(),
 			DeviceSizeInBytes:   md.sizeInBytes,
 		},
-	}
-
-	if verity, err := verity.ReadVeritySuperBlock(ctx, md.hostPath); err != nil {
-		log.G(ctx).WithError(err).WithField("hostPath", md.hostPath).Debug("unable to read dm-verity information from VHD")
-	} else {
-		log.G(ctx).WithFields(logrus.Fields{
-			"hostPath":   md.hostPath,
-			"rootDigest": verity.RootDigest,
-		}).Debug("adding multi-mapped VPMem with dm-verity")
-		guestSettings.VerityInfo = verity
 	}
 
 	request := &hcsschema.ModifySettingRequest{

--- a/pkg/annotations/annotations.go
+++ b/pkg/annotations/annotations.go
@@ -293,9 +293,6 @@ const (
 	// DumpDirectoryPath provides a path to the directory in which dumps for a UVM will be collected in
 	// case the UVM crashes.
 	DumpDirectoryPath = "io.microsoft.virtualmachine.dump-directory-path"
-
-	// GuestReadVerity tells the guest uVM to read verity info from mounted device.
-	GuestReadVerity = "io.microsoft.virtualmachine.lcow.guest-read-verity"
 )
 
 // AnnotationExpansions maps annotations that will be expanded into an array of

--- a/pkg/annotations/annotations.go
+++ b/pkg/annotations/annotations.go
@@ -126,7 +126,7 @@ const (
 	// MemoryHighMMIOBaseInMB indicates the high MMIO base in MB
 	MemoryHighMMIOBaseInMB = "io.microsoft.virtualmachine.computetopology.memory.highmmiobaseinmb"
 
-	// MemoryHighMMIOBaseInMB indicates the high MMIO gap in MB
+	// MemoryHighMMIOGapInMB indicates the high MMIO gap in MB
 	MemoryHighMMIOGapInMB = "io.microsoft.virtualmachine.computetopology.memory.highmmiogapinmb"
 
 	// ProcessorCount overrides the hypervisor isolated vCPU count set
@@ -293,6 +293,9 @@ const (
 	// DumpDirectoryPath provides a path to the directory in which dumps for a UVM will be collected in
 	// case the UVM crashes.
 	DumpDirectoryPath = "io.microsoft.virtualmachine.dump-directory-path"
+
+	// GuestReadVerity tells the guest uVM to read verity info from mounted device.
+	GuestReadVerity = "io.microsoft.virtualmachine.lcow.guest-read-verity"
 )
 
 // AnnotationExpansions maps annotations that will be expanded into an array of


### PR DESCRIPTION
Add an option to mount partitioned disks with dmverity.

Additionally add support for reading verity information from within the guest.
The expectation is that verity hash device is appended to the read-only file system.
The functionality is enabled by default.

Host no longer reads verity superblock and as a result
the `DeviceVerityInfo` protocol message is being
deprecated. The guest will always attempt to read verity
super-block when non-empty security policy is passed.
Security policy is expected to be empty only in regular
LCOW scenarios.
