### PR TITLE
Fix mountSCSI failure in uvmboot

### DIFF
--- a/internal/tools/uvmboot/mounts.go
+++ b/internal/tools/uvmboot/mounts.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/Microsoft/hcsshim/internal/uvm"
-	"github.com/Microsoft/hcsshim/internal/uvm/scsi"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 )
@@ -23,7 +22,7 @@ func mountSCSI(ctx context.Context, c *cli.Context, vm *uvm.UtilityVM) error {
 			m.host,
 			!m.writable,
 			vm.ID(),
-			&scsi.MountConfig{},
+			nil,
 		)
 		if err != nil {
 			return fmt.Errorf("could not mount disk %s: %w", m.host, err)


### PR DESCRIPTION
This pull request fixes an issue with the mount logic inside the `mountSCSI` function of uvmboot, which is called when attaching SCSI disks to the guest.

Passing an empty `MountConfig` to `AddVirtualDisk` causes an error on the add operation inside the guest. As specified in the `AddVirtualDisk` documentation, `nil` should be passed instead to signify that no mount operation should be performed. 

Currently, the guest mount operation is disallowed in `mountSCSI`, so it is not necessary to create a `MountConfig` to pass to `AddVirtualDisk` in that case.