### PR TITLE
cimfs: Add Offline registry API wrappers and export constants

### DIFF
--- a/computestorage/helpers.go
+++ b/computestorage/helpers.go
@@ -16,7 +16,9 @@ import (
 	"github.com/Microsoft/hcsshim/internal/security"
 )
 
-const defaultVHDXBlockSizeInMB = 1
+const (
+	defaultVHDXBlockSizeInMB = 1
+)
 
 // SetupContainerBaseLayer is a helper to setup a containers scratch. It
 // will create and format the vhdx's inside and the size is configurable with the sizeInGB

--- a/internal/wclayer/baselayerreader.go
+++ b/internal/wclayer/baselayerreader.go
@@ -72,8 +72,8 @@ func (r *baseLayerReader) walkUntilCancelled() error {
 		return err
 	}
 
-	utilityVMAbsPath := filepath.Join(r.root, utilityVMPath)
-	utilityVMFilesAbsPath := filepath.Join(r.root, utilityVMFilesPath)
+	utilityVMAbsPath := filepath.Join(r.root, UtilityVMPath)
+	utilityVMFilesAbsPath := filepath.Join(r.root, UtilityVMFilesPath)
 
 	// Ignore a UtilityVM without Files, that's not _really_ a UtiltyVM
 	if _, err = os.Lstat(utilityVMFilesAbsPath); err != nil {

--- a/internal/wclayer/converttobaselayer.go
+++ b/internal/wclayer/converttobaselayer.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"syscall"
 
 	"github.com/Microsoft/hcsshim/internal/hcserror"
 	"github.com/Microsoft/hcsshim/internal/longpath"
@@ -37,7 +36,7 @@ func ensureHive(path string, root *os.File) (err error) {
 		return fmt.Errorf("getting path: %w", err)
 	}
 
-	var key syscall.Handle
+	var key winapi.ORHKey
 	err = winapi.ORCreateHive(&key)
 	if err != nil {
 		return fmt.Errorf("creating hive: %w", err)
@@ -72,7 +71,7 @@ func ensureBaseLayer(root *os.File) (hasUtilityVM bool, err error) {
 		}
 	}
 
-	stat, err := safefile.LstatRelative(utilityVMFilesPath, root)
+	stat, err := safefile.LstatRelative(UtilityVMFilesPath, root)
 
 	if os.IsNotExist(err) {
 		return false, nil
@@ -83,7 +82,7 @@ func ensureBaseLayer(root *os.File) (hasUtilityVM bool, err error) {
 	}
 
 	if !stat.Mode().IsDir() {
-		fullPath := filepath.Join(root.Name(), utilityVMFilesPath)
+		fullPath := filepath.Join(root.Name(), UtilityVMFilesPath)
 		return false, errors.Errorf("%s has unexpected file mode %s", fullPath, stat.Mode().String())
 	}
 
@@ -92,7 +91,7 @@ func ensureBaseLayer(root *os.File) (hasUtilityVM bool, err error) {
 	// Just check that this exists as a regular file. If it exists but is not a valid registry hive,
 	// ProcessUtilityVMImage will complain:
 	// "The registry could not read in, or write out, or flush, one of the files that contain the system's image of the registry."
-	bcdPath := filepath.Join(utilityVMFilesPath, bcdRelativePath)
+	bcdPath := filepath.Join(UtilityVMFilesPath, bcdRelativePath)
 
 	stat, err = safefile.LstatRelative(bcdPath, root)
 	if err != nil {
@@ -122,12 +121,12 @@ func convertToBaseLayer(ctx context.Context, root *os.File) error {
 		return nil
 	}
 
-	err = safefile.EnsureNotReparsePointRelative(utilityVMPath, root)
+	err = safefile.EnsureNotReparsePointRelative(UtilityVMPath, root)
 	if err != nil {
 		return err
 	}
 
-	utilityVMPath := filepath.Join(root.Name(), utilityVMPath)
+	utilityVMPath := filepath.Join(root.Name(), UtilityVMPath)
 	return ProcessUtilityVMImage(ctx, utilityVMPath)
 }
 

--- a/internal/wclayer/legacy.go
+++ b/internal/wclayer/legacy.go
@@ -29,10 +29,19 @@ var mutatedUtilityVMFiles = map[string]bool{
 }
 
 const (
-	filesPath          = `Files`
-	hivesPath          = `Hives`
-	utilityVMPath      = `UtilityVM`
-	utilityVMFilesPath = `UtilityVM\Files`
+	filesPath           = `Files`
+	HivesPath           = `Hives`
+	UtilityVMPath       = `UtilityVM`
+	UtilityVMFilesPath  = `UtilityVM\Files`
+	RegFilesPath        = `Files\Windows\System32\config`
+	BcdFilePath         = `UtilityVM\Files\EFI\Microsoft\Boot\BCD`
+	BootMgrFilePath     = `UtilityVM\Files\EFI\Microsoft\Boot\bootmgfw.efi`
+	ContainerBaseVhd    = `blank-base.vhdx`
+	ContainerScratchVhd = `blank.vhdx`
+	UtilityVMBaseVhd    = `SystemTemplateBase.vhdx`
+	UtilityVMScratchVhd = `SystemTemplate.vhdx`
+	LayoutFileName      = `layout`
+	UvmBuildFileName    = `uvmbuildversion`
 )
 
 func openFileOrDir(path string, mode uint32, createDisposition uint32) (file *os.File, err error) {
@@ -243,11 +252,11 @@ func (r *legacyLayerReader) Next() (path string, size int64, fileInfo *winio.Fil
 	if !hasPathPrefix(path, filesPath) {
 		size = fe.fi.Size()
 		r.backupReader = winio.NewBackupFileReader(f, false)
-		if path == hivesPath || path == filesPath {
+		if path == HivesPath || path == filesPath {
 			// The Hives directory has a non-deterministic file time because of the
 			// nature of the import process. Use the times from System_Delta.
 			var g *os.File
-			g, err = os.Open(filepath.Join(r.root, hivesPath, `System_Delta`))
+			g, err = os.Open(filepath.Join(r.root, HivesPath, `System_Delta`))
 			if err != nil {
 				return
 			}
@@ -409,7 +418,7 @@ func (w *legacyLayerWriter) CloseRoots() {
 
 func (w *legacyLayerWriter) initUtilityVM() error {
 	if !w.HasUtilityVM {
-		err := safefile.MkdirRelative(utilityVMPath, w.destRoot)
+		err := safefile.MkdirRelative(UtilityVMPath, w.destRoot)
 		if err != nil {
 			return err
 		}
@@ -417,7 +426,7 @@ func (w *legacyLayerWriter) initUtilityVM() error {
 		// clone the utility VM from the parent layer into this layer. Use hard
 		// links to avoid unnecessary copying, since most of the files are
 		// immutable.
-		err = cloneTree(w.parentRoots[0], w.destRoot, utilityVMFilesPath, mutatedUtilityVMFiles)
+		err = cloneTree(w.parentRoots[0], w.destRoot, UtilityVMFilesPath, mutatedUtilityVMFiles)
 		if err != nil {
 			return fmt.Errorf("cloning the parent utility VM image failed: %s", err)
 		}
@@ -592,7 +601,7 @@ func (w *legacyLayerWriter) Add(name string, fileInfo *winio.FileBasicInfo) erro
 		return err
 	}
 
-	if name == utilityVMPath {
+	if name == UtilityVMPath {
 		return w.initUtilityVM()
 	}
 
@@ -601,11 +610,11 @@ func (w *legacyLayerWriter) Add(name string, fileInfo *winio.FileBasicInfo) erro
 	}
 
 	name = filepath.Clean(name)
-	if hasPathPrefix(name, utilityVMPath) {
+	if hasPathPrefix(name, UtilityVMPath) {
 		if !w.HasUtilityVM {
 			return errors.New("missing UtilityVM directory")
 		}
-		if !hasPathPrefix(name, utilityVMFilesPath) && name != utilityVMFilesPath {
+		if !hasPathPrefix(name, UtilityVMFilesPath) && name != UtilityVMFilesPath {
 			return errors.New("invalid UtilityVM layer")
 		}
 		createDisposition := uint32(winapi.FILE_OPEN)
@@ -699,7 +708,7 @@ func (w *legacyLayerWriter) Add(name string, fileInfo *winio.FileBasicInfo) erro
 		return err
 	}
 
-	if hasPathPrefix(name, hivesPath) {
+	if hasPathPrefix(name, HivesPath) {
 		w.backupWriter = winio.NewBackupFileWriter(f, false)
 		w.bufWriter.Reset(w.backupWriter)
 	} else {
@@ -731,14 +740,14 @@ func (w *legacyLayerWriter) AddLink(name string, target string) error {
 		// Look for cross-layer hard link targets in the parent layers, since
 		// nothing is in the destination path yet.
 		roots = w.parentRoots
-	} else if hasPathPrefix(target, utilityVMFilesPath) {
+	} else if hasPathPrefix(target, UtilityVMFilesPath) {
 		// Since the utility VM is fully cloned into the destination path
 		// already, look for cross-layer hard link targets directly in the
 		// destination path.
 		roots = []*os.File{w.destRoot}
 	}
 
-	if roots == nil || (!hasPathPrefix(name, filesPath) && !hasPathPrefix(name, utilityVMFilesPath)) {
+	if roots == nil || (!hasPathPrefix(name, filesPath) && !hasPathPrefix(name, UtilityVMFilesPath)) {
 		return errors.New("invalid hard link in layer")
 	}
 
@@ -777,7 +786,7 @@ func (w *legacyLayerWriter) Remove(name string) error {
 	name = filepath.Clean(name)
 	if hasPathPrefix(name, filesPath) {
 		w.Tombstones = append(w.Tombstones, name)
-	} else if hasPathPrefix(name, utilityVMFilesPath) {
+	} else if hasPathPrefix(name, UtilityVMFilesPath) {
 		err := w.initUtilityVM()
 		if err != nil {
 			return err

--- a/internal/winapi/offlinereg.go
+++ b/internal/winapi/offlinereg.go
@@ -1,0 +1,37 @@
+package winapi
+
+// Offline registry management API
+
+type ORHKey uintptr
+
+type RegType uint32
+
+const (
+	// Registry value types: https://docs.microsoft.com/en-us/windows/win32/sysinfo/registry-value-types
+	REG_TYPE_NONE                       RegType = 0
+	REG_TYPE_SZ                         RegType = 1
+	REG_TYPE_EXPAND_SZ                  RegType = 2
+	REG_TYPE_BINARY                     RegType = 3
+	REG_TYPE_DWORD                      RegType = 4
+	REG_TYPE_DWORD_LITTLE_ENDIAN        RegType = 4
+	REG_TYPE_DWORD_BIG_ENDIAN           RegType = 5
+	REG_TYPE_LINK                       RegType = 6
+	REG_TYPE_MULTI_SZ                   RegType = 7
+	REG_TYPE_RESOURCE_LIST              RegType = 8
+	REG_TYPE_FULL_RESOURCE_DESCRIPTOR   RegType = 9
+	REG_TYPE_RESOURCE_REQUIREMENTS_LIST RegType = 10
+	REG_TYPE_QWORD                      RegType = 11
+	REG_TYPE_QWORD_LITTLE_ENDIAN        RegType = 11
+)
+
+//sys ORCreateHive(key *ORHKey) (win32err error) = offreg.ORCreateHive
+//sys ORMergeHives(hiveHandles []ORHKey, result *ORHKey) (win32err error) = offreg.ORMergeHives
+//sys OROpenHive(hivePath string, result *ORHKey) (win32err error) = offreg.OROpenHive
+//sys ORCloseHive(handle ORHKey) (win32err error) = offreg.ORCloseHive
+//sys ORSaveHive(handle ORHKey, hivePath string, osMajorVersion uint32, osMinorVersion uint32) (win32err error) = offreg.ORSaveHive
+//sys OROpenKey(handle ORHKey, subKey string, result *ORHKey) (win32err error) = offreg.OROpenKey
+//sys ORCloseKey(handle ORHKey) (win32err error) = offreg.ORCloseKey
+//sys ORCreateKey(handle ORHKey, subKey string, class uintptr, options uint32, securityDescriptor uintptr, result *ORHKey, disposition *uint32) (win32err error) = offreg.ORCreateKey
+//sys ORDeleteKey(handle ORHKey, subKey string) (win32err error) = offreg.ORDeleteKey
+//sys ORGetValue(handle ORHKey, subKey string, value string, valueType *uint32, data *byte, dataLen *uint32) (win32err error) = offreg.ORGetValue
+//sys ORSetValue(handle ORHKey, valueName string, valueType uint32, data *byte, dataLen uint32) (win32err error) = offreg.ORSetValue

--- a/internal/winapi/ofreg.go
+++ b/internal/winapi/ofreg.go
@@ -1,5 +1,0 @@
-package winapi
-
-//sys ORCreateHive(key *syscall.Handle) (regerrno error) = offreg.ORCreateHive
-//sys ORSaveHive(key syscall.Handle, file string, OsMajorVersion uint32, OsMinorVersion uint32) (regerrno error) = offreg.ORSaveHive
-//sys ORCloseHive(key syscall.Handle) (regerrno error) = offreg.ORCloseHive

--- a/pkg/cimfs/cimfs.go
+++ b/pkg/cimfs/cimfs.go
@@ -13,5 +13,5 @@ func IsCimFsSupported() bool {
 	if err != nil {
 		logrus.WithError(err).Warn("get build revision")
 	}
-	return osversion.Get().Version == 20348 && rv >= 1700
+	return osversion.Build() == 20348 && rv >= 1700
 }

--- a/pkg/ociwclayer/export.go
+++ b/pkg/ociwclayer/export.go
@@ -71,7 +71,7 @@ func writeTarFromLayer(ctx context.Context, r wclayer.LayerReader, w io.Writer) 
 		if fileInfo == nil {
 			// Write a whiteout file.
 			hdr := &tar.Header{
-				Name: filepath.ToSlash(filepath.Join(filepath.Dir(name), whiteoutPrefix+filepath.Base(name))),
+				Name: filepath.ToSlash(filepath.Join(filepath.Dir(name), WhiteoutPrefix+filepath.Base(name))),
 			}
 			err := t.WriteHeader(hdr)
 			if err != nil {

--- a/pkg/ociwclayer/import.go
+++ b/pkg/ociwclayer/import.go
@@ -17,7 +17,7 @@ import (
 	"github.com/Microsoft/hcsshim/internal/wclayer"
 )
 
-const whiteoutPrefix = ".wh."
+const WhiteoutPrefix = ".wh."
 
 var (
 	// mutatedFiles is a list of files that are mutated by the import process
@@ -71,8 +71,8 @@ func writeLayerFromTar(ctx context.Context, r io.Reader, w wclayer.LayerWriter, 
 		}
 
 		base := path.Base(hdr.Name)
-		if strings.HasPrefix(base, whiteoutPrefix) {
-			name := path.Join(path.Dir(hdr.Name), base[len(whiteoutPrefix):])
+		if strings.HasPrefix(base, WhiteoutPrefix) {
+			name := path.Join(path.Dir(hdr.Name), base[len(WhiteoutPrefix):])
 			err = w.Remove(filepath.FromSlash(name))
 			if err != nil {
 				return 0, err


### PR DESCRIPTION
offline registry API is required during CimFS layer import. This commit adds Go wrappers around it.  It also exports some constants from the wclayer package so that those constants can be used by the cim layer package