### PR TITLE
use protojson when formatting for logs

### DIFF
--- a/internal/log/format.go
+++ b/internal/log/format.go
@@ -4,12 +4,13 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"fmt"
 	"net"
 	"reflect"
 	"time"
 
 	"github.com/containerd/containerd/log"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
 )
 
 const TimeFormat = log.RFC3339NanoFixed
@@ -67,16 +68,22 @@ func Format(ctx context.Context, v interface{}) string {
 }
 
 func encode(v interface{}) ([]byte, error) {
-	return encodeBuffer(&bytes.Buffer{}, v)
-}
+	if m, ok := v.(proto.Message); ok {
+		// use canonical JSON encoding for protobufs (instead of [encoding/json])
+		// https://protobuf.dev/programming-guides/proto3/#json
+		return protojson.MarshalOptions{
+			AllowPartial: true,
+			// protobuf defaults to camel case for JSON encoding; use proto field name instead (snake case)
+			UseProtoNames: true,
+		}.Marshal(m)
+	}
 
-func encodeBuffer(buf *bytes.Buffer, v interface{}) ([]byte, error) {
+	buf := &bytes.Buffer{}
 	enc := json.NewEncoder(buf)
 	enc.SetEscapeHTML(false)
 	enc.SetIndent("", "")
 
 	if err := enc.Encode(v); err != nil {
-		err = fmt.Errorf("could not marshall %T to JSON for logging: %w", v, err)
 		return nil, err
 	}
 

--- a/internal/log/scrub.go
+++ b/internal/log/scrub.go
@@ -55,7 +55,7 @@ func ScrubProcessParameters(s string) (string, error) {
 	}
 	pp.Environment = map[string]string{_scrubbedReplacement: _scrubbedReplacement}
 
-	b, err := encodeBuffer(bytes.NewBuffer(b[:0]), pp)
+	b, err := encode(pp)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
use `google.golang.org/protobuf/encoding/protojson` when encoding protobuf structs in logs.
the biggest difference will be enums being encoded by their string name instead of numerical value