### PR TITLE
Use RtlGetVersion instead of GetVersion

### DIFF
--- a/osversion/osversion_windows.go
+++ b/osversion/osversion_windows.go
@@ -26,16 +26,15 @@ var (
 // The calling application must be manifested to get the correct version information.
 func Get() OSVersion {
 	once.Do(func() {
-		var err error
+		v := *windows.RtlGetVersion()
 		osv = OSVersion{}
-		osv.Version, err = windows.GetVersion()
-		if err != nil {
-			// GetVersion never fails.
-			panic(err)
-		}
-		osv.MajorVersion = uint8(osv.Version & 0xFF)
-		osv.MinorVersion = uint8(osv.Version >> 8 & 0xFF)
-		osv.Build = uint16(osv.Version >> 16)
+		osv.MajorVersion = uint8(v.MajorVersion)
+		osv.MinorVersion = uint8(v.MinorVersion)
+		osv.Build = uint16(v.BuildNumber)
+		// Fill version value so that existing clients don't break
+		osv.Version = v.BuildNumber << 16
+		osv.Version = osv.Version | (uint32(v.MinorVersion) << 8)
+		osv.Version = osv.Version | v.MajorVersion
 	})
 	return osv
 }


### PR DESCRIPTION
GetVersion API returns correct OS version values only if the calling binary is manifested.  Hcsshim is manifested. However, other binaries using the osversion package from hcsshim (like containerd) are not manifested and so they are not able to get the accurate OS version information. RtlGetVersion doesn't need the binary to be manifested so this commit replaces the use of GetVersion with RtlGetVersion.

Note that hcsshim is still manifested even if we aren't using GetVersion anymore. This is because there are some other advantages of using a manifest as described here: https://learn.microsoft.com/en-us/windows/win32/w8cookbook/application--executable--manifest. The use of a default thread pool for RPC and the fix for a race condition in GetOverlappedResult are relevant to hcsshim. So in order to keep these behaviors same we want to keep hcsshim binary manifested.