### PR TITLE
disable fail fast on windows tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,6 +230,7 @@ jobs:
     needs: [lint, protos, verify-vendor, go-gen]
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [windows-2019, windows-2022]
     steps:


### PR DESCRIPTION
Prevent cancelling tests if one fails, since its helpful to see all test results