### PR TITLE
Allow setting HclEnabled to false

### DIFF
--- a/internal/hcs/schema2/isolation_settings.go
+++ b/internal/hcs/schema2/isolation_settings.go
@@ -17,5 +17,5 @@ type IsolationSettings struct {
 	DebugPort int64  `json:"DebugPort,omitempty"`
 	// Optional data passed by host on isolated virtual machine start
 	LaunchData string `json:"LaunchData,omitempty"`
-	HclEnabled bool   `json:"HclEnabled,omitempty"`
+	HclEnabled bool   `json:"HclEnabled"`
 }

--- a/internal/hcs/schema2/isolation_settings.go
+++ b/internal/hcs/schema2/isolation_settings.go
@@ -17,5 +17,5 @@ type IsolationSettings struct {
 	DebugPort int64  `json:"DebugPort,omitempty"`
 	// Optional data passed by host on isolated virtual machine start
 	LaunchData string `json:"LaunchData,omitempty"`
-	HclEnabled bool   `json:"HclEnabled"`
+	HclEnabled *bool  `json:"HclEnabled,omitempty"`
 }

--- a/internal/oci/annotations.go
+++ b/internal/oci/annotations.go
@@ -78,6 +78,27 @@ func ParseAnnotationsBool(ctx context.Context, a map[string]string, key string, 
 	return def
 }
 
+// ParseAnnotationsNullableBool searches `a` for `key` and if found verifies that the
+// value is `true` or `false`. If `key` is not found it returns a null pointer.
+// The JSON Marshaller will omit null pointers and will serialise non-null pointers as
+// the value they point at.
+func ParseAnnotationsNullableBool(ctx context.Context, a map[string]string, key string) *bool {
+	if v, ok := a[key]; ok {
+		switch strings.ToLower(v) {
+		case "true":
+			_bool := true
+			return &_bool
+		case "false":
+			_bool := false
+			return &_bool
+		default:
+			err := errors.New("boolean fields must be 'true', 'false', or not set")
+			logAnnotationParseError(ctx, key, v, logfields.Bool, err)
+		}
+	}
+	return nil
+}
+
 // parseAnnotationsUint32 searches `a` for `key` and if found verifies that the
 // value is a 32 bit unsigned integer. If `key` is not found returns `def`.
 func parseAnnotationsUint32(ctx context.Context, a map[string]string, key string, def uint32) uint32 {

--- a/internal/oci/uvm.go
+++ b/internal/oci/uvm.go
@@ -274,8 +274,8 @@ func SpecToUVMCreateOpts(ctx context.Context, s *specs.Spec, id, owner string) (
 
 		// override the default GuestState filename if specified
 		lopts.GuestStateFile = parseAnnotationsString(s.Annotations, annotations.GuestStateFile, lopts.GuestStateFile)
-		// Set HclEnabled if specified, else default to false, this is currently only used in the SNP case.
-		lopts.HclEnabled = ParseAnnotationsBool(ctx, s.Annotations, annotations.HclEnabled, false)
+		// Set HclEnabled if specified. Else default to a null pointer, which is omitted from the resulting JSON.
+		lopts.HclEnabled = ParseAnnotationsNullableBool(ctx, s.Annotations, annotations.HclEnabled)
 		return lopts, nil
 	} else if IsWCOW(s) {
 		wopts := uvm.NewDefaultOptionsWCOW(id, owner)

--- a/internal/oci/uvm.go
+++ b/internal/oci/uvm.go
@@ -274,6 +274,8 @@ func SpecToUVMCreateOpts(ctx context.Context, s *specs.Spec, id, owner string) (
 
 		// override the default GuestState filename if specified
 		lopts.GuestStateFile = parseAnnotationsString(s.Annotations, annotations.GuestStateFile, lopts.GuestStateFile)
+		// Set HclEnabled if specified, else default to false, this is currently only used in the SNP case.
+		lopts.HclEnabled = ParseAnnotationsBool(ctx, s.Annotations, annotations.HclEnabled, false)
 		return lopts, nil
 	} else if IsWCOW(s) {
 		wopts := uvm.NewDefaultOptionsWCOW(id, owner)

--- a/internal/uvm/create_lcow.go
+++ b/internal/uvm/create_lcow.go
@@ -120,6 +120,7 @@ type OptionsLCOW struct {
 	VPCIEnabled             bool                // Whether the kernel should enable pci
 	EnableScratchEncryption bool                // Whether the scratch should be encrypted
 	DisableTimeSyncService  bool                // Disables the time synchronization service
+	HclEnabled              bool                // Whether to enable the host compatibility layer
 }
 
 // defaultLCOWOSBootFilesPath returns the default path used to locate the LCOW
@@ -280,7 +281,8 @@ Example JSON document produced once the hcsschema.ComputeSytem returned by makeL
         "SecuritySettings": {
             "Isolation": {
                 "IsolationType": "SecureNestedPaging",
-                "LaunchData": "kBifgKNijdHjxdSUshmavrNofo2B01LiIi1cr8R4ytI="
+                "LaunchData": "kBifgKNijdHjxdSUshmavrNofo2B01LiIi1cr8R4ytI=",
+				"HclEnabled": false
             }
         },
         "Version": {
@@ -460,6 +462,7 @@ func makeLCOWSecurityDoc(ctx context.Context, opts *OptionsLCOW, uvm *UtilityVM)
 			IsolationType: "SecureNestedPaging",
 			LaunchData:    hostData,
 			// HclEnabled:    true, /* Not available in schema 2.5 - REQUIRED when using BlockStorage in 2.6 */
+			HclEnabled: opts.HclEnabled,
 		},
 	}
 

--- a/internal/uvm/create_lcow.go
+++ b/internal/uvm/create_lcow.go
@@ -120,7 +120,7 @@ type OptionsLCOW struct {
 	VPCIEnabled             bool                // Whether the kernel should enable pci
 	EnableScratchEncryption bool                // Whether the scratch should be encrypted
 	DisableTimeSyncService  bool                // Disables the time synchronization service
-	HclEnabled              bool                // Whether to enable the host compatibility layer
+	HclEnabled              *bool               // Whether to enable the host compatibility layer
 }
 
 // defaultLCOWOSBootFilesPath returns the default path used to locate the LCOW

--- a/pkg/annotations/annotations.go
+++ b/pkg/annotations/annotations.go
@@ -223,6 +223,9 @@ const (
 	// This allows for better fallback mechanics.
 	SecurityPolicyEnforcer = "io.microsoft.virtualmachine.lcow.enforcer"
 
+	// HclEnabled specifies whether to enable the host compatibility layer.
+	HclEnabled = "io.microsoft.virtualmachine.lcow.hcl-enabled"
+
 	// ContainerProcessDumpLocation specifies a path inside of containers to save process dumps to. As
 	// the scratch space for a container is generally cleaned up after exit, this is best set to a volume mount of
 	// some kind (vhd, bind mount, fileshare mount etc.)


### PR DESCRIPTION
This PR:
- changes the `HclEnabled` field's type from a boolean to pointer to a boolean.  
- plumbs in a new annotation `io.microsoft.virtualmachine.lcow.hcl-enabled` which can be used to set the value of `HclEnabled`.
    - If the annotation is not set then the `HclEnabled` field in omitted (as it is currently)

First, currently the JSON Marshaller is set to `omitempty` on the `HclEnabled` field. This means that the field is omitted if it is regarded as empty, and `false` is regarded as empty. See https://pkg.go.dev/encoding/json#Marshal. (This prevents deployment in scenarios where we need to set `HclEnabled` to `false`.) However a pointer to boolean with value `false` is not regarded as empty, while an empty pointer is. 

Second, there is no way to choose the value of `HclEnabled` prior to this annotation.