### PR TITLE
Add support for Task Update MappedPipe operation

### DIFF
--- a/cmd/container-pipe/main.go
+++ b/cmd/container-pipe/main.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/Microsoft/hcsshim/internal/hcs"
+	"github.com/Microsoft/hcsshim/internal/hcs/resourcepaths"
+	hcsschema "github.com/Microsoft/hcsshim/internal/hcs/schema2"
+	"github.com/Microsoft/hcsshim/internal/protocol/guestrequest"
+)
+
+func main() {
+	isAdd := flag.Bool("add", true, "Add or remove the pipe operation")
+	containerIdFlag := flag.String("container-id", "", "The id of the container to map the bind to")
+	hostPipePathFlag := flag.String("host-pipe-path", "", "The host '\\\\.\\pipe' path to map to the container")
+	containerPipePathFlag := flag.String("container-pipe-path", "", "The container '\\\\.\\pipe' path to map the host path to inside the container namespace")
+	flag.Parse()
+
+	ctx := context.Background()
+	var err error
+	if *isAdd {
+		err = addPipe(ctx, *containerIdFlag, *hostPipePathFlag, *containerPipePathFlag)
+	} else {
+		err = removePipe(ctx, *containerIdFlag, *containerPipePathFlag)
+	}
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+}
+
+func addPipe(ctx context.Context, cid, hpp, cpp string) error {
+	err := doWork(ctx, true, cid, hpp, cpp)
+	if err != nil {
+		return fmt.Errorf("failed to map pipe: %w", err)
+	}
+	fmt.Println("successfully mapped pipe")
+	return nil
+}
+
+func removePipe(ctx context.Context, cid, cpp string) error {
+	err := doWork(ctx, false, cid, "", cpp)
+	if err != nil {
+		return fmt.Errorf("failed to unmap pipe: %w", err)
+	}
+	fmt.Println("successfully unmapped pipe")
+	return nil
+}
+
+func doWork(ctx context.Context, add bool, cid, hpp, cpp string) error {
+	c, err := hcs.OpenComputeSystem(ctx, cid)
+	if err != nil {
+		return fmt.Errorf("failed to open container handle: %w", err)
+	}
+	// CPP Fails to map if it contains the pipe prefix. So always remove before modify.
+	cpp = strings.TrimPrefix(cpp, `\\.\pipe\`)
+
+	set := &hcsschema.MappedPipe{
+		ContainerPipeName: cpp,
+	}
+	req := &hcsschema.ModifySettingRequest{
+		ResourcePath: resourcepaths.SiloMappedPipeResourcePath,
+		Settings:     set,
+	}
+	if add {
+		set.HostPath = hpp
+	} else {
+		req.RequestType = guestrequest.RequestTypeRemove
+	}
+	err = c.Modify(ctx, req)
+	if err != nil {
+		return fmt.Errorf("failed to modify container resoources: %w", err)
+	}
+	return nil
+}

--- a/cmd/containerd-shim-runhcs-v1/task.go
+++ b/cmd/containerd-shim-runhcs-v1/task.go
@@ -110,6 +110,7 @@ func verifyTaskUpdateResourcesType(data interface{}) error {
 	case *specs.WindowsResources:
 	case *specs.LinuxResources:
 	case *ctrdtaskapi.PolicyFragment:
+	case *ctrdtaskapi.MappedPipe:
 	default:
 		return errNotSupportedResourcesRequest
 	}

--- a/pkg/ctrdtaskapi/update.go
+++ b/pkg/ctrdtaskapi/update.go
@@ -6,6 +6,7 @@ import (
 
 func init() {
 	typeurl.Register(&PolicyFragment{}, "github.com/Microsoft/hcsshim/pkg/ctrdtaskapi", "PolicyFragment")
+	typeurl.Register(&MappedPipe{}, "github.com/Microsoft/hcsshim/pkg/ctrdtaskapi", "MappedPipe")
 }
 
 type PolicyFragment struct {
@@ -14,4 +15,14 @@ type PolicyFragment struct {
 	// The value is a base64 encoded COSE_Sign1 document that contains the
 	// fragment and any additional information required for validation.
 	Fragment string `json:"fragment,omitempty"`
+}
+
+type MappedPipe struct {
+	// IsRemove, default false, determines if the operation update is a remove or an add.
+	IsRemove bool `json:"remove,omitempty"`
+	// HostPath is the host named pipe path to map to the container. It is required for `add` operations.
+	HostPath string `json:"hp,omitempty"`
+	// ContainerPath is the path name inside the container namespace to map the HostPath to. If it is a remove
+	// operation this path is used to determine which container path to remove from the container namespace.
+	ContainerPath string `json:"cp,omitempty"`
 }


### PR DESCRIPTION
Adds support to the containerd shim to Add/Remove a mapped pipe to a Windows Container Silo (argon) dynamically.

Hey all,

There are two approaches in this CR. We need the ability to dynamically Add/Remove named pipes to an Argon container. Unfortunately all of the v2 API and schema is internal only packages. Because we only need containerd support it seemed ok to add it as an Update API operation to the Task API of containerd shim. However, if we dont want to go down that road, I also added an example `container-pipe.exe` that simply adds a cmdline support for such an operation. Please let me know which approach we would like to continue with in order to add this support and export it to callers. Thanks!!

See: https://github.com/microsoft/hcsshim/issues/1863 for background and FYI.

