### PR TITLE
cimfs: Add a LayerWriter for writing cim layers

### DIFF
--- a/internal/wclayer/cim/LayerWriter.go
+++ b/internal/wclayer/cim/LayerWriter.go
@@ -1,0 +1,287 @@
+package cim
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/Microsoft/go-winio"
+	"github.com/Microsoft/hcsshim/internal/log"
+	"github.com/Microsoft/hcsshim/internal/oc"
+	"github.com/Microsoft/hcsshim/internal/wclayer"
+	"github.com/Microsoft/hcsshim/osversion"
+	"github.com/Microsoft/hcsshim/pkg/cimfs"
+	"go.opencensus.io/trace"
+)
+
+// A CimLayerWriter implements the wclayer.LayerWriter interface to allow writing container
+// image layers in the cim format.
+// A cim layer consist of cim files (which are usually stored in the `cim-layers` directory and
+// some other files which are stored in the directory of that layer (i.e the `path` directory).
+type CimLayerWriter struct {
+	ctx context.Context
+	s   *trace.Span
+	// path to the layer (i.e layer's directory) as provided by the caller.
+	// Even if a layer is stored as a cim in the cim directory, some files associated
+	// with a layer are still stored in this path.
+	path string
+	// parent layer paths
+	parentLayerPaths []string
+	// Handle to the layer cim - writes to the cim file
+	cimWriter *cimfs.CimFsWriter
+	// Handle to the writer for writing files in the local filesystem
+	stdFileWriter *stdFileWriter
+	// reference to currently active writer either cimWriter or stdFileWriter
+	activeWriter io.Writer
+	// denotes if this layer has the UtilityVM directory
+	hasUtilityVM bool
+	// some files are written outside the cim during initial import (via stdFileWriter) because we need to
+	// make some modifications to these files before writing them to the cim. The pendingOps slice
+	// maintains a list of such delayed modifications to the layer cim. These modifications are applied at
+	// the very end of layer import process.
+	pendingOps []pendingCimOp
+}
+
+type hive struct {
+	name  string
+	base  string
+	delta string
+}
+
+var (
+	hives = []hive{
+		{"SYSTEM", "SYSTEM_BASE", "SYSTEM_DELTA"},
+		{"SOFTWARE", "SOFTWARE_BASE", "SOFTWARE_DELTA"},
+		{"SAM", "SAM_BASE", "SAM_DELTA"},
+		{"SECURITY", "SECURITY_BASE", "SECURITY_DELTA"},
+		{"DEFAULT", "DEFAULTUSER_BASE", "DEFAULTUSER_DELTA"},
+	}
+)
+
+func isDeltaOrBaseHive(path string) bool {
+	for _, hv := range hives {
+		if strings.EqualFold(path, filepath.Join(wclayer.HivesPath, hv.delta)) ||
+			strings.EqualFold(path, filepath.Join(wclayer.RegFilesPath, hv.name)) {
+			return true
+		}
+	}
+	return false
+}
+
+// checks if this particular file should be written with a stdFileWriter instead of
+// using the cimWriter.
+func isStdFile(path string) bool {
+	return (isDeltaOrBaseHive(path) ||
+		path == filepath.Join(wclayer.UtilityVMPath, wclayer.RegFilesPath, "SYSTEM") ||
+		path == filepath.Join(wclayer.UtilityVMPath, wclayer.RegFilesPath, "SOFTWARE") ||
+		path == wclayer.BcdFilePath || path == wclayer.BootMgrFilePath)
+}
+
+// Add adds a file to the layer with given metadata.
+func (cw *CimLayerWriter) Add(name string, fileInfo *winio.FileBasicInfo, fileSize int64, securityDescriptor []byte, extendedAttributes []byte, reparseData []byte) error {
+	if name == wclayer.UtilityVMPath {
+		cw.hasUtilityVM = true
+	}
+	if isStdFile(name) {
+		// create a pending op for this file
+		cw.pendingOps = append(cw.pendingOps, &addOp{
+			pathInCim:          name,
+			hostPath:           filepath.Join(cw.path, name),
+			fileInfo:           fileInfo,
+			securityDescriptor: securityDescriptor,
+			extendedAttributes: extendedAttributes,
+			reparseData:        reparseData,
+		})
+		if err := cw.stdFileWriter.Add(name); err != nil {
+			return err
+		}
+		cw.activeWriter = cw.stdFileWriter
+	} else {
+		if err := cw.cimWriter.AddFile(name, fileInfo, fileSize, securityDescriptor, extendedAttributes, reparseData); err != nil {
+			return err
+		}
+		cw.activeWriter = cw.cimWriter
+	}
+	return nil
+}
+
+// AddLink adds a hard link to the layer. The target must already have been added.
+func (cw *CimLayerWriter) AddLink(name string, target string) error {
+	// set active write to nil so that we panic if layer tar is incorrectly formatted.
+	cw.activeWriter = nil
+	if isStdFile(target) {
+		// If this is a link to a std file it will have to be added later once the
+		// std file is written to the CIM. Create a pending op for this
+		cw.pendingOps = append(cw.pendingOps, &linkOp{
+			oldPath: target,
+			newPath: name,
+		})
+		return nil
+	} else if isStdFile(name) {
+		// None of the predefined std files are links. If they show up as links this is unexpected
+		// behavior. Error out.
+		return fmt.Errorf("unexpected link %s in layer", name)
+	} else {
+		return cw.cimWriter.AddLink(target, name)
+	}
+}
+
+// AddAlternateStream creates another alternate stream at the given
+// path. Any writes made after this call will go to that stream.
+func (cw *CimLayerWriter) AddAlternateStream(name string, size uint64) error {
+	if isStdFile(name) {
+		// As of now there is no known case of std file having multiple data streams.
+		// If such a file is encountered our assumptions are wrong. Error out.
+		return fmt.Errorf("unexpected alternate stream %s in layer", name)
+	}
+
+	if err := cw.cimWriter.CreateAlternateStream(name, size); err != nil {
+		return err
+	}
+	cw.activeWriter = cw.cimWriter
+	return nil
+}
+
+// Remove removes a file that was present in a parent layer from the layer.
+func (cw *CimLayerWriter) Remove(name string) error {
+	// set active write to nil so that we panic if layer tar is incorrectly formatted.
+	cw.activeWriter = nil
+	return cw.cimWriter.Unlink(name)
+}
+
+// Write writes data to the current file. The data must be in the format of a Win32
+// backup stream.
+func (cw *CimLayerWriter) Write(b []byte) (int, error) {
+	return cw.activeWriter.Write(b)
+}
+
+// Close finishes the layer writing process and releases any resources.
+func (cw *CimLayerWriter) Close(ctx context.Context) (retErr error) {
+	if err := cw.stdFileWriter.Close(ctx); err != nil {
+		return err
+	}
+
+	// cimWriter must be closed even if there are errors.
+	defer func() {
+		if err := cw.cimWriter.Close(); retErr == nil {
+			retErr = err
+		}
+	}()
+
+	// Find out the osversion of this layer, both base & non-base layers can have UtilityVM layer.
+	processUtilityVM := false
+	if cw.hasUtilityVM {
+		uvmSoftwareHivePath := filepath.Join(cw.path, wclayer.UtilityVMPath, wclayer.RegFilesPath, "SOFTWARE")
+		osvStr, err := getOsBuildNumberFromRegistry(uvmSoftwareHivePath)
+		if err != nil {
+			return fmt.Errorf("read os version string from UtilityVM SOFTWARE hive: %w", err)
+		}
+
+		osv, err := strconv.ParseUint(osvStr, 10, 16)
+		if err != nil {
+			return fmt.Errorf("parse os version string (%s): %w", osvStr, err)
+		}
+
+		// write this version to a file for future reference by the shim process
+		if err = wclayer.WriteLayerUvmBuildFile(cw.path, uint16(osv)); err != nil {
+			return fmt.Errorf("write uvm build version: %w", err)
+		}
+
+		// CIMFS for hyperV isolated is only supported after 20348, processing UtilityVM layer on 2048
+		// & lower will cause failures since those images won't have CIMFS specific UVM files (mostly
+		// BCD entries required for CIMFS)
+		processUtilityVM = (osv > osversion.LTSC2022)
+		log.G(ctx).Debugf("import image os version %d, processing UtilityVM layer: %t\n", osv, processUtilityVM)
+	}
+
+	if len(cw.parentLayerPaths) == 0 {
+		if err := cw.processBaseLayer(ctx, processUtilityVM); err != nil {
+			return fmt.Errorf("process base layer: %w", err)
+		}
+	} else {
+		if err := cw.processNonBaseLayer(ctx, processUtilityVM); err != nil {
+			return fmt.Errorf("process non base layer: %w", err)
+		}
+	}
+
+	for _, op := range cw.pendingOps {
+		if err := op.apply(cw.cimWriter); err != nil {
+			return fmt.Errorf("apply pending operations: %w", err)
+		}
+	}
+	return nil
+}
+
+func NewCimLayerWriter(ctx context.Context, path string, parentLayerPaths []string) (_ *CimLayerWriter, err error) {
+	if !cimfs.IsCimFSSupported() {
+		return nil, fmt.Errorf("CimFs not supported on this build")
+	}
+
+	ctx, span := trace.StartSpan(ctx, "hcsshim::NewCimLayerWriter")
+	defer func() {
+		if err != nil {
+			oc.SetSpanStatus(span, err)
+			span.End()
+		}
+	}()
+	span.AddAttributes(
+		trace.StringAttribute("path", path),
+		trace.StringAttribute("parentLayerPaths", strings.Join(parentLayerPaths, ", ")))
+
+	parentCim := ""
+	cimDirPath := GetCimDirFromLayer(path)
+	if _, err = os.Stat(cimDirPath); os.IsNotExist(err) {
+		// create cim directory
+		if err = os.Mkdir(cimDirPath, 0755); err != nil {
+			return nil, fmt.Errorf("failed while creating cim layers directory: %s", err)
+		}
+	} else if err != nil {
+		return nil, fmt.Errorf("unable to access cim layers directory: %s", err)
+
+	}
+
+	if len(parentLayerPaths) > 0 {
+		parentCim = GetCimNameFromLayer(parentLayerPaths[0])
+	}
+
+	cim, err := cimfs.Create(cimDirPath, parentCim, GetCimNameFromLayer(path))
+	if err != nil {
+		return nil, fmt.Errorf("error in creating a new cim: %s", err)
+	}
+
+	sfw, err := newStdFileWriter(path, parentLayerPaths)
+	if err != nil {
+		return nil, fmt.Errorf("error in creating new standard file writer: %s", err)
+	}
+	return &CimLayerWriter{
+		ctx:              ctx,
+		s:                span,
+		path:             path,
+		parentLayerPaths: parentLayerPaths,
+		cimWriter:        cim,
+		stdFileWriter:    sfw,
+	}, nil
+}
+
+// DestroyCimLayer destroys a cim layer i.e it removes all the cimfs files for the given layer as well as
+// all of the other files that are stored in the layer directory (at path `layerPath`).
+// If this is not a cimfs layer (i.e a cim file for the given layer does not exist) then nothing is done.
+func DestroyCimLayer(ctx context.Context, layerPath string) error {
+	cimPath := GetCimPathFromLayer(layerPath)
+
+	// verify that such a cim exists first, sometimes containerd tries to call
+	// this with the root snapshot directory as the layer path. We don't want to
+	// destroy everything inside the snapshots directory.
+	if _, err := os.Stat(cimPath); err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+
+	return cimfs.DestroyCim(ctx, cimPath)
+}

--- a/internal/wclayer/cim/bcd.go
+++ b/internal/wclayer/cim/bcd.go
@@ -1,0 +1,105 @@
+package cim
+
+import (
+	"bytes"
+	"fmt"
+	"os/exec"
+
+	"github.com/Microsoft/go-winio/pkg/guid"
+)
+
+const (
+	bcdFilePath              = "UtilityVM\\Files\\EFI\\Microsoft\\Boot\\BCD"
+	cimfsDeviceOptionsID     = "{763e9fea-502d-434f-aad9-5fabe9c91a7b}"
+	vmbusDeviceID            = "{c63c9bdf-5fa5-4208-b03f-6b458b365592}"
+	compositeDeviceOptionsID = "{e1787220-d17f-49e7-977a-d8fe4c8537e2}"
+	bootContainerID          = "{b890454c-80de-4e98-a7ab-56b74b4fbd0c}"
+)
+
+func bcdExec(storePath string, args ...string) error {
+	var out bytes.Buffer
+	argsArr := []string{"/store", storePath, "/offline"}
+	argsArr = append(argsArr, args...)
+	cmd := exec.Command("bcdedit.exe", argsArr...)
+	cmd.Stdout = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("bcd command (%s) failed: %s", cmd, err)
+	}
+	return nil
+}
+
+// A registry configuration required for the uvm.
+func setBcdRestartOnFailure(storePath string) error {
+	return bcdExec(storePath, "/set", "{default}", "restartonfailure", "yes")
+}
+
+func setBcdCimBootDevice(storePath, cimPathRelativeToVSMB string, diskID, partitionID guid.GUID) error {
+	// create options for cimfs boot device
+	if err := bcdExec(storePath, "/create", cimfsDeviceOptionsID, "/d", "CimFS Device Options", "/device"); err != nil {
+		return err
+	}
+
+	// Set options. For now we need to set 2 options. First is the parent device i.e the device under
+	// which all cim files will be available. Second is the path of the cim (from which this UVM should
+	// boot) relative to the parent device. Note that even though the 2nd option is named
+	// `cimfsrootdirectory` it expects a path to the cim file and not a directory path.
+	if err := bcdExec(storePath, "/set", cimfsDeviceOptionsID, "cimfsparentdevice", fmt.Sprintf("vmbus=%s", vmbusDeviceID)); err != nil {
+		return err
+	}
+
+	if err := bcdExec(storePath, "/set", cimfsDeviceOptionsID, "cimfsrootdirectory", fmt.Sprintf("\\%s", cimPathRelativeToVSMB)); err != nil {
+		return err
+	}
+
+	// create options for the composite device
+	if err := bcdExec(storePath, "/create", compositeDeviceOptionsID, "/d", "Composite Device Options", "/device"); err != nil {
+		return err
+	}
+
+	// We need to specify the diskID & the partition ID of the boot disk and we need to set the cimfs boot
+	// options ID
+	partitionStr := fmt.Sprintf("gpt_partition={%s};{%s}", diskID, partitionID)
+	if err := bcdExec(storePath, "/set", compositeDeviceOptionsID, "primarydevice", partitionStr); err != nil {
+		return err
+	}
+
+	if err := bcdExec(storePath, "/set", compositeDeviceOptionsID, "secondarydevice", fmt.Sprintf("cimfs=%s,%s", bootContainerID, cimfsDeviceOptionsID)); err != nil {
+		return err
+	}
+
+	if err := bcdExec(storePath, "/set", "{default}", "device", fmt.Sprintf("composite=0,%s", compositeDeviceOptionsID)); err != nil {
+		return err
+	}
+
+	if err := bcdExec(storePath, "/set", "{default}", "osdevice", fmt.Sprintf("composite=0,%s", compositeDeviceOptionsID)); err != nil {
+		return err
+	}
+
+	// Since our UVM file are stored under UtilityVM\Files directory inside the CIM we must prepend that
+	// directory in front of paths used by bootmgr
+	if err := bcdExec(storePath, "/set", "{default}", "path", "\\UtilityVM\\Files\\Windows\\System32\\winload.efi"); err != nil {
+		return err
+	}
+
+	if err := bcdExec(storePath, "/set", "{default}", "systemroot", "\\UtilityVM\\Files\\Windows"); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// updateBcdStoreForBoot Updates the bcd store at path layerPath + UtilityVM\Files\EFI\Microsoft\Boot\BCD` to
+// boot with the disk with given ID and given partitionID.  cimPathRelativeToVSMB is the path of the cim which
+// will be used for booting this UVM relative to the VSMB share. (Usually, the entire snapshots directory will
+// be shared over VSMB, so if this is the cim-layers\1.cim under that directory, the value of
+// `cimPathRelativeToVSMB` should be cim-layers\1.cim)
+func updateBcdStoreForBoot(storePath string, cimPathRelativeToVSMB string, diskID, partitionID guid.GUID) error {
+	if err := setBcdRestartOnFailure(storePath); err != nil {
+		return err
+	}
+
+	if err := setBcdCimBootDevice(storePath, cimPathRelativeToVSMB, diskID, partitionID); err != nil {
+		return err
+	}
+	return nil
+}

--- a/internal/wclayer/cim/common.go
+++ b/internal/wclayer/cim/common.go
@@ -1,0 +1,39 @@
+package cim
+
+import (
+	"os"
+	"path/filepath"
+)
+
+const (
+	// name of the directory in which cims are stored
+	cimDir = "cim-layers"
+)
+
+// Usually layers are stored at ./root/io.containerd.snapshotter.v1.windows/snapshots/<layerid>. For cimfs we
+// must store all layer cims in the same directory (for forked cims to work). So all cim layers are stored in
+// /root/io.containerd.snapshotter.v1.windows/snapshots/cim-layers. And the cim file representing each
+// individual layer is stored at /root/io.containerd.snapshotter.v1.windows/snapshots/cim-layers/<layerid>.cim
+
+// CimName is the filename (<layerid>.cim) of the file representing the cim
+func GetCimNameFromLayer(layerPath string) string {
+	return filepath.Base(layerPath) + ".cim"
+}
+
+// CimPath is the path to the CimDir/<layerid>.cim file that represents a layer cim.
+func GetCimPathFromLayer(layerPath string) string {
+	return filepath.Join(GetCimDirFromLayer(layerPath), GetCimNameFromLayer(layerPath))
+}
+
+// CimDir is the directory inside which all cims are stored.
+func GetCimDirFromLayer(layerPath string) string {
+	dir := filepath.Dir(layerPath)
+	return filepath.Join(dir, cimDir)
+}
+
+// IsCimLayer returns `true` if the layer at path `layerPath` is a cim layer. Returns `false` otherwise.
+func IsCimLayer(layerPath string) bool {
+	cimPath := GetCimPathFromLayer(layerPath)
+	_, err := os.Stat(cimPath)
+	return (err == nil)
+}

--- a/internal/wclayer/cim/file_writer.go
+++ b/internal/wclayer/cim/file_writer.go
@@ -1,0 +1,88 @@
+package cim
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+
+	"github.com/Microsoft/go-winio"
+	"github.com/Microsoft/hcsshim/internal/safefile"
+	"github.com/Microsoft/hcsshim/internal/winapi"
+)
+
+// stdFileWriter writes the files of a layer to the layer folder instead of writing them inside the cim.
+// For some files (like the Hive files or some UtilityVM files) it is necessary to write them as a normal file
+// first, do some modifications on them (for example merging of hives or processing of UtilityVM files)
+// and then write the modified versions into the cim. This writer is used for such files.
+type stdFileWriter struct {
+	activeFile *os.File
+	// parent layer paths
+	parentLayerPaths []string
+	// path to the current layer
+	path string
+	// the open handle to the path directory
+	root *os.File
+}
+
+func newStdFileWriter(root string, parentRoots []string) (sfw *stdFileWriter, err error) {
+	sfw = &stdFileWriter{
+		path:             root,
+		parentLayerPaths: parentRoots,
+	}
+	sfw.root, err = safefile.OpenRoot(root)
+	if err != nil {
+		return
+	}
+	return
+}
+
+func (sfw *stdFileWriter) closeActiveFile() (err error) {
+	if sfw.activeFile != nil {
+		err = sfw.activeFile.Close()
+		sfw.activeFile = nil
+	}
+	return
+}
+
+// Adds a new file or an alternate data stream to an existing file inside the layer directory.
+func (sfw *stdFileWriter) Add(name string) error {
+	if err := sfw.closeActiveFile(); err != nil {
+		return err
+	}
+
+	// The directory of this file might be created inside the cim.
+	// make sure we have the same parent directory chain here
+	if err := os.MkdirAll(filepath.Join(sfw.path, filepath.Dir(name)), 0755); err != nil {
+		return fmt.Errorf("failed to create file %s: %s", name, err)
+	}
+
+	f, err := safefile.OpenRelative(
+		name,
+		sfw.root,
+		syscall.GENERIC_READ|syscall.GENERIC_WRITE|winio.WRITE_DAC|winio.WRITE_OWNER,
+		syscall.FILE_SHARE_READ,
+		winapi.FILE_CREATE,
+		0,
+	)
+	if err != nil {
+		return fmt.Errorf("error creating file %s: %s", name, err)
+	}
+	sfw.activeFile = f
+	return nil
+}
+
+// Write writes data to the current file. The data must be in the format of a Win32
+// backup stream.
+func (sfw *stdFileWriter) Write(b []byte) (int, error) {
+	return sfw.activeFile.Write(b)
+}
+
+// Close finishes the layer writing process and releases any resources.
+func (sfw *stdFileWriter) Close(ctx context.Context) error {
+	if err := sfw.closeActiveFile(); err != nil {
+		return fmt.Errorf("failed to close active file %s : %s", sfw.activeFile.Name(), err)
+	}
+	return nil
+}

--- a/internal/wclayer/cim/pending.go
+++ b/internal/wclayer/cim/pending.go
@@ -1,0 +1,66 @@
+package cim
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/Microsoft/go-winio"
+	"github.com/Microsoft/hcsshim/pkg/cimfs"
+	"golang.org/x/sys/windows"
+)
+
+type pendingCimOp interface {
+	apply(cw *cimfs.CimFsWriter) error
+}
+
+// add op represents a pending operation of adding a new file inside the cim
+type addOp struct {
+	// path inside the cim at which the file should be added
+	pathInCim string
+	// host path where this file was temporarily written.
+	hostPath string
+	// other file metadata fields that were provided during the add call.
+	fileInfo           *winio.FileBasicInfo
+	securityDescriptor []byte
+	extendedAttributes []byte
+	reparseData        []byte
+}
+
+func (o *addOp) apply(cw *cimfs.CimFsWriter) error {
+	f, err := os.Open(o.hostPath)
+	if err != nil {
+		return fmt.Errorf("open file %s: %w", o.hostPath, err)
+	}
+	defer f.Close()
+
+	fs, err := f.Stat()
+	if err != nil {
+		return fmt.Errorf("stat file %s: %w", o.hostPath, err)
+	}
+
+	if err := cw.AddFile(o.pathInCim, o.fileInfo, fs.Size(), o.securityDescriptor, o.extendedAttributes, o.reparseData); err != nil {
+		return fmt.Errorf("cim add file %s: %w", o.hostPath, err)
+	}
+
+	if o.fileInfo.FileAttributes != windows.FILE_ATTRIBUTE_DIRECTORY {
+		written, err := io.Copy(cw, f)
+		if err != nil {
+			return fmt.Errorf("write file %s inside cim: %w", o.hostPath, err)
+		} else if written != fs.Size() {
+			return fmt.Errorf("short write to cim for file %s, expected %d bytes wrote %d", o.hostPath, fs.Size(), written)
+		}
+	}
+	return nil
+}
+
+// linkOp represents a pending link file operation inside the cim
+type linkOp struct {
+	// old & new paths inside the cim where the link should be created
+	oldPath string
+	newPath string
+}
+
+func (o *linkOp) apply(cw *cimfs.CimFsWriter) error {
+	return cw.AddLink(o.oldPath, o.newPath)
+}

--- a/internal/wclayer/cim/process.go
+++ b/internal/wclayer/cim/process.go
@@ -1,0 +1,291 @@
+package cim
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+	"time"
+
+	"github.com/Microsoft/go-winio"
+	"github.com/Microsoft/go-winio/vhd"
+	"github.com/Microsoft/hcsshim/computestorage"
+	"github.com/Microsoft/hcsshim/internal/memory"
+	"github.com/Microsoft/hcsshim/internal/security"
+	"github.com/Microsoft/hcsshim/internal/vhdx"
+	"github.com/Microsoft/hcsshim/internal/wclayer"
+	"golang.org/x/sys/windows"
+)
+
+const defaultVHDXBlockSizeInMB = 1
+
+func createContainerBaseLayerVHDs(ctx context.Context, layerPath string) (err error) {
+	baseVhdPath := filepath.Join(layerPath, wclayer.ContainerBaseVhd)
+	diffVhdPath := filepath.Join(layerPath, wclayer.ContainerScratchVhd)
+	defaultVhdSize := uint64(20)
+
+	if _, err := os.Stat(baseVhdPath); err == nil {
+		if err := os.RemoveAll(baseVhdPath); err != nil {
+			return fmt.Errorf("failed to remove base vhdx path:  %w", err)
+		}
+	}
+	if _, err := os.Stat(diffVhdPath); err == nil {
+		if err := os.RemoveAll(diffVhdPath); err != nil {
+			return fmt.Errorf("failed to remove differencing vhdx: %w", err)
+		}
+	}
+
+	createParams := &vhd.CreateVirtualDiskParameters{
+		Version: 2,
+		Version2: vhd.CreateVersion2{
+			MaximumSize:      defaultVhdSize * memory.GiB,
+			BlockSizeInBytes: defaultVHDXBlockSizeInMB * memory.MiB,
+		},
+	}
+	handle, err := vhd.CreateVirtualDisk(baseVhdPath, vhd.VirtualDiskAccessNone, vhd.CreateVirtualDiskFlagNone, createParams)
+	if err != nil {
+		return fmt.Errorf("failed to create vhdx: %w", err)
+	}
+
+	defer func() {
+		if err != nil {
+			os.RemoveAll(baseVhdPath)
+			os.RemoveAll(diffVhdPath)
+		}
+	}()
+
+	err = computestorage.FormatWritableLayerVhd(ctx, windows.Handle(handle))
+	// we always wanna close the handle whether format succeeds for not.
+	closeErr := syscall.CloseHandle(handle)
+	if err != nil {
+		return err
+	} else if closeErr != nil {
+		return fmt.Errorf("failed to close vhdx handle: %w", closeErr)
+	}
+
+	// Create the differencing disk that will be what's copied for the final rw layer
+	// for a container.
+	if err = vhd.CreateDiffVhd(diffVhdPath, baseVhdPath, defaultVHDXBlockSizeInMB); err != nil {
+		return fmt.Errorf("failed to create differencing disk: %w", err)
+	}
+
+	if err = security.GrantVmGroupAccess(baseVhdPath); err != nil {
+		return fmt.Errorf("failed to grant vm group access to %s: %w", baseVhdPath, err)
+	}
+	if err = security.GrantVmGroupAccess(diffVhdPath); err != nil {
+		return fmt.Errorf("failed to grant vm group access to %s: %w", diffVhdPath, err)
+	}
+	return nil
+}
+
+// processUtilityVMLayer is similar to createContainerBaseLayerVHDs but along with the scratch creation it
+// also does some BCD modifications to allow the UVM to boot from the CIM. It expects that the UVM BCD file is
+// present at layerPath/`wclayer.BcdFilePath` and a UVM SYSTEM hive is present at
+// layerPath/UtilityVM/`wclayer.RegFilesPath`/SYSTEM. The scratch VHDs are created under the `layerPath`
+// directory.
+func processUtilityVMLayer(ctx context.Context, layerPath string) error {
+	// func createUtilityVMLayerVHDs(ctx context.Context, layerPath string) error {
+	baseVhdPath := filepath.Join(layerPath, wclayer.UtilityVMPath, wclayer.UtilityVMBaseVhd)
+	diffVhdPath := filepath.Join(layerPath, wclayer.UtilityVMPath, wclayer.UtilityVMScratchVhd)
+	defaultVhdSize := uint64(10)
+
+	// Just create the vhdx for utilityVM layer, no need to format it.
+	createParams := &vhd.CreateVirtualDiskParameters{
+		Version: 2,
+		Version2: vhd.CreateVersion2{
+			MaximumSize:      defaultVhdSize * memory.GiB,
+			BlockSizeInBytes: defaultVHDXBlockSizeInMB * memory.MiB,
+		},
+	}
+
+	handle, err := vhd.CreateVirtualDisk(baseVhdPath, vhd.VirtualDiskAccessNone, vhd.CreateVirtualDiskFlagNone, createParams)
+	if err != nil {
+		return fmt.Errorf("failed to create vhdx: %w", err)
+	}
+
+	defer func() {
+		if err != nil {
+			os.RemoveAll(baseVhdPath)
+			os.RemoveAll(diffVhdPath)
+		}
+	}()
+
+	err = computestorage.FormatWritableLayerVhd(ctx, windows.Handle(handle))
+	closeErr := syscall.CloseHandle(handle)
+	if err != nil {
+		return err
+	} else if closeErr != nil {
+		return fmt.Errorf("failed to close vhdx handle: %w", closeErr)
+	}
+
+	partitionInfo, err := vhdx.GetScratchVhdPartitionInfo(ctx, baseVhdPath)
+	if err != nil {
+		return fmt.Errorf("failed to get base vhd layout info: %w", err)
+	}
+	// relativeCimPath needs to be the cim path relative to the snapshots directory. The snapshots
+	// directory is shared inside the UVM over VSMB, so during the UVM boot this relative path will be
+	// used to find the cim file under that VSMB share.
+	relativeCimPath := filepath.Join(filepath.Base(GetCimDirFromLayer(layerPath)), GetCimNameFromLayer(layerPath))
+	bcdPath := filepath.Join(layerPath, bcdFilePath)
+	if err = updateBcdStoreForBoot(bcdPath, relativeCimPath, partitionInfo.DiskID, partitionInfo.PartitionID); err != nil {
+		return fmt.Errorf("failed to update BCD: %w", err)
+	}
+
+	if err := enableCimBoot(filepath.Join(layerPath, wclayer.UtilityVMPath, wclayer.RegFilesPath, "SYSTEM")); err != nil {
+		return fmt.Errorf("failed to setup cim image for uvm boot: %s", err)
+	}
+
+	// Note: diff vhd creation and granting of vm group access must be done AFTER
+	// getting the partition info of the base VHD. Otherwise it causes the vhd parent
+	// chain to get corrupted.
+	// TODO(ambarve): figure out why this happens so that bcd update can be moved to a separate function
+
+	// Create the differencing disk that will be what's copied for the final rw layer
+	// for a container.
+	if err = vhd.CreateDiffVhd(diffVhdPath, baseVhdPath, defaultVHDXBlockSizeInMB); err != nil {
+		return fmt.Errorf("failed to create differencing disk: %w", err)
+	}
+
+	if err := security.GrantVmGroupAccess(baseVhdPath); err != nil {
+		return fmt.Errorf("failed to grant vm group access to %s: %w", baseVhdPath, err)
+	}
+	if err := security.GrantVmGroupAccess(diffVhdPath); err != nil {
+		return fmt.Errorf("failed to grant vm group access to %s: %w", diffVhdPath, err)
+	}
+	return nil
+}
+
+// processBaseLayerHives make the base layer specific modifications on the hives and emits equivalent the
+// pendingCimOps that should be applied on the CIM.  In base layer we need to create hard links from registry
+// hives under Files/Windows/Sysetm32/config into Hives/*_BASE. This function creates these links outside so
+// that the registry hives under Hives/ are available during children layers import.  Then we write these hive
+// files inside the cim and create links inside the cim.
+func processBaseLayerHives(layerPath string) ([]pendingCimOp, error) {
+	pendingOps := []pendingCimOp{}
+
+	// make hives directory both outside and in the cim
+	if err := os.Mkdir(filepath.Join(layerPath, wclayer.HivesPath), 0755); err != nil {
+		return pendingOps, fmt.Errorf("hives directory creation: %w", err)
+	}
+
+	hivesDirInfo := &winio.FileBasicInfo{
+		CreationTime:   windows.NsecToFiletime(time.Now().UnixNano()),
+		LastAccessTime: windows.NsecToFiletime(time.Now().UnixNano()),
+		LastWriteTime:  windows.NsecToFiletime(time.Now().UnixNano()),
+		ChangeTime:     windows.NsecToFiletime(time.Now().UnixNano()),
+		FileAttributes: windows.FILE_ATTRIBUTE_DIRECTORY,
+	}
+	pendingOps = append(pendingOps, &addOp{
+		pathInCim: wclayer.HivesPath,
+		hostPath:  filepath.Join(layerPath, wclayer.HivesPath),
+		fileInfo:  hivesDirInfo,
+	})
+
+	// add hard links from base hive files.
+	for _, hv := range hives {
+		oldHivePathRelative := filepath.Join(wclayer.RegFilesPath, hv.name)
+		newHivePathRelative := filepath.Join(wclayer.HivesPath, hv.base)
+		if err := os.Link(filepath.Join(layerPath, oldHivePathRelative), filepath.Join(layerPath, newHivePathRelative)); err != nil {
+			return pendingOps, fmt.Errorf("hive link creation: %w", err)
+		}
+
+		pendingOps = append(pendingOps, &linkOp{
+			oldPath: oldHivePathRelative,
+			newPath: newHivePathRelative,
+		})
+	}
+	return pendingOps, nil
+}
+
+// processLayoutFile creates a file named "layout" in the root of the base layer. This allows certain
+// container startup related functions to understand that the hives are a part of the container rootfs.
+func processLayoutFile(layerPath string) ([]pendingCimOp, error) {
+	fileContents := "vhd-with-hives\n"
+	if err := os.WriteFile(filepath.Join(layerPath, "layout"), []byte(fileContents), 0755); err != nil {
+		return []pendingCimOp{}, fmt.Errorf("write layout file: %w", err)
+	}
+
+	layoutFileInfo := &winio.FileBasicInfo{
+		CreationTime:   windows.NsecToFiletime(time.Now().UnixNano()),
+		LastAccessTime: windows.NsecToFiletime(time.Now().UnixNano()),
+		LastWriteTime:  windows.NsecToFiletime(time.Now().UnixNano()),
+		ChangeTime:     windows.NsecToFiletime(time.Now().UnixNano()),
+		FileAttributes: windows.FILE_ATTRIBUTE_NORMAL,
+	}
+
+	op := &addOp{
+		pathInCim: "layout",
+		hostPath:  filepath.Join(layerPath, "layout"),
+		fileInfo:  layoutFileInfo,
+	}
+	return []pendingCimOp{op}, nil
+}
+
+// Some of the layer files that are generated during the processBaseLayer call must be added back
+// inside the cim, some registry file links must be updated. This function takes care of all those
+// steps. This function opens the cim file for writing and updates it.
+func (cw *CimLayerWriter) processBaseLayer(ctx context.Context, processUtilityVM bool) (err error) {
+	if err = createContainerBaseLayerVHDs(ctx, cw.path); err != nil {
+		return fmt.Errorf("failed to create container base VHDs: %s", err)
+	}
+
+	if processUtilityVM {
+		if err = processUtilityVMLayer(ctx, cw.path); err != nil {
+			return fmt.Errorf("process utilityVM layer: %w", err)
+		}
+	}
+
+	ops, err := processBaseLayerHives(cw.path)
+	if err != nil {
+		return err
+	}
+	cw.pendingOps = append(cw.pendingOps, ops...)
+
+	ops, err = processLayoutFile(cw.path)
+	if err != nil {
+		return err
+	}
+	cw.pendingOps = append(cw.pendingOps, ops...)
+	return nil
+}
+
+// processNonBaseLayer takes care of the processing required for a non base layer. As of now
+// the only processing required for non base layer is to merge the delta registry hives of the
+// non-base layer with it's parent layer.
+func (cw *CimLayerWriter) processNonBaseLayer(ctx context.Context, processUtilityVM bool) (err error) {
+	for _, hv := range hives {
+		baseHive := filepath.Join(wclayer.HivesPath, hv.base)
+		deltaHive := filepath.Join(wclayer.HivesPath, hv.delta)
+		_, err := os.Stat(filepath.Join(cw.path, deltaHive))
+		// merge with parent layer if delta exists.
+		if err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("stat delta hive %s: %w", filepath.Join(cw.path, deltaHive), err)
+		} else if err == nil {
+			// merge base hive of parent layer with the delta hive of this layer and write it as
+			// the base hive of this layer.
+			err = mergeHive(filepath.Join(cw.parentLayerPaths[0], baseHive), filepath.Join(cw.path, deltaHive), filepath.Join(cw.path, baseHive))
+			if err != nil {
+				return err
+			}
+
+			// the newly created merged file must be added to the cim
+			cw.pendingOps = append(cw.pendingOps, &addOp{
+				pathInCim: baseHive,
+				hostPath:  filepath.Join(cw.path, baseHive),
+				fileInfo: &winio.FileBasicInfo{
+					CreationTime:   windows.NsecToFiletime(time.Now().UnixNano()),
+					LastAccessTime: windows.NsecToFiletime(time.Now().UnixNano()),
+					LastWriteTime:  windows.NsecToFiletime(time.Now().UnixNano()),
+					ChangeTime:     windows.NsecToFiletime(time.Now().UnixNano()),
+					FileAttributes: windows.FILE_ATTRIBUTE_NORMAL,
+				},
+			})
+		}
+	}
+
+	if processUtilityVM {
+		return processUtilityVMLayer(ctx, cw.path)
+	}
+	return nil
+}

--- a/internal/wclayer/cim/registry.go
+++ b/internal/wclayer/cim/registry.go
@@ -1,0 +1,170 @@
+package cim
+
+import (
+	"encoding/binary"
+	"fmt"
+	"os"
+	"unsafe"
+
+	"github.com/Microsoft/hcsshim/internal/log"
+	"github.com/Microsoft/hcsshim/internal/winapi"
+	"github.com/Microsoft/hcsshim/osversion"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/sys/windows"
+)
+
+// enableCimBoot Opens the SYSTEM registry hive at path `hivePath` and updates it to include a CIMFS Start
+// registry key. This prepares the uvm to boot from a cim file if requested. The registry changes required to
+// actually make the uvm boot from a cim will be added in the uvm config (look at
+// addBootFromCimRegistryChanges for details).  This registry key needs to be available in the early boot
+// phase and so including it in the uvm config doesn't work.
+func enableCimBoot(hivePath string) (err error) {
+	dataZero := make([]byte, 4)
+	dataOne := make([]byte, 4)
+	binary.LittleEndian.PutUint32(dataOne, 1)
+	dataFour := make([]byte, 4)
+	binary.LittleEndian.PutUint32(dataFour, 4)
+
+	bootGUID, err := windows.UTF16FromString(bootContainerID)
+	if err != nil {
+		return fmt.Errorf("failed to encode boot guid to utf16: %w", err)
+	}
+
+	overrideBootPath, err := windows.UTF16FromString("\\Windows\\")
+	if err != nil {
+		return fmt.Errorf("failed to encode override boot path to utf16: %w", err)
+	}
+
+	regChanges := []struct {
+		keyPath   string
+		valueName string
+		valueType winapi.RegType
+		data      *byte
+		dataLen   uint32
+	}{
+		{"ControlSet001\\Control", "BootContainerGuid", winapi.REG_TYPE_SZ, (*byte)(unsafe.Pointer(&bootGUID[0])), 2 * uint32(len(bootGUID))},
+		{"ControlSet001\\Services\\UnionFS", "Start", winapi.REG_TYPE_DWORD, &dataZero[0], uint32(len(dataZero))},
+		{"ControlSet001\\Services\\wcifs", "Start", winapi.REG_TYPE_DWORD, &dataFour[0], uint32(len(dataZero))},
+		// The bootmgr loads the uvm files from the cim and so uses the relative path `UtilityVM\\Files` inside the cim to access the uvm files. However, once the cim is mounted UnionFS will merge the correct directory (UtilityVM\\Files) of the cim with the scratch and then that point onwards we don't need to use the relative path. Below registry key tells the kernel that the boot path that was provided in BCD should now be overriden with this new path.
+		{"Setup", "BootPathOverride", winapi.REG_TYPE_SZ, (*byte)(unsafe.Pointer(&overrideBootPath[0])), 2 * uint32(len(overrideBootPath))},
+	}
+
+	var storeHandle winapi.ORHKey
+	if err = winapi.OROpenHive(hivePath, &storeHandle); err != nil {
+		return fmt.Errorf("failed to open registry store at %s: %s", hivePath, err)
+	}
+
+	for _, change := range regChanges {
+		var changeKey winapi.ORHKey
+		if err = winapi.ORCreateKey(storeHandle, change.keyPath, 0, 0, 0, &changeKey, nil); err != nil {
+			return fmt.Errorf("failed to open reg key %s: %s", change.keyPath, err)
+		}
+
+		if err = winapi.ORSetValue(changeKey, change.valueName, uint32(change.valueType), change.data, change.dataLen); err != nil {
+			return fmt.Errorf("failed to set value for regkey %s\\%s : %s", change.keyPath, change.valueName, err)
+		}
+	}
+
+	// remove the existing file first
+	if err := os.Remove(hivePath); err != nil {
+		return fmt.Errorf("failed to remove existing registry %s: %s", hivePath, err)
+	}
+
+	if err = winapi.ORSaveHive(winapi.ORHKey(storeHandle), hivePath, uint32(osversion.Get().MajorVersion), uint32(osversion.Get().MinorVersion)); err != nil {
+		return fmt.Errorf("error saving the registry store: %s", err)
+	}
+
+	// close hive irrespective of the errors
+	if err := winapi.ORCloseHive(winapi.ORHKey(storeHandle)); err != nil {
+		return fmt.Errorf("error closing registry store; %s", err)
+	}
+	return nil
+
+}
+
+// mergeHive merges the hive located at parentHivePath with the hive located at deltaHivePath and stores
+// the result into the file at mergedHivePath. If a file already exists at path `mergedHivePath` then it
+// throws an error.
+func mergeHive(parentHivePath, deltaHivePath, mergedHivePath string) (err error) {
+	var baseHive, deltaHive, mergedHive winapi.ORHKey
+	if err := winapi.OROpenHive(parentHivePath, &baseHive); err != nil {
+		return fmt.Errorf("failed to open base hive %s: %s", parentHivePath, err)
+	}
+	defer func() {
+		err2 := winapi.ORCloseHive(baseHive)
+		if err == nil {
+			err = errors.Wrap(err2, "failed to close base hive")
+		}
+	}()
+	if err := winapi.OROpenHive(deltaHivePath, &deltaHive); err != nil {
+		return fmt.Errorf("failed to open delta hive %s: %s", deltaHivePath, err)
+	}
+	defer func() {
+		err2 := winapi.ORCloseHive(deltaHive)
+		if err == nil {
+			err = errors.Wrap(err2, "failed to close delta hive")
+		}
+	}()
+	if err := winapi.ORMergeHives([]winapi.ORHKey{baseHive, deltaHive}, &mergedHive); err != nil {
+		return fmt.Errorf("failed to merge hives: %s", err)
+	}
+	defer func() {
+		err2 := winapi.ORCloseHive(mergedHive)
+		if err == nil {
+			err = errors.Wrap(err2, "failed to close merged hive")
+		}
+	}()
+	if err := winapi.ORSaveHive(mergedHive, mergedHivePath, uint32(osversion.Get().MajorVersion), uint32(osversion.Get().MinorVersion)); err != nil {
+		return fmt.Errorf("failed to save hive: %s", err)
+	}
+	return
+}
+
+// getOsBuildNumberFromRegistry fetches the "CurrentBuild" value at path
+// "Microsoft\Windows NT\CurrentVersion" from the SOFTWARE registry hive at path
+// `regHivePath`. This is used to detect the build version of the uvm.
+func getOsBuildNumberFromRegistry(regHivePath string) (_ string, err error) {
+	var storeHandle, keyHandle winapi.ORHKey
+	var dataType, dataLen uint32
+	keyPath := "Microsoft\\Windows NT\\CurrentVersion"
+	valueName := "CurrentBuild"
+	dataLen = 16 // build version string can't be more than 5 wide chars?
+	dataBuf := make([]byte, dataLen)
+
+	if err = winapi.OROpenHive(regHivePath, &storeHandle); err != nil {
+		return "", fmt.Errorf("failed to open registry store at %s: %s", regHivePath, err)
+	}
+	defer func() {
+		if closeErr := winapi.ORCloseHive(storeHandle); closeErr != nil {
+			log.L.WithFields(logrus.Fields{
+				"error": closeErr,
+				"hive":  regHivePath,
+			}).Warnf("failed to close hive")
+		}
+	}()
+
+	if err = winapi.OROpenKey(storeHandle, keyPath, &keyHandle); err != nil {
+		return "", fmt.Errorf("failed to open key at %s: %s", keyPath, err)
+	}
+	defer func() {
+		if closeErr := winapi.ORCloseKey(keyHandle); closeErr != nil {
+			log.L.WithFields(logrus.Fields{
+				"error": closeErr,
+				"hive":  regHivePath,
+				"key":   keyPath,
+				"value": valueName,
+			}).Warnf("failed to close hive key")
+		}
+	}()
+
+	if err = winapi.ORGetValue(keyHandle, "", valueName, &dataType, &dataBuf[0], &dataLen); err != nil {
+		return "", fmt.Errorf("failed to get value of %s: %s", valueName, err)
+	}
+
+	if dataType != uint32(winapi.REG_TYPE_SZ) {
+		return "", fmt.Errorf("unexpected build number data type (%d)", dataType)
+	}
+
+	return winapi.ParseUtf16LE(dataBuf[:(dataLen - 2)]), nil
+}

--- a/internal/wclayer/layerutils.go
+++ b/internal/wclayer/layerutils.go
@@ -7,6 +7,10 @@ package wclayer
 
 import (
 	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
 	"syscall"
 
 	"github.com/Microsoft/go-winio/pkg/guid"
@@ -100,4 +104,24 @@ func layerPathsToDescriptors(ctx context.Context, parentLayerPaths []string) ([]
 	}
 
 	return layers, nil
+}
+
+// GetLayerUvmBuild looks for a file named `uvmbuildversion` at `layerPath\uvmbuildversion` and returns the
+// build number of the UVM from that file.
+func GetLayerUvmBuild(layerPath string) (uint16, error) {
+	data, err := os.ReadFile(filepath.Join(layerPath, UvmBuildFileName))
+	if err != nil {
+		return 0, err
+	}
+	ver, err := strconv.ParseUint(string(data), 10, 16)
+	if err != nil {
+		return 0, err
+	}
+	return uint16(ver), nil
+}
+
+// WriteLayerUvmBuildFile writes a file at path `layerPath\uvmbuildversion` that contains the given `build`
+// version for future reference.
+func WriteLayerUvmBuildFile(layerPath string, build uint16) error {
+	return os.WriteFile(filepath.Join(layerPath, UvmBuildFileName), []byte(fmt.Sprintf("%d", build)), 0777)
 }

--- a/layer.go
+++ b/layer.go
@@ -32,6 +32,7 @@ func CreateScratchLayer(info DriverInfo, layerId, parentId string, parentLayerPa
 func DeactivateLayer(info DriverInfo, id string) error {
 	return wclayer.DeactivateLayer(context.Background(), layerPath(&info, id))
 }
+
 func DestroyLayer(info DriverInfo, id string) error {
 	return wclayer.DestroyLayer(context.Background(), layerPath(&info, id))
 }

--- a/pkg/cimfs/cim_test.go
+++ b/pkg/cimfs/cim_test.go
@@ -64,7 +64,7 @@ func createCimFileUtil(c *CimFsWriter, fileTuple tuple) error {
 // |- foo
 // |--- bar.txt
 func TestCimReadWrite(t *testing.T) {
-	if !IsCimFsSupported() {
+	if !IsCimFSSupported() {
 		t.Skipf("CimFs not supported")
 	}
 

--- a/pkg/cimfs/cimfs.go
+++ b/pkg/cimfs/cimfs.go
@@ -8,7 +8,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-func IsCimFsSupported() bool {
+func IsCimFSSupported() bool {
 	rv, err := osversion.BuildRevision()
 	if err != nil {
 		logrus.WithError(err).Warn("get build revision")

--- a/pkg/ociwclayer/cim/import.go
+++ b/pkg/ociwclayer/cim/import.go
@@ -1,0 +1,161 @@
+//go:build windows
+// +build windows
+
+package cim
+
+import (
+	"archive/tar"
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"github.com/Microsoft/go-winio/backuptar"
+	"github.com/Microsoft/hcsshim/internal/log"
+	"github.com/Microsoft/hcsshim/internal/wclayer/cim"
+	"github.com/Microsoft/hcsshim/pkg/ociwclayer"
+	"golang.org/x/sys/windows"
+)
+
+// ImportCimLayerFromTar reads a layer from an OCI layer tar stream and extracts it into
+// the CIM format at the specified path. The caller must specify the parent layers, if
+// any, ordered from lowest to highest layer.
+//
+// This function returns the total size of the layer's files, in bytes.
+func ImportCimLayerFromTar(ctx context.Context, r io.Reader, layerPath string, parentLayerPaths []string) (int64, error) {
+	err := os.MkdirAll(layerPath, 0)
+	if err != nil {
+		return 0, err
+	}
+
+	w, err := cim.NewCimLayerWriter(ctx, layerPath, parentLayerPaths)
+	if err != nil {
+		return 0, err
+	}
+
+	n, err := writeCimLayerFromTar(ctx, r, w, layerPath)
+	cerr := w.Close(ctx)
+	if err != nil {
+		return 0, err
+	}
+	if cerr != nil {
+		return 0, cerr
+	}
+	return n, nil
+}
+
+func writeCimLayerFromTar(ctx context.Context, r io.Reader, w *cim.CimLayerWriter, layerPath string) (int64, error) {
+	tr := tar.NewReader(r)
+	buf := bufio.NewWriter(w)
+	size := int64(0)
+
+	// Iterate through the files in the archive.
+	hdr, loopErr := tr.Next()
+	for loopErr == nil {
+		select {
+		case <-ctx.Done():
+			return 0, ctx.Err()
+		default:
+		}
+
+		// Note: path is used instead of filepath to prevent OS specific handling
+		// of the tar path
+		base := path.Base(hdr.Name)
+		if strings.HasPrefix(base, ociwclayer.WhiteoutPrefix) {
+			name := path.Join(path.Dir(hdr.Name), base[len(ociwclayer.WhiteoutPrefix):])
+			if rErr := w.Remove(filepath.FromSlash(name)); rErr != nil {
+				return 0, rErr
+			}
+			hdr, loopErr = tr.Next()
+		} else if hdr.Typeflag == tar.TypeLink {
+			if linkErr := w.AddLink(filepath.FromSlash(hdr.Name), filepath.FromSlash(hdr.Linkname)); linkErr != nil {
+				return 0, linkErr
+			}
+			hdr, loopErr = tr.Next()
+		} else {
+			name, fileSize, fileInfo, err := backuptar.FileInfoFromHeader(hdr)
+			if err != nil {
+				return 0, err
+			}
+			sddl, err := backuptar.SecurityDescriptorFromTarHeader(hdr)
+			if err != nil {
+				return 0, err
+			}
+			eadata, err := backuptar.ExtendedAttributesFromTarHeader(hdr)
+			if err != nil {
+				return 0, err
+			}
+
+			var reparse []byte
+			// As of now the only valid reparse data in a layer will be for a symlink. If file is
+			// a symlink set reparse attribute and ensure reparse data buffer isn't
+			// empty. Otherwise remove the reparse attributed.
+			fileInfo.FileAttributes &^= uint32(windows.FILE_ATTRIBUTE_REPARSE_POINT)
+			if hdr.Typeflag == tar.TypeSymlink {
+				reparse = backuptar.EncodeReparsePointFromTarHeader(hdr)
+				if len(reparse) > 0 {
+					fileInfo.FileAttributes |= uint32(windows.FILE_ATTRIBUTE_REPARSE_POINT)
+				}
+			}
+
+			if addErr := w.Add(filepath.FromSlash(name), fileInfo, fileSize, sddl, eadata, reparse); addErr != nil {
+				return 0, addErr
+			}
+			if hdr.Typeflag == tar.TypeReg {
+				if _, cpErr := io.Copy(buf, tr); cpErr != nil {
+					return 0, cpErr
+				}
+			}
+			size += fileSize
+
+			// Copy all the alternate data streams and return the next non-ADS header.
+			var ahdr *tar.Header
+			for {
+				ahdr, loopErr = tr.Next()
+				if loopErr != nil {
+					break
+				}
+
+				if ahdr.Typeflag != tar.TypeReg || !strings.HasPrefix(ahdr.Name, hdr.Name+":") {
+					hdr = ahdr
+					break
+				}
+
+				// stream names have following format: '<filename>:<stream name>:$DATA'
+				// $DATA is one of the valid types of streams. We currently only support
+				// data streams so fail if this is some other type of stream.
+				if !strings.HasSuffix(ahdr.Name, ":$DATA") {
+					return 0, fmt.Errorf("stream types other than $DATA are not supported, found: %s", ahdr.Name)
+				}
+
+				if addErr := w.AddAlternateStream(filepath.FromSlash(ahdr.Name), uint64(ahdr.Size)); addErr != nil {
+					return 0, addErr
+				}
+
+				if _, cpErr := io.Copy(buf, tr); cpErr != nil {
+					return 0, cpErr
+				}
+			}
+		}
+
+		if flushErr := buf.Flush(); flushErr != nil {
+			if loopErr == nil {
+				loopErr = flushErr
+			} else {
+				log.G(ctx).WithError(flushErr).Warn("flush buffer during layer write failed")
+			}
+		}
+	}
+	if loopErr != io.EOF {
+		return 0, loopErr
+	}
+	return size, nil
+}
+
+func DestroyCimLayer(layerPath string) error {
+	return cim.DestroyCimLayer(context.Background(), layerPath)
+}


### PR DESCRIPTION
Adds a new CimLayerWriter that implements the same LayerWriter interface that the legacy layer writer implements. This CimLayerWriter can be used in containerd to pull images into the cimfs format.