### PR TITLE
Add `OutputHandlerCreator` type for UVMs

### DIFF
--- a/internal/oci/uvm_test.go
+++ b/internal/oci/uvm_test.go
@@ -93,8 +93,8 @@ func Test_SpecToUVMCreateOptions_Default_LCOW(t *testing.T) {
 	dopts := uvm.NewDefaultOptionsLCOW(t.Name(), "")
 
 	// output handler equality is always false, so set to nil
-	lopts.OutputHandler = nil
-	dopts.OutputHandler = nil
+	lopts.OutputHandlerCreator = nil
+	dopts.OutputHandlerCreator = nil
 
 	if !cmp.Equal(*lopts, *dopts) {
 		t.Fatalf("should not have updated create options from default when no annotation are provided:\n%s", cmp.Diff(lopts, dopts))

--- a/internal/tools/uvmboot/lcow.go
+++ b/internal/tools/uvmboot/lcow.go
@@ -227,9 +227,11 @@ func createLCOWOptions(_ context.Context, c *cli.Context, id string) (*uvm.Optio
 		if c.IsSet(outputHandlingArgName) {
 			switch strings.ToLower(c.String(outputHandlingArgName)) {
 			case "stdout":
-				options.OutputHandler = uvm.OutputHandler(func(r io.Reader) {
-					_, _ = io.Copy(os.Stdout, r)
-				})
+				options.OutputHandlerCreator = func(*uvm.Options) uvm.OutputHandler {
+					return func(r io.Reader) {
+						_, _ = io.Copy(os.Stdout, r)
+					}
+				}
 			default:
 				return nil, unrecognizedError(c.String(outputHandlingArgName), outputHandlingArgName)
 			}

--- a/internal/uvm/types.go
+++ b/internal/uvm/types.go
@@ -3,6 +3,7 @@
 package uvm
 
 import (
+	"io"
 	"net"
 	"sync"
 
@@ -146,3 +147,8 @@ type UtilityVM struct {
 func (uvm *UtilityVM) ScratchEncryptionEnabled() bool {
 	return uvm.encryptScratch
 }
+
+// OutputHandler is used to process the output from the program run in the UVM.
+type OutputHandler func(io.Reader)
+
+type OutputHandlerCreator func(*Options) OutputHandler


### PR DESCRIPTION
Currently, `NewDefaultOptionsLCOW` creates a logrus output handler using the provided UVM ID, but if the `ID` field is changed, the `parseLogrus` `OutputHandler` still uses the old ID.

Change `OptionsLCOW` to take `OutputHandlerCreator`, which is a `func(*Options) OutputHandler`, so creating the output handler is delayed until LCOW creation, when all `Option` parameters are finalized.