### PR TITLE
[release/0.11] Add support for platform compatibility check for windows + fix integration test failures

### DIFF
--- a/osversion/platform_compat_windows.go
+++ b/osversion/platform_compat_windows.go
@@ -1,0 +1,35 @@
+package osversion
+
+// List of stable ABI compliant ltsc releases
+// Note: List must be sorted in ascending order
+var compatLTSCReleases = []uint16{
+	V21H2Server,
+}
+
+// CheckHostAndContainerCompat checks if given host and container
+// OS versions are compatible.
+// It includes support for stable ABI compliant versions as well.
+// Every release after WS 2022 will support the previous ltsc
+// container image. Stable ABI is in preview mode for windows 11 client.
+// Refer: https://learn.microsoft.com/en-us/virtualization/windowscontainers/deploy-containers/version-compatibility?tabs=windows-server-2022%2Cwindows-10#windows-server-host-os-compatibility
+func CheckHostAndContainerCompat(host, ctr OSVersion) bool {
+	// check major minor versions of host and guest
+	if host.MajorVersion != ctr.MajorVersion ||
+		host.MinorVersion != ctr.MinorVersion {
+		return false
+	}
+
+	// If host is < WS 2022, exact version match is required
+	if host.Build < V21H2Server {
+		return host.Build == ctr.Build
+	}
+
+	var supportedLtscRelease uint16
+	for i := len(compatLTSCReleases) - 1; i >= 0; i-- {
+		if host.Build >= compatLTSCReleases[i] {
+			supportedLtscRelease = compatLTSCReleases[i]
+			break
+		}
+	}
+	return ctr.Build >= supportedLtscRelease && ctr.Build <= host.Build
+}

--- a/osversion/platform_compat_windows_test.go
+++ b/osversion/platform_compat_windows_test.go
@@ -1,0 +1,68 @@
+package osversion
+
+import (
+	"testing"
+)
+
+// Test the platform compatibility of the different
+// OS Versions considering two ltsc container image
+// versions (ltsc2019, ltsc2022)
+func Test_PlatformCompat(t *testing.T) {
+	for testName, tc := range map[string]struct {
+		hostOs    uint16
+		ctrOs     uint16
+		shouldRun bool
+	}{
+		"RS5Host_ltsc2019": {
+			hostOs:    RS5,
+			ctrOs:     RS5,
+			shouldRun: true,
+		},
+		"RS5Host_ltsc2022": {
+			hostOs:    RS5,
+			ctrOs:     V21H2Server,
+			shouldRun: false,
+		},
+		"WS2022Host_ltsc2019": {
+			hostOs:    V21H2Server,
+			ctrOs:     RS5,
+			shouldRun: false,
+		},
+		"WS2022Host_ltsc2022": {
+			hostOs:    V21H2Server,
+			ctrOs:     V21H2Server,
+			shouldRun: true,
+		},
+		"Wind11Host_ltsc2019": {
+			hostOs:    V22H2Win11,
+			ctrOs:     RS5,
+			shouldRun: false,
+		},
+		"Wind11Host_ltsc2022": {
+			hostOs:    V22H2Win11,
+			ctrOs:     V21H2Server,
+			shouldRun: true,
+		},
+	} {
+		// Check if ltsc2019/ltsc2022 guest images are compatible on
+		// the given host OS versions
+		//
+		hostOSVersion := OSVersion{
+			MajorVersion: 10,
+			MinorVersion: 0,
+			Build:        tc.hostOs,
+		}
+		ctrOSVersion := OSVersion{
+			MajorVersion: 10,
+			MinorVersion: 0,
+			Build:        tc.ctrOs,
+		}
+		if CheckHostAndContainerCompat(hostOSVersion, ctrOSVersion) != tc.shouldRun {
+			var expectedResultStr string
+			if !tc.shouldRun {
+				expectedResultStr = " NOT"
+			}
+			t.Fatalf("Failed %v: host %v should%s be able to run guest %v", testName, tc.hostOs, expectedResultStr, tc.ctrOs)
+		}
+	}
+}


### PR DESCRIPTION
This change is backporting the following commit to release/0.11 
640a5606a855a275cda5b8862221ae32b09b6a35

(cherry picked from commit 640a5606a855a275cda5b8862221ae32b09b6a35)

Note: there could be some CI test failures but they are failures that exist on v0.10.0-rc.8 tag that release/0.11 is based off of. We need the stable ABI changes in upstream to unblock stable ABI work for annual channel Zn release. Fix all the test failures need up to update the containerd version used in go.mod file and this in turn is causing grpc changes while vendoring into containerd/1.7 and upstream seems to have a problem with it.
Since the tests are already present in rc8 tag and aren't new, we should be ok to check in this fix with CI failures (mainly to unblock annual channel work). Once that is done, we can update all tests and containerd tag and have a conversation with upstream folks about this.