### PR TITLE
Clean up NVIDIA hook

### DIFF
--- a/internal/devices/drivers.go
+++ b/internal/devices/drivers.go
@@ -24,12 +24,11 @@ import (
 // `share` is a directory path on the host that contains files for standard driver installation.
 // For windows this means files for pnp installation (.inf, .cat, .sys, .cert files).
 // For linux this means a vhd file that contains the drivers under /lib/modules/`uname -r` for use
-// with depmod and modprobe. For GPU, this vhd may also contain library files (under /usr/lib) and
-// binaries (under /usr/bin or /usr/sbin) to be used in conjunction with the modules.
+// with depmod and modprobe.
 //
 // Returns a ResourceCloser for the added mount. On failure, the mounted share will be released,
 // the returned ResourceCloser will be nil, and an error will be returned.
-func InstallDrivers(ctx context.Context, vm *uvm.UtilityVM, share string, gpuDriver bool) (closer resources.ResourceCloser, err error) {
+func InstallDrivers(ctx context.Context, vm *uvm.UtilityVM, share string) (closer resources.ResourceCloser, err error) {
 	defer func() {
 		if err != nil && closer != nil {
 			// best effort clean up allocated resource on failure
@@ -77,10 +76,6 @@ func InstallDrivers(ctx context.Context, vm *uvm.UtilityVM, share string, gpuDri
 		return closer, fmt.Errorf("failed to create a guid path for driver %+v: %s", share, err)
 	}
 	uvmReadWritePath := fmt.Sprintf(guestpath.LCOWGlobalDriverPrefixFmt, driverGUID.String())
-	if gpuDriver {
-		// if installing gpu drivers in lcow, use the nvidia mount path instead
-		uvmReadWritePath = guestpath.LCOWNvidiaMountPath
-	}
 
 	// install drivers using gcs tool `install-drivers`
 	return closer, execGCSInstallDriver(ctx, vm, uvmPathForShare, uvmReadWritePath)

--- a/internal/guest/runtime/hcsv2/workload_container.go
+++ b/internal/guest/runtime/hcsv2/workload_container.go
@@ -16,7 +16,6 @@ import (
 
 	specInternal "github.com/Microsoft/hcsshim/internal/guest/spec"
 	"github.com/Microsoft/hcsshim/internal/guestpath"
-	"github.com/Microsoft/hcsshim/internal/hooks"
 	"github.com/Microsoft/hcsshim/internal/oc"
 	"github.com/Microsoft/hcsshim/pkg/annotations"
 )
@@ -151,13 +150,6 @@ func setupWorkloadContainerSpec(ctx context.Context, sbid, id string, spec *oci.
 	if spec.Windows != nil {
 		// we only support Nvidia gpus right now
 		if specHasGPUDevice(spec) {
-			// run ldconfig as a `CreateRuntime` hook so that it's executed in the runtime namespace. This is
-			// necessary so that when we execute the nvidia hook to assign the device, the runtime can
-			// find the nvidia library files.
-			ldconfigHook := hooks.NewOCIHook("/sbin/ldconfig", []string{getNvidiaDriversUsrLibPath()}, os.Environ())
-			if err := hooks.AddOCIHook(spec, hooks.CreateRuntime, ldconfigHook); err != nil {
-				return err
-			}
 			if err := addNvidiaDeviceHook(ctx, spec); err != nil {
 				return err
 			}

--- a/internal/guestpath/paths.go
+++ b/internal/guestpath/paths.go
@@ -1,9 +1,6 @@
 package guestpath
 
 const (
-	// LCOWNvidiaMountPath is the path format in LCOW UVM where nvidia tools
-	// are mounted keep this value in sync with opengcs
-	LCOWNvidiaMountPath = "/run/nvidia"
 	// LCOWRootPrefixInUVM is the path inside UVM where LCOW container's root
 	// file system will be mounted
 	LCOWRootPrefixInUVM = "/run/gcs/c"

--- a/internal/oci/uvm.go
+++ b/internal/oci/uvm.go
@@ -309,10 +309,6 @@ func UpdateSpecFromOptions(s specs.Spec, opts *runhcsopts.Options) specs.Spec {
 		s.Annotations[annotations.MemorySizeInMB] = strconv.FormatInt(int64(opts.VmMemorySizeInMb), 10)
 	}
 
-	if _, ok := s.Annotations[annotations.GPUVHDPath]; !ok && opts.GPUVHDPath != "" {
-		s.Annotations[annotations.GPUVHDPath] = opts.GPUVHDPath
-	}
-
 	if _, ok := s.Annotations[annotations.NetworkConfigProxy]; !ok && opts.NCProxyAddr != "" {
 		s.Annotations[annotations.NetworkConfigProxy] = opts.NCProxyAddr
 	}

--- a/pkg/annotations/annotations.go
+++ b/pkg/annotations/annotations.go
@@ -70,6 +70,7 @@ const (
 	// `spec.Windows.Resources.Storage.Iops`.
 	ContainerStorageQoSIopsMaximum = "io.microsoft.container.storage.qos.iopsmaximum"
 
+	// Deprecated: GPU VHDs are no longer supported.
 	// GPUVHDPath overrides the default path to search for the gpu vhd
 	GPUVHDPath = "io.microsoft.lcow.gpuvhdpath"
 

--- a/test/cri-containerd/container_virtual_device_test.go
+++ b/test/cri-containerd/container_virtual_device_test.go
@@ -122,8 +122,6 @@ func findTestVirtualDeviceID() (string, error) {
 }
 
 var lcowPodGPUAnnotations = map[string]string{
-	annotations.KernelDirectBoot:    "false",
-	annotations.AllowOvercommit:     "false",
 	annotations.PreferredRootFSType: "initrd",
 	annotations.VPMemCount:          "0",
 	annotations.VPCIEnabled:         "true",
@@ -131,7 +129,7 @@ var lcowPodGPUAnnotations = map[string]string{
 	// if a given gpu device needs more, this test will fail to create the container
 	// and may hang.
 	annotations.MemoryHighMMIOGapInMB: "64000",
-	annotations.BootFilesRootPath:     testGPUBootFiles,
+	annotations.FullyPhysicallyBacked: "true",
 }
 
 func getGPUContainerRequestLCOW(t *testing.T, podID string, podConfig *runtime.PodSandboxConfig, device *runtime.Device) *runtime.CreateContainerRequest {

--- a/test/cri-containerd/main_test.go
+++ b/test/cri-containerd/main_test.go
@@ -45,8 +45,7 @@ const (
 	testDeviceUtilFilePath    = "C:\\ContainerPlat\\device-util.exe"
 	testJobObjectUtilFilePath = "C:\\ContainerPlat\\jobobject-util.exe"
 
-	testDriversPath  = "C:\\ContainerPlat\\testdrivers"
-	testGPUBootFiles = "C:\\ContainerPlat\\LinuxBootFiles\\nvidiagpu"
+	testDriversPath = "C:\\ContainerPlat\\testdrivers"
 
 	testVMServiceAddress = "C:\\ContainerPlat\\vmservice.sock"
 	testVMServiceBinary  = "C:\\Containerplat\\vmservice.exe"

--- a/test/functional/uvm_virtualdevice_test.go
+++ b/test/functional/uvm_virtualdevice_test.go
@@ -16,8 +16,6 @@ import (
 	tuvm "github.com/Microsoft/hcsshim/test/pkg/uvm"
 )
 
-const lcowGPUBootFilesPath = "C:\\ContainerPlat\\LinuxBootFiles\\nvidiagpu"
-
 // findTestDevices returns the first pcip device on the host
 func findTestVirtualDevice() (string, error) {
 	out, err := exec.Command(
@@ -56,7 +54,6 @@ func TestVirtualDevice(t *testing.T) {
 	opts.KernelFile = uvm.KernelFile
 	opts.RootFSFile = uvm.InitrdFile
 	opts.PreferredRootFSType = uvm.PreferredRootFSTypeInitRd
-	opts.BootFilesPath = lcowGPUBootFilesPath
 
 	// create test uvm and ensure we can assign and remove the device
 	vm := tuvm.CreateAndStartLCOWFromOpts(ctx, t, opts)


### PR DESCRIPTION
This PR cleans up the support for NVIDIA GPUs. Instead of relying on a separate VHD that contains the NVIDIA drivers to be mounted into the UVM at runtime, we assume the UVM image has the drivers and necessary tools (such as libnvidia-container's cli binary) already present. `annotations.GPUVHDPath` is no longer used and will be removed in the future. Functional tests and cri-containerd tests have been cleaned up for this new logic. 