### PR TITLE
Add support for Linux kernel 6.x to fetch attestation report

### DIFF
--- a/internal/guest/linux/ioctl.go
+++ b/internal/guest/linux/ioctl.go
@@ -46,3 +46,10 @@ func Ioctl(f *os.File, command int, dataPtr unsafe.Pointer) error {
 	}
 	return nil
 }
+
+// Ported from _IOWR macro.
+// Returns value for `command` parameter in Ioctl().
+func Iowr(subsystem, ID, parameterSize uint64) int {
+	ioctlBase := IocWRBase | subsystem<<IocTypeShift | parameterSize<<IocSizeShift
+	return int(ID | ioctlBase)
+}

--- a/internal/guest/linux/ioctl.go
+++ b/internal/guest/linux/ioctl.go
@@ -46,10 +46,3 @@ func Ioctl(f *os.File, command int, dataPtr unsafe.Pointer) error {
 	}
 	return nil
 }
-
-// Ported from _IOWR macro.
-// Returns value for `command` parameter in Ioctl().
-func Iowr(subsystem, ID, parameterSize uint64) int {
-	ioctlBase := IocWRBase | subsystem<<IocTypeShift | parameterSize<<IocSizeShift
-	return int(ID | ioctlBase)
-}

--- a/pkg/amdsevsnp/report.go
+++ b/pkg/amdsevsnp/report.go
@@ -56,22 +56,12 @@ type guestRequest6 struct {
 
 // AMD SEV ioctl definitions for kernel 5.x.
 const (
-	// SEV-SNP IOCTL type.
-	guestType5 = 'S'
-	// SEV-SNP IOCTL size, same as unsafe.Sizeof(guestRequest5{}).
-	guestSize5 = 40
-	// SEV-SNP requests
-	reportCode5 = 0x1
+	snpGetReportIoctlCode5 = 3223868161
 )
 
 // AMD SEV ioctl definitions for kernel 6.x.
 const (
-	// SEV-SNP IOCTL type.
-	guestType6 = 'S'
-	// SEV-SNP IOCTL size, same as unsafe.Sizeof(guestRequest6{}).
-	guestSize6 = 32
-	// SEV-SNP requests
-	reportCode6 = 0x0
+	snpGetReportIoctlCode6 = 3223343872
 )
 
 // reportRequest used to issue SEV-SNP request
@@ -222,7 +212,7 @@ func fetchRawSNPReport5(reportData []byte) ([]byte, error) {
 		Error:           0,
 	}
 
-	if err := linux.Ioctl(f, linux.Iowr(guestType5, reportCode5, guestSize5), unsafe.Pointer(payload)); err != nil {
+	if err := linux.Ioctl(f, snpGetReportIoctlCode5, unsafe.Pointer(payload)); err != nil {
 		return nil, err
 	}
 	return msgReportOut.Report[:], nil
@@ -257,7 +247,7 @@ func fetchRawSNPReport6(reportData []byte) ([]byte, error) {
 		Error:        0,
 	}
 
-	if err := linux.Ioctl(f, linux.Iowr(guestType6, reportCode6, guestSize6), unsafe.Pointer(payload)); err != nil {
+	if err := linux.Ioctl(f, snpGetReportIoctlCode6, unsafe.Pointer(payload)); err != nil {
 		return nil, err
 	}
 

--- a/pkg/amdsevsnp/report.go
+++ b/pkg/amdsevsnp/report.go
@@ -9,6 +9,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"os"
 	"unsafe"
@@ -35,7 +36,7 @@ const (
 	msgTypeMax
 )
 
-type guestRequest struct {
+type guestRequest5 struct {
 	RequestMsgType  byte
 	ResponseMsgType byte
 	MsgVersion      byte
@@ -46,16 +47,31 @@ type guestRequest struct {
 	Error           uint32
 }
 
-// AMD SEV ioctl definitions.
+type guestRequest6 struct {
+	MsgVersion   byte
+	RequestData  unsafe.Pointer
+	ResponseData unsafe.Pointer
+	Error        uint64
+}
+
+// AMD SEV ioctl definitions for kernel 5.x.
 const (
 	// SEV-SNP IOCTL type.
-	guestType = 'S'
-	// SEV-SNP IOCTL size, same as unsafe.Sizeof(SevSNPGuestRequest{}).
-	guestSize = 40
-	ioctlBase = linux.IocWRBase | guestType<<linux.IocTypeShift | guestSize<<linux.IocSizeShift
-
+	guestType5 = 'S'
+	// SEV-SNP IOCTL size, same as unsafe.Sizeof(guestRequest5{}).
+	guestSize5 = 40
 	// SEV-SNP requests
-	reportCode = 0x1
+	reportCode5 = 0x1
+)
+
+// AMD SEV ioctl definitions for kernel 6.x.
+const (
+	// SEV-SNP IOCTL type.
+	guestType6 = 'S'
+	// SEV-SNP IOCTL size, same as unsafe.Sizeof(guestRequest6{}).
+	guestSize6 = 32
+	// SEV-SNP requests
+	reportCode6 = 0x0
 )
 
 // reportRequest used to issue SEV-SNP request
@@ -143,9 +159,39 @@ type reportResponse struct {
 	reserved2  [64]byte // padding to the size of SEV_SNP_REPORT_RSP_BUF_SZ (i.e., 1280 bytes)
 }
 
+// Size of `snp_report_resp` in include/uapi/linux/sev-guest.h.
+// It's used only for Linux 6.x.
+// It will have the conteints of reportResponse in the first unsafe.Sizeof(reportResponse{}) bytes.
+const reportResponseContainerLength6 = 4000
+
+const snpDevicePath5 = "/dev/sev"
+const snpDevicePath6 = "/dev/sev-guest"
+
+// Check if the code is being run in SNP VM for Linux kernel version 5.x.
+func isSNPVM5() bool {
+	_, err := os.Stat(snpDevicePath5)
+	return !errors.Is(err, os.ErrNotExist)
+}
+
+// Check if the code is being run in SNP VM for Linux kernel version 6.x.
+func isSNPVM6() bool {
+	_, err := os.Stat(snpDevicePath6)
+	return !errors.Is(err, os.ErrNotExist)
+}
+
 // FetchRawSNPReport returns attestation report bytes.
 func FetchRawSNPReport(reportData []byte) ([]byte, error) {
-	f, err := os.OpenFile("/dev/sev", os.O_RDWR, 0)
+	if isSNPVM5() {
+		return fetchRawSNPReport5(reportData)
+	} else if isSNPVM6() {
+		return fetchRawSNPReport6(reportData)
+	} else {
+		return nil, fmt.Errorf("SEV device is not found")
+	}
+}
+
+func fetchRawSNPReport5(reportData []byte) ([]byte, error) {
+	f, err := os.OpenFile(snpDevicePath5, os.O_RDWR, 0)
 	if err != nil {
 		return nil, err
 	}
@@ -165,7 +211,7 @@ func FetchRawSNPReport(reportData []byte) ([]byte, error) {
 		copy(msgReportIn.ReportData[:], reportData)
 	}
 
-	payload := &guestRequest{
+	payload := &guestRequest5{
 		RequestMsgType:  msgReportRequest,
 		ResponseMsgType: msgReportResponse,
 		MsgVersion:      1,
@@ -176,9 +222,50 @@ func FetchRawSNPReport(reportData []byte) ([]byte, error) {
 		Error:           0,
 	}
 
-	if err := linux.Ioctl(f, reportCode|ioctlBase, unsafe.Pointer(payload)); err != nil {
+	if err := linux.Ioctl(f, linux.Iowr(guestType5, reportCode5, guestSize5), unsafe.Pointer(payload)); err != nil {
 		return nil, err
 	}
+	return msgReportOut.Report[:], nil
+}
+
+func fetchRawSNPReport6(reportData []byte) ([]byte, error) {
+	f, err := os.OpenFile(snpDevicePath6, os.O_RDWR, 0)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		_ = f.Close()
+	}()
+
+	var (
+		msgReportIn  reportRequest
+		msgReportOut reportResponse
+	)
+	reportOutContainer := [reportResponseContainerLength6]byte{}
+
+	if reportData != nil {
+		if len(reportData) > len(msgReportIn.ReportData) {
+			return nil, fmt.Errorf("reportData too large: %s", reportData)
+		}
+		copy(msgReportIn.ReportData[:], reportData)
+	}
+
+	payload := &guestRequest6{
+		MsgVersion:   1,
+		RequestData:  unsafe.Pointer(&msgReportIn),
+		ResponseData: unsafe.Pointer(&reportOutContainer),
+		Error:        0,
+	}
+
+	if err := linux.Ioctl(f, linux.Iowr(guestType6, reportCode6, guestSize6), unsafe.Pointer(payload)); err != nil {
+		return nil, err
+	}
+
+	reportOutSize := unsafe.Sizeof(msgReportOut)
+	reportOutPtr := unsafe.Pointer(&msgReportOut)
+	reportOutAsSlice := (*[reportResponseContainerLength6]byte)(reportOutPtr)
+	copy(reportOutAsSlice[:reportOutSize], reportOutContainer[:reportOutSize])
+
 	return msgReportOut.Report[:], nil
 }
 


### PR DESCRIPTION
Add support for Linux kernel 6.x to fetch attestation report.
Because I can't add tests which require SNP VM under amdsevsnp package, I tested the change in the following way.

### Build test for fetching report

```bash
git apply --ignore-space-change <<EOF
diff --git a/pkg/amdsevsnp/report_test.go b/pkg/amdsevsnp/report_test.go
index e42af6de..65acbc91 100644
--- a/pkg/amdsevsnp/report_test.go
+++ b/pkg/amdsevsnp/report_test.go
@@ -4,6 +4,7 @@
 package amdsevsnp
 
 import (
+       "encoding/hex"
        "testing"
 )
 
@@ -51,3 +52,24 @@ func Test_Mirror_Nil_Slice(t *testing.T) {
                t.Fatalf("expected nil slice, got: %+v", result)
        }
 }
+
+func Test_Fetch_Report(t *testing.T) {
+       const REPORT_DATA_SIZE = 64
+       const REPORT_DATA_OFFSET = 80
+       // Report data for test
+       reportData := [REPORT_DATA_SIZE]byte{}
+       for i := 0; i < REPORT_DATA_SIZE; i++ {
+               reportData[i] = byte(i)
+       }
+       reportBytes, err := FetchRawSNPReport(reportData[:])
+       if err != nil {
+               t.Fatalf("fetching report failed: %v", err)
+       }
+       expectedByteString := hex.EncodeToString(reportData[:])
+
+       if expectedByteString != hex.EncodeToString(reportBytes[REPORT_DATA_OFFSET:REPORT_DATA_OFFSET+REPORT_DATA_SIZE]) {
+               t.Fatalf("report data doesn't match: expected: %s, actual: %s", expectedByteString, hex.EncodeToString(reportBytes[REPORT_DATA_OFFSET:REPORT_DATA_OFFSET+REPORT_DATA_SIZE]))
+       }
+
+       t.Logf("Report contents: %s\n", hex.EncodeToString(reportBytes))
+}
EOF

cd pkg/amdsevsnp/
CGO_ENABLED=0 go test -c
```

### Run test

Copy `amdsevsnp.test` to a SNV VM first.

```bash
./amdsevsnp.test -test.v
```

It was tested in both 5.x and 6.x
