### PR TITLE
defaulting to unbuffered reader for dmverity hashing

### DIFF
--- a/cmd/dmverity-vhd/main.go
+++ b/cmd/dmverity-vhd/main.go
@@ -103,7 +103,13 @@ func fetchImageLayers(ctx *cli.Context) (layers []v1.Layer, err error) {
 		// if only an image name is provided and not a tag, the default is "latest"
 		img, err = tarball.ImageFromPath(tarballPath, &imageNameAndTag)
 	} else if dockerDaemon {
-		img, err = daemon.Image(ref)
+		// use the unbuffered opener, the tradeoff being the image will stream as needed
+		// so it is slower but much more memory efficient
+		var opts []daemon.Option
+		opt := daemon.WithUnbufferedOpener()
+		opts = append(opts, opt)
+
+		img, err = daemon.Image(ref, opts...)
 	} else {
 		var remoteOpts []remote.Option
 		if ctx.IsSet(usernameFlag) && ctx.IsSet(passwordFlag) {


### PR DESCRIPTION
In the `confcom` CLI tooling that uses the dmverity-vhd executable, we were seeing an issue where large OCI images would cause the dmverity hashing process to get killed because the machine ran out of memory: [example](https://github.com/Azure/azure-cli/issues/27275).

This unbuffered option makes go-containerregistry stream in the image as needed instead of loading it all at once, saving memory with the tradeoff of being slower for large images. The typical use case we've seen is to use the `confcom` tooling on a local machine or VM with ~16GB of memory so memory efficiency is more important than time efficiency.

Discussed with Maksim that making this the default should be fine. thanks!