### PR TITLE
github-ci: use go1.19.x (#1689)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
 env:
   GOFLAGS: -mod=vendor
   GOPROXY: off
-  GO_VERSION: '1.18.x'
+  GO_VERSION: '1.19.x'
 
 jobs:
   lint:

--- a/pkg/go-runhcs/runhcs.go
+++ b/pkg/go-runhcs/runhcs.go
@@ -3,6 +3,7 @@ package runhcs
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -34,6 +35,11 @@ func getCommandPath() string {
 	pathi := runhcsPath.Load()
 	if pathi == nil {
 		path, err := exec.LookPath(command)
+		if err != nil {
+			if errors.Is(err, exec.ErrDot) {
+				err = nil
+			}
+		}
 		if err != nil {
 			// LookPath only finds current directory matches based on the
 			// callers current directory but the caller is not likely in the

--- a/test/vendor/github.com/Microsoft/hcsshim/pkg/go-runhcs/runhcs.go
+++ b/test/vendor/github.com/Microsoft/hcsshim/pkg/go-runhcs/runhcs.go
@@ -3,6 +3,7 @@ package runhcs
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -34,6 +35,11 @@ func getCommandPath() string {
 	pathi := runhcsPath.Load()
 	if pathi == nil {
 		path, err := exec.LookPath(command)
+		if err != nil {
+			if errors.Is(err, exec.ErrDot) {
+				err = nil
+			}
+		}
 		if err != nil {
 			// LookPath only finds current directory matches based on the
 			// callers current directory but the caller is not likely in the


### PR DESCRIPTION
rerun protobuild

fix: check for `exec.ErrDot`


(cherry picked from commit 66fe5f7f91d753070ed352ce1edc1f437fe468e9)