### PR TITLE
Skip shim tests if shim binary is not found

### DIFF
--- a/test/containerd-shim-runhcs-v1/global_command_test.go
+++ b/test/containerd-shim-runhcs-v1/global_command_test.go
@@ -5,29 +5,30 @@ package main
 
 import (
 	"bytes"
-	"os"
 	"os/exec"
-	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/Microsoft/hcsshim/test/pkg/require"
 )
+
+const shimExe = "containerd-shim-runhcs-v1.exe"
 
 func runGlobalCommand(t *testing.T, args []string) (string, string, error) {
 	t.Helper()
-	wd, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("failed os.Getwd() with: %v", err)
-	}
+
+	shim := require.BinaryInPath(t, shimExe)
 	cmd := exec.Command(
-		filepath.Join(wd, "containerd-shim-runhcs-v1.exe"),
+		shim,
 		args...,
 	)
+	t.Logf("execing global command: %s", cmd.String())
 
 	outb := bytes.Buffer{}
 	errb := bytes.Buffer{}
 	cmd.Stdout = &outb
 	cmd.Stderr = &errb
-	err = cmd.Run()
+	err := cmd.Run()
 	return outb.String(), errb.String(), err
 }
 

--- a/test/containerd-shim-runhcs-v1/start_test.go
+++ b/test/containerd-shim-runhcs-v1/start_test.go
@@ -16,11 +16,13 @@ import (
 	"time"
 
 	"github.com/Microsoft/go-winio"
-	"github.com/Microsoft/hcsshim/pkg/annotations"
 	task "github.com/containerd/containerd/api/runtime/task/v2"
 	"github.com/containerd/ttrpc"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/runtime-tools/generate"
+
+	"github.com/Microsoft/hcsshim/pkg/annotations"
+	"github.com/Microsoft/hcsshim/test/pkg/require"
 )
 
 func createStartCommand(t *testing.T) (*exec.Cmd, *bytes.Buffer, *bytes.Buffer) {
@@ -31,12 +33,10 @@ func createStartCommand(t *testing.T) (*exec.Cmd, *bytes.Buffer, *bytes.Buffer) 
 func createStartCommandWithID(t *testing.T, id string) (*exec.Cmd, *bytes.Buffer, *bytes.Buffer) {
 	t.Helper()
 	bundleDir := t.TempDir()
-	wd, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("failed os.Getwd() with: %v", err)
-	}
+
+	shim := require.BinaryInPath(t, shimExe)
 	cmd := exec.Command(
-		filepath.Join(wd, "containerd-shim-runhcs-v1.exe"),
+		shim,
 		"--namespace", t.Name(),
 		"--address", "need-a-real-one",
 		"--publish-binary", "need-a-real-one",
@@ -44,6 +44,9 @@ func createStartCommandWithID(t *testing.T, id string) (*exec.Cmd, *bytes.Buffer
 		"start",
 	)
 	cmd.Dir = bundleDir
+
+	t.Logf("execing start command: %s", cmd.String())
+
 	outb := bytes.Buffer{}
 	errb := bytes.Buffer{}
 	cmd.Stdout = &outb


### PR DESCRIPTION
Rather than failing tests when attempting to exec the shim executable, look up its path first and skip if it is not found.

Most testing binaries require that other binaries be located in the same directory as them (see `require.Binary`), but since the CI runs the shim tests directly, add `require.BinaryInPath`, which looks for the binary in the path or current working directory first.