### PR TITLE
Also use `test/go.sum` for caching go dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,12 +156,19 @@ jobs:
       - name: Validate go.mod and vendoring
         shell: powershell
         run: |
-          Write-Output "::group::go mod tidy & vendor"
+          Write-Output "::group::go mod tidy"
           go mod tidy -v -e
+          Write-Output "::endgroup::"
+          if ($LASTEXITCODE -ne 0) {
+            Write-Output "::error title=Go Mod::Error running ``go mod tidy``"
+            exit $LASTEXITCODE
+          }
+
+          Write-Output "::group::go mod vendor"
           go mod vendor -e
           Write-Output "::endgroup::"
           if ($LASTEXITCODE -ne 0) {
-            Write-Output "::error title=Go Mod::Error running ``go mod tidy``` or ``go mod vendor``"
+            Write-Output "::error title=Go Mod::Error running ``go mod vendor``"
             exit $LASTEXITCODE
           }
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,15 +30,18 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          show-progress: false
 
       - name: Install go
         uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
-          # sometimes go cache causes issues with lint
+          # sometimes go cache causes issues when linting
           cache: false
 
-      - uses: golangci/golangci-lint-action@v3
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v3
         with:
           version: v1.52
           args: >-
@@ -66,12 +69,23 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: "${{ github.workspace }}/go/src/github.com/Microsoft/hcsshim"
+          show-progress: false
 
       - name: Install go
         uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
-          cache-dependency-path: go/src/github.com/Microsoft/hcsshim/go.sum
+          cache-dependency-path: |
+            ${{ github.workspace }}/go/src/github.com/Microsoft/hcsshim/go.sum
+            ${{ github.workspace }}/go/src/github.com/Microsoft/hcsshim/test/go.sum
+
+      - name: Pre-fill Module Cache
+        shell: powershell
+        run: |
+          go mod download
+          cd test
+          go mod download
+        working-directory: "${{ github.workspace }}/go/src/github.com/Microsoft/hcsshim"
 
       - name: Install protoc
         shell: powershell
@@ -121,19 +135,35 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          show-progress: false
 
       - name: Install go
         uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache-dependency-path: |
+            go.sum
+            test/go.sum
+
+      - name: Pre-fill Module Cache
+        shell: powershell
+        run: |
+          go mod download
+          cd test
+          go mod download
 
       - name: Validate go.mod and vendoring
         shell: powershell
         run: |
           Write-Output "::group::go mod tidy & vendor"
-          go mod tidy
-          go mod vendor
+          go mod tidy -v -e
+          go mod vendor -e
           Write-Output "::endgroup::"
+          if ($LASTEXITCODE -ne 0) {
+            Write-Output "::error title=Go Mod::Error running ``go mod tidy``` or ``go mod vendor``"
+            exit $LASTEXITCODE
+          }
 
           git add --all --intent-to-add .
           Write-Output "::group::git diff"
@@ -150,8 +180,12 @@ jobs:
         working-directory: test
         run: |
           Write-Output "::group::go mod tidy"
-          go mod tidy
+          go mod tidy -v -e
           Write-Output "::endgroup::"
+          if ($LASTEXITCODE -ne 0) {
+            Write-Output "::error title=Go Mod::Error running ``go mod tidy``` from withing ``./test``"
+            exit $LASTEXITCODE
+          }
 
           git add --all --intent-to-add .
           Write-Output "::group::git diff"
@@ -169,11 +203,23 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          show-progress: false
 
       - name: Install go
         uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache-dependency-path: |
+            go.sum
+            test/go.sum
+
+      - name: Pre-fill Module Cache
+        shell: powershell
+        run: |
+          go mod download
+          cd test
+          go mod download
 
       - name: Validate go generate
         shell: powershell
@@ -201,11 +247,16 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          show-progress: false
 
       - name: Install go
         uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache-dependency-path: |
+            go.sum
+            test/go.sum
 
       - name: Install gotestsum
         run: go install gotest.tools/gotestsum@${{ env.GOTESTSUM_VERSION }}
@@ -236,11 +287,16 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          show-progress: false
 
       - name: Install go
         uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache-dependency-path: |
+            go.sum
+            test/go.sum
 
       - name: Install gotestsum
         run: go install gotest.tools/gotestsum@${{ env.GOTESTSUM_VERSION }}
@@ -301,13 +357,16 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: src/github.com/Microsoft/hcsshim
+          show-progress: false
 
       - name: Install go
         uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
           check-latest: true
-          cache-dependency-path: src/github.com/Microsoft/hcsshim/go.sum
+          cache-dependency-path: |
+            src/github.com/Microsoft/hcsshim/go.sum
+            src/github.com/Microsoft/hcsshim/test/go.sum
 
       - name: Set env
         shell: bash
@@ -330,12 +389,13 @@ jobs:
           "containerd_ref=$v" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
         working-directory: src/github.com/Microsoft/hcsshim
 
-      - uses: actions/checkout@v4
+      - name: Checkout containerd
+        uses: actions/checkout@v4
         with:
           path: src/github.com/containerd/containerd
           repository: "containerd/containerd"
           ref: "${{ env.containerd_ref }}"
-        name: Checkout containerd
+          show-progress: false
 
       - name: Install crictl
         shell: powershell
@@ -503,11 +563,16 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          show-progress: false
 
       - name: Install go
         uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache-dependency-path: |
+            go.sum
+            test/go.sum
 
       - name: Set version info
         shell: pwsh
@@ -563,11 +628,16 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          show-progress: false
 
       - name: Install go
         uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache-dependency-path: |
+            go.sum
+            test/go.sum
 
       - name: Set version info
         shell: pwsh


### PR DESCRIPTION
Update CI to look at both `go.sum` and `test/go.sum` when caching go modules.
Update initial CI josb (`protos`, `verify-vendor`, and `go-gen`) to download all module dependencies (that are not already vendored) to pre-fill the cache and speed up future runs.
This way, on cache miss, the cache is updated with all potential (hcsshim) dependencies.

Also, add `$LASTEXITCODE` check when running `go mod tidy` (and `go mod test`) to catch errors early on.