### PR TITLE
Update containerd log dependency

### DIFF
--- a/cmd/containerd-shim-runhcs-v1/serve.go
+++ b/cmd/containerd-shim-runhcs-v1/serve.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/Microsoft/go-winio"
 	task "github.com/containerd/containerd/api/runtime/task/v2"
-	"github.com/containerd/containerd/log"
 	"github.com/containerd/ttrpc"
 	typeurl "github.com/containerd/typeurl/v2"
 	"github.com/pkg/errors"
@@ -109,7 +108,7 @@ var serveCommand = cli.Command{
 		switch shimOpts.DebugType {
 		case runhcsopts.Options_NPIPE:
 			logrus.SetFormatter(&logrus.TextFormatter{
-				TimestampFormat: log.RFC3339NanoFixed,
+				TimestampFormat: hcslog.TimeFormat,
 				FullTimestamp:   true,
 			})
 			// Setup the log listener

--- a/internal/log/format.go
+++ b/internal/log/format.go
@@ -9,13 +9,16 @@ import (
 	"reflect"
 	"time"
 
-	"github.com/containerd/containerd/log"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 )
 
-const TimeFormat = log.RFC3339NanoFixed
+// TimeFormat is [time.RFC3339Nano] with nanoseconds padded using
+// zeros to ensure the formatted time is always the same number of
+// characters.
+// Based on RFC3339NanoFixed from github.com/containerd/log
+const TimeFormat = "2006-01-02T15:04:05.000000000Z07:00"
 
 func FormatTime(t time.Time) string {
 	return t.Format(TimeFormat)

--- a/internal/log/hook.go
+++ b/internal/log/hook.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/Microsoft/hcsshim/internal/logfields"
-	"github.com/containerd/containerd/log"
 	"github.com/sirupsen/logrus"
 	"go.opencensus.io/trace"
 )
@@ -30,7 +29,7 @@ type Hook struct {
 	// An empty string disables formatting.
 	// When disabled, the fall back will the JSON encoding, if enabled.
 	//
-	// Default is [github.com/containerd/containerd/log.RFC3339NanoFixed].
+	// Default is [TimeFormat].
 	TimeFormat string
 
 	// Duration format converts a [time.Duration] fields to an appropriate encoding.
@@ -49,7 +48,7 @@ var _ logrus.Hook = &Hook{}
 
 func NewHook() *Hook {
 	return &Hook{
-		TimeFormat:     log.RFC3339NanoFixed,
+		TimeFormat:     TimeFormat,
 		DurationFormat: DurationFormatString,
 		AddSpanContext: true,
 	}

--- a/test/cri-containerd/runpodsandbox_test.go
+++ b/test/cri-containerd/runpodsandbox_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/Microsoft/hcsshim/test/pkg/definitions/shimdiag"
 	"github.com/Microsoft/hcsshim/test/pkg/require"
 	testuvm "github.com/Microsoft/hcsshim/test/pkg/uvm"
-	"github.com/containerd/containerd/log"
+	"github.com/containerd/log"
 	"golang.org/x/sys/windows"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 )

--- a/test/go.mod
+++ b/test/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/containerd/cgroups/v3 v3.0.2
 	github.com/containerd/containerd v1.7.0
 	github.com/containerd/go-runc v1.0.0
+	github.com/containerd/log v0.1.0
 	github.com/containerd/ttrpc v1.2.2
 	github.com/containerd/typeurl/v2 v2.1.1
 	github.com/google/go-containerregistry v0.16.1

--- a/test/go.sum
+++ b/test/go.sum
@@ -842,6 +842,8 @@ github.com/containerd/imgcrypt v1.1.1/go.mod h1:xpLnwiQmEUJPvQoAapeb2SNCxz7Xr6PJ
 github.com/containerd/imgcrypt v1.1.3/go.mod h1:/TPA1GIDXMzbj01yd8pIbQiLdQxed5ue1wb8bP7PQu4=
 github.com/containerd/imgcrypt v1.1.4/go.mod h1:LorQnPtzL/T0IyCeftcsMEO7AqxUDbdO8j/tSUpgxvo=
 github.com/containerd/imgcrypt v1.1.7/go.mod h1:FD8gqIcX5aTotCtOmjeCsi3A1dHmTZpnMISGKSczt4k=
+github.com/containerd/log v0.1.0 h1:TCJt7ioM2cr/tfR8GPbGf9/VRAX8D2B4PjzCpfX540I=
+github.com/containerd/log v0.1.0/go.mod h1:VRRf09a7mHDIRezVKTRCrOq78v577GXq3bSa3EhrzVo=
 github.com/containerd/nri v0.0.0-20201007170849-eb1350a75164/go.mod h1:+2wGSDGFYfE5+So4M5syatU0N0f0LbWpuqyMi4/BE8c=
 github.com/containerd/nri v0.0.0-20210316161719-dbaa18c31c14/go.mod h1:lmxnXF6oMkbqs39FiCt1s0R2HSMhcLel9vNL3m4AaeY=
 github.com/containerd/nri v0.1.0/go.mod h1:lmxnXF6oMkbqs39FiCt1s0R2HSMhcLel9vNL3m4AaeY=


### PR DESCRIPTION
Moving the log package to a separate repository is part of our containerd 2.0 effort to break circular dependencies where we can. Importing the `log` package in the internal log seems unnecessary since it only uses a const. If copying that const is still not ideal, it can be updated to use new package as well (removed based on "A little copying is better than a little dependency.")

Uses the new log package for the shim and tests.

