### PR TITLE
Fix closing stdin

### DIFF
--- a/internal/hcs/process.go
+++ b/internal/hcs/process.go
@@ -421,12 +421,6 @@ func (process *Process) CloseStdin(ctx context.Context) (err error) {
 		return makeProcessError(process, operation, ErrAlreadyClosed, nil)
 	}
 
-	process.stdioLock.Lock()
-	defer process.stdioLock.Unlock()
-	if process.stdin == nil {
-		return nil
-	}
-
 	//HcsModifyProcess request to close stdin will fail if the process has already exited
 	if !process.stopped() {
 		modifyRequest := processModifyRequest{
@@ -448,8 +442,12 @@ func (process *Process) CloseStdin(ctx context.Context) (err error) {
 		}
 	}
 
-	process.stdin.Close()
-	process.stdin = nil
+	process.stdioLock.Lock()
+	defer process.stdioLock.Unlock()
+	if process.stdin != nil {
+		process.stdin.Close()
+		process.stdin = nil
+	}
 
 	return nil
 }


### PR DESCRIPTION
moby tried updating hcsshim to 0.11.0 and we had some failures in our tests ([see this PR](https://github.com/moby/moby/pull/45966)).

We tracked the issue to [this change](https://github.com/microsoft/hcsshim/commit/3e090b05a82c0e226e26c0d1e2ae89d336d7ff69), the close request wasn't forwarded any more if stdin is nil. This change moves the nil check to after the modify request, letting the process handle it.

