### PR TITLE
Use `"hcsschema"` in `internal/hcs`

### DIFF
--- a/internal/hcs/process.go
+++ b/internal/hcs/process.go
@@ -12,14 +12,16 @@ import (
 	"syscall"
 	"time"
 
+	"go.opencensus.io/trace"
+
 	"github.com/Microsoft/hcsshim/internal/cow"
+	hcsschema "github.com/Microsoft/hcsshim/internal/hcs/schema2"
 	"github.com/Microsoft/hcsshim/internal/log"
 	"github.com/Microsoft/hcsshim/internal/oc"
+	"github.com/Microsoft/hcsshim/internal/protocol/guestrequest"
 	"github.com/Microsoft/hcsshim/internal/vmcompute"
-	"go.opencensus.io/trace"
 )
 
-// ContainerError is an error encountered in HCS
 type Process struct {
 	handleLock          sync.RWMutex
 	handle              vmcompute.HcsProcess
@@ -49,35 +51,6 @@ func newProcess(process vmcompute.HcsProcess, processID int, computeSystem *Syst
 		waitBlock: make(chan struct{}),
 	}
 }
-
-type processModifyRequest struct {
-	Operation   string
-	ConsoleSize *consoleSize `json:",omitempty"`
-	CloseHandle *closeHandle `json:",omitempty"`
-}
-
-type consoleSize struct {
-	Height uint16
-	Width  uint16
-}
-
-type closeHandle struct {
-	Handle string
-}
-
-type processStatus struct {
-	ProcessID      uint32
-	Exited         bool
-	ExitCode       uint32
-	LastWaitResult int32
-}
-
-const stdIn string = "StdIn"
-
-const (
-	modifyConsoleSize string = "ConsoleSize"
-	modifyCloseHandle string = "CloseHandle"
-)
 
 // Pid returns the process ID of the process within the container.
 func (process *Process) Pid() int {
@@ -260,14 +233,14 @@ func (process *Process) waitBackground() {
 		process.handleLock.RLock()
 		defer process.handleLock.RUnlock()
 
-		// Make sure we didnt race with Close() here
+		// Make sure we didn't race with Close() here
 		if process.handle != 0 {
 			propertiesJSON, resultJSON, err = vmcompute.HcsGetProcessProperties(ctx, process.handle)
 			events := processHcsResult(ctx, resultJSON)
 			if err != nil {
 				err = makeProcessError(process, operation, err, events)
 			} else {
-				properties := &processStatus{}
+				properties := &hcsschema.ProcessStatus{}
 				err = json.Unmarshal([]byte(propertiesJSON), properties)
 				if err != nil {
 					err = makeProcessError(process, operation, err, nil)
@@ -318,10 +291,9 @@ func (process *Process) ResizeConsole(ctx context.Context, width, height uint16)
 	if process.handle == 0 {
 		return makeProcessError(process, operation, ErrAlreadyClosed, nil)
 	}
-
-	modifyRequest := processModifyRequest{
-		Operation: modifyConsoleSize,
-		ConsoleSize: &consoleSize{
+	modifyRequest := hcsschema.ProcessModifyRequest{
+		Operation: guestrequest.ModifyProcessConsoleSize,
+		ConsoleSize: &hcsschema.ConsoleSize{
 			Height: height,
 			Width:  width,
 		},
@@ -429,10 +401,10 @@ func (process *Process) CloseStdin(ctx context.Context) (err error) {
 
 	//HcsModifyProcess request to close stdin will fail if the process has already exited
 	if !process.stopped() {
-		modifyRequest := processModifyRequest{
-			Operation: modifyCloseHandle,
-			CloseHandle: &closeHandle{
-				Handle: stdIn,
+		modifyRequest := hcsschema.ProcessModifyRequest{
+			Operation: guestrequest.CloseProcessHandle,
+			CloseHandle: &hcsschema.CloseHandle{
+				Handle: guestrequest.STDInHandle,
 			},
 		}
 

--- a/internal/hcs/schema2/close_handle.go
+++ b/internal/hcs/schema2/close_handle.go
@@ -9,6 +9,8 @@
 
 package hcsschema
 
+import "github.com/Microsoft/hcsshim/internal/protocol/guestrequest"
+
 type CloseHandle struct {
-	Handle string `json:"Handle,omitempty"`
+	Handle guestrequest.STDIOHandle `json:"Handle,omitempty"` // NOTE: Swagger generated as string. Locally updated.
 }

--- a/internal/hcs/schema2/console_size.go
+++ b/internal/hcs/schema2/console_size.go
@@ -9,8 +9,11 @@
 
 package hcsschema
 
-type ConsoleSize struct {
-	Height int32 `json:"Height,omitempty"`
+// NOTE: Swagger generated fields as int32. Locally updated to uint16 to match documentation.
+// https://learn.microsoft.com/en-us/virtualization/api/hcs/schemareference#ConsoleSize
 
-	Width int32 `json:"Width,omitempty"`
+type ConsoleSize struct {
+	Height uint16 `json:"Height,omitempty"`
+
+	Width uint16 `json:"Width,omitempty"`
 }

--- a/internal/hcs/schema2/process_modify_request.go
+++ b/internal/hcs/schema2/process_modify_request.go
@@ -9,9 +9,11 @@
 
 package hcsschema
 
-//  Passed to HcsRpc_ModifyProcess
+import "github.com/Microsoft/hcsshim/internal/protocol/guestrequest"
+
+// Passed to HcsRpc_ModifyProcess
 type ProcessModifyRequest struct {
-	Operation string `json:"Operation,omitempty"`
+	Operation guestrequest.ProcessModifyOperation `json:"Operation,omitempty"` // NOTE: Swagger generated as string. Locally updated.
 
 	ConsoleSize *ConsoleSize `json:"ConsoleSize,omitempty"`
 

--- a/internal/hcs/schema2/process_status.go
+++ b/internal/hcs/schema2/process_status.go
@@ -9,13 +9,16 @@
 
 package hcsschema
 
-//  Status of a process running in a container
+// NOTE: Swagger generated fields as int32. Locally updated to uint16 to match documentation.
+// https://learn.microsoft.com/en-us/virtualization/api/hcs/schemareference#ConsoleSize
+
+// Status of a process running in a container
 type ProcessStatus struct {
-	ProcessId int32 `json:"ProcessId,omitempty"`
+	ProcessId uint32 `json:"ProcessId,omitempty"` // NOTE: Swagger generated as int32. Locally updated to match documentation.
 
 	Exited bool `json:"Exited,omitempty"`
 
-	ExitCode int32 `json:"ExitCode,omitempty"`
+	ExitCode uint32 `json:"ExitCode,omitempty"` // NOTE: Swagger generated as int32. Locally updated to match documentation.
 
 	LastWaitResult int32 `json:"LastWaitResult,omitempty"`
 }

--- a/internal/protocol/guestrequest/types.go
+++ b/internal/protocol/guestrequest/types.go
@@ -5,7 +5,7 @@ package guestrequest
 type RequestType string
 type ResourceType string
 
-// RequestType const
+// RequestType const.
 const (
 	RequestTypeAdd    RequestType = "Add"
 	RequestTypeRemove RequestType = "Remove"
@@ -53,4 +53,24 @@ var (
 		"b5d2d8d4-3a75-51bf-945b-3444dc6b8579",
 		"305891a9-b251-5dfe-91a2-c25d9212275b",
 	}
+)
+
+// constants for v2 schema ProcessModifyRequest
+
+// Operation type for [hcsschema.ProcessModifyRequest].
+type ProcessModifyOperation string
+
+const (
+	ModifyProcessConsoleSize ProcessModifyOperation = "ConsoleSize"
+	CloseProcessHandle       ProcessModifyOperation = "CloseHandle"
+)
+
+// Standard IO handle(s) to close for [hcsschema.CloseHandle] in [hcsschema.ProcessModifyRequest].
+type STDIOHandle string
+
+const (
+	STDInHandle  STDIOHandle = "StdIn"
+	STDOutHandle STDIOHandle = "StdOut"
+	STDErrHandle STDIOHandle = "StdErr"
+	AllHandles   STDIOHandle = "All"
 )


### PR DESCRIPTION
Use `hcsschema.ProcessModifyRequest` (and associated structs) in `internal/hcs/process` when making modify requests and getting process properties.

Update `hcschema` structs to match documentation (swagger seems to default to `int32` for generated fields regardless of the type specified in the documentation).