### PR TITLE
Support adding mount to running containers

### DIFF
--- a/cmd/containerd-shim-runhcs-v1/service_internal_taskshim_test.go
+++ b/cmd/containerd-shim-runhcs-v1/service_internal_taskshim_test.go
@@ -6,12 +6,16 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
+	"os"
+	"path/filepath"
 	"strconv"
 	"testing"
 	"time"
 
 	"github.com/Microsoft/hcsshim/cmd/containerd-shim-runhcs-v1/options"
 	"github.com/Microsoft/hcsshim/cmd/containerd-shim-runhcs-v1/stats"
+	"github.com/Microsoft/hcsshim/internal/hcsoci"
+	"github.com/Microsoft/hcsshim/pkg/ctrdtaskapi"
 	task "github.com/containerd/containerd/api/runtime/task/v2"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/protobuf"
@@ -533,6 +537,67 @@ func Test_TaskShim_updateInternal_Success(t *testing.T) {
 	}
 	if resp == nil {
 		t.Fatalf("should have returned an empty resp")
+	}
+}
+
+// Tests if a requested mount is valid for windows containers.
+// Currently only host volumes/directories are supported to be mounted
+// on a running windows container.
+func Test_TaskShimWindowsMount_updateInternal_Success(t *testing.T) {
+	s, t1, _ := setupTaskServiceWithFakes(t)
+	t1.isWCOW = true
+
+	hostRWSharedDirectory := t.TempDir()
+	fRW, _ := os.OpenFile(filepath.Join(hostRWSharedDirectory, "readwrite"), os.O_RDWR|os.O_CREATE, 0755)
+	fRW.Close()
+
+	resources := &ctrdtaskapi.ContainerMount{
+		HostPath:      hostRWSharedDirectory,
+		ContainerPath: hostRWSharedDirectory,
+		ReadOnly:      true,
+		Type:          "",
+	}
+	any, err := typeurl.MarshalAny(resources)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp, err := s.updateInternal(context.TODO(), &task.UpdateTaskRequest{ID: t1.ID(), Resources: protobuf.FromAny(any)})
+	if err != nil {
+		t.Fatalf("should not have failed update mount with error, got: %v", err)
+	}
+	if resp == nil {
+		t.Fatalf("should have returned an empty resp")
+	}
+}
+
+func Test_TaskShimWindowsMount_updateInternal_Error(t *testing.T) {
+	s, t1, _ := setupTaskServiceWithFakes(t)
+	t1.isWCOW = true
+
+	hostRWSharedDirectory := t.TempDir()
+	tmpVhdPath := filepath.Join(hostRWSharedDirectory, "test-vhd.vhdx")
+
+	fRW, _ := os.OpenFile(filepath.Join(tmpVhdPath, "readwrite"), os.O_RDWR|os.O_CREATE, 0755)
+	fRW.Close()
+
+	resources := &ctrdtaskapi.ContainerMount{
+		HostPath:      tmpVhdPath,
+		ContainerPath: tmpVhdPath,
+		ReadOnly:      true,
+		Type:          hcsoci.MountTypeVirtualDisk,
+	}
+	any, err := typeurl.MarshalAny(resources)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp, err := s.updateInternal(context.TODO(), &task.UpdateTaskRequest{ID: t1.ID(), Resources: protobuf.FromAny(any)})
+	if err == nil {
+		t.Fatalf("should have failed update mount with error")
+	}
+	if resp != nil {
+		t.Fatalf("should have returned a nil resp, got: %v", resp)
 	}
 }
 

--- a/cmd/containerd-shim-runhcs-v1/task.go
+++ b/cmd/containerd-shim-runhcs-v1/task.go
@@ -110,6 +110,7 @@ func verifyTaskUpdateResourcesType(data interface{}) error {
 	case *specs.WindowsResources:
 	case *specs.LinuxResources:
 	case *ctrdtaskapi.PolicyFragment:
+	case *ctrdtaskapi.ContainerMount:
 	default:
 		return errNotSupportedResourcesRequest
 	}

--- a/cmd/containerd-shim-runhcs-v1/task_test.go
+++ b/cmd/containerd-shim-runhcs-v1/task_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Microsoft/hcsshim/cmd/containerd-shim-runhcs-v1/options"
 	"github.com/Microsoft/hcsshim/cmd/containerd-shim-runhcs-v1/stats"
 	"github.com/Microsoft/hcsshim/internal/shimdiag"
+	"github.com/Microsoft/hcsshim/pkg/ctrdtaskapi"
 	v1 "github.com/containerd/cgroups/v3/cgroup1/stats"
 	task "github.com/containerd/containerd/api/runtime/task/v2"
 	"github.com/containerd/containerd/errdefs"
@@ -107,7 +108,24 @@ func (tst *testShimTask) Update(ctx context.Context, req *task.UpdateTaskRequest
 	if err != nil {
 		return errors.Wrapf(err, "failed to unmarshal resources for container %s update request", req.ID)
 	}
-	return verifyTaskUpdateResourcesType(data)
+	if err := verifyTaskUpdateResourcesType(data); err != nil {
+		return err
+	}
+
+	if tst.isWCOW {
+		switch request := data.(type) {
+		case *ctrdtaskapi.ContainerMount:
+			// Adding mount to a running container is currently only supported for windows containers
+			if isMountTypeSupported(request.HostPath, request.Type) {
+				return nil
+			} else {
+				return errNotSupportedResourcesRequest
+			}
+		default:
+			return nil
+		}
+	}
+	return nil
 }
 
 func (tst *testShimTask) Share(ctx context.Context, req *shimdiag.ShareRequest) error {

--- a/internal/guestpath/paths.go
+++ b/internal/guestpath/paths.go
@@ -13,6 +13,8 @@ const (
 	// HugePagesMountPrefix is mount prefix used in container spec to mark a
 	// huge-pages mount
 	HugePagesMountPrefix = "hugepages://"
+	// PipePrefix is the mount prefix used in container spec to mark a named pipe
+	PipePrefix = `\\.\pipe`
 	// LCOWMountPathPrefixFmt is the path format in the LCOW UVM where
 	// non-global mounts, such as Plan9 mounts are added
 	LCOWMountPathPrefixFmt = "/mounts/m%d"

--- a/pkg/ctrdtaskapi/update.go
+++ b/pkg/ctrdtaskapi/update.go
@@ -6,6 +6,7 @@ import (
 
 func init() {
 	typeurl.Register(&PolicyFragment{}, "github.com/Microsoft/hcsshim/pkg/ctrdtaskapi", "PolicyFragment")
+	typeurl.Register(&ContainerMount{}, "github.com/Microsoft/hcsshim/pkg/ctrdtaskapi", "ContainerMount")
 }
 
 type PolicyFragment struct {
@@ -14,4 +15,11 @@ type PolicyFragment struct {
 	// The value is a base64 encoded COSE_Sign1 document that contains the
 	// fragment and any additional information required for validation.
 	Fragment string `json:"fragment,omitempty"`
+}
+
+type ContainerMount struct {
+	HostPath      string
+	ContainerPath string
+	ReadOnly      bool
+	Type          string
 }


### PR DESCRIPTION
This PR adds hcsshim support to mount host volumes/directories to running windows containers.

HCS supports mounting host volumes/directories to running windows containers by modifying the hcs compute system with ResourcePath of Containers/MappedDirectories. These changes leverage this by extending the hcsTask.Update() function to process and add mounts for running process isolated and hyperV windows containers.
