### PR TITLE
Add layer managers for handling UVM layers

### DIFF
--- a/cmd/containerd-shim-runhcs-v1/pod.go
+++ b/cmd/containerd-shim-runhcs-v1/pod.go
@@ -123,21 +123,10 @@ func createPod(ctx context.Context, events publisher, req *task.CreateTaskReques
 			}
 		case *uvm.OptionsWCOW:
 			wopts := (opts).(*uvm.OptionsWCOW)
-
-			// In order for the UVM sandbox.vhdx not to collide with the actual
-			// nested Argon sandbox.vhdx we append the \vm folder to the last
-			// entry in the list.
-			layersLen := len(s.Windows.LayerFolders)
-			layers := make([]string, layersLen)
-			copy(layers, s.Windows.LayerFolders)
-
-			vmPath := filepath.Join(layers[layersLen-1], "vm")
-			err := os.MkdirAll(vmPath, 0)
-			if err != nil {
-				return nil, err
-			}
-			layers[layersLen-1] = vmPath
-			wopts.LayerFolders = layers
+			// TODO: once we remove the layer validation from rootfs.go
+			// enable this
+			// wopts.LayerFolders = s.Windows.LayerFolders
+			wopts.RootFS = req.Rootfs
 
 			parent, err = uvm.CreateWCOW(ctx, wopts)
 			if err != nil {

--- a/internal/layers/util/util.go
+++ b/internal/layers/util/util.go
@@ -1,0 +1,99 @@
+package util
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/containerd/containerd/api/types"
+	"github.com/containerd/containerd/errdefs"
+	"github.com/containerd/containerd/mount"
+)
+
+// ValidateRootfsAndLayers checks to ensure we have appropriate information
+// for setting up the container's root filesystem. It ensures the following:
+// - One and only one of Rootfs or LayerFolders can be provided.
+// - If LayerFolders are provided, there are at least two entries.
+// - If Rootfs is provided, there is a single entry and it does not have a Target set.
+func ValidateRootfsAndLayers(rootfs []*types.Mount, layerFolders []string) error {
+	if len(rootfs) > 0 && len(layerFolders) > 0 {
+		return fmt.Errorf("cannot pass both a rootfs mount and Windows.LayerFolders: %w", errdefs.ErrFailedPrecondition)
+	}
+	if len(rootfs) == 0 && len(layerFolders) == 0 {
+		return fmt.Errorf("must pass either a rootfs mount or Windows.LayerFolders: %w", errdefs.ErrFailedPrecondition)
+	}
+	if len(rootfs) > 0 {
+		// We have a rootfs.
+
+		if len(rootfs) > 1 {
+			return fmt.Errorf("expected a single rootfs mount: %w", errdefs.ErrFailedPrecondition)
+		}
+		if rootfs[0].Target != "" {
+			return fmt.Errorf("rootfs mount is missing Target path: %w", errdefs.ErrFailedPrecondition)
+		}
+	} else {
+		// We have layerFolders.
+
+		if len(layerFolders) < 2 {
+			return fmt.Errorf("must pass at least two Windows.LayerFolders: %w", errdefs.ErrFailedPrecondition)
+		}
+	}
+
+	return nil
+}
+
+// ParseLegacyRootfsMount parses the rootfs mount format that we have traditionally
+// used for both Linux and Windows containers.
+// The mount format consists of:
+//   - The scratch folder path in m.Source, which contains sandbox.vhdx.
+//   - A mount option in the form parentLayerPaths=<JSON>, where JSON is an array of
+//     string paths to read-only layer directories. The exact contents of these layer
+//     directories are intepreteted differently for Linux and Windows containers.
+func ParseLegacyRootfsMount(m *types.Mount) (string, []string, error) {
+	// parentLayerPaths are passed in layerN, layerN-1, ..., layer 0
+	//
+	// The OCI spec expects:
+	//   layerN, layerN-1, ..., layer0, scratch
+	var parentLayerPaths []string
+	for _, option := range m.Options {
+		if strings.HasPrefix(option, mount.ParentLayerPathsFlag) {
+			err := json.Unmarshal([]byte(option[len(mount.ParentLayerPathsFlag):]), &parentLayerPaths)
+			if err != nil {
+				return "", nil, fmt.Errorf("unmarshal parent layer paths from mount: %v: %w", err, errdefs.ErrFailedPrecondition)
+			}
+			// Would perhaps be worthwhile to check for unrecognized options and return an error,
+			// but since this is a legacy layer mount we don't do that to avoid breaking anyone.
+			break
+		}
+	}
+	return m.Source, parentLayerPaths, nil
+}
+
+// LocateUVMFolder searches a set of layer folders to determine the "uppermost"
+// layer which has a utility VM image. The order of the layers is (for historical) reasons
+// Read-only-layers followed by an optional read-write layer. The RO layers are in reverse
+// order so that the upper-most RO layer is at the start, and the base OS layer is the
+// end.
+func LocateUVMFolder(ctx context.Context, layerFolders []string) (string, error) {
+	var uvmFolder string
+	index := 0
+	for _, layerFolder := range layerFolders {
+		_, err := os.Stat(filepath.Join(layerFolder, `UtilityVM`))
+		if err == nil {
+			uvmFolder = layerFolder
+			break
+		}
+		if !os.IsNotExist(err) {
+			return "", err
+		}
+		index++
+	}
+	if uvmFolder == "" {
+		return "", fmt.Errorf("utility VM folder could not be found in layers")
+	}
+
+	return uvmFolder, nil
+}

--- a/internal/uvm/create_lcow.go
+++ b/internal/uvm/create_lcow.go
@@ -776,7 +776,6 @@ func CreateLCOW(ctx context.Context, opts *OptionsLCOW) (_ *UtilityVM, err error
 		vpciDevices:             make(map[VPCIDeviceKey]*VPCIDevice),
 		physicallyBacked:        !opts.AllowOvercommit,
 		devicesPhysicallyBacked: opts.FullyPhysicallyBacked,
-		createOpts:              opts,
 		vpmemMultiMapping:       !opts.VPMemNoMultiMapping,
 		encryptScratch:          opts.EnableScratchEncryption,
 		noWritableFileShares:    opts.NoWritableFileShares,

--- a/internal/uvm/layers_wcow.go
+++ b/internal/uvm/layers_wcow.go
@@ -1,0 +1,135 @@
+//go:build windows
+
+package uvm
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	hcsschema "github.com/Microsoft/hcsshim/internal/hcs/schema2"
+	layerutil "github.com/Microsoft/hcsshim/internal/layers/util"
+	"github.com/Microsoft/hcsshim/internal/protocol/guestrequest"
+	"github.com/Microsoft/hcsshim/internal/uvm/scsi"
+	"github.com/Microsoft/hcsshim/internal/wclayer"
+	"github.com/Microsoft/hcsshim/internal/wcow"
+	"github.com/containerd/containerd/api/types"
+)
+
+// A manager for handling the layers of a windows UVM
+type wcowUVMLayerManager interface {
+	// configure takes in the hcs schema document of a VM that is about to boot and sets it up properly by
+	// mounting the layers. (if required)
+	// The UtilityVM instance is modified to account for newly added SCSI disks/VSMB shares etc.
+	Configure(context.Context, *UtilityVM, *hcsschema.ComputeSystem) error
+	Close() error
+}
+
+type wcowUVMLegacyLayerManager struct {
+	roLayers     []string
+	scratchLayer string
+}
+
+// Close implements wcowUVMLayerManager
+func (*wcowUVMLegacyLayerManager) Close() error {
+	// legacy layer manager doesn't need any cleanup. SCSI disks & VSMB shares will be automatically
+	// removed when the UVM is closed.
+	return nil
+}
+
+// Configure implements WCOWUVMLayerManager
+func (l *wcowUVMLegacyLayerManager) Configure(ctx context.Context, uvm *UtilityVM, doc *hcsschema.ComputeSystem) error {
+	if uvm.id == "" || doc.VirtualMachine.Devices.Scsi == nil {
+		// UVM struct must be initialized to have a valid ID before calling this method
+		panic("UVM uninitialized")
+	}
+
+	uvmFolder, err := layerutil.LocateUVMFolder(ctx, l.roLayers)
+	if err != nil {
+		return fmt.Errorf("failed to locate utility VM folder from layer folders: %s", err)
+	}
+
+	// Create sandbox.vhdx in the scratch folder based on the template, granting the correct permissions to it
+	scratchPath := filepath.Join(l.scratchLayer, "sandbox.vhdx")
+	if _, err := os.Stat(scratchPath); os.IsNotExist(err) {
+		if err := wcow.CreateUVMScratch(ctx, uvmFolder, l.scratchLayer, uvm.id); err != nil {
+			return fmt.Errorf("failed to create scratch: %s", err)
+		}
+	} else {
+		// Sandbox.vhdx exists, just need to grant vm access to it.
+		if err := wclayer.GrantVmAccess(ctx, uvm.id, scratchPath); err != nil {
+			return fmt.Errorf("failed to grant vm access to scratch: %w", err)
+		}
+	}
+
+	doc.VirtualMachine.Devices.Scsi[guestrequest.ScsiControllerGuids[0]].Attachments["0"] = hcsschema.Attachment{
+
+		Path:  scratchPath,
+		Type_: "VirtualDisk",
+	}
+
+	// Ideally the layer manager should be decoupled from the SCSI management of the UVM and we should
+	// expose some method (like recordSCSIMount) on SCSI manager that can be called here.
+	uvm.reservedSCSISlots = append(uvm.reservedSCSISlots, scsi.Slot{Controller: 0, LUN: 0})
+
+	// UVM rootfs share is readonly.
+	if doc.VirtualMachine.Devices == nil {
+		doc.VirtualMachine.Devices = &hcsschema.Devices{}
+	}
+
+	vsmbOpts := uvm.DefaultVSMBOptions(true)
+	vsmbOpts.TakeBackupPrivilege = true
+	doc.VirtualMachine.Devices.VirtualSmb = &hcsschema.VirtualSmb{
+		DirectFileMappingInMB: 1024, // Sensible default, but could be a tuning parameter somewhere
+		Shares: []hcsschema.VirtualSmbShare{
+			{
+				Name:    "os",
+				Path:    filepath.Join(uvmFolder, `UtilityVM\Files`),
+				Options: vsmbOpts,
+			},
+		},
+	}
+	return nil
+}
+
+// Only one of the `layerFolders` or `rootfs` MUST be provided. If `layerFolders` is
+// provided a legacy layer manager will be returned. If `rootfs` is provided a layer manager
+// based on the type of mount will be returned
+func newWCOWUVMLegacyLayerManager(layerFolders []string, rootfs []*types.Mount) (wcowUVMLayerManager, error) {
+	err := layerutil.ValidateRootfsAndLayers(rootfs, layerFolders)
+	if err != nil {
+		return nil, err
+	}
+
+	var roLayers []string
+	var scratchLayer string
+	if len(layerFolders) > 0 {
+		scratchLayer, roLayers = layerFolders[len(layerFolders)-1], layerFolders[:len(layerFolders)-1]
+	} else {
+		scratchLayer, roLayers, err = layerutil.ParseLegacyRootfsMount(rootfs[0])
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// In non-CRI cases the UVM's scratch VHD will be created in the same directory as that of the
+	// container scratch, since both are named "sandbox.vhdx" we create a directory named "vm" and store
+	// UVM scratch there. Here we have no way of deciding if this is CRI or non-CRI so we always create
+	// the UVM VHD inside the "vm" subdirectory
+	// TODO: BUGBUG Remove this. @jhowardmsft
+	//       It should be the responsibility of the caller to do the creation and population.
+	//       - Update runhcs too (vm.go).
+	//       - Remove comment in function header
+	//       - Update tests that rely on this current behavior.
+	vmPath := filepath.Join(scratchLayer, "vm")
+	err = os.MkdirAll(vmPath, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	return &wcowUVMLegacyLayerManager{
+		roLayers:     roLayers,
+		scratchLayer: vmPath,
+	}, nil
+}

--- a/internal/uvm/types.go
+++ b/internal/uvm/types.go
@@ -124,10 +124,6 @@ type UtilityVM struct {
 	// Location that container process dumps will get written too.
 	processDumpLocation string
 
-	// The CreateOpts used to create this uvm. These can be either of type
-	// uvm.OptionsLCOW or uvm.OptionsWCOW
-	createOpts interface{}
-
 	// Network config proxy client. If nil then this wasn't requested and the
 	// uvms network will be configured locally.
 	ncProxyClientAddress string
@@ -142,6 +138,8 @@ type UtilityVM struct {
 
 	// confidentialUVMOptions hold confidential UVM specific options
 	confidentialUVMOptions *ConfidentialOptions
+
+	wcowLayerManager wcowUVMLayerManager
 }
 
 func (uvm *UtilityVM) ScratchEncryptionEnabled() bool {


### PR DESCRIPTION
Current layer handling (of UVM layers as well as container layers) in hcsshim is very rigid because it forces you to represent all layers as a string array. This worked fine for legacy layers but it isn't a good enough representation for representing other types of layers (like CimFS). This change modifies the UVM layer handling code by adding a new layer manager that directly takes in the layer mount provided by containerd and then prepares the layer according to the type of the mount. In future we can simply add a new layer manager for handling new type of layers (like CimFS).