### PR TITLE
Create container subdirectories for process dump

### DIFF
--- a/internal/hcsoci/hcsdoc_wcow.go
+++ b/internal/hcsoci/hcsdoc_wcow.go
@@ -31,6 +31,8 @@ import (
 	"github.com/Microsoft/hcsshim/pkg/annotations"
 )
 
+const createContainerSubdirectoryForProcessDumpSuffix = "{container_id}"
+
 // A simple wrapper struct around the container mount configs that should be added to the
 // container.
 type mountsConfig struct {
@@ -416,7 +418,23 @@ func createWindowsContainerDocument(ctx context.Context, coi *createOptionsInter
 	}
 
 	if dumpPath != "" {
+		//  If dumpPath specified has createContainerSubdirectoryForProcessDumpSuffix substring
+		// specified as a suffix, then create subdirectory for this container at the specified
+		// dumpPath location. When a fileshare from the host is mounted to the specified dumpPath,
+		// this behavior will help identify dumps coming from differnet containers in the pod.
+		// Check for createContainerSubdirectoryForProcessDumpSuffix in lower case and upper case
+		if strings.HasSuffix(dumpPath, createContainerSubdirectoryForProcessDumpSuffix) {
+			// replace {container_id} with the actual container id
+			dumpPath = strings.TrimSuffix(dumpPath, createContainerSubdirectoryForProcessDumpSuffix) + coi.ID
+		} else if strings.HasSuffix(dumpPath, strings.ToUpper(createContainerSubdirectoryForProcessDumpSuffix)) {
+			// replace {CONTAINER_ID} with the actual container id
+			dumpPath = strings.TrimSuffix(dumpPath, strings.ToUpper(createContainerSubdirectoryForProcessDumpSuffix)) + coi.ID
+		}
 		dumpType, err := parseDumpType(coi.Spec.Annotations)
+		if err != nil {
+			return nil, nil, err
+		}
+		dumpCount, err := parseDumpCount(coi.Spec.Annotations)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -440,6 +458,15 @@ func createWindowsContainerDocument(ctx context.Context, coi *createOptionsInter
 				},
 				Name:       "DumpType",
 				DWordValue: dumpType,
+				Type_:      "DWord",
+			},
+			{
+				Key: &hcsschema.RegistryKey{
+					Hive: "Software",
+					Name: "Microsoft\\Windows\\Windows Error Reporting\\LocalDumps",
+				},
+				Name:       "DumpCount",
+				DWordValue: dumpCount,
 				Type_:      "DWord",
 			},
 		}...)
@@ -477,6 +504,23 @@ func parseAssignedDevices(ctx context.Context, coi *createOptionsInternal, v2 *h
 	}
 	v2.AssignedDevices = v2AssignedDevices
 	return nil
+}
+
+func parseDumpCount(annots map[string]string) (int32, error) {
+	dmpCountStr := annots[annotations.WCOWProcessDumpCount]
+	if dmpCountStr == "" {
+		// If no count is specified, default of 10 is set.
+		return 10, nil
+	}
+
+	dumpCount, err := strconv.Atoi(dmpCountStr)
+	if err != nil {
+		return -1, err
+	}
+	if dumpCount > 0 {
+		return int32(dumpCount), nil
+	}
+	return -1, fmt.Errorf("invaid dump count specified: %v", dmpCountStr)
 }
 
 // parseDumpType parses the passed in string representation of the local user mode process dump type to the

--- a/pkg/annotations/annotations.go
+++ b/pkg/annotations/annotations.go
@@ -237,6 +237,11 @@ const (
 	// See DumpType: https://docs.microsoft.com/en-us/windows/win32/wer/collecting-user-mode-dumps
 	WCOWProcessDumpType = "io.microsoft.wcow.processdumptype"
 
+	// WCOWProcessDumpCount specifies the maximum number of dumps to be collected in the specified
+	// ContainerProcessDumpLocation path. When the maximum value is exceeded, the oldest dump file in the
+	// folder will be replaced by the new dump file. The default value is 10.
+	WCOWProcessDumpCount = "io.microsoft.wcow.processdumpcount"
+
 	// RLimitCore specifies the core rlimit value for a container. This will need to be set
 	// in order to have core dumps generated for a given container.
 	RLimitCore = "io.microsoft.lcow.rlimitcore"


### PR DESCRIPTION
Create new subdirectory at the specified dumpPath with name of the subdirectory as the containerId if dumpPath has a suffix of {container_id}.
Add new annotation to specify the dumpCount for LocalDumps reg key. These annotations can be specified at the pod or container level.

Following configuration was tested for process isolated and hyperV wcow containers:

- The container_annotation field in containerd.toml should be set to "io.microsoft.container.*"
- pod.json:

{
    "metadata": {
        "name": "sandbox-coredump",
        "namespace": "default",
        "attempt": 1
    }
}

- container.json:

{
    "metadata": {
        "name": "wcow-test"
    },
    "image": {
        "image": "mcr.microsoft.com/windows/servercore:ltsc2022"
    },
    "command": [
        "ping",
        "-t",
        "127.0.0.1"
    ],
    "annotations": {
        "io.microsoft.container.processdumplocation": "C:\\CrashDumps\\{container_id}",
        "io.microsoft.container.processdumpcount": "3",
        "io.microsoft.container.processdumptype": "2" 
    },
    "mounts": [
	    {	
		"container_path": "/crash.exe",
		"host_path": "C:\\dumpCollectionAks\\crash.exe"
	    },
	    {
		"container_path": "C:\\CrashDumps",
		"host_path": "C:\\kiashok\\containerdumps"
	    }
    ]
}