### PR TITLE
Update Cmd IO handling

### DIFF
--- a/internal/cmd/cmd_test.go
+++ b/internal/cmd/cmd_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"os/exec"
@@ -213,46 +214,69 @@ func TestCmdStdinBlocked(t *testing.T) {
 	}
 }
 
-type stuckIoProcessHost struct {
+type stuckIOProcessHost struct {
 	cow.ProcessHost
 }
 
-type stuckIoProcess struct {
+type stuckIOProcess struct {
 	cow.Process
-	stdin, pstdout, pstderr *io.PipeWriter
-	pstdin, stdout, stderr  *io.PipeReader
+
+	// don't initialize p.stdin, since it complicates the logic
+	pstdout, pstderr *os.File
+	stdout, stderr   *os.File
 }
 
-func (h *stuckIoProcessHost) CreateProcess(ctx context.Context, cfg interface{}) (cow.Process, error) {
+func (h *stuckIOProcessHost) CreateProcess(ctx context.Context, cfg interface{}) (cow.Process, error) {
 	p, err := h.ProcessHost.CreateProcess(ctx, cfg)
 	if err != nil {
 		return nil, err
 	}
-	sp := &stuckIoProcess{
+	sp := &stuckIOProcess{
 		Process: p,
 	}
-	sp.pstdin, sp.stdin = io.Pipe()
-	sp.stdout, sp.pstdout = io.Pipe()
-	sp.stderr, sp.pstderr = io.Pipe()
+
+	if sp.stdout, sp.pstdout, err = os.Pipe(); err != nil {
+		return nil, fmt.Errorf("create stdout pipe: %w", err)
+	}
+	if sp.stderr, sp.pstderr, err = os.Pipe(); err != nil {
+		return nil, fmt.Errorf("create stderr pipe: %w", err)
+	}
 	return sp, nil
 }
 
-func (p *stuckIoProcess) Stdio() (io.Writer, io.Reader, io.Reader) {
-	return p.stdin, p.stdout, p.stderr
+func (p *stuckIOProcess) Stdio() (io.Writer, io.Reader, io.Reader) {
+	return nil, p.stdout, p.stderr
 }
 
-func (p *stuckIoProcess) Close() error {
-	p.stdin.Close()
+func (*stuckIOProcess) CloseStdin(context.Context) error {
+	return nil
+}
+
+func (p *stuckIOProcess) CloseStdout(context.Context) error {
+	_ = p.pstdout.Close()
+	return p.stdout.Close()
+}
+
+func (p *stuckIOProcess) CloseStderr(context.Context) error {
+	_ = p.pstderr.Close()
+	return p.stderr.Close()
+}
+
+func (p *stuckIOProcess) Close() error {
+	p.pstdout.Close()
+	p.pstderr.Close()
+
 	p.stdout.Close()
 	p.stderr.Close()
+
 	return p.Process.Close()
 }
 
 func TestCmdStuckIo(t *testing.T) {
-	cmd := Command(&stuckIoProcessHost{&localProcessHost{}}, "cmd", "/c", "echo", "hello")
+	cmd := Command(&stuckIOProcessHost{&localProcessHost{}}, "cmd", "/c", "(exit 0)")
 	cmd.CopyAfterExitTimeout = time.Millisecond * 200
 	_, err := cmd.Output()
-	if err != io.ErrClosedPipe { //nolint:errorlint
-		t.Fatal(err)
+	if !errors.Is(err, errIOTimeOut) {
+		t.Fatalf("expected: %v; got: %v", errIOTimeOut, err)
 	}
 }

--- a/internal/cmd/io.go
+++ b/internal/cmd/io.go
@@ -4,11 +4,11 @@ package cmd
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net/url"
 	"time"
 
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -57,7 +57,7 @@ func NewUpstreamIO(ctx context.Context, id, stdout, stderr, stdin string, termin
 
 	// Create IO for binary logging driver.
 	if u.Scheme != "binary" {
-		return nil, errors.Errorf("scheme must be 'binary', got: '%s'", u.Scheme)
+		return nil, fmt.Errorf("scheme must be 'binary', got: '%s'", u.Scheme)
 	}
 
 	return NewBinaryIO(ctx, id, u)


### PR DESCRIPTION
Have `internal\cmd.Cmd` ignore relay and close errors from the underlying IO channel being closed, since not all
`io.Reader`/`io.Writer`s return an `io.EOF` if the are closed during an IO operation.

This standardizes behavior between an `hcs`/`gcs` `Process` (which use a `go-winio.win32File` for their IO channels, and return `io.EOF` for read and write operations on a closed handle) and `JobProcess` (which uses an `os.Pipe` that instead return an `os.ErrClosed`).

Additionally, ignore errors from closing an already-closed std IO channel.

Update `Cmd.Wait` to return a known error value if it times out waiting on IO copy after the command exits (and update `TestCmdStuckIo` to check for that error).
Prior, the test checked for an `io.ErrClosedPipe`, which:
1. is not the best indicator that IO is stuck; and
2. is now ignored as an error value raised durin IO relay.