### PR TITLE
Adding a new "DisableHostPort" network flag

### DIFF
--- a/hcn/hcn.go
+++ b/hcn/hcn.go
@@ -312,6 +312,18 @@ func NestedIpSetSupported() error {
 	return platformDoesNotSupportError("NestedIpSet")
 }
 
+// DisableHostPortSupported returns an error if the HCN version does not support DisableHostPort flag
+func DisableHostPortSupported() error {
+	supported, err := GetCachedSupportedFeatures()
+	if err != nil {
+		return err
+	}
+	if supported.DisableHostPort {
+		return nil
+	}
+	return platformDoesNotSupportError("DisableHostPort")
+}
+
 // RequestType are the different operations performed to settings.
 // Used to update the settings of Endpoint/Namespace objects.
 type RequestType string

--- a/hcn/hcnglobals.go
+++ b/hcn/hcnglobals.go
@@ -84,6 +84,9 @@ var (
 
 	//HNS 15.0 allows for NestedIpSet support
 	NestedIpSetVersion = VersionRanges{VersionRange{MinVersion: Version{Major: 15, Minor: 0}, MaxVersion: Version{Major: math.MaxInt32, Minor: math.MaxInt32}}}
+
+	//HNS 15.1 allows support for DisableHostPort flag.
+	DisableHostPortVersion = VersionRanges{VersionRange{MinVersion: Version{Major: 15, Minor: 1}, MaxVersion: Version{Major: math.MaxInt32, Minor: math.MaxInt32}}}
 )
 
 // GetGlobals returns the global properties of the HCN Service.

--- a/hcn/hcnnetwork.go
+++ b/hcn/hcnnetwork.go
@@ -72,6 +72,7 @@ type NetworkFlags uint32
 const (
 	None                NetworkFlags = 0
 	EnableNonPersistent NetworkFlags = 8
+	DisableHostPort     NetworkFlags = 1024
 )
 
 // HostComputeNetwork represents a network

--- a/hcn/hcnnetwork_test.go
+++ b/hcn/hcnnetwork_test.go
@@ -190,8 +190,8 @@ func TestNetworkFlags(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if network.Flags != EnableNonPersistent {
-		t.Errorf("EnableNonPersistent flag (%d) is not set on network", EnableNonPersistent)
+	if network.Flags&EnableNonPersistent == 0 {
+		t.Errorf("EnableNonPersistent flag (%d) is not set on network. Network's flags value: %d", EnableNonPersistent, network.Flags)
 	}
 
 	err = network.Delete()

--- a/hcn/hcnsupport.go
+++ b/hcn/hcnsupport.go
@@ -37,6 +37,7 @@ type SupportedFeatures struct {
 	TierAcl                  bool        `json:"TierAcl"`
 	NetworkACL               bool        `json:"NetworkACL"`
 	NestedIpSet              bool        `json:"NestedIpSet"`
+	DisableHostPort          bool        `json:"DisableHostPort"`
 }
 
 // AclFeatures are the supported ACL possibilities.
@@ -114,6 +115,7 @@ func getSupportedFeatures() (SupportedFeatures, error) {
 	features.TierAcl = isFeatureSupported(globals.Version, TierAclPolicyVersion)
 	features.NetworkACL = isFeatureSupported(globals.Version, NetworkACLPolicyVersion)
 	features.NestedIpSet = isFeatureSupported(globals.Version, NestedIpSetVersion)
+	features.DisableHostPort = isFeatureSupported(globals.Version, DisableHostPortVersion)
 
 	log.L.WithFields(logrus.Fields{
 		"version":           globals.Version,

--- a/hcn/hcnsupport_test.go
+++ b/hcn/hcnsupport_test.go
@@ -128,6 +128,17 @@ func TestNestedIpSetSupport(t *testing.T) {
 	}
 }
 
+func TestDisableHostPortSupport(t *testing.T) {
+	supportedFeatures := GetSupportedFeatures()
+	err := DisableHostPortSupported()
+	if supportedFeatures.DisableHostPort && err != nil {
+		t.Fatal(err)
+	}
+	if !supportedFeatures.DisableHostPort && err == nil {
+		t.Fatal(err)
+	}
+}
+
 func TestNetworkACLPolicySupport(t *testing.T) {
 	supportedFeatures := GetSupportedFeatures()
 	err := NetworkACLPolicySupported()


### PR DESCRIPTION
When this flag is set, a host-port will not be created for the network.