### PR TITLE
uvmboot and gcs.test bug fix

### DIFF
--- a/internal/tools/uvmboot/main.go
+++ b/internal/tools/uvmboot/main.go
@@ -9,10 +9,11 @@ import (
 	"sync"
 	"time"
 
-	"github.com/Microsoft/hcsshim/internal/uvm"
-	"github.com/Microsoft/hcsshim/internal/winapi"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
+
+	"github.com/Microsoft/hcsshim/internal/uvm"
+	"github.com/Microsoft/hcsshim/internal/winapi"
 )
 
 const (

--- a/internal/tools/uvmboot/wcow.go
+++ b/internal/tools/uvmboot/wcow.go
@@ -11,11 +11,12 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/containerd/console"
+	"github.com/urfave/cli"
+
 	"github.com/Microsoft/hcsshim/internal/cmd"
 	"github.com/Microsoft/hcsshim/internal/log"
 	"github.com/Microsoft/hcsshim/internal/uvm"
-	"github.com/containerd/console"
-	"github.com/urfave/cli"
 )
 
 var (
@@ -121,8 +122,8 @@ var wcowCommand = cli.Command{
 }
 
 func getLayers(imageName string) ([]string, error) {
-	cmd := exec.Command("docker", "inspect", imageName, "-f", `"{{.GraphDriver.Data.dir}}"`)
-	out, err := cmd.Output()
+	c := exec.Command("docker", "inspect", imageName, "-f", `"{{.GraphDriver.Data.dir}}"`)
+	out, err := c.Output()
 	if err != nil {
 		return nil, fmt.Errorf("failed to find layers for %s", imageName)
 	}
@@ -143,7 +144,7 @@ func getLayerChain(layerFolder string) ([]string, error) {
 	var layerChain []string
 	err = json.Unmarshal(content, &layerChain)
 	if err != nil {
-		return nil, fmt.Errorf("failed to unmarshal layerchain: %s", err)
+		return nil, fmt.Errorf("failed to unmarshal layerchain: %w", err)
 	}
 	return layerChain, nil
 }

--- a/test/gcs/main_test.go
+++ b/test/gcs/main_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -60,15 +59,6 @@ var (
 		"Use `/pause` as the sandbox container command",
 	)
 )
-
-var securityPolicy string
-
-func init() {
-	var err error
-	if securityPolicy, err = securitypolicy.NewOpenDoorPolicy().EncodeToString(); err != nil {
-		log.Fatal("could not encode open door policy to string: %w", err)
-	}
-}
 
 func TestMain(m *testing.M) {
 	flag.Parse()
@@ -176,11 +166,11 @@ func getHost(_ context.Context, tb testing.TB, rt runtime.Runtime) *hcsv2.Host {
 }
 
 func getHostErr(rt runtime.Runtime, tp transport.Transport) (*hcsv2.Host, error) {
-	h := hcsv2.NewHost(rt, tp, &securitypolicy.ClosedDoorSecurityPolicyEnforcer{}, os.Stdout)
-	cOpts := &guestresource.LCOWConfidentialOptions{
-		EncodedSecurityPolicy: securityPolicy,
-	}
-	if err := h.SetConfidentialUVMOptions(context.Background(), cOpts); err != nil {
+	h := hcsv2.NewHost(rt, tp, &securitypolicy.OpenDoorSecurityPolicyEnforcer{}, os.Stdout)
+	if err := h.SetConfidentialUVMOptions(
+		context.Background(),
+		&guestresource.LCOWConfidentialOptions{},
+	); err != nil {
 		return nil, fmt.Errorf("could not set host security policy: %w", err)
 	}
 


### PR DESCRIPTION
Fix bugs:
 - Using `boot-files-path` flag name instead of value
 - Explicitly passing open door policy instead of empty string

Functional gcs tests also passed in encoded open door policy string, which is no longer necessary.

Remove unnecessary else blocks.

Pass context through calls.
Use `log.G(ctx)` instead of `logrus`.

Rename variables `cmd` and `scsi` to avoid overshadowing package names.