### PR TITLE
Check for SNP before fetching SNP report

### DIFF
--- a/internal/guest/runtime/hcsv2/hostdata.go
+++ b/internal/guest/runtime/hcsv2/hostdata.go
@@ -6,7 +6,6 @@ package hcsv2
 import (
 	"bytes"
 	"fmt"
-	"os"
 
 	"github.com/Microsoft/hcsshim/pkg/amdsevsnp"
 )
@@ -14,12 +13,12 @@ import (
 // validateHostData fetches SNP report (if applicable) and validates `hostData` against
 // HostData set at UVM launch.
 func validateHostData(hostData []byte) error {
+	// If the UVM is not SNP, then don't try to fetch an SNP report.
+	if !amdsevsnp.IsSNP() {
+		return nil
+	}
 	report, err := amdsevsnp.FetchParsedSNPReport(nil)
 	if err != nil {
-		// For non-SNP hardware /dev/sev will not exist
-		if os.IsNotExist(err) {
-			return nil
-		}
 		return err
 	}
 

--- a/pkg/amdsevsnp/report.go
+++ b/pkg/amdsevsnp/report.go
@@ -157,6 +157,10 @@ const reportResponseContainerLength6 = 4000
 const snpDevicePath5 = "/dev/sev"
 const snpDevicePath6 = "/dev/sev-guest"
 
+func IsSNP() bool {
+	return isSNPVM5() || isSNPVM6()
+}
+
 // Check if the code is being run in SNP VM for Linux kernel version 5.x.
 func isSNPVM5() bool {
 	_, err := os.Stat(snpDevicePath5)


### PR DESCRIPTION
[PR1886](https://github.com/microsoft/hcsshim/pull/1886/files) changed the error type returned by the fetch SNP report code.

It transpires that when validating host data, we would always try to fetch the SNP report, even in non SNP mode, where we expect to get back an os.IsNotExist error and ignore it. 

After PR1886 the SNP report fetch no longer returns an os.IsNotExist and so the new error is not ignored. This PR removes the reliance on the os.IsNotExist error.  