### PR TITLE
Build components in CodeQL pipeline

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,13 +1,35 @@
+# Since we have multiple build targets, and the makefile that CodeQL would use in its autobuild
+# step doesn't build everything, we need to manually add run the Go (and C++) build commands
+#
+# See:
+# https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning
+# https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
+#
+# Additionally, see example CodeQL pipeline (in CodeQL repo):
+# https://github.com/github/codeql/blob/0342b3eba242476cea815e601942021092d0bc10/.github/workflows/codeql-analysis.yml
+
 name: "Code Scanning - CodeQL"
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
+    paths-ignore:
+      - "**/*.md"
+      - "**/*.txt"
+      - "hack/**"
+      - "scripts/**"
+      - ".github/**"
+      - "!.github/workflows/codeql.yml"
   schedule:
+    # run weekly, at midnight on Sunday
     # minute, hour, day of month, month, day of week
-    - cron: '0 0 * * 0'
+    - cron: "0 0 * * 0"
+
+# TODO: consolidate this with ci.yml so they both use the same Go version
+env:
+  GO_VERSION: "1.19.x"
 
 jobs:
   CodeQL-Build:
@@ -15,18 +37,77 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        goos: [windows, linux]
+        # we want a matrix across the two GOOS options, not the product of all options
+        # ! update `targets` field if more binaries are added
+        include:
+          - goos: windows
+            language: go
+            targets: >-
+              cmd/containerd-shim-runhcs-v1,
+              cmd/device-util,
+              cmd/dmverity-vhd,
+              cmd/jobobject-util,
+              cmd/ncproxy,
+              cmd/runhcs,
+              cmd/shimdiag,
+              cmd/tar2ext4,
+              cmd/wclayer,
+              internal/tools/extendedtask,
+              internal/tools/grantvmgroupaccess,
+              internal/tools/networkagent,
+              internal/tools/uvmboot,
+              internal/tools/zapdir,
+
+          - goos: linux
+            language: go, cpp
+            targets: >-
+              cmd/gcs,
+              cmd/gcstools,
+              cmd/hooks/wait-paths,
+              cmd/tar2ext4,
+              internal/tools/policyenginesimulator,
+              internal/tools/securitypolicy,
+              internal/tools/snp-report,
 
     steps:
+      # setup runner before initializing & running CodeQL
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
           show-progress: false
 
+      - name: Install go
+        uses: actions/setup-go@v4
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
       - name: CodeQL Initialize
         uses: github/codeql-action/init@v2
         with:
-          languages: go, cpp
+          languages: ${{matrix.language}}
+
+      # build binaries
+      - name: Build go binaries
+        shell: pwsh
+        run: |
+          $targets = "${{ matrix.targets }}" -split ',' |
+            foreach { $_.Trim() } |
+            where { -not [string]::IsNullOrWhiteSpace($_) }
+          Write-Output "Targets: $targets"
+
+          foreach ( $t in $targets ) {
+            Write-Output "Build: $t"
+            go build "./$t" 2>&1
+          }
+        env:
+          GOOS: ${{ matrix.goos }}
+
+      - name: Build init and vsockexec
+        if: ${{ matrix.goos == 'linux' }}
+        run: make bin/vsockexec bin/init
 
       - name: CodeQL Analyze
         uses: github/codeql-action/analyze@v2
+        with:
+          category: "/language:${{matrix.language}}"


### PR DESCRIPTION
Need to build binaries for CodeQL to work:

> For the compiled languages C/C++, C#, Go, Java, and Swift, the process of populating
> this database involves building the code and extracting data.

https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages#about-the-codeql-analysis-workflow-and-compiled-languages

Without explicit build commands between CodeQL `init` and `analyze` steps, CodeQL will attempt to automatically build go code using the following logic:
https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages#autobuild-for-go

This can be see in the `CodeQL Analyze` step in out pipelines:

```
Attempting to automatically build go code
  Autobuilder was built with go1.21.3, environment has go1.20.10
  LGTM_SRC is /home/runner/work/hcsshim/hcsshim
  Found go.mod, enabling go modules
  Import path is 'github.com/microsoft/hcsshim'
  Makefile found.
  Trying build command make []
  make: *** No rule to make target 'base.tar.gz', needed by 'out/initrd.img'.  Stop.
  Running /usr/bin/make failed, continuing anyway: exit status 2
  Build failed, continuing to install dependencies.
  Skipping dependency installation because a Go vendor directory was found.
  Running extractor command '/opt/hostedtoolcache/CodeQL/2.15.2/x64/codeql/go/tools/linux64/go-extractor [-mod=vendor ./...]' from directory '.'.
  <...>
```

Rather than rely on autobuild, explicitly configure CodeQL and build necessary targets.

Skip running CodeQL on PRs if no code is changed.

Based on guidance from:
https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning
and workflow:
https://github.com/github/codeql/blob/0342b3eba242476cea815e601942021092d0bc10/.github/workflows/codeql-analysis.yml