### PR TITLE
Fix CodeQL code scanning alerts

### DIFF
--- a/internal/guest/bridge/bridge.go
+++ b/internal/guest/bridge/bridge.go
@@ -11,6 +11,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math"
 	"os"
 	"strconv"
 	"sync"
@@ -443,21 +444,23 @@ func setErrorForResponseBase(response *prot.MessageResponseBase, errForResponse 
 	errorMessage := errForResponse.Error()
 	stackString := ""
 	fileName := ""
-	lineNumber := -1
+	// We use -1 as a sentinel if no line number found (or it cannot be parsed),
+	// but that will ultimately end up as [math.MaxUint32], so set it to that explicitly.
+	// (Still keep using -1 for backwards compatibility ...)
+	lineNumber := uint32(math.MaxUint32)
 	functionName := ""
 	if stack := gcserr.BaseStackTrace(errForResponse); stack != nil {
 		bottomFrame := stack[0]
 		stackString = fmt.Sprintf("%+v", stack)
 		fileName = fmt.Sprintf("%s", bottomFrame)
 		lineNumberStr := fmt.Sprintf("%d", bottomFrame)
-		var err error
-		lineNumber, err = strconv.Atoi(lineNumberStr)
-		if err != nil {
+		if n, err := strconv.ParseUint(lineNumberStr, 10, 32); err == nil {
+			lineNumber = uint32(n)
+		} else {
 			logrus.WithFields(logrus.Fields{
 				"line-number":   lineNumberStr,
 				logrus.ErrorKey: err,
 			}).Error("opengcs::bridge::setErrorForResponseBase - failed to parse line number, using -1 instead")
-			lineNumber = -1
 		}
 		functionName = fmt.Sprintf("%n", bottomFrame)
 	}
@@ -474,7 +477,7 @@ func setErrorForResponseBase(response *prot.MessageResponseBase, errForResponse 
 		StackTrace:   stackString,
 		ModuleName:   "gcs",
 		FileName:     fileName,
-		Line:         uint32(lineNumber),
+		Line:         lineNumber,
 		FunctionName: functionName,
 	}
 	response.ErrorRecords = append(response.ErrorRecords, newRecord)

--- a/internal/jobobject/limits.go
+++ b/internal/jobobject/limits.go
@@ -143,6 +143,13 @@ func (job *JobObject) SetCPUAffinity(affinityBitMask uint64) error {
 		return err
 	}
 	info.BasicLimitInformation.LimitFlags |= uint32(windows.JOB_OBJECT_LIMIT_AFFINITY)
+
+	// We really, really shouldn't be running on 32 bit, but just in case (and to satisfy CodeQL) ...
+	const maxUintptr = ^uintptr(0)
+	if affinityBitMask > uint64(maxUintptr) {
+		return fmt.Errorf("affinity bitmask (%d) exceeds max allowable value (%d)", affinityBitMask, maxUintptr)
+	}
+
 	info.BasicLimitInformation.Affinity = uintptr(affinityBitMask)
 	return job.setExtendedInformation(info)
 }

--- a/internal/logfields/fields.go
+++ b/internal/logfields/fields.go
@@ -46,6 +46,7 @@ const (
 
 	ExpectedType = "expected-type"
 	Bool         = "bool"
+	Int32        = "int32"
 	Uint32       = "uint32"
 	Uint64       = "uint64"
 

--- a/internal/oci/annotations.go
+++ b/internal/oci/annotations.go
@@ -221,6 +221,20 @@ func ParseAnnotationsNullableBool(ctx context.Context, a map[string]string, key 
 	return nil
 }
 
+// ParseAnnotationsInt32 searches `a` for `key` and if found verifies that the
+// value is a 32-bit signed integer. If `key` is not found returns `def`.
+func ParseAnnotationsInt32(ctx context.Context, a map[string]string, key string, def int32) int32 {
+	if v, ok := a[key]; ok {
+		countu, err := strconv.ParseInt(v, 10, 32)
+		if err == nil {
+			v := int32(countu)
+			return v
+		}
+		logAnnotationParseError(ctx, key, v, logfields.Int32, err)
+	}
+	return def
+}
+
 // ParseAnnotationsUint32 searches `a` for `key` and if found verifies that the
 // value is a 32 bit unsigned integer. If `key` is not found returns `def`.
 func ParseAnnotationsUint32(ctx context.Context, a map[string]string, key string, def uint32) uint32 {

--- a/internal/oci/uvm.go
+++ b/internal/oci/uvm.go
@@ -21,8 +21,8 @@ import (
 // not found searches `s` for the Windows CPU section. If neither are found
 // returns `def`.
 func ParseAnnotationsCPUCount(ctx context.Context, s *specs.Spec, annotation string, def int32) int32 {
-	if m := ParseAnnotationsUint64(ctx, s.Annotations, annotation, 0); m != 0 {
-		return int32(m)
+	if m := ParseAnnotationsInt32(ctx, s.Annotations, annotation, 0); m != 0 {
+		return m
 	}
 	if s.Windows != nil &&
 		s.Windows.Resources != nil &&
@@ -38,8 +38,8 @@ func ParseAnnotationsCPUCount(ctx context.Context, s *specs.Spec, annotation str
 // not found searches `s` for the Windows CPU section. If neither are found
 // returns `def`.
 func ParseAnnotationsCPULimit(ctx context.Context, s *specs.Spec, annotation string, def int32) int32 {
-	if m := ParseAnnotationsUint64(ctx, s.Annotations, annotation, 0); m != 0 {
-		return int32(m)
+	if m := ParseAnnotationsInt32(ctx, s.Annotations, annotation, 0); m != 0 {
+		return m
 	}
 	if s.Windows != nil &&
 		s.Windows.Resources != nil &&
@@ -55,8 +55,8 @@ func ParseAnnotationsCPULimit(ctx context.Context, s *specs.Spec, annotation str
 // not found searches `s` for the Windows CPU section. If neither are found
 // returns `def`.
 func ParseAnnotationsCPUWeight(ctx context.Context, s *specs.Spec, annotation string, def int32) int32 {
-	if m := ParseAnnotationsUint64(ctx, s.Annotations, annotation, 0); m != 0 {
-		return int32(m)
+	if m := ParseAnnotationsInt32(ctx, s.Annotations, annotation, 0); m != 0 {
+		return m
 	}
 	if s.Windows != nil &&
 		s.Windows.Resources != nil &&
@@ -72,8 +72,8 @@ func ParseAnnotationsCPUWeight(ctx context.Context, s *specs.Spec, annotation st
 // annotation. If not found searches `s` for the Windows Storage section. If
 // neither are found returns `def`.
 func ParseAnnotationsStorageIops(ctx context.Context, s *specs.Spec, annotation string, def int32) int32 {
-	if m := ParseAnnotationsUint64(ctx, s.Annotations, annotation, 0); m != 0 {
-		return int32(m)
+	if m := ParseAnnotationsInt32(ctx, s.Annotations, annotation, 0); m != 0 {
+		return m
 	}
 	if s.Windows != nil &&
 		s.Windows.Resources != nil &&
@@ -89,8 +89,8 @@ func ParseAnnotationsStorageIops(ctx context.Context, s *specs.Spec, annotation 
 // If not found searches `s` for the Windows Storage section. If neither are
 // found returns `def`.
 func ParseAnnotationsStorageBps(ctx context.Context, s *specs.Spec, annotation string, def int32) int32 {
-	if m := ParseAnnotationsUint64(ctx, s.Annotations, annotation, 0); m != 0 {
-		return int32(m)
+	if m := ParseAnnotationsInt32(ctx, s.Annotations, annotation, 0); m != 0 {
+		return m
 	}
 	if s.Windows != nil &&
 		s.Windows.Resources != nil &&


### PR DESCRIPTION
Fix CodeQL alerts for unchecked downcasts from `int`s are to `(u)int32` (or `uintptr`) without checking for overflow. This can (potentially) cause incorrect behavior due to the value wrapping around to an unexpected value.

Alerts:
https://github.com/microsoft/hcsshim/security/code-scanning?query=branch%3Amain+rule%3Ago%2Fincorrect-integer-conversion

Issue description:
https://cwe.mitre.org/data/definitions/190.html
https://cwe.mitre.org/data/definitions/681.html