### PR TITLE
Remove pause containers for process isolated containers

### DIFF
--- a/hcn/hcnnamespace.go
+++ b/hcn/hcnnamespace.go
@@ -9,6 +9,7 @@ import (
 	"syscall"
 
 	"github.com/Microsoft/go-winio/pkg/guid"
+	"github.com/Microsoft/hcsshim"
 	icni "github.com/Microsoft/hcsshim/internal/cni"
 	"github.com/Microsoft/hcsshim/internal/interop"
 	"github.com/Microsoft/hcsshim/internal/regstate"
@@ -63,6 +64,7 @@ type HostComputeNamespace struct {
 	Type          NamespaceType       `json:",omitempty"` // Host, HostDefault, Guest, GuestDefault
 	Resources     []NamespaceResource `json:",omitempty"`
 	SchemaVersion SchemaVersion       `json:",omitempty"`
+	ReadyOnCreate bool                `json:",omitempty"`
 }
 
 // ModifyNamespaceSettingRequest is the structure used to send request to modify a namespace.
@@ -309,9 +311,21 @@ func GetNamespaceContainerIds(namespaceID string) ([]string, error) {
 
 // NewNamespace creates a new Namespace object
 func NewNamespace(nsType NamespaceType) *HostComputeNamespace {
+	// HNS versions >= 15.2 change how network compartments are
+	// initialized for pods and depends on ReadyOnCreate flag in
+	// HCN namespace. It primarily supports removal of pause containers
+	// for process isolation.
+	isReadyOnCreate := false
+	hnsGlobals, err := hcsshim.GetHNSGlobals()
+	if err == nil {
+		isReadyOnCreate = (hnsGlobals.Version.Major > 15) ||
+			(hnsGlobals.Version.Major == 15 && hnsGlobals.Version.Minor >= 2)
+	}
+
 	return &HostComputeNamespace{
 		Type:          nsType,
 		SchemaVersion: V2SchemaVersion(),
+		ReadyOnCreate: isReadyOnCreate,
 	}
 }
 


### PR DESCRIPTION
PR does the following:

- Introduces new HostComputeNamespace.ReadyOnCreate field and sets it for HNS versions that support pause container removal
- Removes pause container creation while creating process isolated pods for HNS versions that support removal of pause containers

The changes have been manually tested with the supported HNS versions. 