### PR TITLE
Add CodeQL suppression for tar extraction code

### DIFF
--- a/pkg/ociwclayer/import.go
+++ b/pkg/ociwclayer/import.go
@@ -61,6 +61,8 @@ func ImportLayerFromTar(ctx context.Context, r io.Reader, path string, parentLay
 
 func writeLayerFromTar(ctx context.Context, r io.Reader, w wclayer.LayerWriter, root string) (int64, error) {
 	t := tar.NewReader(r)
+	// CodeQL [SM03409] False positive, `internal/safefile` package ensures tar extractions are always
+	// bound to the layer root directory.
 	hdr, err := t.Next()
 	totalSize := int64(0)
 	buf := bufio.NewWriter(nil)
@@ -78,12 +80,16 @@ func writeLayerFromTar(ctx context.Context, r io.Reader, w wclayer.LayerWriter, 
 			if err != nil {
 				return 0, err
 			}
+			// CodeQL [SM03409] False positive, `internal/safefile` package ensures tar extractions are always
+			// bound to the layer root directory.
 			hdr, err = t.Next()
 		} else if hdr.Typeflag == tar.TypeLink {
 			err = w.AddLink(filepath.FromSlash(hdr.Name), filepath.FromSlash(hdr.Linkname))
 			if err != nil {
 				return 0, err
 			}
+			// CodeQL [SM03409] False positive, `internal/safefile` package ensures tar extractions are always
+			// bound to the layer root directory.
 			hdr, err = t.Next()
 		} else {
 			var (


### PR DESCRIPTION
CodeQL is generating a warning for tar extraction code suggesting that the tar file entries are used in an unsanitized way and that could lead to file system traversal attacks. However, during tar extraction all the files are written to the disk using the `internal/safefile` package which ensures all the filesystem operations during layer extraction happen under the layer root directory. So this warning can be safely suppressed.