### PR TITLE
tests: update docker images

### DIFF
--- a/test/cri-containerd/test-images/argsescaped/dockerfile
+++ b/test/cri-containerd/test-images/argsescaped/dockerfile
@@ -1,5 +1,5 @@
 # Test image for ArgsEscaped behavior.
 # cplatpublic.azurecr.io/argsescaped:latest
-FROM mcr.microsoft.com/windows/nanoserver:1809@sha256:18dc202bc15c4ab948a993a021b554e70a5bc8f9f854a0674b3f5467cc7092da
+FROM mcr.microsoft.com/windows/nanoserver:1809@sha256:14b967649dca50e3e7718b2367d43c461b1f035850694e85f19942bce7e6f616
 ENTRYPOINT cmd.exe /c
 CMD ping -t 127.0.0.1

--- a/test/cri-containerd/test-images/imagepull_timestamp/Dockerfile
+++ b/test/cri-containerd/test-images/imagepull_timestamp/Dockerfile
@@ -9,7 +9,7 @@
 # `docker push cplatpublic.azurecr.io/timestamp:latest`
 
 # Base image
-FROM mcr.microsoft.com/windows/nanoserver:ltsc2022@sha256:56a7c823d8aed810849a38f47d995a727bf3de1ec611394025e1de24898a9622
+FROM mcr.microsoft.com/windows/nanoserver:ltsc2022@sha256:1abc7e4d96a7dd1f80a31597abf6b98f112f1e24c2b448747e28bbea5ba97975
 # Get administrator privileges
 USER containeradministrator
 

--- a/test/cri-containerd/test-images/nanoserver-gracefultermination-repro/latest/Dockerfile
+++ b/test/cri-containerd/test-images/nanoserver-gracefultermination-repro/latest/Dockerfile
@@ -10,7 +10,7 @@ WORKDIR /app
 COPY ./delayed-shutdown.go ./
 RUN go build -o delayed-shutdown.exe
 
-FROM mcr.microsoft.com/windows/nanoserver:ltsc2022@sha256:56a7c823d8aed810849a38f47d995a727bf3de1ec611394025e1de24898a9622
+FROM mcr.microsoft.com/windows/nanoserver:ltsc2022@sha256:1abc7e4d96a7dd1f80a31597abf6b98f112f1e24c2b448747e28bbea5ba97975
 WORKDIR /app
 COPY --from=build /app/delayed-shutdown.exe .
 ENTRYPOINT ["delayed-shutdown.exe"]

--- a/test/cri-containerd/test-images/servercore-gracefultermination-repro/latest/Dockerfile
+++ b/test/cri-containerd/test-images/servercore-gracefultermination-repro/latest/Dockerfile
@@ -10,7 +10,7 @@ WORKDIR /app
 COPY ./delayed-shutdown.go ./
 RUN go build -o delayed-shutdown.exe
 
-FROM mcr.microsoft.com/windows/servercore:ltsc2022@sha256:029d8eb737c978e3df0f26abb529efd38d3c9ecee9d8d0bba6d0c205f32dc263
+FROM mcr.microsoft.com/windows/servercore:ltsc2022@sha256:ba06e92a92c3533354926622f405265d31d86ef5080f5531a4705e7936de0b1d
 WORKDIR /app
 COPY --from=build /app/delayed-shutdown.exe .
 ENTRYPOINT ["delayed-shutdown.exe"]


### PR DESCRIPTION
tests: update docker images

Update docker image hashes to satisfy compliance requirements.

The images have been rebuilt.