### PR TITLE
osversion: Add Parse function and make partially cross-platform

### DIFF
--- a/osversion/osversion.go
+++ b/osversion/osversion.go
@@ -1,0 +1,20 @@
+package osversion
+
+import (
+	"fmt"
+)
+
+// OSVersion is a wrapper for Windows version information
+// https://msdn.microsoft.com/en-us/library/windows/desktop/ms724439(v=vs.85).aspx
+type OSVersion struct {
+	Version      uint32
+	MajorVersion uint8
+	MinorVersion uint8
+	Build        uint16
+}
+
+// String returns the OSVersion formatted as a string. It implements the
+// [fmt.Stringer] interface.
+func (osv OSVersion) String() string {
+	return fmt.Sprintf("%d.%d.%d", osv.MajorVersion, osv.MinorVersion, osv.Build)
+}

--- a/osversion/osversion.go
+++ b/osversion/osversion.go
@@ -2,6 +2,8 @@ package osversion
 
 import (
 	"fmt"
+	"strconv"
+	"strings"
 )
 
 // OSVersion is a wrapper for Windows version information
@@ -11,6 +13,51 @@ type OSVersion struct {
 	MajorVersion uint8
 	MinorVersion uint8
 	Build        uint16
+}
+
+func newVersion(majorVersion, minorVersion uint8, buildNumber uint16) OSVersion {
+	osv := OSVersion{
+		MajorVersion: majorVersion,
+		MinorVersion: minorVersion,
+		Build:        buildNumber,
+	}
+	// Fill version value so that existing clients don't break
+	osv.Version = uint32(buildNumber) << 16
+	osv.Version |= uint32(osv.MinorVersion) << 8
+	osv.Version |= uint32(osv.MajorVersion)
+	return osv
+}
+
+// Parse parses a string representation of OSVersion as produced by String
+// method.
+// The expected format is:
+// Major.Minor.Build
+//
+// The version string may also include a Revision component:
+// Major.Minor.Build.Revision
+// It will also be parsed but the Revision component will be ignored.
+func Parse(str string) (OSVersion, error) {
+	p := strings.SplitN(str, ".", 5)
+	if len(p) < 3 || len(p) > 4 {
+		return OSVersion{}, fmt.Errorf("unexpected OSVersion format %q", str)
+	}
+
+	majorVersion, err := strconv.ParseUint(p[0], 10, 8)
+	if err != nil {
+		return OSVersion{}, fmt.Errorf("major version is not a valid integer %q", p[0])
+	}
+
+	minorVersion, err := strconv.ParseUint(p[1], 10, 8)
+	if err != nil {
+		return OSVersion{}, fmt.Errorf("minor version is not a valid integer %q", p[1])
+	}
+
+	buildNumber, err := strconv.ParseUint(p[2], 10, 16)
+	if err != nil {
+		return OSVersion{}, fmt.Errorf("build number is not a valid integer %q", p[2])
+	}
+
+	return newVersion(uint8(majorVersion), uint8(minorVersion), uint16(buildNumber)), nil
 }
 
 // String returns the OSVersion formatted as a string. It implements the

--- a/osversion/osversion_test.go
+++ b/osversion/osversion_test.go
@@ -27,3 +27,35 @@ func TestOSVersionString(t *testing.T) {
 		}
 	})
 }
+
+func TestOSVersionIgnoreRevision(t *testing.T) {
+	expected := OSVersion{
+		Version:      809042555,
+		MajorVersion: 123,
+		MinorVersion: 2,
+		Build:        12345,
+	}
+	actual, err := Parse("123.2.12345.9876")
+	if err != nil {
+		t.Errorf("failed to parse back: %q", err)
+	}
+	if actual != expected {
+		t.Errorf("expected: %q, got: %q", expected, actual)
+	}
+}
+
+func TestOSVersionFailUnexpected(t *testing.T) {
+	for _, tc := range []string{
+		"123.2.12345.9876.432134",
+		"123",
+		"10.0",
+		"windows",
+	} {
+		t.Run(tc, func(t *testing.T) {
+			_, err := Parse(tc)
+			if err == nil {
+				t.Errorf("parsing %q should fail", tc)
+			}
+		})
+	}
+}

--- a/osversion/osversion_test.go
+++ b/osversion/osversion_test.go
@@ -1,0 +1,29 @@
+package osversion
+
+import (
+	"testing"
+)
+
+func TestOSVersionString(t *testing.T) {
+	v := OSVersion{
+		Version:      809042555,
+		MajorVersion: 123,
+		MinorVersion: 2,
+		Build:        12345,
+	}
+	expected := "123.2.12345"
+	actual := v.String()
+	if actual != expected {
+		t.Errorf("expected: %q, got: %q", expected, actual)
+	}
+
+	t.Run("parse back", func(t *testing.T) {
+		parsed, err := Parse(actual)
+		if err != nil {
+			t.Errorf("failed to parse back: %q", err)
+		}
+		if parsed != v {
+			t.Errorf("parsed version is not the same, original: %+v (%d) parsed: %+v (%d)", v, v.Version, parsed, parsed.Version)
+		}
+	})
+}

--- a/osversion/osversion_windows.go
+++ b/osversion/osversion_windows.go
@@ -8,15 +8,6 @@ import (
 	"golang.org/x/sys/windows/registry"
 )
 
-// OSVersion is a wrapper for Windows version information
-// https://msdn.microsoft.com/en-us/library/windows/desktop/ms724439(v=vs.85).aspx
-type OSVersion struct {
-	Version      uint32
-	MajorVersion uint8
-	MinorVersion uint8
-	Build        uint16
-}
-
 var (
 	osv  OSVersion
 	once sync.Once
@@ -43,12 +34,6 @@ func Get() OSVersion {
 // The calling application must be manifested to get the correct version information.
 func Build() uint16 {
 	return Get().Build
-}
-
-// String returns the OSVersion formatted as a string. It implements the
-// [fmt.Stringer] interface.
-func (osv OSVersion) String() string {
-	return fmt.Sprintf("%d.%d.%d", osv.MajorVersion, osv.MinorVersion, osv.Build)
 }
 
 // ToString returns the OSVersion formatted as a string.

--- a/osversion/osversion_windows.go
+++ b/osversion/osversion_windows.go
@@ -18,14 +18,7 @@ var (
 func Get() OSVersion {
 	once.Do(func() {
 		v := *windows.RtlGetVersion()
-		osv = OSVersion{}
-		osv.MajorVersion = uint8(v.MajorVersion)
-		osv.MinorVersion = uint8(v.MinorVersion)
-		osv.Build = uint16(v.BuildNumber)
-		// Fill version value so that existing clients don't break
-		osv.Version = v.BuildNumber << 16
-		osv.Version = osv.Version | (uint32(v.MinorVersion) << 8)
-		osv.Version = osv.Version | v.MajorVersion
+		osv = newVersion(uint8(v.MajorVersion), uint8(v.MinorVersion), uint16(v.BuildNumber))
 	})
 	return osv
 }

--- a/osversion/osversion_windows_test.go
+++ b/osversion/osversion_windows_test.go
@@ -1,20 +1,17 @@
 package osversion
 
 import (
-	"fmt"
 	"testing"
 )
 
-func TestOSVersionString(t *testing.T) {
-	v := OSVersion{
-		Version:      809042555,
-		MajorVersion: 123,
-		MinorVersion: 2,
-		Build:        12345,
+func TestOSVersionParseGet(t *testing.T) {
+	v := Get()
+	parsed, err := Parse(v.String())
+	if err != nil {
+		t.Errorf("unexpected parse error: %q", err)
 	}
-	expected := "the version is: 123.2.12345"
-	actual := fmt.Sprintf("the version is: %s", v)
-	if actual != expected {
-		t.Errorf("expected: %q, got: %q", expected, actual)
+
+	if parsed != v {
+		t.Errorf("unable to reparse into the same version, original: %q, parsed: %q", v, parsed)
 	}
 }


### PR DESCRIPTION
address: https://github.com/microsoft/hcsshim/issues/2018

**osversion: Add Parse function**

Add function that parses the string representation back to the `OSVersion` struct.

**osversion: Make OSVersion cross-platform**

Move non-Windows dependent code outside of the `windows` build tagged files. This makes it possible to use the version parse/stringifying code on non-Windows platforms and keep the code that interacts with Windows API only for the Windows builds.
