### PR TITLE
Allow silo/bindflt to be turned off via an annotation

### DIFF
--- a/cmd/containerd-shim-runhcs-v1/pod.go
+++ b/cmd/containerd-shim-runhcs-v1/pod.go
@@ -332,6 +332,7 @@ func (p *pod) CreateTask(ctx context.Context, req *task.CreateTaskRequest, s *sp
 			s.Annotations,
 			annotations.HostProcessInheritUser,
 			annotations.HostProcessRootfsLocation,
+			annotations.HostProcessDisableSilo,
 		)
 	}
 

--- a/internal/jobcontainers/jobcontainer.go
+++ b/internal/jobcontainers/jobcontainer.go
@@ -25,6 +25,7 @@ import (
 	"github.com/Microsoft/hcsshim/internal/queue"
 	"github.com/Microsoft/hcsshim/internal/resources"
 	"github.com/Microsoft/hcsshim/internal/winapi"
+	"github.com/Microsoft/hcsshim/pkg/annotations"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
 	"golang.org/x/sys/windows"
@@ -187,6 +188,12 @@ func Create(ctx context.Context, id string, s *specs.Spec) (_ cow.Container, _ *
 			fileBindingSupport = true
 		}
 	})
+
+	if forceNoSilo, ok := s.Annotations[annotations.HostProcessDisableSilo]; ok {
+		if forceNoSilo == "true" {
+			fileBindingSupport = false
+		}
+	}
 
 	var closer resources.ResourceCloser
 	if fileBindingSupport {

--- a/pkg/annotations/annotations.go
+++ b/pkg/annotations/annotations.go
@@ -102,6 +102,9 @@ const (
 	// supplied was C:\rootfs and the container's ID is 12345678 the rootfs will be located at C:\rootfs\12345678.
 	HostProcessRootfsLocation = "microsoft.com/hostprocess-rootfs-location"
 
+	// HostProcessDisableSilo indicates to turn off silo/bindflt features, even if the host supports it.
+	HostProcessDisableSilo = "microsoft.com/hostprocess-no-silo"
+
 	// AllowOvercommit indicates if we should allow over commit memory for UVM.
 	// Defaults to true. For physical backed memory, set to false.
 	AllowOvercommit = "io.microsoft.virtualmachine.computetopology.memory.allowovercommit"


### PR DESCRIPTION
This should fix regression #1699, but I haven't built the full Kubernetes/containerd/hcsshim stack myself and tested it manually.

To turn off silo/bindflt on a job container, set the pod annotation `microsoft.com/hostprocess-no-silo: true`.