### PR TITLE
Revert "gcs: Support routing container stdio to sidecar"

### DIFF
--- a/internal/guest/runtime/runc/runc.go
+++ b/internal/guest/runtime/runc/runc.go
@@ -193,8 +193,7 @@ func (r *runcRuntime) runCreateCommand(id string, bundlePath string, stdioSet *s
 	}
 
 	args := []string{"create", "-b", bundlePath, "--no-pivot"}
-
-	p, err := c.startProcess(tempProcessDir, spec.Process.Terminal, stdioSet, spec.Annotations, args...)
+	p, err := c.startProcess(tempProcessDir, spec.Process.Terminal, stdioSet, args...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This reverts commit b1b07686425bd7e4594f46a153aa84bf224acf66.

This work was done as an experiment, and is no longer being used.