### PR TITLE
Fix CodeQL pipeline failure

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -31,6 +31,11 @@ on:
 env:
   GO_VERSION: "1.19.x"
 
+permissions:
+  contents: read
+  packages: read
+  security-events: write
+
 jobs:
   CodeQL-Build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
CodeQL Analyze job fails with:`Resource not accessible by integration`, and logs show the following help:

This run of the CodeQL Action does not have permission to access Code Scanning API endpoints.
As a result, it will not be opted into any experimental features. This could be because the Action is running on a pull request from a fork. If not, please ensure the Action has the 'security-events: write' permission. Details: Resource not accessible by integration

Add `security-events: write`, along with default `contents` and `packages` read permissions.