### PR TITLE
fix SILOOBJECT_BASIC_INFORMATION alignment

### DIFF
--- a/internal/jobobject/jobobject.go
+++ b/internal/jobobject/jobobject.go
@@ -523,12 +523,16 @@ func (job *JobObject) ApplyFileBinding(root, target string, readOnly bool) error
 func isJobSilo(h windows.Handle) bool {
 	// None of the information from the structure that this info class expects will be used, this is just used as
 	// the call will fail if the job hasn't been upgraded to a silo so we can use this to tell when we open a job
-	// if it's a silo or not. Because none of the info matters simply define a dummy struct with the size that the call
-	// expects which is 16 bytes.
-	type isSiloObj struct {
-		_ [16]byte
+	// if it's a silo or not. We still need to define the struct layout as expected by Win32, else the struct
+	// alignment might be different and the call will fail.
+	type SILOOBJECT_BASIC_INFORMATION struct {
+		SiloID            uint32
+		SiloParentID      uint32
+		NumberOfProcesses uint32
+		IsInServerSilo    bool
+		Reserved          [3]uint8
 	}
-	var siloInfo isSiloObj
+	var siloInfo SILOOBJECT_BASIC_INFORMATION
 	err := winapi.QueryInformationJobObject(
 		h,
 		winapi.JobObjectSiloBasicInformation,

--- a/internal/jobobject/jobobject.go
+++ b/internal/jobobject/jobobject.go
@@ -525,14 +525,7 @@ func isJobSilo(h windows.Handle) bool {
 	// the call will fail if the job hasn't been upgraded to a silo so we can use this to tell when we open a job
 	// if it's a silo or not. We still need to define the struct layout as expected by Win32, else the struct
 	// alignment might be different and the call will fail.
-	type SILOOBJECT_BASIC_INFORMATION struct {
-		SiloID            uint32
-		SiloParentID      uint32
-		NumberOfProcesses uint32
-		IsInServerSilo    bool
-		Reserved          [3]uint8
-	}
-	var siloInfo SILOOBJECT_BASIC_INFORMATION
+	var siloInfo winapi.SILOOBJECT_BASIC_INFORMATION
 	err := winapi.QueryInformationJobObject(
 		h,
 		winapi.JobObjectSiloBasicInformation,

--- a/internal/winapi/jobobject.go
+++ b/internal/winapi/jobobject.go
@@ -160,6 +160,21 @@ type JOBOBJECT_ASSOCIATE_COMPLETION_PORT struct {
 	CompletionPort windows.Handle
 }
 
+//	typedef struct _SILOOBJECT_BASIC_INFORMATION {
+//	    DWORD SiloId;
+//	    DWORD SiloParentId;
+//	    DWORD NumberOfProcesses;
+//	    BOOLEAN IsInServerSilo;
+//	    BYTE  Reserved[3];
+//	} SILOOBJECT_BASIC_INFORMATION, *PSILOOBJECT_BASIC_INFORMATION;
+type SILOOBJECT_BASIC_INFORMATION struct {
+	SiloID            uint32
+	SiloParentID      uint32
+	NumberOfProcesses uint32
+	IsInServerSilo    bool
+	Reserved          [3]uint8
+}
+
 // BOOL IsProcessInJob(
 // 		HANDLE ProcessHandle,
 // 		HANDLE JobHandle,


### PR DESCRIPTION
`isJobSilo` is currently at the mercy of the Go compiler, as it is using a `SILOOBJECT_BASIC_INFORMATION` with a wrong alignment. Win32 expects it to be 4-bytes aligned, while `struct { _ [16]byte}` is 1-byte aligned.

This hasn't produced any failure yet because previous to Go 1.22, the Go compiler always laid memory aligned to 16-bytes, but that's no longer the case since Go 1.22. Extract from [1.22 release notes](https://go.dev/doc/go1.22):

> ... this change adjusts the size class boundaries of the memory allocator ...

> A consequence of this change is that some objects' addresses that were previously always aligned to a 16 byte (or higher) boundary will now only be aligned to an 8 byte boundary. Some programs that use assembly instructions that require memory addresses to be more than 8-byte aligned and rely on the memory allocator's previous alignment behavior may break, but we expect such programs to be rare. Such programs may be built with GOEXPERIMENT=noallocheaders to revert to the old metadata layout and restore the previous alignment behavior, but package owners should update their assembly code to avoid the alignment assumption, as this workaround will be removed in a future release.

In fact, `TestSiloCreateAndOpen` test fails with Go 1.22 due to this reason.

This PR fixes this issue.
