### PR TITLE
Add hvsock service config annotation

### DIFF
--- a/internal/annotations/annotations.go
+++ b/internal/annotations/annotations.go
@@ -1,5 +1,6 @@
-// This package contains annotations that are not exposed to end users and mainly for
-// testing and debugging purposes.
+// This package contains annotations that are not exposed to end users and are either:
+//  1. intended for testing and debugging purposes; or
+//  2. rely on undocumented Windows APIs that are subject to change.
 //
 // Do not rely on these annotations to customize production workload behavior.
 package annotations
@@ -7,6 +8,28 @@ package annotations
 // uVM specific annotations
 
 const (
+	// UVMHyperVSocketConfigPrefix is the prefix of an annotation to map a [hyper-v socket] service GUID
+	// to a JSON-encoded string of its [configuration].
+	//
+	// The service GUID should be part of the annotation.
+	// For example:
+	//
+	// 	"io.microsoft.virtualmachine.hv-socket.service-table.00000000-0000-0000-0000-000000000000" =
+	// 		"{\"AllowWildcardBinds\": true, \"BindSecurityDescriptor\": \"D:P(A;;FA;;;WD)\"}"
+	//
+	// If multiple annotations with the same GUID are present, then it is undefined which configuration will
+	// take precedence.
+	//
+	// For LCOW, it is preferred to use [ExtraVSockPorts], as vsock ports specified there will take precedence.
+	//
+	// # Warning
+	//
+	// Setting the configuration for special services (e.g., the GCS) can cause catastrophic failures.
+	//
+	// [hyper-v socket]: https://learn.microsoft.com/en-us/virtualization/hyper-v-on-windows/user-guide/make-integration-service
+	// [configuration]: https://learn.microsoft.com/en-us/virtualization/api/hcs/schemareference#HvSocketServiceConfig
+	UVMHyperVSocketConfigPrefix = "io.microsoft.virtualmachine.hv-socket.service-table."
+
 	// AdditionalRegistryValues specifies additional registry keys and their values to set in the WCOW UVM.
 	// The format is a JSON-encoded string of an array containing [HCS RegistryValue] objects.
 	//

--- a/internal/uvm/create_wcow.go
+++ b/internal/uvm/create_wcow.go
@@ -5,6 +5,7 @@ package uvm
 import (
 	"context"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
 
@@ -196,15 +197,18 @@ func prepareConfigDoc(ctx context.Context, uvm *UtilityVM, opts *OptionsWCOW, uv
 			Devices: &hcsschema.Devices{
 				HvSocket: &hcsschema.HvSocket2{
 					HvSocketConfig: &hcsschema.HvSocketSystemConfig{
-						// Allow administrators and SYSTEM to bind to vsock sockets
-						// so that we can create a GCS log socket.
+						// Allow administrators and SYSTEM to bind to hyper-v sockets
+						// so that we can communicate to the GCS.
 						DefaultBindSecurityDescriptor: "D:P(A;;FA;;;SY)(A;;FA;;;BA)",
+						ServiceTable:                  make(map[string]hcsschema.HvSocketServiceConfig),
 					},
 				},
 				VirtualSmb: virtualSMB,
 			},
 		},
 	}
+
+	maps.Copy(doc.VirtualMachine.Devices.HvSocket.HvSocketConfig.ServiceTable, opts.AdditionalHyperVConfig)
 
 	// Handle StorageQoS if set
 	if opts.StorageQoSBandwidthMaximum > 0 || opts.StorageQoSIopsMaximum > 0 {

--- a/internal/uvm/start.go
+++ b/internal/uvm/start.go
@@ -122,7 +122,7 @@ func parseLogrus(o *Options) OutputHandler {
 }
 
 // When using an external GCS connection it is necessary to send a ModifySettings request
-// for HvSockt so that the GCS can setup some registry keys that are required for running
+// for HvSocket so that the GCS can setup some registry keys that are required for running
 // containers inside the UVM. In non external GCS connection scenarios this is done by the
 // HCS immediately after the GCS connection is done. Since, we are using the external GCS
 // connection we should do that setup here after we connect with the GCS.


### PR DESCRIPTION
Allow specifying the hyper-v configuration for specific service GUIDs via an annotation to allow dedicated hvsocket communication from the host to the guest