### PR TITLE
Updating Release CI Yaml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,8 @@ env:
 
 jobs:
   build:
+    permissions:
+      contents: write
     runs-on: "windows-2019"
     steps:
       - uses: actions/checkout@v4
@@ -39,7 +41,7 @@ jobs:
           name: binaries
           
       - name: Publish release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2.0.4
         with:
           prerelease: ${{ contains(github.ref, 'rc') }}
           files: |


### PR DESCRIPTION
Updating job permissions to be "write" instead of the default "read" so that the pipeline is able to succeed. Updating the GitHub release action version to 2.0.4 to remove node.js warning.