### PR TITLE
gh-actions: prevent publishing release automatically

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
             dmverity-vhd.exe
             dmverity-vhd
 
-  create_release:
+  draft_release:
     needs: build
     runs-on: ubuntu-latest
     permissions:
@@ -40,10 +40,12 @@ jobs:
         with:
           name: binaries
           
-      - name: Publish release
+      - name: Publish draft release
         uses: softprops/action-gh-release@v2.0.4
         with:
-          prerelease: ${{ contains(github.ref, 'rc') }}
+          # This is to make sure that the release is not created if a non-rc tag is pushed
+          draft: true
+          generate_release_notes: true
           files: |
             dmverity-vhd.exe
             dmverity-vhd


### PR DESCRIPTION
The release Github action will automatically publish a release for each non-rc tag
in a form `v*`, which is not desired. This may lead to accidents described in https://github.com/microsoft/hcsshim/issues/2084

Change the release action to instead create draft releases, regardless of the tag being
final or RC.

It will be up to the maintainers to decide when to publish an official release.