### PR TITLE
Update `JOB_OBJECT_ALL_ACCESS` and `OpenJobObject`

### DIFF
--- a/internal/jobobject/jobobject.go
+++ b/internal/jobobject/jobobject.go
@@ -188,7 +188,7 @@ func Open(ctx context.Context, options *Options) (_ *JobObject, err error) {
 			return nil, winapi.RtlNtStatusToDosError(status)
 		}
 	} else {
-		jobHandle, err = winapi.OpenJobObject(winapi.JOB_OBJECT_ALL_ACCESS, 0, unicodeJobName.Buffer)
+		jobHandle, err = winapi.OpenJobObject(winapi.JOB_OBJECT_ALL_ACCESS, false, unicodeJobName.Buffer)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/winapi/jobobject.go
+++ b/internal/winapi/jobobject.go
@@ -28,7 +28,7 @@ const (
 // https://docs.microsoft.com/en-us/windows/win32/procthread/job-object-security-and-access-rights
 const (
 	JOB_OBJECT_QUERY      = 0x0004
-	JOB_OBJECT_ALL_ACCESS = 0x1F001F
+	JOB_OBJECT_ALL_ACCESS = 0x1F003F
 )
 
 // IO limit flags
@@ -199,7 +199,7 @@ type SILOOBJECT_BASIC_INFORMATION struct {
 //		LPCWSTR lpName
 // );
 //
-//sys OpenJobObject(desiredAccess uint32, inheritHandle int32, lpName *uint16) (handle windows.Handle, err error) = kernel32.OpenJobObjectW
+//sys OpenJobObject(desiredAccess uint32, inheritHandle bool, lpName *uint16) (handle windows.Handle, err error) = kernel32.OpenJobObjectW
 
 // DWORD SetIoRateControlInformationJobObject(
 //		HANDLE                                hJob,

--- a/internal/winapi/zsyscall_windows.go
+++ b/internal/winapi/zsyscall_windows.go
@@ -473,8 +473,12 @@ func LocalFree(ptr uintptr) {
 	return
 }
 
-func OpenJobObject(desiredAccess uint32, inheritHandle int32, lpName *uint16) (handle windows.Handle, err error) {
-	r0, _, e1 := syscall.Syscall(procOpenJobObjectW.Addr(), 3, uintptr(desiredAccess), uintptr(inheritHandle), uintptr(unsafe.Pointer(lpName)))
+func OpenJobObject(desiredAccess uint32, inheritHandle bool, lpName *uint16) (handle windows.Handle, err error) {
+	var _p0 uint32
+	if inheritHandle {
+		_p0 = 1
+	}
+	r0, _, e1 := syscall.Syscall(procOpenJobObjectW.Addr(), 3, uintptr(desiredAccess), uintptr(_p0), uintptr(unsafe.Pointer(lpName)))
 	handle = windows.Handle(r0)
 	if handle == 0 {
 		err = errnoErr(e1)


### PR DESCRIPTION
Update `JOB_OBJECT_ALL_ACCESS` value to the most recent one.
Update `winapi.OpenJobObject` to accept `inheritHandle` as `bool`
as the documentation suggests.