### PR TITLE
Remove no-cgroups option in gpu code path

### DIFF
--- a/internal/guest/runtime/hcsv2/nvidia_utils.go
+++ b/internal/guest/runtime/hcsv2/nvidia_utils.go
@@ -62,7 +62,7 @@ func addNvidiaDeviceHook(ctx context.Context, spec *oci.Spec, ociBundlePath stri
 	}
 
 	// add template for pid argument to be injected later by the generic hook binary
-	args = append(args, "--no-cgroups", "--pid={{pid}}", spec.Root.Path)
+	args = append(args, "--pid={{pid}}", spec.Root.Path)
 
 	// setup environment variables for the hook to run in
 	hookLogDebugFileEnvOpt := fmt.Sprintf("%s=%s", generichook.LogDebugFileEnvKey, toolDebugPath)


### PR DESCRIPTION
Removing an out-of-date configuration option on libnvidia-container that prevented devices from being added to container device cgroups. This caused the need to run containers as privileged to access devices. 