### PR TITLE
Remove requirement on initrd for fully physically backed UVM

### DIFF
--- a/internal/oci/uvm.go
+++ b/internal/oci/uvm.go
@@ -177,8 +177,6 @@ func handleAnnotationFullyPhysicallyBacked(ctx context.Context, a map[string]str
 		options.FullyPhysicallyBacked = ParseAnnotationsBool(ctx, a, annotations.FullyPhysicallyBacked, options.FullyPhysicallyBacked)
 		if options.FullyPhysicallyBacked {
 			options.AllowOvercommit = false
-			options.PreferredRootFSType = uvm.PreferredRootFSTypeInitRd
-			options.RootFSFile = uvm.InitrdFile
 			options.VPMemDeviceCount = 0
 		}
 	case *uvm.OptionsWCOW:
@@ -282,9 +280,6 @@ func SpecToUVMCreateOpts(ctx context.Context, s *specs.Spec, id, owner string) (
 		lopts.DisableTimeSyncService = ParseAnnotationsBool(ctx, s.Annotations, annotations.DisableLCOWTimeSyncService, lopts.DisableTimeSyncService)
 		handleAnnotationPreferredRootFSType(ctx, s.Annotations, lopts)
 		handleAnnotationKernelDirectBoot(ctx, s.Annotations, lopts)
-
-		// parsing of FullyPhysicallyBacked needs to go after handling kernel direct boot and
-		// preferred rootfs type since it may overwrite settings created by those
 		handleAnnotationFullyPhysicallyBacked(ctx, s.Annotations, lopts)
 
 		// SecurityPolicy is very sensitive to other settings and will silently change those that are incompatible.


### PR DESCRIPTION
Since we added support to use the rootfs VHD as a `VirtualDisk` instead of a vpmem device when the vpmem count is 0 (code [here](https://github.com/microsoft/hcsshim/blob/c248e516653406d3be399a48dd8bc012f0ac3f09/internal/uvm/create_lcow.go#L730)), we can use the rootfs VHD in scenarios where we want the UVM to be backed entirely with physical memory. 