### PR TITLE
fix: set `ReadOnly` when unmounting LCOW mapped virtual disk

### DIFF
--- a/internal/uvm/scsi/backend.go
+++ b/internal/uvm/scsi/backend.go
@@ -217,6 +217,7 @@ func unmountRequest(controller, lun uint, path string, config *mountConfig, osTy
 	case "linux":
 		req.Settings = guestresource.LCOWMappedVirtualDisk{
 			MountPath:  path,
+			ReadOnly:   config.readOnly,
 			Lun:        uint8(lun),
 			Partition:  config.partition,
 			Controller: uint8(controller),


### PR DESCRIPTION
When unmounting LCOW read-only container layers with layer integrity enabled, the guest checks whether the unmount request is coming for a read-only SCSI device. If that's the case, GCS also attempts to clear out the corresponding verity targets. Current implementation omits the `ReadOnly` setting in the guest request, which results in verity targets to linger even though the target has been unmounted. The security policy is also unaware that the layer has been unmounted, since it's enforced only when `ReadOnly` is set to `true`.
This PR fixes this on the host side, by ensuring that the `ReadOnly` is set in the guest request. It seems, though, we may need to revisit the enforcement logic to potentially deny unmounting a read-only layer when the host is not explicitly specifies it as read-only.