### PR TITLE
Support passing oci devices on pod boot

### DIFF
--- a/internal/oci/uvm.go
+++ b/internal/oci/uvm.go
@@ -10,6 +10,7 @@ import (
 
 	runhcsopts "github.com/Microsoft/hcsshim/cmd/containerd-shim-runhcs-v1/options"
 	iannotations "github.com/Microsoft/hcsshim/internal/annotations"
+	"github.com/Microsoft/hcsshim/internal/devices"
 	"github.com/Microsoft/hcsshim/internal/log"
 	"github.com/Microsoft/hcsshim/internal/uvm"
 	"github.com/Microsoft/hcsshim/pkg/annotations"
@@ -227,6 +228,28 @@ func handleSecurityPolicy(ctx context.Context, a map[string]string, lopts *uvm.O
 	}
 }
 
+func parseDevices(ctx context.Context, specWindows *specs.Windows) []uvm.VPCIDeviceID {
+	if specWindows == nil || specWindows.Devices == nil {
+		return nil
+	}
+	extraDevices := make([]uvm.VPCIDeviceID, len(specWindows.Devices))
+	for i, d := range specWindows.Devices {
+		pciID, index := devices.GetDeviceInfoFromPath(d.ID)
+		if uvm.IsValidDeviceType(d.IDType) {
+			key := uvm.NewVPCIDeviceID(pciID, index)
+			extraDevices[i] = key
+		} else {
+			log.G(ctx).WithFields(logrus.Fields{
+				"device": d,
+			}).Warnf("device type %s invalid, skipping", d.IDType)
+		}
+	}
+	// nil out the devices on the spec so that they aren't re-added to the
+	// pause container.
+	specWindows.Devices = nil
+	return extraDevices
+}
+
 // sets options common to both WCOW and LCOW from annotations.
 func specToUVMCreateOptionsCommon(ctx context.Context, opts *uvm.Options, s *specs.Spec) {
 	opts.MemorySizeInMB = ParseAnnotationsMemory(ctx, s, annotations.MemorySizeInMB, opts.MemorySizeInMB)
@@ -298,6 +321,10 @@ func SpecToUVMCreateOpts(ctx context.Context, s *specs.Spec, id, owner string) (
 		lopts.DmVerityMode = ParseAnnotationsBool(ctx, s.Annotations, annotations.DmVerityMode, lopts.DmVerityMode)
 		// Set HclEnabled if specified. Else default to a null pointer, which is omitted from the resulting JSON.
 		lopts.HclEnabled = ParseAnnotationsNullableBool(ctx, s.Annotations, annotations.HclEnabled)
+
+		// Add devices on the spec to the UVM's options
+		lopts.AssignedDevices = parseDevices(ctx, s.Windows)
+
 		return lopts, nil
 	} else if IsWCOW(s) {
 		wopts := uvm.NewDefaultOptionsWCOW(id, owner)

--- a/internal/uvm/create.go
+++ b/internal/uvm/create.go
@@ -226,6 +226,15 @@ func (uvm *UtilityVM) CloseCtx(ctx context.Context) (err error) {
 	windows.Close(uvm.vmmemProcess)
 
 	if uvm.hcsSystem != nil {
+		for key, dev := range uvm.vpciDevices {
+			// Try to remove any devices that are still on the UVM, but do not
+			// fail the close if there is an error.
+			// This would be devices that were added on pod creation.
+			if err := dev.Release(ctx); err != nil {
+				log.G(ctx).Errorf("graceful removal of vpci device %v failed: %s", key, err)
+			}
+		}
+
 		_ = uvm.hcsSystem.Terminate(ctx)
 		// uvm.Wait() waits on <-uvm.outputProcessingDone, which may not be closed until below
 		// (for a Create -> Stop without a Start), or uvm.outputHandler may be blocked on IO and

--- a/internal/uvm/create_lcow.go
+++ b/internal/uvm/create_lcow.go
@@ -132,6 +132,7 @@ type OptionsLCOW struct {
 	DisableTimeSyncService  bool                 // Disables the time synchronization service
 	HclEnabled              *bool                // Whether to enable the host compatibility layer
 	ExtraVSockPorts         []uint32             // Extra vsock ports to allow
+	AssignedDevices         []VPCIDeviceID       // AssignedDevices are devices to add on pod boot
 }
 
 // defaultLCOWOSBootFilesPath returns the default path used to locate the LCOW
@@ -649,6 +650,44 @@ func makeLCOWDoc(ctx context.Context, opts *OptionsLCOW, uvm *UtilityVM) (_ *hcs
 		},
 	}
 
+	// Add optional devices that were specified on the UVM spec
+	if len(opts.AssignedDevices) > 0 {
+		if doc.VirtualMachine.Devices.VirtualPci == nil {
+			doc.VirtualMachine.Devices.VirtualPci = make(map[string]hcsschema.VirtualPciDevice)
+		}
+		for _, d := range opts.AssignedDevices {
+			// we don't need to hold the modify lock here because the UVM has
+			// not yet been created.
+			existingDevice := uvm.vpciDevices[d]
+			if existingDevice != nil {
+				return nil, fmt.Errorf("device %s with index %d is specified multiple times", d.deviceInstanceID, d.virtualFunctionIndex)
+			}
+
+			vmbusGUID, err := guid.NewV4()
+			if err != nil {
+				return nil, err
+			}
+
+			doc.VirtualMachine.Devices.VirtualPci[vmbusGUID.String()] = hcsschema.VirtualPciDevice{
+				Functions: []hcsschema.VirtualPciFunction{
+					{
+						DeviceInstancePath: d.deviceInstanceID,
+						VirtualFunction:    d.virtualFunctionIndex,
+					},
+				},
+			}
+
+			device := &VPCIDevice{
+				vm:                   uvm,
+				VMBusGUID:            vmbusGUID.String(),
+				deviceInstanceID:     d.deviceInstanceID,
+				virtualFunctionIndex: d.virtualFunctionIndex,
+				refCount:             1,
+			}
+			uvm.vpciDevices[d] = device
+		}
+	}
+
 	maps.Copy(doc.VirtualMachine.Devices.HvSocket.HvSocketConfig.ServiceTable, opts.AdditionalHyperVConfig)
 
 	// Handle StorageQoS if set
@@ -862,7 +901,7 @@ func CreateLCOW(ctx context.Context, opts *OptionsLCOW) (_ *UtilityVM, err error
 		scsiControllerCount:     opts.SCSIControllerCount,
 		vpmemMaxCount:           opts.VPMemDeviceCount,
 		vpmemMaxSizeBytes:       opts.VPMemSizeBytes,
-		vpciDevices:             make(map[VPCIDeviceKey]*VPCIDevice),
+		vpciDevices:             make(map[VPCIDeviceID]*VPCIDevice),
 		physicallyBacked:        !opts.AllowOvercommit,
 		devicesPhysicallyBacked: opts.FullyPhysicallyBacked,
 		createOpts:              opts,

--- a/internal/uvm/create_wcow.go
+++ b/internal/uvm/create_wcow.go
@@ -263,7 +263,7 @@ func CreateWCOW(ctx context.Context, opts *OptionsWCOW) (_ *UtilityVM, err error
 		scsiControllerCount:     opts.SCSIControllerCount,
 		vsmbDirShares:           make(map[string]*VSMBShare),
 		vsmbFileShares:          make(map[string]*VSMBShare),
-		vpciDevices:             make(map[VPCIDeviceKey]*VPCIDevice),
+		vpciDevices:             make(map[VPCIDeviceID]*VPCIDevice),
 		noInheritHostTimezone:   opts.NoInheritHostTimezone,
 		physicallyBacked:        !opts.AllowOvercommit,
 		devicesPhysicallyBacked: opts.FullyPhysicallyBacked,

--- a/internal/uvm/types.go
+++ b/internal/uvm/types.go
@@ -93,8 +93,8 @@ type UtilityVM struct {
 	scsiControllerCount uint32 // Number of SCSI controllers in the utility VM
 	reservedSCSISlots   []scsi.Slot
 
-	encryptScratch bool                          // Enable scratch encryption
-	vpciDevices    map[VPCIDeviceKey]*VPCIDevice // map of device instance id to vpci device
+	encryptScratch bool                         // Enable scratch encryption
+	vpciDevices    map[VPCIDeviceID]*VPCIDevice // map of device instance id to vpci device
 
 	// Plan9 are directories mapped into a Linux utility VM
 	plan9Counter uint64 // Each newly-added plan9 share has a counter used as its ID in the ResourceURI and for the name


### PR DESCRIPTION
This PR adds the ability pass devices on the OCI spec for the pod as devices on the UVM's compute system document sent to HCS. This will add devices at the UVM's boot time, instead of hot adding them afterwards. 