### PR TITLE
Change runhcs create-scratch to use physical backed memory by default

### DIFF
--- a/cmd/runhcs/create-scratch.go
+++ b/cmd/runhcs/create-scratch.go
@@ -32,6 +32,10 @@ var createScratchCommand = cli.Command{
 			Name:  "cache-path",
 			Usage: "optional: The path to an existing scratch.vhdx to copy instead of create.",
 		},
+		cli.BoolFlag{
+			Name:  "use-virtual-memory",
+			Usage: "optional: Whether the UVM should be backed with virtual memory.",
+		},
 	},
 	Before: appargs.Validate(),
 	Action: func(context *cli.Context) (err error) {
@@ -52,10 +56,16 @@ var createScratchCommand = cli.Command{
 
 		// 256MB with boot from vhd supported.
 		opts.MemorySizeInMB = 256
-		opts.VPMemDeviceCount = 1
 		// Default SCSI controller count is 4, we don't need that for this UVM,
 		// bring it back to 1 to avoid any confusion with SCSI controller numbers.
 		opts.SCSIControllerCount = 1
+
+		if context.Bool("use-virtual-memory") {
+			opts.VPMemDeviceCount = 1
+		} else {
+			opts.AllowOvercommit = false
+			opts.VPMemDeviceCount = 0
+		}
 
 		sizeGB := uint32(context.Uint("sizeGB"))
 		if sizeGB == 0 {

--- a/pkg/go-runhcs/runhcs_create-scratch.go
+++ b/pkg/go-runhcs/runhcs_create-scratch.go
@@ -22,6 +22,9 @@ type CreateScratchOpts struct {
 	// CacheFile is the path to an existing `scratch.vhx` to copy. If
 	// `CacheFile` does not exit the scratch will be created.
 	CacheFile string
+	// UseVirtualMemory indicates whether the UVM used to create the
+	// scratch should be backed with virtual memory or not.
+	UseVirtualMemory bool
 }
 
 func (opt *CreateScratchOpts) args() ([]string, error) {
@@ -37,6 +40,9 @@ func (opt *CreateScratchOpts) args() ([]string, error) {
 			return nil, err
 		}
 		out = append(out, "--cache-path", abs)
+	}
+	if opt.UseVirtualMemory {
+		out = append(out, "--use-virtual-memory")
 	}
 	return out, nil
 }


### PR DESCRIPTION
The create-scratch command creates a UVM that is used to mount a vhdx file and format as ext4. This is necessary since windows does not have any existing tooling that can format a disk as ext4. This PR changes the create-scratch code such that the UVM uses physical backed memory instead of virtual backed memory by default. Additionally, the PR adds the option to specify that you want a virtual backed UVM instead. 

The create-scratch command is called by containerd [here](https://github.com/containerd/containerd/blob/ccc41e6705c9f8fd8d1ec9ea2a4b9db2a03e809e/plugins/snapshots/lcow/lcow.go#L469) to create scratch vhdxs for containers. This should only happen once per deployment of containerd on the hosting machine since the first time we attempt to pull an image with the lcow snapshotter, the code will create a template scratch file that is then copied for each lcow container created afterwards. 

While using physical memory to back the UVM does result in a slower boot time, I believe this is acceptable since this should only be run once on the host per containerd deployment and the UVM is short lived. 