### PR TITLE
Add support for loading modules in init script when makefile variable is set

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,17 @@ GO:=go
 GO_FLAGS:=-ldflags "-s -w" # strip Go binaries
 CGO_ENABLED:=0
 GOMODVENDOR:=
+KMOD:=0
 
 CFLAGS:=-O2 -Wall
-LDFLAGS:=-static -s # strip C binaries
+LDFLAGS:=-static -s #strip C binaries
+LDLIBS:=
+PREPROCESSORFLAGS:=
+ifeq "$(KMOD)" "1"
+LDFLAGS:= -s
+LDLIBS:= -lkmod
+PREPROCESSORFLAGS:=-DMODULES=1
+endif
 
 GO_FLAGS_EXTRA:=
 ifeq "$(GOMODVENDOR)" "1"
@@ -83,8 +91,8 @@ bin/vsockexec: vsockexec/vsockexec.o vsockexec/vsock.o
 
 bin/init: init/init.o vsockexec/vsock.o
 	@mkdir -p bin
-	$(CC) $(LDFLAGS) -o $@ $^
+	$(CC) $(LDFLAGS) -o $@ $^ $(LDLIBS)
 
 %.o: %.c
 	@mkdir -p $(dir $@)
-	$(CC) $(CFLAGS) $(CPPFLAGS) -c -o $@ $<
+	$(CC) $(PREPROCESSORFLAGS) $(CFLAGS) $(CPPFLAGS) -c -o $@ $<


### PR DESCRIPTION
This PR adds back the support for loading kernel modules in the init script and adds a definition block around the code. This was necessary because some images we use do not have all the dependencies that kmod needs installed, causing the pods to fail to boot. To compile with this variable, you can run:  

```
 make KMOD=1 bin/init
```

This PR is essentially this PR https://github.com/microsoft/hcsshim/pull/2034 with the additional Makefile work and C macro. 