### PR TITLE
[release/0.11] Backport networking commits

### DIFF
--- a/hcn/hcn.go
+++ b/hcn/hcn.go
@@ -264,6 +264,18 @@ func SetPolicySupported() error {
 	return platformDoesNotSupportError("SetPolicy")
 }
 
+// ModifyLoadbalancerSupported returns an error if the HCN version does not support ModifyLoadbalancer.
+func ModifyLoadbalancerSupported() error {
+	supported, err := GetCachedSupportedFeatures()
+	if err != nil {
+		return err
+	}
+	if supported.ModifyLoadbalancer {
+		return nil
+	}
+	return platformDoesNotSupportError("ModifyLoadbalancer")
+}
+
 // VxlanPortSupported returns an error if the HCN version does not support configuring the VXLAN TCP port.
 func VxlanPortSupported() error {
 	supported, err := GetCachedSupportedFeatures()

--- a/hcn/hcnerrors.go
+++ b/hcn/hcnerrors.go
@@ -51,6 +51,7 @@ type ErrorCode uint32
 const (
 	ERROR_NOT_FOUND                     = ErrorCode(windows.ERROR_NOT_FOUND)
 	HCN_E_PORT_ALREADY_EXISTS ErrorCode = ErrorCode(windows.HCN_E_PORT_ALREADY_EXISTS)
+	HCN_E_NOTIMPL             ErrorCode = ErrorCode(windows.E_NOTIMPL)
 )
 
 type HcnError struct {
@@ -76,6 +77,10 @@ func IsElementNotFoundError(err error) bool {
 
 func IsPortAlreadyExistsError(err error) bool {
 	return CheckErrorWithCode(err, HCN_E_PORT_ALREADY_EXISTS)
+}
+
+func IsNotImplemented(err error) bool {
+	return CheckErrorWithCode(err, HCN_E_NOTIMPL)
 }
 
 func new(hr error, title string, rest string) error {

--- a/hcn/hcnglobals.go
+++ b/hcn/hcnglobals.go
@@ -84,6 +84,11 @@ var (
 
 	//HNS 15.0 allows for NestedIpSet support
 	NestedIpSetVersion = VersionRanges{VersionRange{MinVersion: Version{Major: 15, Minor: 0}, MaxVersion: Version{Major: math.MaxInt32, Minor: math.MaxInt32}}}
+
+	//HNS 15.1 allows support for DisableHostPort flag.
+	DisableHostPortVersion = VersionRanges{VersionRange{MinVersion: Version{Major: 15, Minor: 1}, MaxVersion: Version{Major: math.MaxInt32, Minor: math.MaxInt32}}}
+	// HNS 15.4 allows for Modify Loadbalancer support
+	ModifyLoadbalancerVersion = VersionRanges{VersionRange{MinVersion: Version{Major: 15, Minor: 4}, MaxVersion: Version{Major: math.MaxInt32, Minor: math.MaxInt32}}}
 )
 
 // GetGlobals returns the global properties of the HCN Service.

--- a/hcn/hcnloadbalancer.go
+++ b/hcn/hcnloadbalancer.go
@@ -163,6 +163,49 @@ func createLoadBalancer(settings string) (*HostComputeLoadBalancer, error) {
 	return &outputLoadBalancer, nil
 }
 
+func updateLoadBalancer(loadbalancerId string, settings string) (*HostComputeLoadBalancer, error) {
+	loadBalancerGuid, err := guid.FromString(loadbalancerId)
+	if err != nil {
+		return nil, errInvalidLoadBalancerID
+	}
+	// Update loadBalancer.
+	var (
+		loadBalancerHandle hcnLoadBalancer
+		resultBuffer       *uint16
+		propertiesBuffer   *uint16
+	)
+	hr := hcnOpenLoadBalancer(&loadBalancerGuid, &loadBalancerHandle, &resultBuffer)
+	if err := checkForErrors("hcnOpenLoadBalancer", hr, resultBuffer); err != nil {
+		return nil, err
+	}
+	hr = hcnModifyLoadBalancer(loadBalancerHandle, settings, &resultBuffer)
+	if err := checkForErrors("hcnModifyLoadBalancer", hr, resultBuffer); err != nil {
+		return nil, err
+	}
+	// Query loadBalancer.
+	hcnQuery := defaultQuery()
+	query, err := json.Marshal(hcnQuery)
+	if err != nil {
+		return nil, err
+	}
+	hr = hcnQueryLoadBalancerProperties(loadBalancerHandle, string(query), &propertiesBuffer, &resultBuffer)
+	if err := checkForErrors("hcnQueryLoadBalancerProperties", hr, resultBuffer); err != nil {
+		return nil, err
+	}
+	properties := interop.ConvertAndFreeCoTaskMemString(propertiesBuffer)
+	// Close loadBalancer.
+	hr = hcnCloseLoadBalancer(loadBalancerHandle)
+	if err := checkForErrors("hcnCloseLoadBalancer", hr, nil); err != nil {
+		return nil, err
+	}
+	// Convert output to HostComputeLoadBalancer
+	var outputLoadBalancer HostComputeLoadBalancer
+	if err := json.Unmarshal([]byte(properties), &outputLoadBalancer); err != nil {
+		return nil, err
+	}
+	return &outputLoadBalancer, nil
+}
+
 func deleteLoadBalancer(loadBalancerID string) error {
 	loadBalancerGUID, err := guid.FromString(loadBalancerID)
 	if err != nil {
@@ -231,6 +274,23 @@ func (loadBalancer *HostComputeLoadBalancer) Create() (*HostComputeLoadBalancer,
 
 	logrus.Debugf("hcn::HostComputeLoadBalancer::Create JSON: %s", jsonString)
 	loadBalancer, hcnErr := createLoadBalancer(string(jsonString))
+	if hcnErr != nil {
+		return nil, hcnErr
+	}
+	return loadBalancer, nil
+}
+
+// Update Loadbalancer.
+func (loadBalancer *HostComputeLoadBalancer) Update(hnsLoadbalancerID string) (*HostComputeLoadBalancer, error) {
+	logrus.Debugf("hcn::HostComputeLoadBalancer::Create id=%s", hnsLoadbalancerID)
+
+	jsonString, err := json.Marshal(loadBalancer)
+	if err != nil {
+		return nil, err
+	}
+
+	logrus.Debugf("hcn::HostComputeLoadBalancer::Update JSON: %s", jsonString)
+	loadBalancer, hcnErr := updateLoadBalancer(hnsLoadbalancerID, string(jsonString))
 	if hcnErr != nil {
 		return nil, hcnErr
 	}

--- a/hcn/hcnloadbalancer_test.go
+++ b/hcn/hcnloadbalancer_test.go
@@ -42,6 +42,70 @@ func TestCreateDeleteLoadBalancer(t *testing.T) {
 	}
 }
 
+func TestCreateUpdateDeleteLoadBalancer(t *testing.T) {
+	network, err := CreateTestOverlayNetwork()
+	if err != nil {
+		t.Fatal(err)
+	}
+	endpoint, err := HcnCreateTestEndpoint(network)
+	if err != nil {
+		t.Fatal(err)
+	}
+	loadBalancer, err := HcnCreateTestLoadBalancer(endpoint)
+	if err != nil {
+		t.Fatal(err)
+	}
+	jsonString, err := json.Marshal(loadBalancer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fmt.Printf("LoadBalancer JSON:\n%s \n", jsonString)
+
+	secondEndpoint, err := HcnCreateTestEndpoint(network)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	HcnLoadBalancerTestAddBackend(loadBalancer, secondEndpoint.Id)
+
+	loadBalancer, err = loadBalancer.Update(loadBalancer.Id)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(loadBalancer.HostComputeEndpoints) != 2 {
+		t.Fatalf("Update loadBalancer with backend add failed")
+	}
+
+	HcnLoadBalancerTestRemoveBackend(loadBalancer, secondEndpoint.Id)
+
+	loadBalancer, err = loadBalancer.Update(loadBalancer.Id)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(loadBalancer.HostComputeEndpoints) != 1 {
+		t.Fatalf("Update loadBalancer with backend remove failed")
+	}
+
+	err = loadBalancer.Delete()
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = secondEndpoint.Delete()
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = endpoint.Delete()
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = network.Delete()
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestGetLoadBalancerById(t *testing.T) {
 	network, err := CreateTestOverlayNetwork()
 	if err != nil {

--- a/hcn/hcnpolicy.go
+++ b/hcn/hcnpolicy.go
@@ -144,10 +144,11 @@ type QosPolicySetting struct {
 
 // OutboundNatPolicySetting sets outbound Network Address Translation on an Endpoint.
 type OutboundNatPolicySetting struct {
-	VirtualIP    string   `json:",omitempty"`
-	Exceptions   []string `json:",omitempty"`
-	Destinations []string `json:",omitempty"`
-	Flags        NatFlags `json:",omitempty"`
+	VirtualIP        string   `json:",omitempty"`
+	Exceptions       []string `json:",omitempty"`
+	Destinations     []string `json:",omitempty"`
+	Flags            NatFlags `json:",omitempty"`
+	MaxPortPoolUsage uint16   `json:",omitempty"`
 }
 
 // SDNRoutePolicySetting sets SDN Route on an Endpoint.

--- a/hcn/hcnsupport.go
+++ b/hcn/hcnsupport.go
@@ -37,6 +37,8 @@ type SupportedFeatures struct {
 	TierAcl                  bool        `json:"TierAcl"`
 	NetworkACL               bool        `json:"NetworkACL"`
 	NestedIpSet              bool        `json:"NestedIpSet"`
+	DisableHostPort          bool        `json:"DisableHostPort"`
+	ModifyLoadbalancer       bool        `json:"ModifyLoadbalancer"`
 }
 
 // AclFeatures are the supported ACL possibilities.
@@ -114,6 +116,8 @@ func getSupportedFeatures() (SupportedFeatures, error) {
 	features.TierAcl = isFeatureSupported(globals.Version, TierAclPolicyVersion)
 	features.NetworkACL = isFeatureSupported(globals.Version, NetworkACLPolicyVersion)
 	features.NestedIpSet = isFeatureSupported(globals.Version, NestedIpSetVersion)
+	features.DisableHostPort = isFeatureSupported(globals.Version, DisableHostPortVersion)
+	features.ModifyLoadbalancer = isFeatureSupported(globals.Version, ModifyLoadbalancerVersion)
 
 	log.L.WithFields(logrus.Fields{
 		"version":           globals.Version,

--- a/hcn/hcnutils_test.go
+++ b/hcn/hcnutils_test.go
@@ -317,6 +317,23 @@ func HcnCreateTestLoadBalancer(endpoint *HostComputeEndpoint) (*HostComputeLoadB
 	return loadBalancer.Create()
 }
 
+func HcnLoadBalancerTestAddBackend(loadBalancer *HostComputeLoadBalancer, endpointId string) {
+	endpointIds := loadBalancer.HostComputeEndpoints
+	endpointIds = append(endpointIds, endpointId)
+	loadBalancer.HostComputeEndpoints = endpointIds
+}
+
+func HcnLoadBalancerTestRemoveBackend(loadBalancer *HostComputeLoadBalancer, endpointId string) {
+	endpointIds := loadBalancer.HostComputeEndpoints
+	for i, v := range endpointIds {
+		if v == endpointId {
+			endpointIds = append(endpointIds[:i], endpointIds[i+1:]...)
+			break
+		}
+	}
+	loadBalancer.HostComputeEndpoints = endpointIds
+}
+
 func HcnCreateTestRemoteSubnetRoute() (*PolicyNetworkRequest, error) {
 	rsr := RemoteSubnetRoutePolicySetting{
 		DestinationPrefix:           "192.168.2.0/24",

--- a/internal/hns/hnspolicy.go
+++ b/internal/hns/hnspolicy.go
@@ -57,9 +57,10 @@ type PaPolicy struct {
 
 type OutboundNatPolicy struct {
 	Policy
-	VIP          string   `json:"VIP,omitempty"`
-	Exceptions   []string `json:"ExceptionList,omitempty"`
-	Destinations []string `json:",omitempty"`
+	VIP              string   `json:"VIP,omitempty"`
+	Exceptions       []string `json:"ExceptionList,omitempty"`
+	Destinations     []string `json:",omitempty"`
+	MaxPortPoolUsage uint16   `json:",omitempty"`
 }
 
 type ProxyPolicy struct {


### PR DESCRIPTION
These are direct ports of the following commits without any additional changes from main to release/0.12 :

https://github.com/microsoft/hcsshim/commit/c79a6310e6f15a893430063ca76f44dcb7711426 : https://github.com/microsoft/hcsshim/pull/2106 ---> direct cherry-pick

https://github.com/microsoft/hcsshim/commit/8beabacfc2d21767a07c20f8dd5f9f3932dbf305 : https://github.com/microsoft/hcsshim/pull/2139 ---> This commit had merge conflicts that were fixed.

https://github.com/microsoft/hcsshim/commit/0f7d8de9948c3ebfd45911dc55b451d8902d48b2 : https://github.com/microsoft/hcsshim/pull/2085 ---> This commit had merge conflicts that were fixed.