### PR TITLE
Adding state attribute to the HNSEndpoint struct to support hyperv 

### DIFF
--- a/internal/hns/hnsendpoint.go
+++ b/internal/hns/hnsendpoint.go
@@ -10,6 +10,28 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+// EndpointState represents the states of an HNS Endpoint lifecycle.
+type EndpointState uint16
+
+// EndpointState const
+// The lifecycle of an Endpoint goes through created, attached, AttachedSharing - endpoint is being shared with other containers,
+// detached, after being attached, degraded and finally destroyed.
+// Note: This attribute is used by calico to define stale containers and is dependent on HNS v1 api, if we move to HNS v2 api we will need
+// to update the current calico code and cordinate the change with calico. Reach out to Microsoft to facilate the change via HNS.
+const (
+	Uninitialized   EndpointState = iota
+	Created         EndpointState = 1
+	Attached        EndpointState = 2
+	AttachedSharing EndpointState = 3
+	Detached        EndpointState = 4
+	Degraded        EndpointState = 5
+	Destroyed       EndpointState = 6
+)
+
+func (es EndpointState) String() string {
+	return [...]string{"Uninitialized", "Attached", "AttachedSharing", "Detached", "Degraded", "Destroyed"}[es]
+}
+
 // HNSEndpoint represents a network endpoint in HNS
 type HNSEndpoint struct {
 	Id                 string            `json:"ID,omitempty"`
@@ -34,6 +56,7 @@ type HNSEndpoint struct {
 	Namespace          *Namespace        `json:",omitempty"`
 	EncapOverhead      uint16            `json:",omitempty"`
 	SharedContainers   []string          `json:",omitempty"`
+	State              EndpointState     `json:",omitempty"`
 }
 
 // SystemType represents the type of the system on which actions are done


### PR DESCRIPTION
The struct HNSEndpoint is used by CNIs like calico to validate the state of an endpoint. In order to support Hyperv containers on k8s we need to expose the State attribute. This attribute can be used by CNIs to determine the state of the endpoint.

HNS API versions: 
Hcsshim supports both APIS v1 and v2 via the HCN folder (documented way) or via hns files in the root which expose internal/hns apis 

CodeFlow:   
Calico::endpoint_mgr.go::RefreshHnsEndpointCache  --> hns.HNSListEndpointRequest() which lands at hcsshim/hnsendpoint.go which calls into the internal HNS package at /hcsshim/internal/hns which runs a get call into HNS OS code.