### PR TITLE
Remove load-kmods option to libnvidia-container

### DIFF
--- a/internal/guest/runtime/hcsv2/nvidia_utils.go
+++ b/internal/guest/runtime/hcsv2/nvidia_utils.go
@@ -38,7 +38,6 @@ func addNvidiaDeviceHook(ctx context.Context, spec *oci.Spec, ociBundlePath stri
 		genericHookPath,
 		nvidiaToolBinary,
 		debugOption,
-		"--load-kmods",
 		"--no-pivot",
 		"configure",
 		"--ldconfig=@/sbin/ldconfig",


### PR DESCRIPTION
Previously the `load-kmods` option was set for libnvidia-container because we were not loading the kernel modules at pod boot time. However, recent changes https://github.com/microsoft/hcsshim/pull/2167 would allow for loading kernel modules at boot time. We need to remove `load-kmods` so we don't attempt to load the modules twice. 

Note: this also requires that persistence mode has been set in the pod so that the GPUs stay initialized between pod boot and container start.