### PR TITLE
[release/0.9] Fix process handle leak when launching a job container

### DIFF
--- a/internal/exec/exec.go
+++ b/internal/exec/exec.go
@@ -209,8 +209,8 @@ func (e *Exec) Start() error {
 	if err != nil {
 		return fmt.Errorf("failed to create process: %w", err)
 	}
-	// Don't need the thread handle for anything.
 	defer func() {
+		_ = windows.CloseHandle(windows.Handle(pi.Process))
 		_ = windows.CloseHandle(windows.Handle(pi.Thread))
 	}()
 


### PR DESCRIPTION
Cherry-picking this PR into release/0.9

https://github.com/microsoft/hcsshim/pull/2020

commit: https://github.com/microsoft/hcsshim/commit/976716ed6294e3a641d80196dcb08ac5eefd4091



CreateProcess gives us back a handle to the newly created process. Previously, we ignored this handle, which meant it was leaking every time we created a new job container (or anything else that uses internal/exec in the future).

Process handle leaks can be bad as an exited process is left as a "zombie" until all handles to it have closed, continuing to use memory.

Fix this by closing the handle from CreateProcess.