### PR TITLE
[release/0.11] Update golang version in ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   - pull_request
 
 env:
-  GO_VERSION: "1.19.x"
+  GO_VERSION: "1.20.x"
   GOTESTSUM_VERSION: "latest"
 
 jobs:

--- a/cmd/containerd-shim-runhcs-v1/pod_test.go
+++ b/cmd/containerd-shim-runhcs-v1/pod_test.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/runtime/v2/task"
@@ -96,8 +97,10 @@ func setupTestPodWithFakes(t *testing.T) (*pod, *testShimTask) {
 		execs: make(map[string]*testShimExec),
 	}
 	// Add a 2nd exec
-	seid := strconv.Itoa(rand.Int())
-	st.execs[seid] = newTestShimExec(t.Name(), seid, int(rand.Int31()))
+	seed := time.Now().UnixNano()
+	source := rand.New(rand.NewSource(seed))
+	seid := strconv.FormatInt((int64)(source.Uint64()), 10)
+	st.execs[seid] = newTestShimExec(t.Name(), seid, int(source.Uint64()))
 	p := &pod{
 		id:          t.Name(),
 		sandboxTask: st,
@@ -107,10 +110,13 @@ func setupTestPodWithFakes(t *testing.T) (*pod, *testShimTask) {
 
 func setupTestTaskInPod(t *testing.T, p *pod) *testShimTask {
 	t.Helper()
-	tid := strconv.Itoa(rand.Int())
+	seed := time.Now().UnixNano()
+	source := rand.New(rand.NewSource(seed))
+	tid := strconv.FormatInt((int64)(source.Uint64()), 10)
+
 	wt := &testShimTask{
 		id:   tid,
-		exec: newTestShimExec(tid, tid, int(rand.Int31())),
+		exec: newTestShimExec(tid, tid, int(source.Uint64())),
 	}
 	p.workloadTasks.Store(wt.id, wt)
 	return wt
@@ -385,6 +391,9 @@ func Test_pod_DeleteTask_TaskID_Not_Created(t *testing.T) {
 	setupTestTaskInPod(t, p)
 	setupTestTaskInPod(t, p)
 
-	err := p.KillTask(context.Background(), strconv.Itoa(rand.Int()), "", 0xf, true)
+	seed := time.Now().UnixNano()
+	source := rand.New(rand.NewSource(seed))
+
+	err := p.KillTask(context.Background(), strconv.Itoa((int)(source.Uint64())), "", 0xf, true)
 	verifyExpectedError(t, nil, err, errdefs.ErrNotFound)
 }

--- a/cmd/containerd-shim-runhcs-v1/service_internal_podshim_test.go
+++ b/cmd/containerd-shim-runhcs-v1/service_internal_podshim_test.go
@@ -20,7 +20,9 @@ import (
 
 func setupPodServiceWithFakes(t *testing.T) (*service, *testShimTask, *testShimTask, *testShimExec) {
 	t.Helper()
-	tid := strconv.Itoa(rand.Int())
+	seed := time.Now().UnixNano()
+	source := rand.New(rand.NewSource(seed))
+	tid := strconv.FormatInt((int64)(source.Uint64()), 10)
 
 	s, err := NewService(WithTID(tid), WithIsSandbox(true))
 	if err != nil {
@@ -47,8 +49,9 @@ func setupPodServiceWithFakes(t *testing.T) (*service, *testShimTask, *testShimT
 	}
 
 	// create a 2nd fake container
-	secondTaskID := strconv.Itoa(rand.Int())
-	secondTaskSecondExecID := strconv.Itoa(rand.Int())
+	secondTaskID := strconv.FormatInt((int64)(source.Uint64()), 10)
+	secondTaskSecondExecID := strconv.FormatInt((int64)(source.Uint64()), 10)
+
 	task2 := &testShimTask{
 		id:    secondTaskID,
 		exec:  newTestShimExec(secondTaskID, secondTaskID, 101),

--- a/cmd/containerd-shim-runhcs-v1/service_internal_taskshim_test.go
+++ b/cmd/containerd-shim-runhcs-v1/service_internal_taskshim_test.go
@@ -24,7 +24,9 @@ import (
 
 func setupTaskServiceWithFakes(t *testing.T) (*service, *testShimTask, *testShimExec) {
 	t.Helper()
-	tid := strconv.Itoa(rand.Int())
+	seed := time.Now().UnixNano()
+	source := rand.New(rand.NewSource(seed))
+	tid := strconv.FormatInt((int64)(source.Uint64()), 10)
 
 	s, err := NewService(WithTID(tid), WithIsSandbox(false))
 	if err != nil {
@@ -46,7 +48,7 @@ func setupTaskServiceWithFakes(t *testing.T) (*service, *testShimTask, *testShim
 		exec:  newTestShimExec(tid, tid, 10),
 		execs: make(map[string]*testShimExec),
 	}
-	secondExecID := strconv.Itoa(rand.Int())
+	secondExecID := strconv.FormatInt((int64)(source.Uint64()), 10)
 	secondExec := newTestShimExec(tid, secondExecID, 101)
 	task.execs[secondExecID] = secondExec
 	s.taskOrPod.Store(task)

--- a/cmd/containerd-shim-runhcs-v1/task_hcs_test.go
+++ b/cmd/containerd-shim-runhcs-v1/task_hcs_test.go
@@ -14,15 +14,18 @@ import (
 
 func setupTestHcsTask(t *testing.T) (*hcsTask, *testShimExec, *testShimExec) {
 	t.Helper()
-	initExec := newTestShimExec(t.Name(), t.Name(), int(rand.Int31()))
+	seed := time.Now().UnixNano()
+	source := rand.New(rand.NewSource(seed))
+
+	initExec := newTestShimExec(t.Name(), t.Name(), int(source.Uint64()))
 	lt := &hcsTask{
 		events: newFakePublisher(),
 		id:     t.Name(),
 		init:   initExec,
 		closed: make(chan struct{}),
 	}
-	secondExecID := strconv.Itoa(rand.Int())
-	secondExec := newTestShimExec(t.Name(), secondExecID, int(rand.Int31()))
+	secondExecID := strconv.FormatInt((int64)(source.Uint64()), 10)
+	secondExec := newTestShimExec(t.Name(), secondExecID, int(source.Int31()))
 	lt.execs.Store(secondExecID, secondExec)
 	return lt, initExec, secondExec
 }

--- a/ext4/dmverity/dmverity_test.go
+++ b/ext4/dmverity/dmverity_test.go
@@ -2,9 +2,9 @@ package dmverity
 
 import (
 	"bytes"
+	"crypto/rand"
 	"encoding/binary"
 	"io"
-	"math/rand"
 	"os"
 	"strings"
 	"testing"

--- a/internal/tools/networkagent/main.go
+++ b/internal/tools/networkagent/main.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"context"
+
 	"flag"
 	"fmt"
 	"math/rand"
@@ -13,6 +14,9 @@ import (
 	"strconv"
 	"strings"
 	"syscall"
+	"time"
+
+	cryptorand "crypto/rand"
 
 	"github.com/Microsoft/go-winio/pkg/guid"
 	"github.com/Microsoft/hcsshim/hcn"
@@ -37,7 +41,7 @@ const (
 func generateMAC() (string, error) {
 	buf := make([]byte, 6)
 
-	_, err := rand.Read(buf)
+	_, err := cryptorand.Read(buf)
 	if err != nil {
 		return "", err
 	}
@@ -65,7 +69,9 @@ func generateIPs(prefixLength string) (string, string, string) {
 	ipGatewayString := ipGateway.String()
 
 	// set last byte for IP address in range
-	last := byte(rand.Intn(255-2) + 2)
+	seed := time.Now().UnixNano()
+	source := rand.New(rand.NewSource(seed))
+	last := byte(source.Uint64())
 	ipBytes := append(buf, last)
 	ip := net.IP(ipBytes)
 	ipString := ip.String()


### PR DESCRIPTION
Update ci.yml to use golang 1.20 + fix lint errors with math.Rand

This change fixes the long standing mingw errors PRs were running into in release/0.11 

![image](https://github.com/microsoft/hcsshim/assets/99994218/b5ab1b84-7398-4cdc-99fa-d1beda237e53)
