### PR TITLE
fix: uvmboot gcs exec

### DIFF
--- a/internal/tools/uvmboot/lcow.go
+++ b/internal/tools/uvmboot/lcow.go
@@ -296,7 +296,7 @@ func runLCOW(ctx context.Context, options *uvm.OptionsLCOW, c *cli.Context) erro
 }
 
 func execViaGCS(ctx context.Context, vm *uvm.UtilityVM, cCtx *cli.Context) error {
-	c := cmd.CommandContext(ctx, vm, "/bin/sh", "-c", cCtx.String(execCommandLineArgName))
+	c := cmd.CommandContext(ctx, vm, "sh", "-c", cCtx.String(execCommandLineArgName))
 	c.Log = log.L.Dup()
 	if lcowUseTerminal {
 		c.Spec.Terminal = true


### PR DESCRIPTION
Rely on default `sh` to be in `PATH` rather than hardcoding to `/bin/sh`
when using uvmboot with GCS and exec.