### PR TITLE
[release/0.12] Backport networking commits for L1VH feature

### DIFF
--- a/hcn/hcn.go
+++ b/hcn/hcn.go
@@ -336,6 +336,18 @@ func DisableHostPortSupported() error {
 	return platformDoesNotSupportError("DisableHostPort")
 }
 
+// AccelnetSupported returns an error if the HCN version does not support Accelnet Feature.
+func AccelnetSupported() error {
+	supported, err := GetCachedSupportedFeatures()
+	if err != nil {
+		return err
+	}
+	if supported.Accelnet {
+		return nil
+	}
+	return platformDoesNotSupportError("Accelnet")
+}
+
 // RequestType are the different operations performed to settings.
 // Used to update the settings of Endpoint/Namespace objects.
 type RequestType string

--- a/hcn/hcnglobals.go
+++ b/hcn/hcnglobals.go
@@ -89,6 +89,8 @@ var (
 	DisableHostPortVersion = VersionRanges{VersionRange{MinVersion: Version{Major: 15, Minor: 1}, MaxVersion: Version{Major: math.MaxInt32, Minor: math.MaxInt32}}}
 	// HNS 15.4 allows for Modify Loadbalancer support
 	ModifyLoadbalancerVersion = VersionRanges{VersionRange{MinVersion: Version{Major: 15, Minor: 4}, MaxVersion: Version{Major: math.MaxInt32, Minor: math.MaxInt32}}}
+	// HNS 15.4 allows for Accelnet support
+	AccelnetVersion = VersionRanges{VersionRange{MinVersion: Version{Major: 15, Minor: 4}, MaxVersion: Version{Major: math.MaxInt32, Minor: math.MaxInt32}}}
 )
 
 // GetGlobals returns the global properties of the HCN Service.

--- a/hcn/hcnnetwork.go
+++ b/hcn/hcnnetwork.go
@@ -73,6 +73,7 @@ const (
 	None                NetworkFlags = 0
 	EnableNonPersistent NetworkFlags = 8
 	DisableHostPort     NetworkFlags = 1024
+	EnableIov           NetworkFlags = 8192
 )
 
 // HostComputeNetwork represents a network

--- a/hcn/hcnsupport.go
+++ b/hcn/hcnsupport.go
@@ -39,6 +39,7 @@ type SupportedFeatures struct {
 	NestedIpSet              bool        `json:"NestedIpSet"`
 	DisableHostPort          bool        `json:"DisableHostPort"`
 	ModifyLoadbalancer       bool        `json:"ModifyLoadbalancer"`
+	Accelnet                 bool        `json:"Accelnet"`
 }
 
 // AclFeatures are the supported ACL possibilities.
@@ -118,6 +119,7 @@ func getSupportedFeatures() (SupportedFeatures, error) {
 	features.NestedIpSet = isFeatureSupported(globals.Version, NestedIpSetVersion)
 	features.DisableHostPort = isFeatureSupported(globals.Version, DisableHostPortVersion)
 	features.ModifyLoadbalancer = isFeatureSupported(globals.Version, ModifyLoadbalancerVersion)
+	features.Accelnet = isFeatureSupported(globals.Version, AccelnetVersion)
 
 	log.L.WithFields(logrus.Fields{
 		"version":           globals.Version,

--- a/hcn/hnsv1_test.go
+++ b/hcn/hnsv1_test.go
@@ -129,3 +129,53 @@ func TestNetwork(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestAccelnetNnvManagementMacAddresses(t *testing.T) {
+	network, err := CreateTestNetwork()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	macList := []string{"00-15-5D-0A-B7-C6", "00-15-5D-38-01-00"}
+	newMacList, err := hcsshim.SetNnvManagementMacAddresses(macList)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(newMacList.MacAddressList) != 2 {
+		t.Errorf("After Create: Expected macaddress count %d, got %d", 2, len(newMacList.MacAddressList))
+	}
+
+	newMacList, err = hcsshim.GetNnvManagementMacAddresses()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(newMacList.MacAddressList) != 2 {
+		t.Errorf("Get After Create: Expected macaddress count %d, got %d", 2, len(newMacList.MacAddressList))
+	}
+
+	newMacList, err = hcsshim.DeleteNnvManagementMacAddresses()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(newMacList.MacAddressList) != 0 {
+		t.Errorf("After Delete: Expected macaddress count %d, got %d", 0, len(newMacList.MacAddressList))
+	}
+
+	newMacList, err = hcsshim.GetNnvManagementMacAddresses()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(newMacList.MacAddressList) != 0 {
+		t.Errorf("Get After Delete: Expected macaddress count %d, got %d", 0, len(newMacList.MacAddressList))
+	}
+
+	_, err = network.Delete()
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/hnsaccelnet.go
+++ b/hnsaccelnet.go
@@ -1,0 +1,46 @@
+//go:build windows
+
+package hcsshim
+
+import (
+	"errors"
+
+	"github.com/Microsoft/hcsshim/internal/hns"
+)
+
+// HNSNnvManagementMacAddress represents management mac address
+// which needs to be excluded from VF reassignment
+type HNSNnvManagementMacAddress = hns.HNSNnvManagementMacAddress
+
+// HNSNnvManagementMacList represents a list of management
+// mac addresses for exclusion from VF reassignment
+type HNSNnvManagementMacList = hns.HNSNnvManagementMacList
+
+var (
+	ErrorEmptyMacAddressList = errors.New("management mac_address list is empty")
+)
+
+// SetNnvManagementMacAddresses sets a list of
+// management mac addresses in hns for exclusion from VF reassignment.
+func SetNnvManagementMacAddresses(managementMacAddresses []string) (*HNSNnvManagementMacList, error) {
+	if len(managementMacAddresses) == 0 {
+		return nil, ErrorEmptyMacAddressList
+	}
+	nnvManagementMacList := &HNSNnvManagementMacList{}
+	for _, mac := range managementMacAddresses {
+		nnvManagementMacList.MacAddressList = append(nnvManagementMacList.MacAddressList, HNSNnvManagementMacAddress{MacAddress: mac})
+	}
+	return nnvManagementMacList.Set()
+}
+
+// GetNnvManagementMacAddresses retrieves a list of
+// management mac addresses in hns for exclusion from VF reassignment.
+func GetNnvManagementMacAddresses() (*HNSNnvManagementMacList, error) {
+	return hns.GetNnvManagementMacAddressList()
+}
+
+// DeleteNnvManagementMacAddresses delete list of
+// management mac addresses in hns which are excluded from VF reassignment.
+func DeleteNnvManagementMacAddresses() (*HNSNnvManagementMacList, error) {
+	return hns.DeleteNnvManagementMacAddressList()
+}

--- a/internal/hns/hnsaccelnet.go
+++ b/internal/hns/hnsaccelnet.go
@@ -1,0 +1,60 @@
+//go:build windows
+
+package hns
+
+import (
+	"encoding/json"
+
+	"github.com/sirupsen/logrus"
+)
+
+// HNSNnvManagementMacAddress represents management mac address
+// which needs to be excluded from VF reassignment
+type HNSNnvManagementMacAddress struct {
+	MacAddress string `json:",omitempty"`
+}
+
+// HNSNnvManagementMacList represents a list of management
+// mac addresses for exclusion from VF reassignment
+type HNSNnvManagementMacList struct {
+	MacAddressList []HNSNnvManagementMacAddress `json:",omitempty"`
+}
+
+// HNSNnvManagementMacRequest makes a HNS call to modify/query NnvManagementMacList
+func HNSNnvManagementMacRequest(method, path, request string) (*HNSNnvManagementMacList, error) {
+	nnvManagementMacList := &HNSNnvManagementMacList{}
+	err := hnsCall(method, "/accelnet/"+path, request, &nnvManagementMacList)
+	if err != nil {
+		return nil, err
+	}
+	return nnvManagementMacList, nil
+}
+
+// Set ManagementMacAddressList by sending "POST" NnvManagementMacRequest to HNS.
+func (nnvManagementMacList *HNSNnvManagementMacList) Set() (*HNSNnvManagementMacList, error) {
+	operation := "Set"
+	title := "hcsshim::nnvManagementMacList::" + operation
+	logrus.Debugf(title+" id=%s", nnvManagementMacList.MacAddressList)
+
+	jsonString, err := json.Marshal(nnvManagementMacList)
+	if err != nil {
+		return nil, err
+	}
+	return HNSNnvManagementMacRequest("POST", "", string(jsonString))
+}
+
+// Get ManagementMacAddressList by sending "GET" NnvManagementMacRequest to HNS.
+func GetNnvManagementMacAddressList() (*HNSNnvManagementMacList, error) {
+	operation := "Get"
+	title := "hcsshim::nnvManagementMacList::" + operation
+	logrus.Debugf(title)
+	return HNSNnvManagementMacRequest("GET", "", "")
+}
+
+// Delete ManagementMacAddressList by sending "DELETE" NnvManagementMacRequest to HNS.
+func DeleteNnvManagementMacAddressList() (*HNSNnvManagementMacList, error) {
+	operation := "Delete"
+	title := "hcsshim::nnvManagementMacList::" + operation
+	logrus.Debugf(title)
+	return HNSNnvManagementMacRequest("DELETE", "", "")
+}


### PR DESCRIPTION
These are direct ports of the following commits without any additional changes from main to release/0.12 :

c8451ee02b701ab1b7efbad6e21e3fbaea6cb038 -> 0ec29e7298d54fd10a7703e36af3ee6ac04a49e1

ab958a7a2e2e4ad63089183a8a6bc0df1c1167b7 -> e4f58faee160ca1849956b97c34c8b6b6b56934e