### PR TITLE
Remove graceful removal of DDA devices added on pod boot

### DIFF
--- a/internal/uvm/create.go
+++ b/internal/uvm/create.go
@@ -234,15 +234,6 @@ func (uvm *UtilityVM) CloseCtx(ctx context.Context) (err error) {
 	windows.Close(uvm.vmmemProcess)
 
 	if uvm.hcsSystem != nil {
-		for key, dev := range uvm.vpciDevices {
-			// Try to remove any devices that are still on the UVM, but do not
-			// fail the close if there is an error.
-			// This would be devices that were added on pod creation.
-			if err := dev.Release(ctx); err != nil {
-				log.G(ctx).Errorf("graceful removal of vpci device %v failed: %s", key, err)
-			}
-		}
-
 		_ = uvm.hcsSystem.Terminate(ctx)
 		// uvm.Wait() waits on <-uvm.outputProcessingDone, which may not be closed until below
 		// (for a Create -> Stop without a Start), or uvm.outputHandler may be blocked on IO and


### PR DESCRIPTION
This code previously attempted to gracefully remove DDA'd devices from a pod on close. However, the platform does not require that we gracefully remove DDA devices and attempting to do so may increase the time it takes to stop the pod. 

For example, the attempted graceful removal of NVIDIA GPUs when nvidia-persistenced is running increases the pod stop time by more than 3x. 