### PR TITLE
Add higher memory size for create scratch UVM 

### DIFF
--- a/cmd/runhcs/create-scratch.go
+++ b/cmd/runhcs/create-scratch.go
@@ -54,8 +54,8 @@ var createScratchCommand = cli.Command{
 
 		opts := uvm.NewDefaultOptionsLCOW("createscratch-uvm", context.GlobalString("owner"))
 
-		// 256MB with boot from vhd supported.
-		opts.MemorySizeInMB = 256
+		// 512MB with boot from vhd supported.
+		opts.MemorySizeInMB = 512
 		// Default SCSI controller count is 4, we don't need that for this UVM,
 		// bring it back to 1 to avoid any confusion with SCSI controller numbers.
 		opts.SCSIControllerCount = 1


### PR DESCRIPTION
This PR increases the memory size of the UVM that is created to create the initial scratch VHD. Since creation of the scratch VHD should only happen once per installation/reboot, this should not negatively impact any scenarios. 

This change was needed after testing running with an Azure Linux based UVM. Azure Linux needs more memory to boot than the previous UVM which was leading to a kernel panic during creation of the scratch. 
