### PR TITLE
Sort the endpoints such that eth0 is first

### DIFF
--- a/internal/uvm/network_test.go
+++ b/internal/uvm/network_test.go
@@ -1,0 +1,69 @@
+//go:build windows
+
+package uvm
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/Microsoft/hcsshim/internal/hns"
+)
+
+func Test_SortEndpoints(t *testing.T) {
+	type config struct {
+		endpointNames []string
+		targetName    string
+	}
+	tests := []config{
+		{
+			endpointNames: []string{"eth1", "eth0"},
+			targetName:    "eth0",
+		},
+		{
+			endpointNames: []string{"eth0", "eth1"},
+			targetName:    "eth0",
+		},
+		{
+			endpointNames: []string{"eth1", "name-eth0"},
+			targetName:    "name-eth0",
+		},
+		{
+			endpointNames: []string{"name-eth098", "name-eth0"},
+			targetName:    "name-eth0",
+		},
+		{
+			endpointNames: []string{"name-eth0", "name-eth098"},
+			targetName:    "name-eth0",
+		},
+		{
+			endpointNames: []string{"random-ifname", "another-random-ifname"},
+			// ordering shouldn't change so the first entry should still be first
+			targetName: "random-ifname",
+		},
+		{
+			endpointNames: []string{"eth0-name", "name-eth0"},
+			targetName:    "name-eth0",
+		},
+		{
+			endpointNames: []string{},
+		},
+	}
+	for i, test := range tests {
+		t.Run(fmt.Sprint(t.Name(), i), func(st *testing.T) {
+			endpoints := []*hns.HNSEndpoint{}
+			for _, n := range test.endpointNames {
+				e := &hns.HNSEndpoint{
+					Name: n,
+				}
+				endpoints = append(endpoints, e)
+			}
+
+			sortEndpoints(endpoints)
+			if len(test.endpointNames) != 0 {
+				if endpoints[0].Name != test.targetName {
+					st.Fatalf("expected endpoint sorting to return endpoint with name %s first, instead got %s", test.targetName, endpoints[0].Name)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
This addresses an issue where when adding multiple interfaces, the eth0 interface in the guest does not correspond correctly to the primary NIC that the CNI intended. This happens because hcsshim queries HNS to get the list of endpoints for the network namespace and adds the endpoints sequentially based on what is returned from HNS. HNS guarantees no specific ordering of endpoints returned from this query. 

CNI names the interfaces such that they have the suffix `-ethX` where X is the index for the interface. We could leverage this information in the future to sort all the endpoints according to index. However, I didn't think that was necessary here since we are only working with two endpoints added to the UVM and the CNI team confirmed they do not care about the ordering of the non-eth0 endpoints for now. We are working on a better long-term solution for that scenario. 

Without this change, if an endpoint is incorrectly added first as the eth0 when it should not be, the pod may not be able to communicate with other pods as expected since the eth0 interfaces on other pods may be using endpoints from different subnets. 