### PR TITLE
Update dmverity tool to fix bug where hdv creation fails

### DIFF
--- a/cmd/dmverity-vhd/main.go
+++ b/cmd/dmverity-vhd/main.go
@@ -488,9 +488,6 @@ var createVHDCommand = cli.Command{
 			sanitisedFileName := sanitiseVHDFilename(layerID)
 
 			suffixes := []string{".vhd"}
-			if verityHashDev {
-				suffixes = append(suffixes, ".hash-dev.vhd")
-			}
 
 			for _, srcSuffix := range suffixes {
 				src := filepath.Join(os.TempDir(), sanitisedFileName+srcSuffix)


### PR DESCRIPTION
Update dmverity tool to fix bug where hdv creation fails to move all VHDs from the temp dir.

To recreate the error, run:
go run cmd\dmverity-vhd\main.go create -i python:latest -o python_layers -hdv

You will notice the following output:
hash device created at python_layers\8f4ceb8cc1a2056b98f0424fad4715dd334aecc9769186b3ea0394f131524e27.hash-dev.vhd
hash device created at python_layers\916d866d5b0dc17158c78e5a09717fcf619b04450125caafa9c1b8f7aa6a2c45.hash-dev.vhd
hash device created at python_layers\0d80db6a0977d5ade37d5d248772c0e9aaa1b6c898ddb31b26c803ee1a9f57a2.hash-dev.vhd
hash device created at python_layers\28e03088bc157bfe42d66970cf7f47de35821aabaece5f767804902a8fa1d779.hash-dev.vhd
hash device created at python_layers\2c3d7750fa05a52d63169a54cb95f1c7415cff5abe04d8e8f083b1a66a7a90fc.hash-dev.vhd
hash device created at python_layers\418eda943d8d99d77490798330feb2fe1bf339821c6e7f6a316f5f49f597fa40.hash-dev.vhd
hash device created at python_layers\06a1f32472403fd53c9111fb980487a0cb32c74326d0e86b4dee72c0f3d19922.hash-dev.vhd
hash device created at python_layers\5f7a708450e3b4ba4ab4f748eb69eede08cdce541dd8280a3ad57dbf6a0d1ed2.hash-dev.vhd
Layer VHD created at python_layers\8f4ceb8cc1a2056b98f0424fad4715dd334aecc9769186b3ea0394f131524e27.vhd
layer VHD C:\Users\<user>\AppData\Local\Temp\8f4ceb8cc1a2056b98f0424fad4715dd334aecc9769186b3ea0394f131524e27.hash-dev.vhd does not exist
exit status 1

After including this fix, the output is:
hash device created at python_layers\8f4ceb8cc1a2056b98f0424fad4715dd334aecc9769186b3ea0394f131524e27.hash-dev.vhd
hash device created at python_layers\916d866d5b0dc17158c78e5a09717fcf619b04450125caafa9c1b8f7aa6a2c45.hash-dev.vhd
hash device created at python_layers\0d80db6a0977d5ade37d5d248772c0e9aaa1b6c898ddb31b26c803ee1a9f57a2.hash-dev.vhd
hash device created at python_layers\28e03088bc157bfe42d66970cf7f47de35821aabaece5f767804902a8fa1d779.hash-dev.vhd
hash device created at python_layers\2c3d7750fa05a52d63169a54cb95f1c7415cff5abe04d8e8f083b1a66a7a90fc.hash-dev.vhd
hash device created at python_layers\418eda943d8d99d77490798330feb2fe1bf339821c6e7f6a316f5f49f597fa40.hash-dev.vhd
hash device created at python_layers\06a1f32472403fd53c9111fb980487a0cb32c74326d0e86b4dee72c0f3d19922.hash-dev.vhd
hash device created at python_layers\5f7a708450e3b4ba4ab4f748eb69eede08cdce541dd8280a3ad57dbf6a0d1ed2.hash-dev.vhd
Layer VHD created at python_layers\8f4ceb8cc1a2056b98f0424fad4715dd334aecc9769186b3ea0394f131524e27.vhd
Layer VHD created at python_layers\916d866d5b0dc17158c78e5a09717fcf619b04450125caafa9c1b8f7aa6a2c45.vhd
Layer VHD created at python_layers\0d80db6a0977d5ade37d5d248772c0e9aaa1b6c898ddb31b26c803ee1a9f57a2.vhd
Layer VHD created at python_layers\28e03088bc157bfe42d66970cf7f47de35821aabaece5f767804902a8fa1d779.vhd
Layer VHD created at python_layers\2c3d7750fa05a52d63169a54cb95f1c7415cff5abe04d8e8f083b1a66a7a90fc.vhd
Layer VHD created at python_layers\418eda943d8d99d77490798330feb2fe1bf339821c6e7f6a316f5f49f597fa40.vhd
Layer VHD created at python_layers\06a1f32472403fd53c9111fb980487a0cb32c74326d0e86b4dee72c0f3d19922.vhd
Layer VHD created at python_layers\5f7a708450e3b4ba4ab4f748eb69eede08cdce541dd8280a3ad57dbf6a0d1ed2.vhd