### PR TITLE
Use `atomic` types instead of raw values

### DIFF
--- a/internal/guest/runtime/hcsv2/uvm.go
+++ b/internal/guest/runtime/hcsv2/uvm.go
@@ -308,9 +308,9 @@ func (h *Host) CreateContainer(ctx context.Context, id string, settings *prot.VM
 		isSandbox:      criType == "sandbox",
 		exitType:       prot.NtUnexpectedExit,
 		processes:      make(map[uint32]*containerProcess),
-		status:         containerCreating,
 		scratchDirPath: settings.ScratchDirPath,
 	}
+	c.setStatus(containerCreating)
 
 	if err := h.AddContainer(id, c); err != nil {
 		return nil, err

--- a/internal/jobobject/jobobject_test.go
+++ b/internal/jobobject/jobobject_test.go
@@ -60,7 +60,7 @@ func TestSiloCreateAndOpen(t *testing.T) {
 	}
 	defer jobOpen.Close()
 
-	if !jobOpen.isSilo() {
+	if !jobOpen.silo.Load() {
 		t.Fatal("job is supposed to be a silo")
 	}
 }

--- a/internal/log/scrub.go
+++ b/internal/log/scrub.go
@@ -22,23 +22,14 @@ var (
 	// case sensitive keywords, so "env" is not a substring on "Environment"
 	_scrubKeywords = [][]byte{[]byte("env"), []byte("Environment")}
 
-	_scrub int32
+	_scrub atomic.Bool
 )
 
 // SetScrubbing enables scrubbing
-func SetScrubbing(enable bool) {
-	v := int32(0) // cant convert from bool to int32 directly
-	if enable {
-		v = 1
-	}
-	atomic.StoreInt32(&_scrub, v)
-}
+func SetScrubbing(enable bool) { _scrub.Store(enable) }
 
 // IsScrubbingEnabled checks if scrubbing is enabled
-func IsScrubbingEnabled() bool {
-	v := atomic.LoadInt32(&_scrub)
-	return v != 0
-}
+func IsScrubbingEnabled() bool { return _scrub.Load() }
 
 // ScrubProcessParameters scrubs HCS Create Process requests with config parameters of
 // type internal/hcs/schema2.ScrubProcessParameters (aka hcsshema.ScrubProcessParameters)

--- a/internal/uvm/counter.go
+++ b/internal/uvm/counter.go
@@ -2,18 +2,15 @@
 
 package uvm
 
-import (
-	"sync/atomic"
-)
-
-// ContainerCounter is used for where we layout things for a container in
-// a utility VM. For WCOW it'll be C:\c\N\. For LCOW it'll be /run/gcs/c/N/.
+// ContainerCounter is used for where we layout things for a container in a utility VM.
+// For WCOW it'll be C:\c\N\.
+// For LCOW it'll be /run/gcs/c/N/.
 func (uvm *UtilityVM) ContainerCounter() uint64 {
-	return atomic.AddUint64(&uvm.containerCounter, 1)
+	return uvm.containerCounter.Add(1)
 }
 
 // mountCounter is used for maintaining the number of mounts to the UVM.
 // This helps in generating unique mount paths for every mount.
 func (uvm *UtilityVM) UVMMountCounter() uint64 {
-	return atomic.AddUint64(&uvm.mountCounter, 1)
+	return uvm.mountCounter.Add(1)
 }

--- a/internal/uvm/types.go
+++ b/internal/uvm/types.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net"
 	"sync"
+	"sync/atomic"
 
 	"github.com/Microsoft/go-winio/pkg/guid"
 	"golang.org/x/sys/windows"
@@ -56,11 +57,9 @@ type UtilityVM struct {
 	protocol  uint32
 	guestCaps schema1.GuestDefinedCapabilities
 
-	// containerCounter is the current number of containers that have been
-	// created. This is never decremented in the life of the UVM.
-	//
-	// NOTE: All accesses to this MUST be done atomically.
-	containerCounter uint64
+	// containerCounter is the current number of containers that have been created.
+	// This is never decremented in the life of the UVM.
+	containerCounter atomic.Uint64
 
 	// noWritableFileShares disables mounting any writable vSMB or Plan9 shares
 	// on the uVM. This prevents containers in the uVM modifying files and directories
@@ -118,8 +117,7 @@ type UtilityVM struct {
 
 	// mountCounter is the number of mounts that have been added to the UVM
 	// This is used in generating a unique mount path inside the UVM for every mount.
-	// Access to this variable should be done atomically.
-	mountCounter uint64
+	mountCounter atomic.Uint64
 
 	// Location that container process dumps will get written too.
 	processDumpLocation string

--- a/test/gcs/helper_conn_test.go
+++ b/test/gcs/helper_conn_test.go
@@ -27,8 +27,12 @@ const (
 // port numbers to assign to connections.
 var (
 	_pipes      sync.Map
-	_portNumber uint32 = 1
+	_portNumber atomic.Uint32
 )
+
+func init() {
+	_portNumber.Store(1) // start at port 1
+}
 
 type PipeTransport struct{}
 
@@ -250,9 +254,7 @@ func newConnectionSettings(in, out, err bool) stdio.ConnectionSettings {
 	return c
 }
 
-func nextPortNumber() uint32 {
-	return atomic.AddUint32(&_portNumber, 2)
-}
+func nextPortNumber() uint32 { return _portNumber.Add(2) }
 
 func TestFakeSocket(t *testing.T) {
 	ctx := context.Background()


### PR DESCRIPTION
Per Go documentation recommendation (e.g. [link](https://pkg.go.dev/sync/atomic#AddUint64)), use the `atomic` types and their associated methods instead of the `atomic.Add*`/`.Store*` functions.

This makes the intent for atomic access clearer, prevents (accidental) non-atomic access, and (for boolean variables) simplifies code.