### PR TITLE
Configure advanced codeql.yml scanning

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,10 @@
+name: "CodeQL config"
+
+# uncomment to run extra queries:
+# https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning#using-queries-in-ql-packs
+# queries:
+#   - uses: security-and-quality
+
+paths-ignore:
+  - "/vendor/"
+  - "/test/"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,13 +8,13 @@
 # Additionally, see example CodeQL pipeline (in CodeQL repo):
 # https://github.com/github/codeql/blob/0342b3eba242476cea815e601942021092d0bc10/.github/workflows/codeql-analysis.yml
 
-name: "Code Scanning - CodeQL"
+name: "CodeQL"
 
 on:
   push:
-    branches: [main]
+    branches: ["main", "release/*"]
   pull_request:
-    branches: [main]
+    branches: ["main", "release/*"]
     paths-ignore:
       - "**/*.md"
       - "**/*.txt"
@@ -31,14 +31,22 @@ on:
 env:
   GO_VERSION: "1.21.x"
 
-permissions:
-  contents: read
-  packages: read
-  security-events: write
-
 jobs:
-  CodeQL-Build:
+  analyze:
+    name: Analyze (${{ matrix.language }} - ${{ matrix.goos }})
     runs-on: ubuntu-latest
+
+    permissions:
+      # required for all workflows
+      security-events: write
+
+      # required to fetch internal or private CodeQL packs
+      packages: read
+
+      # only required for workflows in private repositories
+      actions: read
+      contents: read
+
     strategy:
       fail-fast: false
       matrix:
@@ -64,7 +72,7 @@ jobs:
               internal/tools/zapdir,
 
           - goos: linux
-            language: go, cpp
+            language: go, c-cpp
             targets: >-
               cmd/gcs,
               cmd/gcstools,
@@ -90,7 +98,9 @@ jobs:
       - name: CodeQL Initialize
         uses: github/codeql-action/init@v3
         with:
+          build-mode: manual
           languages: ${{matrix.language}}
+          config-file: ./.github/codeql/codeql-config.yml
 
       # build binaries
       - name: Build go binaries


### PR DESCRIPTION
It appears GH doesn't recognize our CodeQL pipeline and attempts to run its own default version.
Rename the workflow to conform to what GH expects of the standard "advanced setup" for CodeQL, with some minor updates:
 - run on `release/*` branches
 - use the recommended job permissions
 - explicit `manual` build mode
 - use `c-cpp` instead of `cpp`
 - add a `codeql-config` file to ignore the test and vendor directories

Based on recommendations here, which simple create the appropriate workflow:
https://docs.github.com/en/enterprise-cloud@latest/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/configuring-advanced-setup-for-code-scanning-with-codeql-at-scale