### PR TITLE
Consolidate Go installation step

### DIFF
--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -1,0 +1,51 @@
+name: Setup Go
+description: Wraps actions/setup-go with default values.
+
+branding:
+  icon: package
+  color: gray-dark
+
+inputs:
+  go-version:
+    description: The Go version to download.
+    default: oldstable
+  cache:
+    description: Enable caching Go modules and build outputs,
+    default: "true"
+  repo-path:
+    description: Location this repo is checked out to.
+    default: ${{ github.workspace }}
+  fill-module-cache:
+    description: Pre-fill the Go module cache.
+    default: "false"
+
+outputs:
+  go-version:
+    description: The installed Go version.
+    value: ${{ steps.setup-go.outputs.go-version }}
+  cache-hit:
+    description: A boolean value to indicate if there was a cache hit.
+    value: ${{ steps.setup-go.outputs.cache-hit }}
+
+runs:
+  using: composite
+  steps:
+    - name: Install Go
+      id: setup-go
+      uses: actions/setup-go@v5
+      with:
+        go-version: ${{ inputs.go-version }}
+        check-latest: true
+        cache: ${{ inputs.cache }}
+        cache-dependency-path: |
+          ${{ inputs.repo-path }}/go.sum
+          ${{ inputs.repo-path }}/test/go.sum
+
+    - name: Pre-Fill Module Cache
+      if: ${{ fromJSON(inputs.fill-module-cache) }}
+      shell: pwsh # a shell value is required; pwsh is available on all GH runners
+      run: |
+        go mod download
+        cd test
+        go mod download
+      working-directory: ${{ inputs.repo-path }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,8 +4,6 @@ on:
   - pull_request
 
 env:
-  GO_VERSION: "oldstable"
-
   GO_BUILD_CMD: 'go build "-ldflags=-s -w" -trimpath'
   GO_BUILD_TEST_CMD: "go test -mod=mod -gcflags=all=-d=checkptr -c -tags functional"
 
@@ -29,10 +27,9 @@ jobs:
         with:
           show-progress: false
 
-      - name: Install go
-        uses: actions/setup-go@v5
+      - name: Install Go
+        uses: ./.github/actions/setup-go
         with:
-          go-version: ${{ env.GO_VERSION }}
           # sometimes go cache causes issues when linting
           cache: false
 
@@ -67,21 +64,11 @@ jobs:
           path: "${{ github.workspace }}/go/src/github.com/Microsoft/hcsshim"
           show-progress: false
 
-      - name: Install go
-        uses: actions/setup-go@v5
+      - name: Install Go
+        uses: ./go/src/github.com/Microsoft/hcsshim/.github/actions/setup-go
         with:
-          go-version: ${{ env.GO_VERSION }}
-          cache-dependency-path: |
-            ${{ github.workspace }}/go/src/github.com/Microsoft/hcsshim/go.sum
-            ${{ github.workspace }}/go/src/github.com/Microsoft/hcsshim/test/go.sum
-
-      - name: Pre-fill Module Cache
-        shell: powershell
-        run: |
-          go mod download
-          cd test
-          go mod download
-        working-directory: "${{ github.workspace }}/go/src/github.com/Microsoft/hcsshim"
+          repo-path: ${{ github.workspace }}/go/src/github.com/Microsoft/hcsshim
+          fill-module-cache: true
 
       - name: Install protoc
         shell: powershell
@@ -134,20 +121,10 @@ jobs:
         with:
           show-progress: false
 
-      - name: Install go
-        uses: actions/setup-go@v5
+      - name: Install Go
+        uses: ./.github/actions/setup-go
         with:
-          go-version: ${{ env.GO_VERSION }}
-          cache-dependency-path: |
-            go.sum
-            test/go.sum
-
-      - name: Pre-fill Module Cache
-        shell: powershell
-        run: |
-          go mod download
-          cd test
-          go mod download
+          fill-module-cache: true
 
       - name: Validate go.mod and vendoring
         shell: powershell
@@ -209,20 +186,10 @@ jobs:
         with:
           show-progress: false
 
-      - name: Install go
-        uses: actions/setup-go@v5
+      - name: Install Go
+        uses: ./.github/actions/setup-go
         with:
-          go-version: ${{ env.GO_VERSION }}
-          cache-dependency-path: |
-            go.sum
-            test/go.sum
-
-      - name: Pre-fill Module Cache
-        shell: powershell
-        run: |
-          go mod download
-          cd test
-          go mod download
+          fill-module-cache: true
 
       - name: Validate go generate
         shell: powershell
@@ -274,13 +241,10 @@ jobs:
         with:
           show-progress: false
 
-      - name: Install go
-        uses: actions/setup-go@v5
+      - name: Install Go
+        uses: ./.github/actions/setup-go
         with:
-          go-version: ${{ env.GO_VERSION }}
-          cache-dependency-path: |
-            go.sum
-            test/go.sum
+          fill-module-cache: true
 
       - name: Install gotestsum
         run: go install gotest.tools/gotestsum@${{ env.GOTESTSUM_VERSION }}
@@ -314,13 +278,8 @@ jobs:
         with:
           show-progress: false
 
-      - name: Install go
-        uses: actions/setup-go@v5
-        with:
-          go-version: ${{ env.GO_VERSION }}
-          cache-dependency-path: |
-            go.sum
-            test/go.sum
+      - name: Install Go
+        uses: ./.github/actions/setup-go
 
       - name: Install gotestsum
         run: go install gotest.tools/gotestsum@${{ env.GOTESTSUM_VERSION }}
@@ -447,14 +406,10 @@ jobs:
           path: src/github.com/Microsoft/hcsshim
           show-progress: false
 
-      - name: Install go
-        uses: actions/setup-go@v5
+      - name: Install Go
+        uses: ./src/github.com/Microsoft/hcsshim/.github/actions/setup-go
         with:
-          go-version: ${{ env.GO_VERSION }}
-          check-latest: true
-          cache-dependency-path: |
-            src/github.com/Microsoft/hcsshim/go.sum
-            src/github.com/Microsoft/hcsshim/test/go.sum
+          repo-path: src/github.com/Microsoft/hcsshim
 
       - name: Set env
         shell: bash
@@ -653,13 +608,8 @@ jobs:
         with:
           show-progress: false
 
-      - name: Install go
-        uses: actions/setup-go@v5
-        with:
-          go-version: ${{ env.GO_VERSION }}
-          cache-dependency-path: |
-            go.sum
-            test/go.sum
+      - name: Install Go
+        uses: ./.github/actions/setup-go
 
       - name: Set version info
         shell: pwsh
@@ -737,13 +687,8 @@ jobs:
         with:
           show-progress: false
 
-      - name: Install go
-        uses: actions/setup-go@v5
-        with:
-          go-version: ${{ env.GO_VERSION }}
-          cache-dependency-path: |
-            go.sum
-            test/go.sum
+      - name: Install Go
+        uses: ./.github/actions/setup-go
 
       - name: Set version info
         shell: pwsh

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,10 +27,6 @@ on:
     # minute, hour, day of month, month, day of week
     - cron: "0 0 * * 0"
 
-# TODO: consolidate this with ci.yml so they both use the same Go version
-env:
-  GO_VERSION: "1.21.x"
-
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }} - ${{ matrix.goos }})
@@ -92,10 +88,10 @@ jobs:
         with:
           show-progress: false
 
-      - name: Install go
-        uses: actions/setup-go@v5
+      - name: Install Go
+        uses: ./.github/actions/setup-go
         with:
-          go-version: ${{ env.GO_VERSION }}
+          fill-module-cache: true
 
       - name: CodeQL Initialize
         uses: github/codeql-action/init@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,23 +2,19 @@ name: Build & Release
 on:
   push:
     tags:
-      - 'v*'
-
-env:
-  GO_VERSION: "1.21.x"
+      - "v*"
 
 jobs:
   build:
     runs-on: "windows-2019"
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
-        with:
-          go-version: ${{ env.GO_VERSION }}
+      - name: Install Go
+        uses: ./.github/actions/setup-go
 
       - run: go build ./cmd/dmverity-vhd
       - run: go build ./cmd/dmverity-vhd
-        env: 
+        env:
           GOOS: linux
           GOARCH: amd64
 
@@ -39,7 +35,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: binaries
-          
+
       - name: Publish draft release
         uses: softprops/action-gh-release@v2.0.8
         with:
@@ -49,4 +45,3 @@ jobs:
           files: |
             dmverity-vhd.exe
             dmverity-vhd
-


### PR DESCRIPTION
Create composite action to call `actions/setup-go` with common values and logic across different jobs and workflows to reduce duplication and make sure workflows all use the same Go version.

Specifically, the action defaults to `oldstable` for the Go version, uses both `go.sum` and `test/go.sum` for the cache dependency, and allows pre-filling the Go module cache after installing Go.

It exposes the same outputs as `actions/setup-go` as well.