### PR TITLE
Add `.clang-format` and format C files

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,12 @@
+Language: Cpp
+BasedOnStyle: Microsoft
+BreakBeforeBraces: Attach
+PointerAlignment: Left
+AllowShortFunctionsOnASingleLine: All
+# match Go style
+IndentCaseLabels: false
+# don't break comments over line limit (needed for CodeQL exceptions)
+ReflowComments: false
+InsertNewlineAtEOF: true
+KeepEmptyLines:
+  AtEndOfFile: true

--- a/init/init.c
+++ b/init/init.c
@@ -2,7 +2,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <getopt.h>
-#include <linux/random.h>  // RNDADDENTROPY
+#include <linux/random.h> // RNDADDENTROPY
 #include <net/if.h>
 #include <netinet/ip.h>
 #include <signal.h>
@@ -35,12 +35,9 @@ static const int tcpmode;
 // vsockexec opens vsock connections for the specified stdio descriptors and
 // then execs the specified process.
 
-
-static int opentcp(unsigned short port)
-{
+static int opentcp(unsigned short port) {
     int s = socket(AF_INET, SOCK_STREAM, 0);
-    if (s < 0)
-    {
+    if (s < 0) {
         return -1;
     }
 
@@ -48,8 +45,7 @@ static int opentcp(unsigned short port)
     addr.sin_family = AF_INET;
     addr.sin_port = htons(port);
     addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
-    if (connect(s, (struct sockaddr *)&addr, sizeof(addr)) < 0)
-    {
+    if (connect(s, (struct sockaddr*)&addr, sizeof(addr)) < 0) {
         return -1;
     }
 
@@ -60,38 +56,38 @@ static int opentcp(unsigned short port)
 #define DEFAULT_PATH_ENV "PATH=/sbin:/usr/sbin:/bin:/usr/bin"
 #define OPEN_FDS 15
 
-const char *const default_envp[] = {
+const char* const default_envp[] = {
     DEFAULT_PATH_ENV,
     NULL,
 };
 
 #ifdef MODULES
 // global kmod k_ctx so we can access it in the file tree traversal
-struct kmod_ctx *k_ctx;
+struct kmod_ctx* k_ctx;
 
 // possible extensions for the kernel modules files
-const char *kmod_ext = ".ko";
-const char *kmod_xz_ext = ".ko.xz";
+const char* kmod_ext = ".ko";
+const char* kmod_xz_ext = ".ko.xz";
 #endif
 
 // When nothing is passed, default to the LCOWv1 behavior.
-const char *const default_argv[] = { "/bin/gcs", "-loglevel", "debug", "-logfile=/run/gcs/gcs.log" };
-const char *const default_shell = "/bin/sh";
-const char *const lib_modules = "/lib/modules";
+const char* const default_argv[] = {"/bin/gcs", "-loglevel", "debug", "-logfile=/run/gcs/gcs.log"};
+const char* const default_shell = "/bin/sh";
+const char* const lib_modules = "/lib/modules";
 
 struct Mount {
     const char *source, *target, *type;
     unsigned long flags;
-    const void *data;
+    const void* data;
 };
 
 struct Mkdir {
-    const char *path;
+    const char* path;
     mode_t mode;
 };
 
 struct Mknod {
-    const char *path;
+    const char* path;
     mode_t mode;
     int major, minor;
 };
@@ -119,36 +115,36 @@ struct InitOp {
 
 const struct InitOp ops[] = {
     // mount /proc (which should already exist)
-    { OpMount, .mount = { "proc", "/proc", "proc", MS_NODEV | MS_NOSUID | MS_NOEXEC } },
+    {OpMount, .mount = {"proc", "/proc", "proc", MS_NODEV | MS_NOSUID | MS_NOEXEC}},
 
     // add symlinks in /dev (which is already mounted)
-    { OpSymlink, .symlink = { "/dev/fd", "/proc/self/fd" } },
-    { OpSymlink, .symlink = { "/dev/stdin", "/proc/self/fd/0" } },
-    { OpSymlink, .symlink = { "/dev/stdout", "/proc/self/fd/1" } },
-    { OpSymlink, .symlink = { "/dev/stderr", "/proc/self/fd/2" } },
+    {OpSymlink, .symlink = {"/dev/fd", "/proc/self/fd"}},
+    {OpSymlink, .symlink = {"/dev/stdin", "/proc/self/fd/0"}},
+    {OpSymlink, .symlink = {"/dev/stdout", "/proc/self/fd/1"}},
+    {OpSymlink, .symlink = {"/dev/stderr", "/proc/self/fd/2"}},
 
     // mount tmpfs on /run and /tmp (which should already exist)
-    { OpMount, .mount = { "tmpfs", "/run", "tmpfs", MS_NODEV | MS_NOSUID | MS_NOEXEC, "mode=0755" } },
-    { OpMount, .mount = { "tmpfs", "/tmp", "tmpfs", MS_NODEV | MS_NOSUID | MS_NOEXEC } },
+    {OpMount, .mount = {"tmpfs", "/run", "tmpfs", MS_NODEV | MS_NOSUID | MS_NOEXEC, "mode=0755"}},
+    {OpMount, .mount = {"tmpfs", "/tmp", "tmpfs", MS_NODEV | MS_NOSUID | MS_NOEXEC}},
 
     // mount shm and devpts
-    { OpMkdir, .mkdir = { "/dev/shm", 0755 } },
-    { OpMount, .mount = { "shm", "/dev/shm", "tmpfs", MS_NODEV | MS_NOSUID | MS_NOEXEC } },
-    { OpMkdir, .mkdir = { "/dev/pts", 0755 } },
-    { OpMount, .mount = { "devpts", "/dev/pts", "devpts", MS_NOSUID | MS_NOEXEC } },
+    {OpMkdir, .mkdir = {"/dev/shm", 0755}},
+    {OpMount, .mount = {"shm", "/dev/shm", "tmpfs", MS_NODEV | MS_NOSUID | MS_NOEXEC}},
+    {OpMkdir, .mkdir = {"/dev/pts", 0755}},
+    {OpMount, .mount = {"devpts", "/dev/pts", "devpts", MS_NOSUID | MS_NOEXEC}},
 
     // mount /sys (which should already exist)
-    { OpMount, .mount = { "sysfs", "/sys", "sysfs", MS_NODEV | MS_NOSUID | MS_NOEXEC } },
-    { OpMount, .mount = { "cgroup_root", "/sys/fs/cgroup", "tmpfs", MS_NODEV | MS_NOSUID | MS_NOEXEC, "mode=0755" } },
+    {OpMount, .mount = {"sysfs", "/sys", "sysfs", MS_NODEV | MS_NOSUID | MS_NOEXEC}},
+    {OpMount, .mount = {"cgroup_root", "/sys/fs/cgroup", "tmpfs", MS_NODEV | MS_NOSUID | MS_NOEXEC, "mode=0755"}},
 };
 
-void warn(const char *msg) {
+void warn(const char* msg) {
     int error = errno;
     perror(msg);
     errno = error;
 }
 
-void warn2(const char *msg1, const char *msg2) {
+void warn2(const char* msg1, const char* msg2) {
     int error = errno;
     fputs(msg1, stderr);
     fputs(": ", stderr);
@@ -157,18 +153,18 @@ void warn2(const char *msg1, const char *msg2) {
 }
 
 _Noreturn void dien() {
-    #ifdef DEBUG
+#ifdef DEBUG
     printf("dien errno = %d", errno);
-    #endif
+#endif
     exit(errno);
 }
 
-_Noreturn void die(const char *msg) {
+_Noreturn void die(const char* msg) {
     warn(msg);
     dien();
 }
 
-_Noreturn void die2(const char *msg1, const char *msg2) {
+_Noreturn void die2(const char* msg1, const char* msg2) {
     warn2(msg1, msg2);
     dien();
 }
@@ -191,9 +187,9 @@ void init_rlimit() {
 
 void init_dev() {
     if (mount("dev", "/dev", "devtmpfs", MS_NOSUID | MS_NOEXEC, NULL) < 0) {
-        #ifdef DEBUG
+#ifdef DEBUG
         printf("mount - errno %d\n", errno);
-        #endif
+#endif
         warn2("mount", "/dev");
         // /dev will be already mounted if devtmpfs.mount = 1 on the kernel
         // command line or CONFIG_DEVTMPFS_MOUNT is set. Do not consider this
@@ -204,24 +200,25 @@ void init_dev() {
     }
 }
 
-void init_fs(const struct InitOp *ops, size_t count) {
+void init_fs(const struct InitOp* ops, size_t count) {
     for (size_t i = 0; i < count; i++) {
         switch (ops[i].op) {
         case OpMount: {
-            const struct Mount *m = &ops[i].mount;
-            #ifdef DEBUG
-            printf("OpMount src %s target %s type %s flags %lu data %p\n", m->source, m->target, m->type, m->flags, m->data);
-            #endif
+            const struct Mount* m = &ops[i].mount;
+#ifdef DEBUG
+            printf("OpMount src %s target %s type %s flags %lu data %p\n", m->source, m->target, m->type, m->flags,
+                   m->data);
+#endif
             if (mount(m->source, m->target, m->type, m->flags, m->data) < 0) {
                 die2("mount", m->target);
             }
             break;
         }
         case OpMkdir: {
-            const struct Mkdir *m = &ops[i].mkdir;
-            #ifdef DEBUG
+            const struct Mkdir* m = &ops[i].mkdir;
+#ifdef DEBUG
             printf("OpMkdir path %s mode %d\n", m->path, m->mode);
-            #endif
+#endif
             if (mkdir(m->path, m->mode) < 0) {
                 warn2("mkdir", m->path);
                 if (errno != EEXIST) {
@@ -231,10 +228,10 @@ void init_fs(const struct InitOp *ops, size_t count) {
             break;
         }
         case OpMknod: {
-            const struct Mknod *n = &ops[i].mknod;
-            #ifdef DEBUG
+            const struct Mknod* n = &ops[i].mknod;
+#ifdef DEBUG
             printf("OpMknod path %s mode %d major %d minor %d\n", n->path, n->mode, n->major, n->minor);
-            #endif
+#endif
             if (mknod(n->path, n->mode, makedev(n->major, n->minor)) < 0) {
                 warn2("mknod", n->path);
                 if (errno != EEXIST) {
@@ -244,10 +241,10 @@ void init_fs(const struct InitOp *ops, size_t count) {
             break;
         }
         case OpSymlink: {
-            const struct Symlink *sl = &ops[i].symlink;
-            #ifdef DEBUG
+            const struct Symlink* sl = &ops[i].symlink;
+#ifdef DEBUG
             printf("OpSymlink targeg %s link %s\n", sl->target, sl->linkpath);
-            #endif
+#endif
             if (symlink(sl->target, sl->linkpath) < 0) {
                 warn2("symlink", sl->linkpath);
                 if (errno != EEXIST) {
@@ -261,8 +258,8 @@ void init_fs(const struct InitOp *ops, size_t count) {
 }
 
 void init_cgroups() {
-    const char *fpath = "/proc/cgroups";
-    FILE *f = fopen(fpath, "r");
+    const char* fpath = "/proc/cgroups";
+    FILE* f = fopen(fpath, "r");
     if (f == NULL) {
         die2("fopen", fpath);
     }
@@ -283,7 +280,7 @@ void init_cgroups() {
             break;
         }
         if (r != 4) {
-            errno = errno ? : EINVAL;
+            errno = errno ?: EINVAL;
             die2("fscanf", fpath);
         }
         if (enabled) {
@@ -299,7 +296,7 @@ void init_cgroups() {
     fclose(f);
 }
 
-void init_network(const char *iface, int domain) {
+void init_network(const char* iface, int domain) {
     int s = socket(domain, SOCK_DGRAM, IPPROTO_IP);
     if (s < 0) {
         if (errno == EAFNOSUPPORT) {
@@ -351,7 +348,7 @@ void init_entropy(int port) {
         }
 
         buf.entropy_count = n * 8; // in bits
-        buf.buf_size = n; // in bytes
+        buf.buf_size = n;          // in bytes
         if (ioctl(e, RNDADDENTROPY, &buf) < 0) {
             die("ioctl(RNDADDENTROPY)");
         }
@@ -366,21 +363,20 @@ void init_entropy(int port) {
 //
 // /dev/kmsg exports the structured data in the following line format:
 // "<level>,<sequnum>,<timestamp>,<contflag>[,additional_values, ... ];<message text>\n"
-void dmesg(const unsigned int level, const char *msg)
-{
+void dmesg(const unsigned int level, const char* msg) {
     int fd_kmsg = open("/dev/kmsg", O_WRONLY);
     if (fd_kmsg == -1) {
         // failed to open the kmsg device
         warn("error opening /dev/kmsg");
         return;
     }
-    FILE * f_kmsg = fdopen(fd_kmsg, "w");
+    FILE* f_kmsg = fdopen(fd_kmsg, "w");
     if (f_kmsg == NULL) {
         warn("error getting /dev/kmsg file");
         close(fd_kmsg);
         return;
     }
-    fprintf(f_kmsg,  "<%u>%s", level, msg);
+    fprintf(f_kmsg, "<%u>%s", level, msg);
     fflush(f_kmsg);
     int close_ret = fclose(f_kmsg); // closes the underlying fd_kmsg as well
     if (close_ret != 0) {
@@ -389,11 +385,11 @@ void dmesg(const unsigned int level, const char *msg)
 }
 
 // see https://man7.org/linux/man-pages/man2/syslog.2.html for definitions of levels
-void dmesgErr(const char *msg) { dmesg(3, msg); }
-void dmesgWarn(const char *msg) { dmesg(4, msg); }
-void dmesgInfo(const char *msg) { dmesg(6, msg); }
+void dmesgErr(const char* msg) { dmesg(3, msg); }
+void dmesgWarn(const char* msg) { dmesg(4, msg); }
+void dmesgInfo(const char* msg) { dmesg(6, msg); }
 
-pid_t launch(int argc, char **argv) {
+pid_t launch(int argc, char** argv) {
     int pid = fork();
     if (pid != 0) {
         if (pid < 0) {
@@ -413,7 +409,7 @@ pid_t launch(int argc, char **argv) {
     setpgid(0, 0);
 
     // Terminate the arguments and exec.
-    char **argvn = alloca(sizeof(argv[0]) * (argc + 1));
+    char** argvn = alloca(sizeof(argv[0]) * (argc + 1));
     memcpy(argvn, argv, sizeof(argv[0]) * argc);
     argvn[argc] = NULL;
     if (putenv(DEFAULT_PATH_ENV)) { // Specify the PATH used for execvpe
@@ -451,13 +447,13 @@ int reap_until(pid_t until_pid) {
 #ifdef MODULES
 // load_module gets the module from the absolute path to the module and then
 // inserts into the kernel.
-int load_module(struct kmod_ctx *ctx, const char *module_path) {
-    struct kmod_module *mod = NULL;
+int load_module(struct kmod_ctx* ctx, const char* module_path) {
+    struct kmod_module* mod = NULL;
     int err;
 
-    #ifdef DEBUG
+#ifdef DEBUG
     printf("loading module: %s\n", module_path);
-    #endif
+#endif
 
     err = kmod_module_new_from_path(ctx, module_path, &mod);
     if (err < 0) {
@@ -488,7 +484,7 @@ bool has_extension(const char* fpath, const char* ext) {
 
 // parse_tree_entry is called by ftw for each directory and file in the file tree.
 // If this entry is a file and has a .ko file extension, attempt to load into kernel.
-int parse_tree_entry(const char *fpath, const struct stat *sb, int typeflag) {
+int parse_tree_entry(const char* fpath, const struct stat* sb, int typeflag) {
     int result;
 
     if (typeflag != FTW_F) {
@@ -560,22 +556,17 @@ void load_all_modules() {
 #endif
 
 #ifdef DEBUG
-int debug_main(int argc, char **argv) {
+int debug_main(int argc, char** argv) {
     unsigned int ports[3] = {2056, 2056, 2056};
     int sockets[3] = {-1, -1, -1};
 
-    for (int i = 0; i < 3; i++)
-    {
-        if (ports[i] != 0)
-        {
+    for (int i = 0; i < 3; i++) {
+        if (ports[i] != 0) {
             int j;
-            for (j = 0; j < i; j++)
-            {
-                if (ports[i] == ports[j])
-                {
+            for (j = 0; j < i; j++) {
+                if (ports[i] == ports[j]) {
                     int s = dup(sockets[j]);
-                    if (s < 0)
-                    {
+                    if (s < 0) {
                         perror("dup");
                         return 1;
                     }
@@ -584,11 +575,9 @@ int debug_main(int argc, char **argv) {
                 }
             }
 
-            if (j == i)
-            {
+            if (j == i) {
                 int s = tcpmode ? opentcp(ports[i]) : openvsock(VMADDR_CID_HOST, ports[i]);
-                if (s < 0)
-                {
+                if (s < 0) {
                     fprintf(stderr, "connect: port %u: %s", ports[i], strerror(errno));
                     return 1;
                 }
@@ -597,10 +586,8 @@ int debug_main(int argc, char **argv) {
         }
     }
 
-    for (int i = 0; i < 3; i++)
-    {
-        if (sockets[i] >= 0)
-        {
+    for (int i = 0; i < 3; i++) {
+        if (sockets[i] >= 0) {
             dup2(sockets[i], i);
             close(sockets[i]);
         }
@@ -618,7 +605,7 @@ void start_services() {
     // While execvpe will already search the path for the executable, it does
     // so after forking. We can avoid that unnecessary fork by stating the
     // binary beforehand.
-    char *persistenced_name = "/bin/nvidia-persistenced";
+    char* persistenced_name = "/bin/nvidia-persistenced";
     struct stat persistenced_stat;
     if (stat(persistenced_name, &persistenced_stat) == -1) {
         dmesgWarn("nvidia-persistenced not present, skipping ");
@@ -632,7 +619,7 @@ void start_services() {
         }
     }
 
-    char *fm_name = "/bin/nv-fabricmanager";
+    char* fm_name = "/bin/nv-fabricmanager";
     struct stat fabric_stat;
     if (stat(fm_name, &fabric_stat) == -1) {
         dmesgWarn("nv-fabricmanager not present, skipping ");
@@ -647,20 +634,20 @@ void start_services() {
     }
 }
 
-int main(int argc, char **argv) {
-    #ifdef DEBUG
+int main(int argc, char** argv) {
+#ifdef DEBUG
     debug_main(argc, argv);
     printf("Running init\n");
-    #endif
-    char *debug_shell = NULL;
+#endif
+    char* debug_shell = NULL;
     int entropy_port = 0;
     if (argc <= 1) {
-        argv = (char **)default_argv;
+        argv = (char**)default_argv;
         argc = sizeof(default_argv) / sizeof(default_argv[0]);
         optind = 0;
         debug_shell = (char*)default_shell;
     } else {
-        for (int opt; (opt = getopt(argc, argv, "+d:e:")) >= 0; ) {
+        for (int opt; (opt = getopt(argc, argv, "+d:e:")) >= 0;) {
             switch (opt) {
             case 'd':
                 debug_shell = optarg;
@@ -668,9 +655,9 @@ int main(int argc, char **argv) {
 
             case 'e':
                 entropy_port = atoi(optarg);
-                #ifdef DEBUG
+#ifdef DEBUG
                 printf("entropy port %d\n", entropy_port);
-                #endif
+#endif
                 if (entropy_port == 0) {
                     fputs("invalid entropy port\n", stderr);
                     exit(1);
@@ -684,56 +671,56 @@ int main(int argc, char **argv) {
         }
     }
 
-    char **child_argv = argv + optind;
+    char** child_argv = argv + optind;
     int child_argc = argc - optind;
 
     // Block all signals in init. SIGCHLD will still cause wait() to return.
     sigset_t set;
-    #ifdef DEBUG
+#ifdef DEBUG
     printf("sigfillset(&set)\n");
-    #endif
+#endif
     sigfillset(&set);
 
-    #ifdef DEBUG
+#ifdef DEBUG
     printf("sigfillset\n");
-    #endif
+#endif
     sigprocmask(SIG_BLOCK, &set, 0);
 
-    #ifdef DEBUG
+#ifdef DEBUG
     printf("init_rlimit\n");
-    #endif
+#endif
     init_rlimit();
 
-    #ifdef DEBUG
+#ifdef DEBUG
     printf("init_dev\n");
-    #endif
+#endif
     init_dev();
 
-    #ifdef DEBUG
+#ifdef DEBUG
     printf("init_fs\n");
-    #endif
+#endif
     init_fs(ops, sizeof(ops) / sizeof(ops[0]));
 
-    #ifdef DEBUG
+#ifdef DEBUG
     printf("init_cgroups\n");
-    #endif
+#endif
     init_cgroups();
 
-    #ifdef DEBUG
+#ifdef DEBUG
     printf("init_network\n");
-    #endif
+#endif
     init_network("lo", AF_INET);
     init_network("lo", AF_INET6);
     if (entropy_port != 0) {
         init_entropy(entropy_port);
     }
 
-    #ifdef MODULES
-    #ifdef DEBUG
+#ifdef MODULES
+#ifdef DEBUG
     printf("loading modules\n");
-    #endif
+#endif
     load_all_modules();
-    #endif
+#endif
 
     start_services();
 

--- a/vsockexec/vsock.c
+++ b/vsockexec/vsock.c
@@ -2,14 +2,12 @@
 #include <sys/socket.h>
 
 struct sockaddr_vm {
-	unsigned short svm_family;
-	unsigned short svm_reserved1;
-	unsigned int svm_port;
-	unsigned int svm_cid;
-	unsigned char svm_zero[sizeof(struct sockaddr) -
-			       sizeof(sa_family_t) -
-			       sizeof(unsigned short) -
-			       sizeof(unsigned int) - sizeof(unsigned int)];
+    unsigned short svm_family;
+    unsigned short svm_reserved1;
+    unsigned int svm_port;
+    unsigned int svm_cid;
+    unsigned char svm_zero[sizeof(struct sockaddr) - sizeof(sa_family_t) - sizeof(unsigned short) -
+                           sizeof(unsigned int) - sizeof(unsigned int)];
 };
 
 int openvsock(unsigned int cid, unsigned int port) {
@@ -22,7 +20,7 @@ int openvsock(unsigned int cid, unsigned int port) {
     addr.svm_family = AF_VSOCK;
     addr.svm_port = port;
     addr.svm_cid = cid;
-    if (connect(s, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
+    if (connect(s, (struct sockaddr*)&addr, sizeof(addr)) < 0) {
         return -1;
     }
 

--- a/vsockexec/vsockexec.c
+++ b/vsockexec/vsockexec.c
@@ -1,14 +1,14 @@
 // vsockexec opens vsock connections for the specified stdio descriptors and
 // then execs the specified process.
 
+#include "vsock.h"
 #include <errno.h>
-#include <sys/socket.h>
 #include <netinet/in.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/socket.h>
 #include <unistd.h>
-#include "vsock.h"
 
 #ifdef USE_TCP
 static const int tcpmode = 1;
@@ -16,8 +16,7 @@ static const int tcpmode = 1;
 static const int tcpmode;
 #endif
 
-static int opentcp(unsigned short port)
-{
+static int opentcp(unsigned short port) {
     int s = socket(AF_INET, SOCK_STREAM, 0);
     if (s < 0) {
         return -1;
@@ -27,21 +26,19 @@ static int opentcp(unsigned short port)
     addr.sin_family = AF_INET;
     addr.sin_port = htons(port);
     addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
-    if (connect(s, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
+    if (connect(s, (struct sockaddr*)&addr, sizeof(addr)) < 0) {
         return -1;
     }
 
     return s;
 }
 
-_Noreturn static void usage(const char *argv0)
-{
+_Noreturn static void usage(const char* argv0) {
     fprintf(stderr, "%s [-i port] [-o port] [-e port] -- program [args...]\n", argv0);
     exit(1);
 }
 
-int main(int argc, char **argv)
-{
+int main(int argc, char** argv) {
     unsigned int ports[3] = {0};
     int sockets[3] = {-1, -1, -1};
     int c;


### PR DESCRIPTION
Add `.clang-format` file that can be used directly by the clang formatter or by the Microsoft C/C++ VSCode extension. Style based on Microsoft default style guide, but update brace and case indentation settings to match current files better (as well as Go code).

Run formatter on `init\init.c` and `vsockexec\*`. Changes mostly with brace position, spacing, indentation, and pointer alignment.