### PR TITLE
Support passing in fabric manager config

### DIFF
--- a/init/init.c
+++ b/init/init.c
@@ -625,7 +625,8 @@ void start_services() {
         dmesgWarn("nv-fabricmanager not present, skipping ");
     } else {
         dmesgInfo("start nv-fabricmanager daemon");
-        pid_t fm_pid = launch(1, &fm_name);
+        char* command[] = {fm_name, "-c", "/usr/share/nvidia/nvswitch/fabricmanager.cfg"};
+        pid_t fm_pid = launch(3, command);
         if (fm_pid < 0) {
             // do not return early if we fail to start this, since it's possible that
             // this service doesn't exist on the system, which is a valid scenario


### PR DESCRIPTION
This PR adds support for passing in a configuration file when running fabric manager in the init program. If this configuration file is not present on the machine, fabric manager will fall back to running with all default settings. 

The config file can be customized to determine where the fabric manager's logs will be output, when to rotate the log files, fabric operation mode, and more. See [fabric manager doc](https://docs.nvidia.com/datacenter/tesla/pdf/fabric-manager-user-guide.pdf) for more details on how fabric manager works and how it can be configured. 