### PR TITLE
Downgrade go-cose to v1.1.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -98,7 +98,7 @@ require (
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/tchap/go-patricia/v2 v2.3.1 // indirect
 	github.com/vbatts/tar-split v0.11.3 // indirect
-	github.com/veraison/go-cose v1.2.0 // indirect
+	github.com/veraison/go-cose v1.1.0 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect


### PR DESCRIPTION
Go-cose v1.2.0 has been removed see https://github.com/veraison/go-cose/pull/153 

This package requiring this version limits other projects, hence, downgrading should resolve this issue (see #2216 and #2162), I've followed @andrew-lawson-tumelo 's suggestion for v1.1.0.

Hopefully, I've done this correctly!