### PR TITLE
Make tar2ext4 deterministic with files without parent dir in tar

### DIFF
--- a/ext4/internal/compactext4/compact.go
+++ b/ext4/internal/compactext4/compact.go
@@ -538,6 +538,7 @@ func (w *Writer) lookup(name string, mustExist bool) (*inode, *inode, string, er
 // with the same permissions as that of it's parent directory. It is expected that the a
 // call to make these parent directories will be made at a later point with the correct
 // permissions, at that time the permissions of these directories will be updated.
+// We treat Atime, Mtime, Ctime, and Crtime in the same way.
 func (w *Writer) MakeParents(name string) error {
 	if err := w.finishInode(); err != nil {
 		return err
@@ -556,10 +557,10 @@ func (w *Writer) MakeParents(name string) error {
 		if _, ok := root.Children[dirname]; !ok {
 			f := &File{
 				Mode:     root.Mode,
-				Atime:    time.Now(),
-				Mtime:    time.Now(),
-				Ctime:    time.Now(),
-				Crtime:   time.Now(),
+				Atime:    fsTimeToTime(root.Atime),
+				Mtime:    fsTimeToTime(root.Mtime),
+				Ctime:    fsTimeToTime(root.Ctime),
+				Crtime:   fsTimeToTime(root.Crtime),
 				Size:     0,
 				Uid:      root.Uid,
 				Gid:      root.Gid,

--- a/ext4/tar2ext4/tar2ext4_test.go
+++ b/ext4/tar2ext4/tar2ext4_test.go
@@ -1,6 +1,9 @@
 package tar2ext4
 
 import (
+	"crypto/sha256"
+	"fmt"
+	"io"
 	"path/filepath"
 	"testing"
 
@@ -160,5 +163,117 @@ func Test_TarHardlinkToSymlink(t *testing.T) {
 
 	if err := Convert(layerTar, layerVhd, opts...); err != nil {
 		t.Fatalf("failed to convert tar to layer vhd: %s", err)
+	}
+}
+
+// Test_MissingParentDirExpansion tests that we are correctly able to expand a layer tar file
+// even if its file does not include the parent directory in its file name.
+func Test_MissingParentDirExpansion(t *testing.T) {
+	tmpTarFilePath := filepath.Join(os.TempDir(), "test-layer.tar")
+	layerTar, err := os.Create(tmpTarFilePath)
+	if err != nil {
+		t.Fatalf("failed to create output file: %s", err)
+	}
+	defer os.Remove(tmpTarFilePath)
+
+	tw := tar.NewWriter(layerTar)
+	var files = []struct {
+		path, body string
+	}{
+		{"foo/bar.txt", "inside bar.txt"},
+	}
+	for _, file := range files {
+		var hdr *tar.Header
+		if strings.HasSuffix(file.path, "/") {
+			hdr = &tar.Header{
+				Name:       file.path,
+				Mode:       0777,
+				Size:       0,
+				ModTime:    time.Now(),
+				AccessTime: time.Now(),
+				ChangeTime: time.Now(),
+			}
+		} else {
+			hdr = &tar.Header{
+				Name:       file.path,
+				Mode:       0777,
+				Size:       int64(len(file.body)),
+				ModTime:    time.Now(),
+				AccessTime: time.Now(),
+				ChangeTime: time.Now(),
+			}
+		}
+		if err := tw.WriteHeader(hdr); err != nil {
+			t.Fatal(err)
+		}
+		if !strings.HasSuffix(file.path, "/") {
+			if _, err := tw.Write([]byte(file.body)); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Now import the tar file and check the conversion to ext4 is deterministic.
+	if _, err := layerTar.Seek(0, 0); err != nil {
+		t.Fatalf("failed to seek file: %s", err)
+	}
+
+	opts := []Option{ConvertWhiteout}
+
+	tmpVhdPath1 := filepath.Join(os.TempDir(), "test-vhd1.ext4")
+	layerVhd1, err := os.Create(tmpVhdPath1)
+	if err != nil {
+		t.Fatalf("failed to create output VHD: %s", err)
+	}
+	defer os.Remove(tmpVhdPath1)
+
+	if err := Convert(layerTar, layerVhd1, opts...); err != nil {
+		t.Fatalf("failed to convert tar to layer vhd: %s", err)
+	}
+
+	// Check the conversion is deterministic.
+	tmpVhdPath2 := filepath.Join(os.TempDir(), "test-vhd2.ext4")
+	layerVhd2, err := os.Create(tmpVhdPath2)
+	if err != nil {
+		t.Fatalf("failed to create output VHD: %s", err)
+	}
+	defer os.Remove(tmpVhdPath2)
+
+	if _, err := layerTar.Seek(0, 0); err != nil {
+		t.Fatalf("failed to seek file: %s", err)
+	}
+
+	if err := Convert(layerTar, layerVhd2, opts...); err != nil {
+		t.Fatalf("failed to convert tar to layer vhd: %s", err)
+	}
+
+	if _, err := layerVhd1.Seek(0, 0); err != nil {
+		t.Fatalf("failed to seek file: %s", err)
+	}
+
+	if _, err := layerVhd2.Seek(0, 0); err != nil {
+		t.Fatalf("failed to seek file: %s", err)
+	}
+
+	hasher1 := sha256.New()
+	if _, err = io.Copy(hasher1, layerVhd1); err != nil {
+		t.Fatalf("filed to initialize hasher: %s", err)
+	}
+
+	hash1 := hasher1.Sum(nil)
+	hash1hex := fmt.Sprintf("%x", hash1)
+
+	hasher2 := sha256.New()
+	if _, err = io.Copy(hasher2, layerVhd2); err != nil {
+		t.Fatalf("filed to initialize hasher: %s", err)
+	}
+	hash2 := hasher2.Sum(nil)
+	hash2hex := fmt.Sprintf("%x", hash2)
+
+	if hash1hex != hash2hex {
+		t.Fatalf("hash doesn't match")
 	}
 }

--- a/ext4/tar2ext4/tar2ext4_test.go
+++ b/ext4/tar2ext4/tar2ext4_test.go
@@ -174,12 +174,12 @@ func calcExt4Sha256(t *testing.T, layerTar *os.File) string {
 
 	opts := []Option{ConvertWhiteout}
 
-	tmpVhdPath := filepath.Join(os.TempDir(), "test-vhd.ext4")
-	layerVhd, err := os.Create(tmpVhdPath)
+	tmpExt4Path := filepath.Join(os.TempDir(), "test.ext4")
+	layerVhd, err := os.Create(tmpExt4Path)
 	if err != nil {
 		t.Fatalf("failed to create output VHD: %s", err)
 	}
-	defer os.Remove(tmpVhdPath)
+	defer os.Remove(tmpExt4Path)
 
 	if err := Convert(layerTar, layerVhd, opts...); err != nil {
 		t.Fatalf("failed to convert tar to layer vhd: %s", err)

--- a/ext4/tar2ext4/tar2ext4_test.go
+++ b/ext4/tar2ext4/tar2ext4_test.go
@@ -167,6 +167,7 @@ func Test_TarHardlinkToSymlink(t *testing.T) {
 }
 
 func calcExt4Sha256(t *testing.T, layerTar *os.File) string {
+	t.Helper()
 	if _, err := layerTar.Seek(0, 0); err != nil {
 		t.Fatalf("failed to seek file: %s", err)
 	}


### PR DESCRIPTION
## Problem to fix

`./dmverity-vhd roothash` is  not deterministic for some file docker images.

```bash
IMAGE=gcr.io/distroless/cc-debian11@sha256:d5a2169bc2282598f0cf886a3d301269d0ee5bf7f7392184198dd41d36b70548

docker pull $IMAGE > /dev/null

./dmverity-vhd -v -d roothash -i $IMAGE > bad-debian-1.txt
./dmverity-vhd -v -d roothash -i $IMAGE > bad-debian-2.txt

diff  bad-debian-1.txt bad-debian-2.txt
```

The above command shows a diff which suggest it's not deterministic.
This is causing a problem for `az confcom` tool that the generated security policy is not consistent for each run (`./dmverity-vhd roothash`  is called [here](https://github.com/Azure/azure-cli-extensions/blob/316fd959d9904c1d91a66ce0242eddaa87c4202d/src/confcom/azext_confcom/rootfs_proxy.py#L120)).
Container deployment is blocked as well for C-ACI.

## Cause of the problem

In the example image, there is a problematic tar file only  with a file `etc/nsswitch.conf`. For most of tar files there would be also `etc/` directory as the parent of `nsswitch.conf`, but for this specific tar there isn't.
For the such files without parent, `MakeParents()` makes the parent directories for ext4, but it uses `time.Now()` and it's causing the non-deterministic behavior.

## Fix

Change `time.Now()` to the child's value.

## Test

- `diff  bad-debian-1.txt bad-debian-2.txt` doesn't show any diff after the fix
- `go test ./ext4/tar2ext4/...`. It includes new a unit test case.

## Note

`go test ./ext4/internal/compactext4/...` is broken, but it seems to be the case even for main branch. Does anyone now the problem?

```log
--- FAIL: TestBasic (0.01s)                                                              
    compact_test.go:221: e2fsck 1.45.5 (07-Jan-2020)                                     
        Pass 1: Checking inodes, blocks, and sizes                                       
        Pass 2: Checking directory structure                                             
        Pass 3: Checking directory connectivity                                          
        Pass 4: Checking reference counts                                                
        Pass 5: Checking group summary information                                       
        Padding at end of inode bitmap is not set. Fix? no                               
                                                                                         
                                                                                         
        testfs.img: ********** WARNING: Filesystem still has errors **********           
                                                                                         
                                                                                         
                  26 inodes used (81.25%, out of 32)                                     
                   0 non-contiguous files (0.0%)                                         
                   0 non-contiguous directories (0.0%)                                   
                     # of inodes with ind/dind/tind blocks: 0/0/0                        
                     Extent depth histogram: 9                                           
                  16 blocks used (100.00%, out of 16)                                    
                   0 bad blocks                                                          
                   0 large files                                                         
                                                                                         
                   5 regular files                                                       
                   3 directories                                                         
                   1 character device file                                               
                   1 block device file                                                   
                   1 fifo                   
                   1 link                   
                   5 symbolic links (2 fast symbolic links)                              
                   1 socket                 
        ------------                        
                  18 files                  
    compact_test.go:221: exit status 4 
```


