### PR TITLE
[release/0.11] Update golang CI version + containerd version to v1.6.36

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   - pull_request
 
 env:
-  GO_VERSION: "1.20.x"
+  GO_VERSION: "1.21.x"
   GOTESTSUM_VERSION: "latest"
 
 jobs:
@@ -38,9 +38,9 @@ jobs:
           # sometimes go cache causes issues with lint
           cache: false
 
-      - uses: golangci/golangci-lint-action@v3
+      - uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.52
+          version: v1.54
           args: >-
             --verbose
             --max-issues-per-linter=0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
       - 'v*'
 
 env:
-  GO_VERSION: "1.18.x"
+  GO_VERSION: "1.21.x"
 
 jobs:
   build:

--- a/cmd/containerd-shim-runhcs-v1/pod_test.go
+++ b/cmd/containerd-shim-runhcs-v1/pod_test.go
@@ -391,9 +391,6 @@ func Test_pod_DeleteTask_TaskID_Not_Created(t *testing.T) {
 	setupTestTaskInPod(t, p)
 	setupTestTaskInPod(t, p)
 
-	seed := time.Now().UnixNano()
-	source := rand.New(rand.NewSource(seed))
-
-	err := p.KillTask(context.Background(), strconv.Itoa((int)(source.Uint64())), "", 0xf, true)
+	err := p.KillTask(context.Background(), strconv.Itoa(rand.Int()), "", 0xf, true)
 	verifyExpectedError(t, nil, err, errdefs.ErrNotFound)
 }

--- a/cmd/containerd-shim-runhcs-v1/task_hcs_test.go
+++ b/cmd/containerd-shim-runhcs-v1/task_hcs_test.go
@@ -14,18 +14,16 @@ import (
 
 func setupTestHcsTask(t *testing.T) (*hcsTask, *testShimExec, *testShimExec) {
 	t.Helper()
-	seed := time.Now().UnixNano()
-	source := rand.New(rand.NewSource(seed))
 
-	initExec := newTestShimExec(t.Name(), t.Name(), int(source.Uint64()))
+	initExec := newTestShimExec(t.Name(), t.Name(), int(rand.Int31()))
 	lt := &hcsTask{
 		events: newFakePublisher(),
 		id:     t.Name(),
 		init:   initExec,
 		closed: make(chan struct{}),
 	}
-	secondExecID := strconv.FormatInt((int64)(source.Uint64()), 10)
-	secondExec := newTestShimExec(t.Name(), secondExecID, int(source.Int31()))
+	secondExecID := strconv.Itoa(rand.Int())
+	secondExec := newTestShimExec(t.Name(), secondExecID, int(rand.Int31()))
 	lt.execs.Store(secondExecID, secondExec)
 	return lt, initExec, secondExec
 }

--- a/ext4/tar2ext4/tar2ext4.go
+++ b/ext4/tar2ext4/tar2ext4.go
@@ -148,7 +148,7 @@ func ConvertTarToExt4(r io.Reader, w io.ReadWriteSeeker, options ...Option) erro
 
 			var typ uint16
 			switch hdr.Typeflag {
-			case tar.TypeReg, tar.TypeRegA:
+			case tar.TypeReg:
 				typ = compactext4.S_IFREG
 			case tar.TypeSymlink:
 				typ = compactext4.S_IFLNK

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/cenkalti/backoff/v4 v4.2.0
 	github.com/containerd/cgroups v1.1.0
 	github.com/containerd/console v1.0.3
-	github.com/containerd/containerd v1.6.33
+	github.com/containerd/containerd v1.6.36
 	github.com/containerd/errdefs v0.1.0
 	github.com/containerd/go-runc v1.0.0
 	github.com/containerd/ttrpc v1.1.2

--- a/go.sum
+++ b/go.sum
@@ -215,8 +215,8 @@ github.com/containerd/containerd v1.5.7/go.mod h1:gyvv6+ugqY25TiXxcZC3L5yOeYgEw0
 github.com/containerd/containerd v1.5.8/go.mod h1:YdFSv5bTFLpG2HIYmfqDpSYYTDX+mc5qtSuYx1YUb/s=
 github.com/containerd/containerd v1.6.1/go.mod h1:1nJz5xCZPusx6jJU8Frfct988y0NpumIq9ODB0kLtoE=
 github.com/containerd/containerd v1.6.6/go.mod h1:ZoP1geJldzCVY3Tonoz7b1IXk8rIX0Nltt5QE4OMNk0=
-github.com/containerd/containerd v1.6.33 h1:8FYSFoV3UbizMgX7IKcP0GGAFw4+V3VPLo/CiU765WU=
-github.com/containerd/containerd v1.6.33/go.mod h1:Om5z+jDo6b8RkAxWf0ukj9JrPS/RYdhXNPwkZuuIyMk=
+github.com/containerd/containerd v1.6.36 h1:Bcj0ZXqgIs6GG+YbaKkMX3Dap0JsIVG4UYFOLRo7iX4=
+github.com/containerd/containerd v1.6.36/go.mod h1:gSufNaPbqri6ifEQ3eihFSXoGwqTENkqB7j//aEgE0s=
 github.com/containerd/continuity v0.0.0-20190426062206-aaeac12a7ffc/go.mod h1:GL3xCUCBDV3CZiTSEKksMWbLE66hEyuu9qyDOOqM47Y=
 github.com/containerd/continuity v0.0.0-20190815185530-f2a389ac0a02/go.mod h1:GL3xCUCBDV3CZiTSEKksMWbLE66hEyuu9qyDOOqM47Y=
 github.com/containerd/continuity v0.0.0-20191127005431-f65d91d395eb/go.mod h1:GL3xCUCBDV3CZiTSEKksMWbLE66hEyuu9qyDOOqM47Y=

--- a/internal/cmd/io_npipe.go
+++ b/internal/cmd/io_npipe.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"math/rand"
 	"net"
 	"sync"
 	"syscall"
@@ -19,11 +18,6 @@ import (
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/windows"
 )
-
-func init() {
-	// Need to seed for the rng in backoff.NextBackoff()
-	rand.Seed(time.Now().UnixNano())
-}
 
 // NewNpipeIO creates connected upstream io. It is the callers responsibility to validate that `if terminal == true`, `stderr == ""`. retryTimeout
 // refers to the timeout used to try and reconnect to the server end of the named pipe if the connection is severed. A value of 0 for retryTimeout

--- a/internal/winapi/utils.go
+++ b/internal/winapi/utils.go
@@ -4,7 +4,6 @@ package winapi
 
 import (
 	"errors"
-	"reflect"
 	"syscall"
 	"unsafe"
 
@@ -14,11 +13,7 @@ import (
 // Uint16BufferToSlice wraps a uint16 pointer-and-length into a slice
 // for easier interop with Go APIs
 func Uint16BufferToSlice(buffer *uint16, bufferLength int) (result []uint16) {
-	hdr := (*reflect.SliceHeader)(unsafe.Pointer(&result))
-	hdr.Data = uintptr(unsafe.Pointer(buffer))
-	hdr.Cap = bufferLength
-	hdr.Len = bufferLength
-
+	result = unsafe.Slice(buffer, bufferLength)
 	return
 }
 

--- a/test/go.mod
+++ b/test/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Microsoft/go-winio v0.6.2
 	github.com/Microsoft/hcsshim v0.10.0-rc.3
 	github.com/containerd/cgroups v1.1.0
-	github.com/containerd/containerd v1.6.33
+	github.com/containerd/containerd v1.6.36
 	github.com/containerd/errdefs v0.1.0
 	github.com/containerd/go-runc v1.0.0
 	github.com/containerd/log v0.1.0

--- a/test/go.sum
+++ b/test/go.sum
@@ -271,8 +271,8 @@ github.com/containerd/containerd v1.6.1/go.mod h1:1nJz5xCZPusx6jJU8Frfct988y0Npu
 github.com/containerd/containerd v1.6.6/go.mod h1:ZoP1geJldzCVY3Tonoz7b1IXk8rIX0Nltt5QE4OMNk0=
 github.com/containerd/containerd v1.6.18/go.mod h1:1RdCUu95+gc2v9t3IL+zIlpClSmew7/0YS8O5eQZrOw=
 github.com/containerd/containerd v1.6.23/go.mod h1:UrQOiyzrLi3n4aezYJbQH6Il+YzTvnHFbEuO3yfDrM4=
-github.com/containerd/containerd v1.6.33 h1:8FYSFoV3UbizMgX7IKcP0GGAFw4+V3VPLo/CiU765WU=
-github.com/containerd/containerd v1.6.33/go.mod h1:Om5z+jDo6b8RkAxWf0ukj9JrPS/RYdhXNPwkZuuIyMk=
+github.com/containerd/containerd v1.6.36 h1:Bcj0ZXqgIs6GG+YbaKkMX3Dap0JsIVG4UYFOLRo7iX4=
+github.com/containerd/containerd v1.6.36/go.mod h1:gSufNaPbqri6ifEQ3eihFSXoGwqTENkqB7j//aEgE0s=
 github.com/containerd/continuity v0.0.0-20190815185530-f2a389ac0a02/go.mod h1:GL3xCUCBDV3CZiTSEKksMWbLE66hEyuu9qyDOOqM47Y=
 github.com/containerd/continuity v0.0.0-20191127005431-f65d91d395eb/go.mod h1:GL3xCUCBDV3CZiTSEKksMWbLE66hEyuu9qyDOOqM47Y=
 github.com/containerd/continuity v0.0.0-20200710164510-efbc4488d8fe/go.mod h1:cECdGN1O8G9bgKTlLhuPJimka6Xb/Gg7vYzCTNVxhvo=

--- a/vendor/github.com/containerd/containerd/mount/temp.go
+++ b/vendor/github.com/containerd/containerd/mount/temp.go
@@ -29,6 +29,10 @@ var tempMountLocation = getTempDir()
 // WithTempMount mounts the provided mounts to a temp dir, and pass the temp dir to f.
 // The mounts are valid during the call to the f.
 // Finally we will unmount and remove the temp dir regardless of the result of f.
+//
+// NOTE: The volatile option of overlayfs doesn't allow to mount again using the
+// same upper / work dirs. Since it's a temp mount, avoid using that option here
+// if found.
 func WithTempMount(ctx context.Context, mounts []Mount, f func(root string) error) (err error) {
 	root, uerr := os.MkdirTemp(tempMountLocation, "containerd-mount")
 	if uerr != nil {
@@ -58,13 +62,53 @@ func WithTempMount(ctx context.Context, mounts []Mount, f func(root string) erro
 			}
 		}
 	}()
-	if uerr = All(mounts, root); uerr != nil {
+
+	if uerr = All(RemoveVolatileOption(mounts), root); uerr != nil {
 		return fmt.Errorf("failed to mount %s: %w", root, uerr)
 	}
 	if err := f(root); err != nil {
 		return fmt.Errorf("mount callback failed on %s: %w", root, err)
 	}
 	return nil
+}
+
+// RemoveVolatileOption copies and remove the volatile option for overlay
+// type, since overlayfs doesn't allow to mount again using the same upper/work
+// dirs.
+//
+// REF: https://docs.kernel.org/filesystems/overlayfs.html#volatile-mount
+//
+// TODO: Make this logic conditional once the kernel supports reusing
+// overlayfs volatile mounts.
+func RemoveVolatileOption(mounts []Mount) []Mount {
+	var out []Mount
+	for i, m := range mounts {
+		if m.Type != "overlay" {
+			continue
+		}
+		for j, opt := range m.Options {
+			if opt == "volatile" {
+				if out == nil {
+					out = copyMounts(mounts)
+				}
+				out[i].Options = append(out[i].Options[:j], out[i].Options[j+1:]...)
+				break
+			}
+		}
+	}
+
+	if out != nil {
+		return out
+	}
+
+	return mounts
+}
+
+// copyMounts creates a copy of the original slice to allow for modification and not altering the original
+func copyMounts(in []Mount) []Mount {
+	out := make([]Mount, len(in))
+	copy(out, in)
+	return out
 }
 
 // WithReadonlyTempMount mounts the provided mounts to a temp dir as readonly,

--- a/vendor/github.com/containerd/containerd/version/version.go
+++ b/vendor/github.com/containerd/containerd/version/version.go
@@ -23,7 +23,7 @@ var (
 	Package = "github.com/containerd/containerd"
 
 	// Version holds the complete version number. Filled in at linking time.
-	Version = "1.6.33+unknown"
+	Version = "1.6.36+unknown"
 
 	// Revision is filled with the VCS (e.g. git) revision being used to build
 	// the program at linking time.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -36,7 +36,7 @@ github.com/containerd/cgroups/stats/v1
 # github.com/containerd/console v1.0.3
 ## explicit; go 1.13
 github.com/containerd/console
-# github.com/containerd/containerd v1.6.33
+# github.com/containerd/containerd v1.6.36
 ## explicit; go 1.19
 github.com/containerd/containerd/api/events
 github.com/containerd/containerd/api/services/ttrpc/events/v1


### PR DESCRIPTION
Update golang versions used in github actions to 1.21.x, update containerd versiont o v1.6.26 and fix lint errors.