### PR TITLE
scsi: relax mount re-use constraint

### DIFF
--- a/internal/uvm/scsi/manager_test.go
+++ b/internal/uvm/scsi/manager_test.go
@@ -191,11 +191,11 @@ func TestGuestPath(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	// m3 should get the guest path it asked for.
-	if m3.GuestPath() != "/mnt2" {
+	// m3 asked for a guest path, but it is already mounted, so it should get that one instead.
+	if m3.GuestPath() != "/mnt1" {
 		t.Errorf("wrong guest path for m3: %s", m2.GuestPath())
 	}
-	if !reflect.DeepEqual(gb.mountPaths(), []string{"/mnt1", "/mnt2"}) {
+	if !reflect.DeepEqual(gb.mountPaths(), []string{"/mnt1"}) {
 		t.Errorf("wrong mount paths after adding m3: %v", gb.mountPaths())
 	}
 

--- a/internal/uvm/scsi/mount.go
+++ b/internal/uvm/scsi/mount.go
@@ -123,7 +123,6 @@ func (mm *mountManager) trackMount(controller, lun uint, path string, c *mountCo
 			}
 		} else if controller == mount.controller &&
 			lun == mount.lun &&
-			(path == "" || path == mount.path) &&
 			reflect.DeepEqual(c, mount.config) {
 
 			mount.refCount++


### PR DESCRIPTION
This is to fix a case with shared scratch enabled where the pause container scratch and workload container scratch should be the same mountpoint. This effectively changes the SCSI mount logic to have the same semantics as before the SCSI refactor, which mainly affected:
 * where the `runc` config.json for a container is written
 * scratch encryption

The old semantics ensured that the scratch (in a shared scratch case) is encrypted only once and also ensured that runc config.json for a given container is written to a unique location: either container's scratch (when scratch isn't shared) or tmpfs (when scratch is shared).

As before, the eventual hope is to remove guestPath support, and always generate a path, but that requires more extensive work to pass this path to the GCS.
