### PR TITLE
[release/0.11] Fixing typo

### DIFF
--- a/internal/hns/hnsendpoint.go
+++ b/internal/hns/hnsendpoint.go
@@ -29,7 +29,7 @@ const (
 )
 
 func (es EndpointState) String() string {
-	return [...]string{"Uninitialized", "Attached", "AttachedSharing", "Detached", "Degraded", "Destroyed"}[es]
+	return [...]string{"Uninitialized", "Created", "Attached", "AttachedSharing", "Detached", "Degraded", "Destroyed"}[es]
 }
 
 // HNSEndpoint represents a network endpoint in HNS


### PR DESCRIPTION
We missed setting "Created" as an Endpoint state option, fixing that.
(cherry picked from commit 166e62a783e2ca9a19ab0402821178b15479b77f)