### PR TITLE
Switch from pkg/errors to Go 1.13+ error wrapping

### DIFF
--- a/cmd/containerd-shim-runhcs-v1/delete.go
+++ b/cmd/containerd-shim-runhcs-v1/delete.go
@@ -4,13 +4,13 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"time"
 
 	task "github.com/containerd/containerd/api/runtime/task/v2"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 	"google.golang.org/protobuf/proto"
@@ -27,7 +27,7 @@ import (
 func limitedRead(filePath string, readLimitBytes int64) ([]byte, error) {
 	f, err := os.Open(filePath)
 	if err != nil {
-		return nil, errors.Wrapf(err, "limited read failed to open file: %s", filePath)
+		return nil, err
 	}
 	defer f.Close()
 	if fi, err := f.Stat(); err == nil {
@@ -37,11 +37,11 @@ func limitedRead(filePath string, readLimitBytes int64) ([]byte, error) {
 		buf := make([]byte, readLimitBytes)
 		_, err := f.Read(buf)
 		if err != nil {
-			return []byte{}, errors.Wrapf(err, "limited read failed during file read: %s", filePath)
+			return nil, err
 		}
 		return buf, nil
 	}
-	return []byte{}, errors.Wrapf(err, "limited read failed during file stat: %s", filePath)
+	return nil, err
 }
 
 var deleteCommand = cli.Command{

--- a/cmd/containerd-shim-runhcs-v1/exec.go
+++ b/cmd/containerd-shim-runhcs-v1/exec.go
@@ -4,10 +4,10 @@ package main
 
 import (
 	"context"
+	"fmt"
 
 	task "github.com/containerd/containerd/api/runtime/task/v2"
 	"github.com/containerd/errdefs"
-	"github.com/pkg/errors"
 )
 
 type shimExecState string
@@ -86,11 +86,6 @@ type shimExec interface {
 }
 
 func newExecInvalidStateError(tid, eid string, state shimExecState, op string) error {
-	return errors.Wrapf(
-		errdefs.ErrFailedPrecondition,
-		"exec: '%s' in task: '%s' is in invalid state: '%s' for %s",
-		eid,
-		tid,
-		state,
-		op)
+	return fmt.Errorf("exec: %q in task: %q is in invalid state: %q for %s: %w",
+		eid, tid, state, op, errdefs.ErrFailedPrecondition)
 }

--- a/cmd/containerd-shim-runhcs-v1/exec_wcow_podsandbox.go
+++ b/cmd/containerd-shim-runhcs-v1/exec_wcow_podsandbox.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
@@ -13,7 +14,6 @@ import (
 	containerd_v1_types "github.com/containerd/containerd/api/types/task"
 	"github.com/containerd/containerd/runtime"
 	"github.com/containerd/errdefs"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -166,7 +166,7 @@ func (wpse *wcowPodSandboxExec) Kill(ctx context.Context, signal uint32) error {
 		close(wpse.exited)
 		return nil
 	case shimExecStateExited:
-		return errors.Wrapf(errdefs.ErrNotFound, "exec: '%s' in task: '%s' not found", wpse.tid, wpse.tid)
+		return fmt.Errorf("exec: %q in task: %q: %w", wpse.tid, wpse.tid, errdefs.ErrNotFound)
 	default:
 		return newExecInvalidStateError(wpse.tid, wpse.tid, wpse.state, "kill")
 	}
@@ -177,7 +177,7 @@ func (wpse *wcowPodSandboxExec) ResizePty(ctx context.Context, width, height uin
 	defer wpse.sl.Unlock()
 	// We will never have IO for a sandbox container so we wont have a tty
 	// either.
-	return errors.Wrapf(errdefs.ErrFailedPrecondition, "exec: '%s' in task: '%s' is not a tty", wpse.tid, wpse.tid)
+	return fmt.Errorf("exec: %q in task: %q is not a tty: %w", wpse.tid, wpse.tid, errdefs.ErrFailedPrecondition)
 }
 
 func (wpse *wcowPodSandboxExec) CloseIO(ctx context.Context, stdin bool) error {

--- a/cmd/containerd-shim-runhcs-v1/service_internal_test.go
+++ b/cmd/containerd-shim-runhcs-v1/service_internal_test.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
 	"testing"
@@ -12,12 +13,11 @@ import (
 	"github.com/Microsoft/hcsshim/cmd/containerd-shim-runhcs-v1/stats"
 	v1 "github.com/containerd/cgroups/v3/cgroup1/stats"
 	task "github.com/containerd/containerd/api/runtime/task/v2"
-	"github.com/pkg/errors"
 )
 
 func verifyExpectedError(t *testing.T, resp interface{}, actual, expected error) {
 	t.Helper()
-	if actual == nil || errors.Cause(actual) != expected || !errors.Is(actual, expected) { //nolint:errorlint
+	if actual == nil || !errors.Is(actual, expected) { //nolint:errorlint
 		t.Fatalf("expected error: %v, got: %v", expected, actual)
 	}
 

--- a/cmd/containerd-shim-runhcs-v1/task_test.go
+++ b/cmd/containerd-shim-runhcs-v1/task_test.go
@@ -4,6 +4,8 @@ package main
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"time"
 
 	"github.com/Microsoft/hcsshim/cmd/containerd-shim-runhcs-v1/options"
@@ -15,7 +17,6 @@ import (
 	"github.com/containerd/errdefs"
 	typeurl "github.com/containerd/typeurl/v2"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/pkg/errors"
 )
 
 var _ = (shimTask)(&testShimTask{})
@@ -106,7 +107,7 @@ func (tst *testShimTask) DumpGuestStacks(ctx context.Context) string {
 func (tst *testShimTask) Update(ctx context.Context, req *task.UpdateTaskRequest) error {
 	data, err := typeurl.UnmarshalAny(req.Resources)
 	if err != nil {
-		return errors.Wrapf(err, "failed to unmarshal resources for container %s update request", req.ID)
+		return fmt.Errorf("failed to unmarshal resources for container %q update request: %w", req.ID, err)
 	}
 	if err := verifyTaskUpdateResourcesType(data); err != nil {
 		return err

--- a/cmd/ncproxy/computeagent_cache.go
+++ b/cmd/ncproxy/computeagent_cache.go
@@ -3,9 +3,8 @@
 package main
 
 import (
+	"errors"
 	"sync"
-
-	"github.com/pkg/errors"
 )
 
 var errNilCache = errors.New("cannot access a nil cache")

--- a/cmd/ncproxy/config.go
+++ b/cmd/ncproxy/config.go
@@ -4,11 +4,11 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 
-	"github.com/pkg/errors"
 	"github.com/urfave/cli"
 )
 
@@ -30,20 +30,20 @@ var configCommand = cli.Command{
 
 				configData, err := json.MarshalIndent(defaultConfig(), "", "  ")
 				if err != nil {
-					return errors.Wrap(err, "failed to marshal ncproxy config to json")
+					return fmt.Errorf("failed to marshal ncproxy config to json: %w", err)
 				}
 
 				if file != "" {
 					// Make the directory if it doesn't exist.
 					if _, err := os.Stat(filepath.Dir(file)); err != nil {
-						if err := os.MkdirAll(filepath.Dir(file), 0700); err != nil {
-							return errors.Wrap(err, "failed to make path to config file")
+						if err := os.MkdirAll(filepath.Dir(file), 0o700); err != nil {
+							return fmt.Errorf("failed to make path to config file: %w", err)
 						}
 					}
 					if err := os.WriteFile(
 						file,
 						[]byte(configData),
-						0700,
+						0o700,
 					); err != nil {
 						return err
 					}
@@ -96,7 +96,7 @@ func loadConfig(path string) (*config, error) {
 func readConfig(path string) (*config, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to read config file")
+		return nil, fmt.Errorf("failed to read config file: %w", err)
 	}
 	conf := &config{}
 	if err := json.Unmarshal(data, conf); err != nil {

--- a/cmd/ncproxy/run.go
+++ b/cmd/ncproxy/run.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -16,7 +17,7 @@ import (
 	"github.com/Microsoft/go-winio/pkg/etwlogrus"
 	"github.com/Microsoft/go-winio/pkg/guid"
 	"github.com/containerd/ttrpc"
-	"github.com/pkg/errors"
+
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 	"go.opencensus.io/plugin/ocgrpc"
@@ -173,7 +174,7 @@ func run(clicontext *cli.Context) error {
 		// If a log dir was provided, make sure it exists.
 		if _, err := os.Stat(logDir); err != nil {
 			if err := os.MkdirAll(logDir, 0); err != nil {
-				return errors.Wrap(err, "failed to make log directory")
+				return fmt.Errorf("failed to make log directory: %w", err)
 			}
 		}
 	}
@@ -208,7 +209,7 @@ func run(clicontext *cli.Context) error {
 	ctx := context.Background()
 	conf, err := loadConfig(configPath)
 	if err != nil {
-		return errors.Wrap(err, "failed getting configuration file")
+		return fmt.Errorf("failed getting configuration file: %w", err)
 	}
 
 	if conf.GRPCAddr == "" {
@@ -269,7 +270,7 @@ func run(clicontext *cli.Context) error {
 		dir := filepath.Dir(dbPath)
 		if _, err := os.Stat(dir); err != nil {
 			if err := os.MkdirAll(dir, 0); err != nil {
-				return errors.Wrap(err, "failed to make database directory")
+				return fmt.Errorf("failed to make database directory: %w", err)
 			}
 		}
 	}
@@ -306,7 +307,7 @@ func run(clicontext *cli.Context) error {
 		log.G(ctx).Info("Received interrupt. Closing")
 	case err := <-serveErr:
 		if err != nil {
-			return errors.Wrap(err, "server failure")
+			return fmt.Errorf("server failure: %w", err)
 		}
 	case <-serviceDone:
 		log.G(ctx).Info("Windows service stopped or shutdown")

--- a/cmd/ncproxy/server.go
+++ b/cmd/ncproxy/server.go
@@ -4,6 +4,8 @@ package main
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"net"
 	"strings"
 	"sync"
@@ -16,7 +18,7 @@ import (
 	ncproxygrpc "github.com/Microsoft/hcsshim/pkg/ncproxy/ncproxygrpc/v1"
 	"github.com/Microsoft/hcsshim/pkg/octtrpc"
 	"github.com/containerd/ttrpc"
-	"github.com/pkg/errors"
+
 	"github.com/sirupsen/logrus"
 	bolt "go.etcd.io/bbolt"
 	"go.opencensus.io/plugin/ocgrpc"
@@ -205,7 +207,7 @@ func reconnectComputeAgents(ctx context.Context, agentStore *ncproxystore.Comput
 func disconnectComputeAgents(ctx context.Context, containerIDToComputeAgent *computeAgentCache) error {
 	agents, err := containerIDToComputeAgent.getAllAndClear()
 	if err != nil {
-		return errors.Wrapf(err, "failed to get all cached compute agent clients")
+		return fmt.Errorf("failed to get all cached compute agent clients: %w", err)
 	}
 	for _, agent := range agents {
 		if err := agent.Close(); err != nil {

--- a/cmd/ncproxy/server_test.go
+++ b/cmd/ncproxy/server_test.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"net"
 	"path/filepath"
 	"testing"
@@ -17,7 +18,7 @@ import (
 	nodenetsvc "github.com/Microsoft/hcsshim/pkg/ncproxy/nodenetsvc/v1"
 	nodenetsvcMock "github.com/Microsoft/hcsshim/pkg/ncproxy/nodenetsvc/v1/mock"
 	"github.com/containerd/ttrpc"
-	"github.com/pkg/errors"
+
 	bolt "go.etcd.io/bbolt"
 	"go.uber.org/mock/gomock"
 	"google.golang.org/grpc/codes"

--- a/cmd/runhcs/create-scratch.go
+++ b/cmd/runhcs/create-scratch.go
@@ -4,13 +4,14 @@ package main
 
 import (
 	gcontext "context"
+	"errors"
+	"fmt"
 
 	"github.com/Microsoft/hcsshim/internal/appargs"
 	"github.com/Microsoft/hcsshim/internal/lcow"
 	"github.com/Microsoft/hcsshim/internal/oc"
 	"github.com/Microsoft/hcsshim/internal/uvm"
 	"github.com/Microsoft/hcsshim/osversion"
-	"github.com/pkg/errors"
 	"github.com/urfave/cli"
 )
 
@@ -74,14 +75,14 @@ var createScratchCommand = cli.Command{
 
 		convertUVM, err := uvm.CreateLCOW(ctx, opts)
 		if err != nil {
-			return errors.Wrapf(err, "failed to create '%s'", opts.ID)
+			return fmt.Errorf("failed to create %q: %w", opts.ID, err)
 		}
 		defer convertUVM.Close()
 		if err := convertUVM.Start(ctx); err != nil {
-			return errors.Wrapf(err, "failed to start '%s'", opts.ID)
+			return fmt.Errorf("failed to start %q: %w", opts.ID, err)
 		}
 		if err := lcow.CreateScratch(ctx, convertUVM, dest, sizeGB, context.String("cache-path")); err != nil {
-			return errors.Wrapf(err, "failed to create ext4vhdx for '%s'", opts.ID)
+			return fmt.Errorf("failed to create ext4vhdx for %q: %w", opts.ID, err)
 		}
 
 		return nil

--- a/cmd/runhcs/prepare-disk.go
+++ b/cmd/runhcs/prepare-disk.go
@@ -4,13 +4,14 @@ package main
 
 import (
 	gcontext "context"
+	"errors"
+	"fmt"
 
 	"github.com/Microsoft/hcsshim/internal/appargs"
 	"github.com/Microsoft/hcsshim/internal/lcow"
 	"github.com/Microsoft/hcsshim/internal/oc"
 	"github.com/Microsoft/hcsshim/internal/uvm"
 	"github.com/Microsoft/hcsshim/osversion"
-	"github.com/pkg/errors"
 	"github.com/urfave/cli"
 )
 
@@ -51,14 +52,14 @@ var prepareDiskCommand = cli.Command{
 
 		preparediskUVM, err := uvm.CreateLCOW(ctx, opts)
 		if err != nil {
-			return errors.Wrapf(err, "failed to create '%s'", opts.ID)
+			return fmt.Errorf("failed to create %q: %w", opts.ID, err)
 		}
 		defer preparediskUVM.Close()
 		if err := preparediskUVM.Start(ctx); err != nil {
-			return errors.Wrapf(err, "failed to start '%s'", opts.ID)
+			return fmt.Errorf("failed to start %q: %w", opts.ID, err)
 		}
 		if err := lcow.FormatDisk(ctx, preparediskUVM, dest); err != nil {
-			return errors.Wrapf(err, "failed to format disk '%s' with ext4", opts.ID)
+			return fmt.Errorf("failed to format disk %q with ext4: %w", opts.ID, err)
 		}
 
 		return nil

--- a/cmd/runhcs/vm.go
+++ b/cmd/runhcs/vm.go
@@ -5,6 +5,7 @@ package main
 import (
 	gcontext "context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -16,7 +17,7 @@ import (
 	"github.com/Microsoft/hcsshim/internal/logfields"
 	"github.com/Microsoft/hcsshim/internal/runhcs"
 	"github.com/Microsoft/hcsshim/internal/uvm"
-	"github.com/pkg/errors"
+
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 )

--- a/cmd/wclayer/volumemountutils.go
+++ b/cmd/wclayer/volumemountutils.go
@@ -5,10 +5,10 @@ package main
 // Simple wrappers around SetVolumeMountPoint and DeleteVolumeMountPoint
 
 import (
+	"fmt"
 	"path/filepath"
 	"strings"
 
-	"github.com/pkg/errors"
 	"golang.org/x/sys/windows"
 )
 
@@ -16,7 +16,7 @@ import (
 // https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-setvolumemountpointw
 func setVolumeMountPoint(targetPath string, volumePath string) error {
 	if !strings.HasPrefix(volumePath, "\\\\?\\Volume{") {
-		return errors.Errorf("unable to mount non-volume path %s", volumePath)
+		return fmt.Errorf("unable to mount non-volume path %s", volumePath)
 	}
 
 	// Both must end in a backslash
@@ -25,16 +25,16 @@ func setVolumeMountPoint(targetPath string, volumePath string) error {
 
 	targetP, err := windows.UTF16PtrFromString(slashedTarget)
 	if err != nil {
-		return errors.Wrapf(err, "unable to utf16-ise %s", slashedTarget)
+		return fmt.Errorf("unable to utf16-ise %s: %w", slashedTarget, err)
 	}
 
 	volumeP, err := windows.UTF16PtrFromString(slashedVolume)
 	if err != nil {
-		return errors.Wrapf(err, "unable to utf16-ise %s", slashedVolume)
+		return fmt.Errorf("unable to utf16-ise %s: %w", slashedVolume, err)
 	}
 
 	if err := windows.SetVolumeMountPoint(targetP, volumeP); err != nil {
-		return errors.Wrapf(err, "failed calling SetVolumeMount('%s', '%s')", slashedTarget, slashedVolume)
+		return fmt.Errorf("failed calling SetVolumeMount(%q, %q): %w", slashedTarget, slashedVolume, err)
 	}
 
 	return nil
@@ -48,11 +48,11 @@ func deleteVolumeMountPoint(targetPath string) error {
 
 	targetP, err := windows.UTF16PtrFromString(slashedTarget)
 	if err != nil {
-		return errors.Wrapf(err, "unable to utf16-ise %s", slashedTarget)
+		return fmt.Errorf("unable to utf16-ise %s: %w", slashedTarget, err)
 	}
 
 	if err := windows.DeleteVolumeMountPoint(targetP); err != nil {
-		return errors.Wrapf(err, "failed calling DeleteVolumeMountPoint('%s')", slashedTarget)
+		return fmt.Errorf("failed calling DeleteVolumeMountPoint(%q): %w", slashedTarget, err)
 	}
 
 	return nil

--- a/computestorage/attach.go
+++ b/computestorage/attach.go
@@ -5,9 +5,10 @@ package computestorage
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 
 	"github.com/Microsoft/hcsshim/internal/oc"
-	"github.com/pkg/errors"
+
 	"go.opencensus.io/trace"
 )
 
@@ -34,7 +35,7 @@ func AttachLayerStorageFilter(ctx context.Context, layerPath string, layerData L
 
 	err = hcsAttachLayerStorageFilter(layerPath, string(bytes))
 	if err != nil {
-		return errors.Wrap(err, "failed to attach layer storage filter")
+		return fmt.Errorf("failed to attach layer storage filter: %w", err)
 	}
 	return nil
 }
@@ -62,7 +63,7 @@ func AttachOverlayFilter(ctx context.Context, volumePath string, layerData Layer
 
 	err = hcsAttachOverlayFilter(volumePath, string(bytes))
 	if err != nil {
-		return errors.Wrap(err, "failed to attach overlay filter")
+		return fmt.Errorf("failed to attach overlay filter: %w", err)
 	}
 	return nil
 }

--- a/computestorage/destroy.go
+++ b/computestorage/destroy.go
@@ -4,9 +4,10 @@ package computestorage
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/Microsoft/hcsshim/internal/oc"
-	"github.com/pkg/errors"
+
 	"go.opencensus.io/trace"
 )
 
@@ -22,7 +23,7 @@ func DestroyLayer(ctx context.Context, layerPath string) (err error) {
 
 	err = hcsDestroyLayer(layerPath)
 	if err != nil {
-		return errors.Wrap(err, "failed to destroy layer")
+		return fmt.Errorf("failed to destroy layer: %w", err)
 	}
 	return nil
 }

--- a/computestorage/detach.go
+++ b/computestorage/detach.go
@@ -5,10 +5,11 @@ package computestorage
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 
 	hcsschema "github.com/Microsoft/hcsshim/internal/hcs/schema2"
 	"github.com/Microsoft/hcsshim/internal/oc"
-	"github.com/pkg/errors"
+
 	"go.opencensus.io/trace"
 )
 
@@ -24,7 +25,7 @@ func DetachLayerStorageFilter(ctx context.Context, layerPath string) (err error)
 
 	err = hcsDetachLayerStorageFilter(layerPath)
 	if err != nil {
-		return errors.Wrap(err, "failed to detach layer storage filter")
+		return fmt.Errorf("failed to detach layer storage filter: %w", err)
 	}
 	return nil
 }
@@ -48,7 +49,7 @@ func DetachOverlayFilter(ctx context.Context, volumePath string, filterType hcss
 
 	err = hcsDetachOverlayFilter(volumePath, string(bytes))
 	if err != nil {
-		return errors.Wrap(err, "failed to detach overlay filter")
+		return fmt.Errorf("failed to detach overlay filter: %w", err)
 	}
 	return nil
 }

--- a/computestorage/export.go
+++ b/computestorage/export.go
@@ -5,9 +5,10 @@ package computestorage
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 
 	"github.com/Microsoft/hcsshim/internal/oc"
-	"github.com/pkg/errors"
+
 	"go.opencensus.io/trace"
 )
 
@@ -42,7 +43,7 @@ func ExportLayer(ctx context.Context, layerPath, exportFolderPath string, layerD
 
 	err = hcsExportLayer(layerPath, exportFolderPath, string(ldBytes), string(oBytes))
 	if err != nil {
-		return errors.Wrap(err, "failed to export layer")
+		return fmt.Errorf("failed to export layer: %w", err)
 	}
 	return nil
 }

--- a/computestorage/format.go
+++ b/computestorage/format.go
@@ -4,9 +4,10 @@ package computestorage
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/Microsoft/hcsshim/internal/oc"
-	"github.com/pkg/errors"
+
 	"golang.org/x/sys/windows"
 )
 
@@ -26,7 +27,7 @@ func FormatWritableLayerVhd(ctx context.Context, vhdHandle windows.Handle) (err 
 
 	err = hcsFormatWritableLayerVhd(vhdHandle)
 	if err != nil {
-		return errors.Wrap(err, "failed to format writable layer vhd")
+		return fmt.Errorf("failed to format writable layer vhd: %w", err)
 	}
 	return nil
 }

--- a/computestorage/import.go
+++ b/computestorage/import.go
@@ -5,9 +5,10 @@ package computestorage
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 
 	"github.com/Microsoft/hcsshim/internal/oc"
-	"github.com/pkg/errors"
+
 	"go.opencensus.io/trace"
 )
 
@@ -37,7 +38,7 @@ func ImportLayer(ctx context.Context, layerPath, sourceFolderPath string, layerD
 
 	err = hcsImportLayer(layerPath, sourceFolderPath, string(bytes))
 	if err != nil {
-		return errors.Wrap(err, "failed to import layer")
+		return fmt.Errorf("failed to import layer: %w", err)
 	}
 	return nil
 }

--- a/computestorage/initialize.go
+++ b/computestorage/initialize.go
@@ -5,9 +5,10 @@ package computestorage
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 
 	"github.com/Microsoft/hcsshim/internal/oc"
-	"github.com/pkg/errors"
+
 	"go.opencensus.io/trace"
 )
 
@@ -34,7 +35,7 @@ func InitializeWritableLayer(ctx context.Context, layerPath string, layerData La
 	// Options are not used in the platform as of RS5
 	err = hcsInitializeWritableLayer(layerPath, string(bytes), "")
 	if err != nil {
-		return errors.Wrap(err, "failed to intitialize container layer")
+		return fmt.Errorf("failed to intitialize container layer: %w", err)
 	}
 	return nil
 }

--- a/computestorage/mount.go
+++ b/computestorage/mount.go
@@ -4,10 +4,11 @@ package computestorage
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/Microsoft/hcsshim/internal/interop"
 	"github.com/Microsoft/hcsshim/internal/oc"
-	"github.com/pkg/errors"
+
 	"golang.org/x/sys/windows"
 )
 
@@ -21,7 +22,7 @@ func GetLayerVhdMountPath(ctx context.Context, vhdHandle windows.Handle) (path s
 	var mountPath *uint16
 	err = hcsGetLayerVhdMountPath(vhdHandle, &mountPath)
 	if err != nil {
-		return "", errors.Wrap(err, "failed to get vhd mount path")
+		return "", fmt.Errorf("failed to get vhd mount path: %w", err)
 	}
 	path = interop.ConvertAndFreeCoTaskMemString(mountPath)
 	return path, nil

--- a/computestorage/setup.go
+++ b/computestorage/setup.go
@@ -5,10 +5,12 @@ package computestorage
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 
 	"github.com/Microsoft/hcsshim/internal/oc"
 	"github.com/Microsoft/hcsshim/osversion"
-	"github.com/pkg/errors"
+
 	"go.opencensus.io/trace"
 	"golang.org/x/sys/windows"
 )
@@ -38,7 +40,7 @@ func SetupBaseOSLayer(ctx context.Context, layerPath string, vhdHandle windows.H
 
 	err = hcsSetupBaseOSLayer(layerPath, vhdHandle, string(bytes))
 	if err != nil {
-		return errors.Wrap(err, "failed to setup base OS layer")
+		return fmt.Errorf("failed to setup base OS layer: %w", err)
 	}
 	return nil
 }
@@ -74,7 +76,7 @@ func SetupBaseOSVolume(ctx context.Context, layerPath, volumePath string, option
 
 	err = hcsSetupBaseOSVolume(layerPath, volumePath, string(bytes))
 	if err != nil {
-		return errors.Wrap(err, "failed to setup base OS layer")
+		return fmt.Errorf("failed to setup base OS layer: %w", err)
 	}
 	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,6 @@ require (
 	github.com/opencontainers/runc v1.1.14
 	github.com/opencontainers/runtime-spec v1.2.0
 	github.com/pelletier/go-toml v1.9.5
-	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.9.3
 	github.com/urfave/cli v1.22.15
 	github.com/vishvananda/netlink v1.3.0
@@ -91,6 +90,7 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.0 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_golang v1.20.2 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect

--- a/hcn/hcnsupport.go
+++ b/hcn/hcnsupport.go
@@ -3,9 +3,9 @@
 package hcn
 
 import (
+	"fmt"
 	"sync"
 
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
 	"github.com/Microsoft/hcsshim/internal/log"
@@ -89,7 +89,7 @@ func getSupportedFeatures() (SupportedFeatures, error) {
 	globals, err := GetGlobals()
 	if err != nil {
 		// It's expected if this fails once, it should always fail. It should fail on pre 1803 builds for example.
-		return SupportedFeatures{}, errors.Wrap(err, "failed to query HCN version number: this is expected on pre 1803 builds.")
+		return SupportedFeatures{}, fmt.Errorf("failed to query HCN version number: this is expected on pre 1803 builds.: %w", err)
 	}
 	features.Acl = AclFeatures{
 		AclAddressLists:       isFeatureSupported(globals.Version, HNSVersion1803),

--- a/internal/cmd/io_binary.go
+++ b/internal/cmd/io_binary.go
@@ -4,6 +4,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -16,7 +17,6 @@ import (
 
 	"github.com/Microsoft/go-winio"
 	"github.com/containerd/containerd/namespaces"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
 	"github.com/Microsoft/hcsshim/internal/log"
@@ -101,7 +101,7 @@ func NewBinaryIO(ctx context.Context, id string, uri *url.URL) (_ UpstreamIO, er
 	select {
 	case err = <-errCh:
 		if err != nil {
-			return nil, errors.Wrap(err, "failed to start binary logger")
+			return nil, fmt.Errorf("failed to start binary logger: %w", err)
 		}
 	case <-time.After(binaryCmdStartTimeout):
 		return nil, errors.New("failed to start binary logger: timeout")
@@ -275,7 +275,7 @@ func openNPipe(path string) (io.ReadWriteCloser, error) {
 func (p *pipe) Write(b []byte) (int, error) {
 	p.conWg.Wait()
 	if p.conErr != nil {
-		return 0, errors.Wrap(p.conErr, "connection error")
+		return 0, fmt.Errorf("connection error: %w", p.conErr)
 	}
 	return p.con.Write(b)
 }
@@ -283,7 +283,7 @@ func (p *pipe) Write(b []byte) (int, error) {
 func (p *pipe) Read(b []byte) (int, error) {
 	p.conWg.Wait()
 	if p.conErr != nil {
-		return 0, errors.Wrap(p.conErr, "connection error")
+		return 0, fmt.Errorf("connection error: %w", p.conErr)
 	}
 	return p.con.Read(b)
 }

--- a/internal/cpugroup/cpugroup.go
+++ b/internal/cpugroup/cpugroup.go
@@ -5,12 +5,12 @@ package cpugroup
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 
 	"github.com/Microsoft/hcsshim/internal/hcs"
 	hcsschema "github.com/Microsoft/hcsshim/internal/hcs/schema2"
-	"github.com/pkg/errors"
 )
 
 const NullGroupID = "00000000-0000-0000-0000-000000000000"
@@ -50,7 +50,7 @@ func Create(ctx context.Context, id string, logicalProcessors []uint32) error {
 		LogicalProcessorCount: uint32(len(logicalProcessors)),
 	}
 	if err := modifyCPUGroupRequest(ctx, operation, details); err != nil {
-		return errors.Wrapf(err, "failed to make cpugroups CreateGroup request for details %+v", details)
+		return fmt.Errorf("failed to make cpugroups CreateGroup request for details %+v: %w", details, err)
 	}
 	return nil
 }
@@ -66,7 +66,7 @@ func GetCPUGroupConfig(ctx context.Context, id string) (*hcsschema.CpuGroupConfi
 	}
 	groupConfigs := &hcsschema.CpuGroupConfigurations{}
 	if err := json.Unmarshal(cpuGroupsPresent.Properties[0], groupConfigs); err != nil {
-		return nil, errors.Wrap(err, "failed to unmarshal host cpugroups")
+		return nil, fmt.Errorf("failed to unmarshal host cpugroups: %w", err)
 	}
 
 	for _, c := range groupConfigs.CpuGroups {

--- a/internal/devices/assigned_devices.go
+++ b/internal/devices/assigned_devices.go
@@ -12,7 +12,6 @@ import (
 	"github.com/Microsoft/hcsshim/internal/cmd"
 	"github.com/Microsoft/hcsshim/internal/log"
 	"github.com/Microsoft/hcsshim/internal/uvm"
-	"github.com/pkg/errors"
 )
 
 // AddDevice is the api exposed to oci/hcsoci to handle assigning a device on a WCOW UVM
@@ -43,7 +42,7 @@ func AddDevice(ctx context.Context, vm *uvm.UtilityVM, idType, deviceID string, 
 	if uvm.IsValidDeviceType(idType) {
 		vpci, err = vm.AssignDevice(ctx, deviceID, index, "")
 		if err != nil {
-			return vpci, nil, errors.Wrapf(err, "failed to assign device %s of type %s to pod %s", deviceID, idType, vm.ID())
+			return vpci, nil, fmt.Errorf("failed to assign device %s of type %s to pod %s: %w", deviceID, idType, vm.ID(), err)
 		}
 		vmBusInstanceID := vm.GetAssignedDeviceVMBUSInstanceID(vpci.VMBusGUID)
 		log.G(ctx).WithField("vmbus id", vmBusInstanceID).Info("vmbus instance ID")
@@ -77,7 +76,7 @@ func getChildrenDeviceLocationPaths(ctx context.Context, vm *uvm.UtilityVM, vmBu
 	}
 	exitCode, err := cmd.ExecInUvm(ctx, vm, cmdReq)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to find devices with exit code %d", exitCode)
+		return nil, fmt.Errorf("failed to find devices with exit code %d: %w", exitCode, err)
 	}
 
 	// wait to finish parsing stdout results

--- a/internal/gcs/guestconnection.go
+++ b/internal/gcs/guestconnection.go
@@ -7,6 +7,7 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -20,7 +21,7 @@ import (
 	"github.com/Microsoft/hcsshim/internal/log"
 	"github.com/Microsoft/hcsshim/internal/logfields"
 	"github.com/Microsoft/hcsshim/internal/oc"
-	"github.com/pkg/errors"
+
 	"github.com/sirupsen/logrus"
 	"go.opencensus.io/trace"
 )

--- a/internal/guest/network/netns.go
+++ b/internal/guest/network/netns.go
@@ -5,6 +5,7 @@ package network
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"os/exec"
@@ -14,7 +15,7 @@ import (
 
 	"github.com/Microsoft/hcsshim/internal/guest/prot"
 	"github.com/Microsoft/hcsshim/internal/log"
-	"github.com/pkg/errors"
+
 	"github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
 	"github.com/vishvananda/netns"
@@ -26,15 +27,15 @@ func MoveInterfaceToNS(ifStr string, pid int) error {
 	// Get a reference to the interface and make sure it's down
 	link, err := netlink.LinkByName(ifStr)
 	if err != nil {
-		return errors.Wrapf(err, "netlink.LinkByName(%s) failed", ifStr)
+		return fmt.Errorf("netlink.LinkByName(%s) failed: %w", ifStr, err)
 	}
 	if err := netlink.LinkSetDown(link); err != nil {
-		return errors.Wrapf(err, "netlink.LinkSetDown(%#v) failed", link)
+		return fmt.Errorf("netlink.LinkSetDown(%#v) failed: %w", link, err)
 	}
 
 	// Move the interface to the new network namespace
 	if err := netlink.LinkSetNsPid(link, pid); err != nil {
-		return errors.Wrapf(err, "netlink.SetNsPid(%#v, %d) failed", link, pid)
+		return fmt.Errorf("netlink.SetNsPid(%#v, %d) failed: %w", link, pid, err)
 	}
 	return nil
 }
@@ -49,12 +50,12 @@ func DoInNetNS(ns netns.NsHandle, run func() error) error {
 
 	origNs, err := netns.Get()
 	if err != nil {
-		return errors.Wrap(err, "failed to get current network namespace")
+		return fmt.Errorf("failed to get current network namespace: %w", err)
 	}
 	defer origNs.Close()
 
 	if err := netns.Set(ns); err != nil {
-		return errors.Wrapf(err, "failed to set network namespace to %v", ns)
+		return fmt.Errorf("failed to set network namespace to %v: %w", ns, err)
 	}
 	// Defer so we can re-enter the threads original netns on exit.
 	defer netns.Set(origNs) //nolint:errcheck
@@ -79,7 +80,7 @@ func NetNSConfig(ctx context.Context, ifStr string, nsPid int, adapter *prot.Net
 	entry.Trace("Obtaining current namespace")
 	ns, err := netns.Get()
 	if err != nil {
-		return errors.Wrap(err, "netns.Get() failed")
+		return fmt.Errorf("netns.Get() failed: %w", err)
 	}
 	defer ns.Close()
 	entry.WithField("namespace", ns).Debug("New network namespace from PID")
@@ -88,7 +89,7 @@ func NetNSConfig(ctx context.Context, ifStr string, nsPid int, adapter *prot.Net
 	entry.Trace("Getting reference to interface")
 	link, err := netlink.LinkByName(ifStr)
 	if err != nil {
-		return errors.Wrapf(err, "netlink.LinkByName(%s) failed", ifStr)
+		return fmt.Errorf("netlink.LinkByName(%s) failed: %w", ifStr, err)
 	}
 
 	// User requested non-default MTU size
@@ -96,7 +97,7 @@ func NetNSConfig(ctx context.Context, ifStr string, nsPid int, adapter *prot.Net
 		mtu := link.Attrs().MTU - int(adapter.EncapOverhead)
 		entry.WithField("mtu", mtu).Debug("EncapOverhead non-zero, will set MTU")
 		if err = netlink.LinkSetMTU(link, mtu); err != nil {
-			return errors.Wrapf(err, "netlink.LinkSetMTU(%#v, %d) failed", link, mtu)
+			return fmt.Errorf("netlink.LinkSetMTU(%#v, %d) failed: %w", link, mtu, err)
 		}
 	}
 
@@ -112,7 +113,7 @@ func NetNSConfig(ctx context.Context, ifStr string, nsPid int, adapter *prot.Net
 
 		// Bring the interface up
 		if err := netlink.LinkSetUp(link); err != nil {
-			return errors.Wrapf(err, "netlink.LinkSetUp(%#v) failed", link)
+			return fmt.Errorf("netlink.LinkSetUp(%#v) failed: %w", link, err)
 		}
 		if err := assignIPToLink(ctx, ifStr, nsPid, link,
 			adapter.AllocatedIPAddress, adapter.HostIPAddress, adapter.HostIPPrefixLength,
@@ -156,7 +157,7 @@ func NetNSConfig(ctx context.Context, ifStr string, nsPid int, adapter *prot.Net
 			}
 			if err != nil {
 				entry.WithError(err).Debugf("udhcpc failed [%s]", cos)
-				return errors.Wrapf(err, "process failed (%s)", cos)
+				return fmt.Errorf("process failed (%s): %w", cos, err)
 			}
 		}
 		var cos string
@@ -210,7 +211,7 @@ func assignIPToLink(ctx context.Context,
 	// Set IP address
 	ip, addr, err := net.ParseCIDR(allocatedIP + "/" + strconv.FormatUint(uint64(prefixLen), 10))
 	if err != nil {
-		return errors.Wrapf(err, "parsing address %s/%d failed", allocatedIP, prefixLen)
+		return fmt.Errorf("parsing address %s/%d failed: %w", allocatedIP, prefixLen, err)
 	}
 	// the IP address field in addr is masked, so replace it with the original ip address
 	addr.IP = ip
@@ -220,7 +221,7 @@ func assignIPToLink(ctx context.Context,
 	}).Debugf("parsed ip address %s/%d", allocatedIP, prefixLen)
 	ipAddr := &netlink.Addr{IPNet: addr, Label: ""}
 	if err := netlink.AddrAdd(link, ipAddr); err != nil {
-		return errors.Wrapf(err, "netlink.AddrAdd(%#v, %#v) failed", link, ipAddr)
+		return fmt.Errorf("netlink.AddrAdd(%#v, %#v) failed: %w", link, ipAddr, err)
 	}
 	if gatewayIP == "" {
 		return nil
@@ -228,7 +229,7 @@ func assignIPToLink(ctx context.Context,
 	// Set gateway
 	gw := net.ParseIP(gatewayIP)
 	if gw == nil {
-		return errors.Wrapf(err, "parsing gateway address %s failed", gatewayIP)
+		return fmt.Errorf("parsing gateway address %s failed: %w", gatewayIP, err)
 	}
 
 	if !addr.Contains(gw) {
@@ -243,7 +244,7 @@ func assignIPToLink(ctx context.Context,
 			Mask: net.CIDRMask(ml, ml)}
 		ipAddr2 := &netlink.Addr{IPNet: addr2, Label: ""}
 		if err := netlink.AddrAdd(link, ipAddr2); err != nil {
-			return errors.Wrapf(err, "netlink.AddrAdd(%#v, %#v) failed", link, ipAddr2)
+			return fmt.Errorf("netlink.AddrAdd(%#v, %#v) failed: %w", link, ipAddr2, err)
 		}
 	}
 
@@ -262,7 +263,7 @@ func assignIPToLink(ctx context.Context,
 		rule.Priority = 5
 
 		if err := netlink.RuleAdd(rule); err != nil {
-			return errors.Wrapf(err, "netlink.RuleAdd(%#v) failed", rule)
+			return fmt.Errorf("netlink.RuleAdd(%#v) failed: %w", rule, err)
 		}
 		table = rule.Table
 	}
@@ -275,7 +276,7 @@ func assignIPToLink(ctx context.Context,
 		Priority:  metric,
 	}
 	if err := netlink.RouteAdd(&route); err != nil {
-		return errors.Wrapf(err, "netlink.RouteAdd(%#v) failed", route)
+		return fmt.Errorf("netlink.RouteAdd(%#v) failed: %w", route, err)
 	}
 	return nil
 }

--- a/internal/guest/prot/protocol.go
+++ b/internal/guest/prot/protocol.go
@@ -5,11 +5,11 @@ package prot
 
 import (
 	"encoding/json"
+	"fmt"
 	"strconv"
 
 	v1 "github.com/containerd/cgroups/v3/cgroup1/stats"
 	oci "github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/pkg/errors"
 
 	"github.com/Microsoft/hcsshim/internal/guest/commonutils"
 	hcsschema "github.com/Microsoft/hcsshim/internal/hcs/schema2"
@@ -518,14 +518,14 @@ func UnmarshalContainerModifySettings(b []byte) (*ContainerModifySettings, error
 	var requestRawSettings json.RawMessage
 	request.Request = &requestRawSettings
 	if err := commonutils.UnmarshalJSONWithHresult(b, &request); err != nil {
-		return nil, errors.Wrap(err, "failed to unmarshal ContainerModifySettings")
+		return nil, fmt.Errorf("failed to unmarshal ContainerModifySettings: %w", err)
 	}
 
 	var msr guestrequest.ModificationRequest
 	var msrRawSettings json.RawMessage
 	msr.Settings = &msrRawSettings
 	if err := commonutils.UnmarshalJSONWithHresult(requestRawSettings, &msr); err != nil {
-		return &request, errors.Wrap(err, "failed to unmarshal request.Settings as ModifySettingRequest")
+		return &request, fmt.Errorf("failed to unmarshal request.Settings as ModifySettingRequest: %w", err)
 	}
 
 	if msr.RequestType == "" {
@@ -537,65 +537,65 @@ func UnmarshalContainerModifySettings(b []byte) (*ContainerModifySettings, error
 	case guestresource.ResourceTypeSCSIDevice:
 		msd := &guestresource.SCSIDevice{}
 		if err := commonutils.UnmarshalJSONWithHresult(msrRawSettings, msd); err != nil {
-			return &request, errors.Wrap(err, "failed to unmarshal settings as SCSIDevice")
+			return &request, fmt.Errorf("failed to unmarshal settings as SCSIDevice: %w", err)
 		}
 		msr.Settings = msd
 	case guestresource.ResourceTypeMappedVirtualDisk:
 		mvd := &guestresource.LCOWMappedVirtualDisk{}
 		if err := commonutils.UnmarshalJSONWithHresult(msrRawSettings, mvd); err != nil {
-			return &request, errors.Wrap(err, "failed to unmarshal settings as MappedVirtualDiskV2")
+			return &request, fmt.Errorf("failed to unmarshal settings as MappedVirtualDiskV2: %w", err)
 		}
 		msr.Settings = mvd
 	case guestresource.ResourceTypeMappedDirectory:
 		md := &guestresource.LCOWMappedDirectory{}
 		if err := commonutils.UnmarshalJSONWithHresult(msrRawSettings, md); err != nil {
-			return &request, errors.Wrap(err, "failed to unmarshal settings as MappedDirectoryV2")
+			return &request, fmt.Errorf("failed to unmarshal settings as MappedDirectoryV2: %w", err)
 		}
 		msr.Settings = md
 	case guestresource.ResourceTypeVPMemDevice:
 		vpd := &guestresource.LCOWMappedVPMemDevice{}
 		if err := commonutils.UnmarshalJSONWithHresult(msrRawSettings, vpd); err != nil {
-			return &request, errors.Wrap(err, "failed to unmarshal hosted settings as MappedVPMemDeviceV2")
+			return &request, fmt.Errorf("failed to unmarshal hosted settings as MappedVPMemDeviceV2: %w", err)
 		}
 		msr.Settings = vpd
 	case guestresource.ResourceTypeCombinedLayers:
 		cl := &guestresource.LCOWCombinedLayers{}
 		if err := commonutils.UnmarshalJSONWithHresult(msrRawSettings, cl); err != nil {
-			return &request, errors.Wrap(err, "failed to unmarshal settings as CombinedLayersV2")
+			return &request, fmt.Errorf("failed to unmarshal settings as CombinedLayersV2: %w", err)
 		}
 		msr.Settings = cl
 	case guestresource.ResourceTypeNetwork:
 		na := &guestresource.LCOWNetworkAdapter{}
 		if err := commonutils.UnmarshalJSONWithHresult(msrRawSettings, na); err != nil {
-			return &request, errors.Wrap(err, "failed to unmarshal settings as NetworkAdapterV2")
+			return &request, fmt.Errorf("failed to unmarshal settings as NetworkAdapterV2: %w", err)
 		}
 		msr.Settings = na
 	case guestresource.ResourceTypeVPCIDevice:
 		vd := &guestresource.LCOWMappedVPCIDevice{}
 		if err := commonutils.UnmarshalJSONWithHresult(msrRawSettings, vd); err != nil {
-			return &request, errors.Wrap(err, "failed to unmarshal settings as MappedVPCIDeviceV2")
+			return &request, fmt.Errorf("failed to unmarshal settings as MappedVPCIDeviceV2: %w", err)
 		}
 		msr.Settings = vd
 	case guestresource.ResourceTypeContainerConstraints:
 		cc := &guestresource.LCOWContainerConstraints{}
 		if err := commonutils.UnmarshalJSONWithHresult(msrRawSettings, cc); err != nil {
-			return &request, errors.Wrap(err, "failed to unmarshal settings as ContainerConstraintsV2")
+			return &request, fmt.Errorf("failed to unmarshal settings as ContainerConstraintsV2: %w", err)
 		}
 		msr.Settings = cc
 	case guestresource.ResourceTypeSecurityPolicy:
 		enforcer := &guestresource.LCOWConfidentialOptions{}
 		if err := commonutils.UnmarshalJSONWithHresult(msrRawSettings, enforcer); err != nil {
-			return &request, errors.Wrap(err, "failed to unmarshal settings as LCOWConfidentialOptions")
+			return &request, fmt.Errorf("failed to unmarshal settings as LCOWConfidentialOptions: %w", err)
 		}
 		msr.Settings = enforcer
 	case guestresource.ResourceTypePolicyFragment:
 		fragment := &guestresource.LCOWSecurityPolicyFragment{}
 		if err := commonutils.UnmarshalJSONWithHresult(msrRawSettings, fragment); err != nil {
-			return &request, errors.Wrap(err, "failed to unmarshal settings as LCOWSecurityPolicyFragment")
+			return &request, fmt.Errorf("failed to unmarshal settings as LCOWSecurityPolicyFragment: %w", err)
 		}
 		msr.Settings = fragment
 	default:
-		return &request, errors.Errorf("invalid ResourceType '%s'", msr.ResourceType)
+		return &request, fmt.Errorf("invalid ResourceType %q", msr.ResourceType)
 	}
 	request.Request = &msr
 	return &request, nil

--- a/internal/guest/runtime/hcsv2/container.go
+++ b/internal/guest/runtime/hcsv2/container.go
@@ -14,7 +14,7 @@ import (
 	cgroups "github.com/containerd/cgroups/v3/cgroup1"
 	v1 "github.com/containerd/cgroups/v3/cgroup1/stats"
 	oci "github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/pkg/errors"
+
 	"github.com/sirupsen/logrus"
 	"go.opencensus.io/trace"
 
@@ -267,7 +267,7 @@ func (c *Container) GetStats(ctx context.Context) (*v1.Metrics, error) {
 	cgroupPath := c.spec.Linux.CgroupsPath
 	cg, err := cgroups.Load(cgroups.StaticPath(cgroupPath))
 	if err != nil {
-		return nil, errors.Errorf("failed to get container stats for %v: %v", c.id, err)
+		return nil, fmt.Errorf("failed to get container stats for %v: %v", c.id, err)
 	}
 
 	return cg.Stat(cgroups.IgnoreNotExist)

--- a/internal/guest/runtime/hcsv2/nvidia_utils.go
+++ b/internal/guest/runtime/hcsv2/nvidia_utils.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 
 	oci "github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/pkg/errors"
 
 	"github.com/Microsoft/hcsshim/cmd/gcstools/generichook"
 	"github.com/Microsoft/hcsshim/internal/guest/storage/pci"
@@ -29,7 +28,7 @@ func addNvidiaDeviceHook(ctx context.Context, spec *oci.Spec, ociBundlePath stri
 	genericHookBinary := "generichook"
 	genericHookPath, err := exec.LookPath(genericHookBinary)
 	if err != nil {
-		return errors.Wrapf(err, "failed to find %s for container device support", genericHookBinary)
+		return fmt.Errorf("failed to find %s for container device support: %w", genericHookBinary, err)
 	}
 
 	toolDebugPath := filepath.Join(ociBundlePath, nvidiaDebugFilePath)
@@ -54,7 +53,7 @@ func addNvidiaDeviceHook(ctx context.Context, spec *oci.Spec, ociBundlePath stri
 		case "gpu":
 			busLocation, err := pci.FindDeviceBusLocationFromVMBusGUID(ctx, d.ID)
 			if err != nil {
-				return errors.Wrapf(err, "failed to find nvidia gpu bus location")
+				return fmt.Errorf("failed to find nvidia gpu bus location: %w", err)
 			}
 			args = append(args, fmt.Sprintf("--device=%s", busLocation))
 		}

--- a/internal/guest/runtime/hcsv2/process.go
+++ b/internal/guest/runtime/hcsv2/process.go
@@ -5,6 +5,7 @@ package hcsv2
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os/exec"
 	"sync"
@@ -17,7 +18,7 @@ import (
 	"github.com/Microsoft/hcsshim/internal/logfields"
 	"github.com/Microsoft/hcsshim/internal/oc"
 	oci "github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/pkg/errors"
+
 	"github.com/sirupsen/logrus"
 	"go.opencensus.io/trace"
 )
@@ -233,7 +234,7 @@ func newExternalProcess(ctx context.Context, cmd *exec.Cmd, tty *stdio.TtyRelay,
 		remove:    onRemove,
 	}
 	if err := cmd.Start(); err != nil {
-		return nil, errors.Wrap(err, "failed to call Start for external process")
+		return nil, fmt.Errorf("failed to call Start for external process: %w", err)
 	}
 	if tty != nil {
 		tty.Start()

--- a/internal/guest/runtime/hcsv2/spec_devices.go
+++ b/internal/guest/runtime/hcsv2/spec_devices.go
@@ -5,6 +5,7 @@ package hcsv2
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -14,7 +15,6 @@ import (
 	"github.com/Microsoft/hcsshim/internal/log"
 	"github.com/opencontainers/runc/libcontainer/devices"
 	oci "github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/pkg/errors"
 )
 
 const (
@@ -42,12 +42,12 @@ func addAssignedDevice(ctx context.Context, spec *oci.Spec) error {
 			// validate that the device is available
 			fullPCIPath, err := pci.FindDeviceFullPath(ctx, d.ID)
 			if err != nil {
-				return errors.Wrapf(err, "failed to find device pci path for device %v", d)
+				return fmt.Errorf("failed to find device pci path for device %v: %w", d, err)
 			}
 			// find the device nodes that link to the pci path we just got
 			devs, err := devicePathsFromPCIPath(ctx, fullPCIPath)
 			if err != nil {
-				return errors.Wrapf(err, "failed to find dev node for device %v", d)
+				return fmt.Errorf("failed to find dev node for device %v: %w", d, err)
 			}
 			for _, dev := range devs {
 				addLinuxDeviceToSpec(ctx, dev, spec, true)

--- a/internal/guest/stdio/connection.go
+++ b/internal/guest/stdio/connection.go
@@ -4,10 +4,11 @@
 package stdio
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/Microsoft/hcsshim/internal/guest/transport"
-	"github.com/pkg/errors"
+
 	"github.com/sirupsen/logrus"
 )
 
@@ -75,7 +76,7 @@ func Connect(tport transport.Transport, settings ConnectionSettings) (_ *Connect
 	if settings.StdIn != nil {
 		c, err := tport.Dial(*settings.StdIn)
 		if err != nil {
-			return nil, errors.Wrap(err, "failed creating stdin Connection")
+			return nil, fmt.Errorf("failed creating stdin Connection: %w", err)
 		}
 		connSet.In = &logConnection{
 			con:  c,
@@ -85,7 +86,7 @@ func Connect(tport transport.Transport, settings ConnectionSettings) (_ *Connect
 	if settings.StdOut != nil {
 		c, err := tport.Dial(*settings.StdOut)
 		if err != nil {
-			return nil, errors.Wrap(err, "failed creating stdout Connection")
+			return nil, fmt.Errorf("failed creating stdout Connection: %w", err)
 		}
 		connSet.Out = &logConnection{
 			con:  c,
@@ -95,7 +96,7 @@ func Connect(tport transport.Transport, settings ConnectionSettings) (_ *Connect
 	if settings.StdErr != nil {
 		c, err := tport.Dial(*settings.StdErr)
 		if err != nil {
-			return nil, errors.Wrap(err, "failed creating stderr Connection")
+			return nil, fmt.Errorf("failed creating stderr Connection: %w", err)
 		}
 		connSet.Err = &logConnection{
 			con:  c,

--- a/internal/guest/stdio/stdio.go
+++ b/internal/guest/stdio/stdio.go
@@ -4,13 +4,15 @@
 package stdio
 
 import (
+	"errors"
+	"fmt"
 	"io"
 	"os"
 	"strings"
 	"sync"
 
 	"github.com/Microsoft/hcsshim/internal/guest/transport"
-	"github.com/pkg/errors"
+
 	"github.com/sirupsen/logrus"
 )
 
@@ -25,19 +27,19 @@ func (s *ConnectionSet) Close() error {
 	var err error
 	if s.In != nil {
 		if cerr := s.In.Close(); cerr != nil {
-			err = errors.Wrap(cerr, "failed Close on stdin")
+			err = fmt.Errorf("failed Close on stdin: %w", cerr)
 		}
 		s.In = nil
 	}
 	if s.Out != nil {
 		if cerr := s.Out.Close(); cerr != nil && err == nil {
-			err = errors.Wrap(cerr, "failed Close on stdout")
+			err = fmt.Errorf("failed Close on stdout: %w", cerr)
 		}
 		s.Out = nil
 	}
 	if s.Err != nil {
 		if cerr := s.Err.Close(); cerr != nil && err == nil {
-			err = errors.Wrap(cerr, "failed Close on stderr")
+			err = fmt.Errorf("failed Close on stderr: %w", cerr)
 		}
 		s.Err = nil
 	}
@@ -55,19 +57,19 @@ func (fs *FileSet) Close() error {
 	var err error
 	if fs.In != nil {
 		if cerr := fs.In.Close(); cerr != nil {
-			err = errors.Wrap(cerr, "failed Close on stdin")
+			err = fmt.Errorf("failed Close on stdin: %w", cerr)
 		}
 		fs.In = nil
 	}
 	if fs.Out != nil {
 		if cerr := fs.Out.Close(); cerr != nil && err == nil {
-			err = errors.Wrap(cerr, "failed Close on stdout")
+			err = fmt.Errorf("failed Close on stdout: %w", cerr)
 		}
 		fs.Out = nil
 	}
 	if fs.Err != nil {
 		if cerr := fs.Err.Close(); cerr != nil && err == nil {
-			err = errors.Wrap(cerr, "failed Close on stderr")
+			err = fmt.Errorf("failed Close on stderr: %w", cerr)
 		}
 		fs.Err = nil
 	}
@@ -86,19 +88,19 @@ func (s *ConnectionSet) Files() (_ *FileSet, err error) {
 	if s.In != nil {
 		fs.In, err = s.In.File()
 		if err != nil {
-			return nil, errors.Wrap(err, "failed to dup stdin socket for command")
+			return nil, fmt.Errorf("failed to dup stdin socket for command: %w", err)
 		}
 	}
 	if s.Out != nil {
 		fs.Out, err = s.Out.File()
 		if err != nil {
-			return nil, errors.Wrap(err, "failed to dup stdout socket for command")
+			return nil, fmt.Errorf("failed to dup stdout socket for command: %w", err)
 		}
 	}
 	if s.Err != nil {
 		fs.Err, err = s.Err.File()
 		if err != nil {
-			return nil, errors.Wrap(err, "failed to dup stderr socket for command")
+			return nil, fmt.Errorf("failed to dup stderr socket for command: %w", err)
 		}
 	}
 	return fs, nil
@@ -117,19 +119,19 @@ func NewPipeRelay(s *ConnectionSet) (_ *PipeRelay, err error) {
 	if s == nil || s.In != nil {
 		pr.pipes[0], pr.pipes[1], err = os.Pipe()
 		if err != nil {
-			return nil, errors.Wrap(err, "failed to create stdin pipe relay")
+			return nil, fmt.Errorf("failed to create stdin pipe relay: %w", err)
 		}
 	}
 	if s == nil || s.Out != nil {
 		pr.pipes[2], pr.pipes[3], err = os.Pipe()
 		if err != nil {
-			return nil, errors.Wrap(err, "failed to create stdout pipe relay")
+			return nil, fmt.Errorf("failed to create stdout pipe relay: %w", err)
 		}
 	}
 	if s == nil || s.Err != nil {
 		pr.pipes[4], pr.pipes[5], err = os.Pipe()
 		if err != nil {
-			return nil, errors.Wrap(err, "failed to create stderr pipe relay")
+			return nil, fmt.Errorf("failed to create stderr pipe relay: %w", err)
 		}
 	}
 	return pr, nil

--- a/internal/guest/storage/crypt/crypt.go
+++ b/internal/guest/storage/crypt/crypt.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"github.com/Microsoft/hcsshim/internal/log"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
 )
@@ -96,7 +95,8 @@ func cryptsetupFormat(ctx context.Context, source string, keyFilePath string) er
 		// supposed to derive a strong key from it. In our case, we already pass
 		// a strong key to cryptsetup, so we don't need a strong KDF. Ideally,
 		// it would be bypassed completely, but this isn't possible.
-		"--pbkdf", "pbkdf2", "--pbkdf-force-iterations", "1000"}
+		"--pbkdf", "pbkdf2", "--pbkdf-force-iterations", "1000",
+	}
 
 	return cryptsetupCommand(ctx, formatArgs)
 }
@@ -107,7 +107,8 @@ func cryptsetupOpen(ctx context.Context, source string, deviceName string, keyFi
 		// Open device with the key passed to luksFormat
 		"luksOpen", source, deviceName, "--key-file", keyFilePath,
 		// Don't use a journal to increase performance
-		"--integrity-no-journal", "--persistent"}
+		"--integrity-no-journal", "--persistent",
+	}
 
 	return cryptsetupCommand(ctx, openArgs)
 }
@@ -148,7 +149,7 @@ func EncryptDevice(ctx context.Context, source string, dmCryptName string) (path
 	// Create temporary directory to store the keyfile and xfs image
 	tempDir, err := _osMkdirTemp("", "dm-crypt")
 	if err != nil {
-		return "", errors.Wrapf(err, "failed to create temporary folder: %s", source)
+		return "", fmt.Errorf("failed to create temporary folder: %w", err)
 	}
 
 	defer func() {

--- a/internal/guest/storage/crypt/crypt_test.go
+++ b/internal/guest/storage/crypt/crypt_test.go
@@ -5,9 +5,8 @@ package crypt
 
 import (
 	"context"
+	"errors"
 	"testing"
-
-	"github.com/pkg/errors"
 )
 
 const tempDir = "/tmp/dir/"
@@ -47,7 +46,7 @@ func Test_Encrypt_Generate_Key_Error(t *testing.T) {
 	}
 
 	_, err := EncryptDevice(context.Background(), source, "dm-crypt-target")
-	if errors.Unwrap(err) != expectedErr { //nolint:errorlint
+	if !errors.Is(err, expectedErr) {
 		t.Fatalf("expected err: '%v' got: '%v'", expectedErr, err)
 	}
 }
@@ -80,7 +79,7 @@ func Test_Encrypt_Cryptsetup_Format_Error(t *testing.T) {
 	}
 
 	_, err := EncryptDevice(context.Background(), expectedSource, "dm-crypt-target")
-	if errors.Unwrap(err) != expectedErr { //nolint:errorlint
+	if !errors.Is(err, expectedErr) {
 		t.Fatalf("expected err: '%v' got: '%v", expectedErr, err)
 	}
 }
@@ -120,7 +119,7 @@ func Test_Encrypt_Cryptsetup_Open_Error(t *testing.T) {
 	}
 
 	_, err := EncryptDevice(context.Background(), expectedSource, dmCryptName)
-	if errors.Unwrap(err) != expectedErr { //nolint:errorlint
+	if !errors.Is(err, expectedErr) {
 		t.Fatalf("expected err: '%v' got: '%v'", expectedErr, err)
 	}
 }
@@ -175,7 +174,7 @@ func Test_Cleanup_Dm_Crypt_Error(t *testing.T) {
 	}
 
 	err := CleanupCryptDevice(context.TODO(), dmCryptName)
-	if errors.Unwrap(err) != expectedErr { //nolint:errorlint
+	if !errors.Is(err, expectedErr) {
 		t.Fatalf("expected err: '%v' got: '%v'", expectedErr, err)
 	}
 }

--- a/internal/guest/storage/mount.go
+++ b/internal/guest/storage/mount.go
@@ -6,21 +6,22 @@ package storage
 import (
 	"bufio"
 	"context"
-	gerrors "errors"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
 	"syscall"
 
-	"github.com/pkg/errors"
 	"go.opencensus.io/trace"
 	"golang.org/x/sys/unix"
 
 	"github.com/Microsoft/hcsshim/internal/oc"
 )
 
-const procMountFile = "/proc/mounts"
-const numProcMountFields = 6
+const (
+	procMountFile      = "/proc/mounts"
+	numProcMountFields = 6
+)
 
 // Test dependencies
 var (
@@ -128,14 +129,14 @@ func UnmountPath(ctx context.Context, target string, removeTarget bool) (err err
 		if os.IsNotExist(err) {
 			return nil
 		}
-		return errors.Wrapf(err, "failed to determine if path '%s' exists", target)
+		return fmt.Errorf("failed to determine if path %q exists: %w", target, err)
 	}
 
 	if err := unixUnmount(target, 0); err != nil {
 		// If `Unmount` returns `EINVAL` it's not mounted. Just delete the
 		// folder.
-		if !gerrors.Is(err, unix.EINVAL) {
-			return errors.Wrapf(err, "failed to unmount path '%s'", target)
+		if !errors.Is(err, unix.EINVAL) {
+			return fmt.Errorf("failed to unmount path %q: %w", target, err)
 		}
 	}
 	if removeTarget {

--- a/internal/guest/storage/mount_test.go
+++ b/internal/guest/storage/mount_test.go
@@ -5,10 +5,11 @@ package storage
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"os"
 	"testing"
 
-	"github.com/pkg/errors"
 	"golang.org/x/sys/unix"
 )
 
@@ -59,7 +60,7 @@ func Test_Unmount_Stat_OtherError_Error(t *testing.T) {
 		return nil, expectedErr
 	}
 	err := UnmountPath(context.Background(), "/dev/fake", false)
-	if errors.Cause(err) != expectedErr { //nolint:errorlint
+	if !errors.Is(err, expectedErr) {
 		t.Fatalf("expected err: %v, got: %v", expectedErr, err)
 	}
 }
@@ -129,7 +130,7 @@ func Test_Unmount_OtherError(t *testing.T) {
 		return expectedErr
 	}
 	err := UnmountPath(context.Background(), "/dev/fake", false)
-	if errors.Cause(err) != expectedErr { //nolint:errorlint
+	if !errors.Is(err, expectedErr) {
 		t.Fatalf("expected err: %v, got: %v", expectedErr, err)
 	}
 }
@@ -195,7 +196,7 @@ func Test_UnmountAllInPath_Unmount_Order(t *testing.T) {
 	timesCalled := 0
 	unixUnmount = func(target string, flags int) error {
 		if timesCalled == 0 && target != child {
-			return errors.Errorf("expected to unmount %v first, got %v", child, target)
+			return fmt.Errorf("expected to unmount %v first, got %v", child, target)
 		}
 		timesCalled += 1
 		return nil
@@ -206,7 +207,6 @@ func Test_UnmountAllInPath_Unmount_Order(t *testing.T) {
 	}
 
 	err := UnmountAllInPath(context.Background(), parent, true)
-
 	if err != nil {
 		t.Fatalf("expected nil error, got: %v", err)
 	}

--- a/internal/guest/storage/pmem/pmem.go
+++ b/internal/guest/storage/pmem/pmem.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/pkg/errors"
 	"go.opencensus.io/trace"
 	"golang.org/x/sys/unix"
 
@@ -38,7 +37,7 @@ const (
 
 // mount mounts source to target via unix.Mount
 func mount(ctx context.Context, source, target string) (err error) {
-	if err := osMkdirAll(target, 0700); err != nil {
+	if err := osMkdirAll(target, 0o700); err != nil {
 		return err
 	}
 	defer func() {
@@ -51,7 +50,7 @@ func mount(ctx context.Context, source, target string) (err error) {
 
 	flags := uintptr(unix.MS_RDONLY)
 	if err := unixMount(source, target, "ext4", flags, "noload"); err != nil {
-		return errors.Wrapf(err, "failed to mount %s onto %s", source, target)
+		return fmt.Errorf("failed to mount %s onto %s: %w", source, target, err)
 	}
 	return nil
 }
@@ -141,7 +140,7 @@ func Unmount(
 		trace.StringAttribute("target", target))
 
 	if err := storage.UnmountPath(ctx, target, true); err != nil {
-		return errors.Wrapf(err, "failed to unmount target: %s", target)
+		return fmt.Errorf("failed to unmount target %s: %w", target, err)
 	}
 
 	if verityInfo != nil {

--- a/internal/guest/storage/pmem/pmem_test.go
+++ b/internal/guest/storage/pmem/pmem_test.go
@@ -5,11 +5,11 @@ package pmem
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"testing"
 
-	"github.com/pkg/errors"
 	"golang.org/x/sys/unix"
 
 	"github.com/Microsoft/hcsshim/internal/protocol/guestresource"
@@ -33,7 +33,7 @@ func Test_Mount_Mkdir_Fails_Error(t *testing.T) {
 		return expectedErr
 	}
 	err := Mount(context.Background(), 0, "", nil, nil)
-	if errors.Cause(err) != expectedErr { //nolint:errorlint
+	if !errors.Is(err, expectedErr) {
 		t.Fatalf("expected err: %v, got: %v", expectedErr, err)
 	}
 }
@@ -70,8 +70,8 @@ func Test_Mount_Mkdir_ExpectedPerm(t *testing.T) {
 
 	target := "/fake/path"
 	osMkdirAll = func(path string, perm os.FileMode) error {
-		if perm != os.FileMode(0700) {
-			t.Errorf("expected perm: %v, got: %v", os.FileMode(0700), perm)
+		if perm != os.FileMode(0o700) {
+			t.Errorf("expected perm: %v, got: %v", os.FileMode(0o700), perm)
 			return errors.New("unexpected perm")
 		}
 		return nil
@@ -108,7 +108,7 @@ func Test_Mount_Calls_RemoveAll_OnMountFailure(t *testing.T) {
 		return expectedErr
 	}
 	err := Mount(context.Background(), 0, target, nil, nil)
-	if errors.Cause(err) != expectedErr { //nolint:errorlint
+	if !errors.Is(err, expectedErr) {
 		t.Fatalf("expected err: %v, got: %v", expectedErr, err)
 	}
 	if !removeAllCalled {

--- a/internal/guest/transport/vsock.go
+++ b/internal/guest/transport/vsock.go
@@ -4,13 +4,12 @@
 package transport
 
 import (
-	gerrors "errors"
+	"errors"
 	"fmt"
 	"syscall"
 	"time"
 
 	"github.com/linuxkit/virtsock/pkg/vsock"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -36,12 +35,11 @@ func (t *VsockTransport) Dial(port uint32) (Connection, error) {
 			return conn, nil
 		}
 		// If the error was ETIMEDOUT retry, otherwise fail.
-		var errno syscall.Errno
-		if gerrors.As(err, &errno) && errno == syscall.ETIMEDOUT {
+		if errors.Is(err, syscall.ETIMEDOUT) {
 			time.Sleep(100 * time.Millisecond)
 			continue
 		} else {
-			return nil, errors.Wrapf(err, "vsock Dial port (%d) failed", port)
+			return nil, fmt.Errorf("vsock Dial port (%d) failed: %w", port, err)
 		}
 	}
 	return nil, fmt.Errorf("failed connecting the VsockConnection: can't connect after 10 attempts")

--- a/internal/hcs/schema2/com_port.go
+++ b/internal/hcs/schema2/com_port.go
@@ -9,7 +9,7 @@
 
 package hcsschema
 
-//  ComPort specifies the named pipe that will be used for the port, with empty string indicating a disconnected port.
+// ComPort specifies the named pipe that will be used for the port, with empty string indicating a disconnected port.
 type ComPort struct {
 	NamedPipe string `json:"NamedPipe,omitempty"`
 

--- a/internal/hcs/schema2/container_memory_information.go
+++ b/internal/hcs/schema2/container_memory_information.go
@@ -9,7 +9,7 @@
 
 package hcsschema
 
-//  memory usage as viewed from within the container
+// memory usage as viewed from within the container
 type ContainerMemoryInformation struct {
 	TotalPhysicalBytes int32 `json:"TotalPhysicalBytes,omitempty"`
 

--- a/internal/hcs/schema2/guest_connection_info.go
+++ b/internal/hcs/schema2/guest_connection_info.go
@@ -9,7 +9,7 @@
 
 package hcsschema
 
-//  Information about the guest.
+// Information about the guest.
 type GuestConnectionInfo struct {
 
 	//  Each schema version x.y stands for the range of versions a.b where a==x  and b<=y. This list comes from the SupportedSchemaVersions field in  GcsCapabilities.

--- a/internal/hcs/schema2/hv_socket_2.go
+++ b/internal/hcs/schema2/hv_socket_2.go
@@ -9,7 +9,7 @@
 
 package hcsschema
 
-//  HvSocket configuration for a VM
+// HvSocket configuration for a VM
 type HvSocket2 struct {
 	HvSocketConfig *HvSocketSystemConfig `json:"HvSocketConfig,omitempty"`
 }

--- a/internal/hcs/schema2/hv_socket_address.go
+++ b/internal/hcs/schema2/hv_socket_address.go
@@ -9,8 +9,8 @@
 
 package hcsschema
 
-//  This class defines address settings applied to a VM
-//  by the GCS every time a VM starts or restores.
+// This class defines address settings applied to a VM
+// by the GCS every time a VM starts or restores.
 type HvSocketAddress struct {
 	LocalAddress  string `json:"LocalAddress,omitempty"`
 	ParentAddress string `json:"ParentAddress,omitempty"`

--- a/internal/hcs/schema2/hv_socket_system_config.go
+++ b/internal/hcs/schema2/hv_socket_system_config.go
@@ -9,7 +9,7 @@
 
 package hcsschema
 
-//  This is the HCS Schema version of the HvSocket configuration. The VMWP version is  located in Config.Devices.IC in V1.
+// This is the HCS Schema version of the HvSocket configuration. The VMWP version is  located in Config.Devices.IC in V1.
 type HvSocketSystemConfig struct {
 
 	//  SDDL string that HvSocket will check before allowing a host process to bind  to an unlisted service for this specific container/VM (not wildcard binds).

--- a/internal/hcs/schema2/memory_stats.go
+++ b/internal/hcs/schema2/memory_stats.go
@@ -9,7 +9,7 @@
 
 package hcsschema
 
-//  Memory runtime statistics
+// Memory runtime statistics
 type MemoryStats struct {
 	MemoryUsageCommitBytes uint64 `json:"MemoryUsageCommitBytes,omitempty"`
 

--- a/internal/hcs/schema2/numa_setting.go
+++ b/internal/hcs/schema2/numa_setting.go
@@ -12,10 +12,10 @@
 package hcsschema
 
 type NumaSetting struct {
-	VirtualNodeNumber        uint32            `json:"VirtualNodeNumber,omitempty"`
-	PhysicalNodeNumber       uint32            `json:"PhysicalNodeNumber,omitempty"`
-	VirtualSocketNumber      uint32            `json:"VirtualSocketNumber,omitempty"`
-	CountOfProcessors        uint32            `json:"CountOfProcessors,omitempty"`
-	CountOfMemoryBlocks      uint64            `json:"CountOfMemoryBlocks,omitempty"`
-	MemoryBackingType        MemoryBackingType `json:"MemoryBackingType,omitempty"`
+	VirtualNodeNumber   uint32            `json:"VirtualNodeNumber,omitempty"`
+	PhysicalNodeNumber  uint32            `json:"PhysicalNodeNumber,omitempty"`
+	VirtualSocketNumber uint32            `json:"VirtualSocketNumber,omitempty"`
+	CountOfProcessors   uint32            `json:"CountOfProcessors,omitempty"`
+	CountOfMemoryBlocks uint64            `json:"CountOfMemoryBlocks,omitempty"`
+	MemoryBackingType   MemoryBackingType `json:"MemoryBackingType,omitempty"`
 }

--- a/internal/hcs/schema2/pause_notification.go
+++ b/internal/hcs/schema2/pause_notification.go
@@ -9,7 +9,7 @@
 
 package hcsschema
 
-//  Notification data that is indicated to components running in the Virtual Machine.
+// Notification data that is indicated to components running in the Virtual Machine.
 type PauseNotification struct {
 	Reason string `json:"Reason,omitempty"`
 }

--- a/internal/hcs/schema2/pause_options.go
+++ b/internal/hcs/schema2/pause_options.go
@@ -9,7 +9,7 @@
 
 package hcsschema
 
-//  Options for HcsPauseComputeSystem
+// Options for HcsPauseComputeSystem
 type PauseOptions struct {
 	SuspensionLevel string `json:"SuspensionLevel,omitempty"`
 

--- a/internal/hcs/schema2/process_details.go
+++ b/internal/hcs/schema2/process_details.go
@@ -13,7 +13,7 @@ import (
 	"time"
 )
 
-//  Information about a process running in a container
+// Information about a process running in a container
 type ProcessDetails struct {
 	ProcessId int32 `json:"ProcessId,omitempty"`
 

--- a/internal/hcs/schema2/processor_stats.go
+++ b/internal/hcs/schema2/processor_stats.go
@@ -9,7 +9,7 @@
 
 package hcsschema
 
-//  CPU runtime statistics
+// CPU runtime statistics
 type ProcessorStats struct {
 	TotalRuntime100ns uint64 `json:"TotalRuntime100ns,omitempty"`
 

--- a/internal/hcs/schema2/property_query.go
+++ b/internal/hcs/schema2/property_query.go
@@ -9,7 +9,7 @@
 
 package hcsschema
 
-//   By default the basic properties will be returned. This query provides a way to  request specific properties.
+// By default the basic properties will be returned. This query provides a way to  request specific properties.
 type PropertyQuery struct {
 	PropertyTypes []PropertyType `json:"PropertyTypes,omitempty"`
 }

--- a/internal/hcs/schema2/silo_properties.go
+++ b/internal/hcs/schema2/silo_properties.go
@@ -9,7 +9,7 @@
 
 package hcsschema
 
-//  Silo job information
+// Silo job information
 type SiloProperties struct {
 	Enabled bool `json:"Enabled,omitempty"`
 

--- a/internal/hcs/schema2/statistics.go
+++ b/internal/hcs/schema2/statistics.go
@@ -13,7 +13,7 @@ import (
 	"time"
 )
 
-//  Runtime statistics for a container
+// Runtime statistics for a container
 type Statistics struct {
 	Timestamp time.Time `json:"Timestamp,omitempty"`
 

--- a/internal/hcs/schema2/storage_stats.go
+++ b/internal/hcs/schema2/storage_stats.go
@@ -9,7 +9,7 @@
 
 package hcsschema
 
-//  Storage runtime statistics
+// Storage runtime statistics
 type StorageStats struct {
 	ReadCountNormalized uint64 `json:"ReadCountNormalized,omitempty"`
 

--- a/internal/hcs/schema2/topology.go
+++ b/internal/hcs/schema2/topology.go
@@ -12,7 +12,7 @@
 package hcsschema
 
 type Topology struct {
-	Memory        *VirtualMachineMemory                `json:"Memory,omitempty"`
-	Processor     *VirtualMachineProcessor             `json:"Processor,omitempty"`
-	Numa          *Numa                                `json:"Numa,omitempty"`
+	Memory    *VirtualMachineMemory    `json:"Memory,omitempty"`
+	Processor *VirtualMachineProcessor `json:"Processor,omitempty"`
+	Numa      *Numa                    `json:"Numa,omitempty"`
 }

--- a/internal/hcs/schema2/virtual_machine.go
+++ b/internal/hcs/schema2/virtual_machine.go
@@ -15,15 +15,15 @@ package hcsschema
 type VirtualMachine struct {
 	Version *Version `json:"Version,omitempty"`
 	// When set to true, the virtual machine will treat a reset as a stop, releasing resources and cleaning up state.
-	StopOnReset     bool             `json:"StopOnReset,omitempty"`
-	Chipset         *Chipset         `json:"Chipset,omitempty"`
-	ComputeTopology *Topology        `json:"ComputeTopology,omitempty"`
-	Devices         *Devices         `json:"Devices,omitempty"`
-	GuestState      *GuestState      `json:"GuestState,omitempty"`
-	RestoreState    *RestoreState    `json:"RestoreState,omitempty"`
-	RegistryChanges *RegistryChanges `json:"RegistryChanges,omitempty"`
-	StorageQoS      *StorageQoS      `json:"StorageQoS,omitempty"`
-	DebugOptions    *DebugOptions    `json:"DebugOptions,omitempty"`
-	GuestConnection *GuestConnection `json:"GuestConnection,omitempty"`
-	SecuritySettings  *SecuritySettings `json:"SecuritySettings,omitempty"`
+	StopOnReset      bool              `json:"StopOnReset,omitempty"`
+	Chipset          *Chipset          `json:"Chipset,omitempty"`
+	ComputeTopology  *Topology         `json:"ComputeTopology,omitempty"`
+	Devices          *Devices          `json:"Devices,omitempty"`
+	GuestState       *GuestState       `json:"GuestState,omitempty"`
+	RestoreState     *RestoreState     `json:"RestoreState,omitempty"`
+	RegistryChanges  *RegistryChanges  `json:"RegistryChanges,omitempty"`
+	StorageQoS       *StorageQoS       `json:"StorageQoS,omitempty"`
+	DebugOptions     *DebugOptions     `json:"DebugOptions,omitempty"`
+	GuestConnection  *GuestConnection  `json:"GuestConnection,omitempty"`
+	SecuritySettings *SecuritySettings `json:"SecuritySettings,omitempty"`
 }

--- a/internal/hcs/schema2/virtual_machine_memory.go
+++ b/internal/hcs/schema2/virtual_machine_memory.go
@@ -15,7 +15,7 @@ type VirtualMachineMemory struct {
 	SizeInMB uint64             `json:"SizeInMB,omitempty"`
 	Backing  *MemoryBackingType `json:"Backing,omitempty"`
 	// If enabled, then the VM's memory is backed by the Windows pagefile rather than physically backed, statically allocated memory.
-	AllowOvercommit bool                   `json:"AllowOvercommit,omitempty"`
+	AllowOvercommit bool `json:"AllowOvercommit,omitempty"`
 	// If enabled, then the memory hot hint feature is exposed to the VM, allowing it to prefetch pages into its working set. (if supported by the guest operating system).
 	EnableHotHint bool `json:"EnableHotHint,omitempty"`
 	// If enabled, then the memory cold hint feature is exposed to the VM, allowing it to trim zeroed pages from its working set (if supported by the guest operating system).
@@ -27,7 +27,7 @@ type VirtualMachineMemory struct {
 	// Low MMIO region allocated below 4GB
 	LowMMIOGapInMB uint64 `json:"LowMmioGapInMB,omitempty"`
 	// High MMIO region allocated above 4GB (base and size)
-	HighMMIOBaseInMB         uint64                 `json:"HighMmioBaseInMB,omitempty"`
-	HighMMIOGapInMB          uint64                 `json:"HighMmioGapInMB,omitempty"`
-	SlitType                   *VirtualSlitType                   `json:"SlitType,omitempty"`
+	HighMMIOBaseInMB uint64           `json:"HighMmioBaseInMB,omitempty"`
+	HighMMIOGapInMB  uint64           `json:"HighMmioGapInMB,omitempty"`
+	SlitType         *VirtualSlitType `json:"SlitType,omitempty"`
 }

--- a/internal/hcs/schema2/virtual_machine_processor.go
+++ b/internal/hcs/schema2/virtual_machine_processor.go
@@ -12,10 +12,10 @@
 package hcsschema
 
 type VirtualMachineProcessor struct {
-	Count       uint32 `json:"Count,omitempty"`
-	Limit       uint64 `json:"Limit,omitempty"`
-	Weight      uint64 `json:"Weight,omitempty"`
-	Reservation uint64 `json:"Reservation,omitempty"`
-	CpuGroup                   *CpuGroup            `json:"CpuGroup,omitempty"`
-	NumaProcessorsSettings     *NumaProcessors      `json:"NumaProcessorsSettings,omitempty"`
+	Count                  uint32          `json:"Count,omitempty"`
+	Limit                  uint64          `json:"Limit,omitempty"`
+	Weight                 uint64          `json:"Weight,omitempty"`
+	Reservation            uint64          `json:"Reservation,omitempty"`
+	CpuGroup               *CpuGroup       `json:"CpuGroup,omitempty"`
+	NumaProcessorsSettings *NumaProcessors `json:"NumaProcessorsSettings,omitempty"`
 }

--- a/internal/hcs/schema2/virtual_pci_device.go
+++ b/internal/hcs/schema2/virtual_pci_device.go
@@ -12,6 +12,6 @@ package hcsschema
 // TODO: PropagateNumaAffinity is pre-release/experimental field in schema 2.11. Need to add build number
 // docs when a public build with this is out.
 type VirtualPciDevice struct {
-	Functions []VirtualPciFunction `json:",omitempty"`
-	PropagateNumaAffinity *bool	`json:"PropagateNumaAffinity,omitempty"`
+	Functions             []VirtualPciFunction `json:",omitempty"`
+	PropagateNumaAffinity *bool                `json:"PropagateNumaAffinity,omitempty"`
 }

--- a/internal/jobcontainers/env.go
+++ b/internal/jobcontainers/env.go
@@ -3,10 +3,10 @@
 package jobcontainers
 
 import (
+	"errors"
 	"unicode/utf16"
 	"unsafe"
 
-	"github.com/pkg/errors"
 	"golang.org/x/sys/windows"
 )
 

--- a/internal/jobcontainers/logon.go
+++ b/internal/jobcontainers/logon.go
@@ -4,6 +4,7 @@ package jobcontainers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"unsafe"
@@ -11,7 +12,7 @@ import (
 	"github.com/Microsoft/go-winio/pkg/guid"
 	"github.com/Microsoft/hcsshim/internal/log"
 	"github.com/Microsoft/hcsshim/internal/winapi"
-	"github.com/pkg/errors"
+
 	"golang.org/x/sys/windows"
 )
 
@@ -162,7 +163,7 @@ func (c *JobContainer) processToken(ctx context.Context, userOrGroup string) (wi
 func openCurrentProcessToken() (windows.Token, error) {
 	var token windows.Token
 	if err := windows.OpenProcessToken(windows.CurrentProcess(), windows.TOKEN_ALL_ACCESS, &token); err != nil {
-		return 0, errors.Wrap(err, "failed to open current process token")
+		return 0, fmt.Errorf("failed to open current process token: %w", err)
 	}
 	return token, nil
 }

--- a/internal/jobcontainers/mounts.go
+++ b/internal/jobcontainers/mounts.go
@@ -4,6 +4,7 @@ package jobcontainers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -13,7 +14,7 @@ import (
 	"github.com/Microsoft/hcsshim/internal/log"
 	"github.com/Microsoft/hcsshim/internal/logfields"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/pkg/errors"
+
 	"github.com/sirupsen/logrus"
 )
 
@@ -52,11 +53,11 @@ func fallbackMountSetup(spec *specs.Spec, sandboxVolumePath string) error {
 		// Make sure all of the dirs leading up to the full path exist.
 		strippedCtrPath := filepath.Dir(fullCtrPath)
 		if err := os.MkdirAll(strippedCtrPath, 0777); err != nil {
-			return errors.Wrap(err, "failed to make directory for job container mount")
+			return fmt.Errorf("failed to make directory for job container mount: %w", err)
 		}
 
 		if err := os.Symlink(mount.Source, fullCtrPath); err != nil {
-			return errors.Wrap(err, "failed to setup mount for job container")
+			return fmt.Errorf("failed to setup mount for job container: %w", err)
 		}
 	}
 	return nil

--- a/internal/jobcontainers/path.go
+++ b/internal/jobcontainers/path.go
@@ -3,12 +3,13 @@
 package jobcontainers
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strings"
 
 	"github.com/Microsoft/hcsshim/internal/winapi"
-	"github.com/pkg/errors"
+
 	"golang.org/x/sys/windows"
 )
 
@@ -224,13 +225,13 @@ func getSystemPaths() (string, error) {
 	var searchPath string
 	systemDir, err := windows.GetSystemDirectory()
 	if err != nil {
-		return "", errors.Wrap(err, "failed to get system directory")
+		return "", fmt.Errorf("failed to get system directory: %w", err)
 	}
 	searchPath += systemDir + ";"
 
 	windowsDir, err := windows.GetWindowsDirectory()
 	if err != nil {
-		return "", errors.Wrap(err, "failed to get Windows directory")
+		return "", fmt.Errorf("failed to get Windows directory: %w", err)
 	}
 
 	searchPath += windowsDir + "\\System;" + windowsDir + ";"

--- a/internal/layers/lcow.go
+++ b/internal/layers/lcow.go
@@ -6,12 +6,13 @@ package layers
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"strings"
 
 	"github.com/containerd/containerd/api/types"
-	"github.com/pkg/errors"
+
 	"github.com/sirupsen/logrus"
 
 	"github.com/Microsoft/hcsshim/internal/guestpath"

--- a/internal/layers/wcow_mount.go
+++ b/internal/layers/wcow_mount.go
@@ -5,12 +5,12 @@ package layers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"time"
 
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/windows"
 
@@ -135,7 +135,7 @@ func mountProcessIsolatedWCIFSLayers(ctx context.Context, l *wcowWCIFSLayers) (_
 	// If we got unlucky and ran into one of the two errors mentioned five times in a row and left the loop, we need to check
 	// the loop error here and fail also.
 	if lErr != nil {
-		return nil, nil, errors.Wrap(lErr, "layer retry loop failed")
+		return nil, nil, fmt.Errorf("layer retry loop failed: %w", lErr)
 	}
 
 	// If any of the below fails, we want to detach the filter and unmount the disk.
@@ -409,7 +409,7 @@ func MountSandboxVolume(ctx context.Context, hostPath, volumeName string) (err e
 	}
 
 	if err = windows.SetVolumeMountPoint(windows.StringToUTF16Ptr(hostPath), windows.StringToUTF16Ptr(volumeName)); err != nil {
-		return errors.Wrapf(err, "failed to mount sandbox volume to %s on host", hostPath)
+		return fmt.Errorf("failed to mount sandbox volume to %s on host: %w", hostPath, err)
 	}
 	return nil
 }
@@ -421,10 +421,10 @@ func RemoveSandboxMountPoint(ctx context.Context, hostPath string) error {
 	}).Debug("removing volume mount point for container")
 
 	if err := windows.DeleteVolumeMountPoint(windows.StringToUTF16Ptr(hostPath)); err != nil {
-		return errors.Wrap(err, "failed to delete sandbox volume mount point")
+		return fmt.Errorf("failed to delete sandbox volume mount point: %w", err)
 	}
 	if err := os.Remove(hostPath); err != nil {
-		return errors.Wrapf(err, "failed to remove sandbox mounted folder path %q", hostPath)
+		return fmt.Errorf("failed to remove sandbox mounted folder path %q: %w", hostPath, err)
 	}
 	return nil
 }

--- a/internal/memory/pool.go
+++ b/internal/memory/pool.go
@@ -1,7 +1,7 @@
 package memory
 
 import (
-	"github.com/pkg/errors"
+	"errors"
 )
 
 const (
@@ -69,8 +69,10 @@ type PoolAllocator struct {
 	pools [memoryClassNumber]*memoryPool
 }
 
-var _ MappedRegion = &region{}
-var _ Allocator = &PoolAllocator{}
+var (
+	_ MappedRegion = &region{}
+	_ Allocator    = &PoolAllocator{}
+)
 
 func (r *region) Offset() uint64 {
 	return r.offset

--- a/internal/memory/types.go
+++ b/internal/memory/types.go
@@ -1,6 +1,8 @@
 package memory
 
-import "github.com/pkg/errors"
+import (
+	"errors"
+)
 
 type classType uint32
 

--- a/internal/regopolicyinterpreter/regopolicyinterpreter.go
+++ b/internal/regopolicyinterpreter/regopolicyinterpreter.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	_ "embed"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -14,7 +15,6 @@ import (
 	"github.com/open-policy-agent/opa/rego"
 	"github.com/open-policy-agent/opa/storage/inmem"
 	"github.com/open-policy-agent/opa/topdown"
-	"github.com/pkg/errors"
 )
 
 type LogLevel int
@@ -312,7 +312,7 @@ func (r *RegoPolicyInterpreter) EnableLogging(path string, level LogLevel) error
 	r.compiledModules = nil
 	r.logLevel = level
 
-	file, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0666)
+	file, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o666)
 	if err != nil {
 		return err
 	}
@@ -561,7 +561,6 @@ func (r *RegoPolicyInterpreter) RawQuery(rule string, input map[string]interface
 	}
 
 	resultSet, err := r.query(rule, input)
-
 	if err != nil {
 		return nil, err
 	}
@@ -585,7 +584,6 @@ func (r *RegoPolicyInterpreter) Query(rule string, input map[string]interface{})
 	}
 
 	rawResult, err := r.query(rule, input)
-
 	if err != nil {
 		return nil, err
 	}

--- a/internal/tools/networkagent/defs.go
+++ b/internal/tools/networkagent/defs.go
@@ -4,9 +4,9 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
 	"os"
-
-	"github.com/pkg/errors"
 
 	ncproxygrpc "github.com/Microsoft/hcsshim/pkg/ncproxy/ncproxygrpc/v1"
 	nodenetsvcV0 "github.com/Microsoft/hcsshim/pkg/ncproxy/nodenetsvc/v0"
@@ -58,7 +58,7 @@ type config struct {
 func readConfig(path string) (*config, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to read config file")
+		return nil, fmt.Errorf("failed to read config file: %w", err)
 	}
 	conf := &config{}
 	if err := json.Unmarshal(data, conf); err != nil {

--- a/internal/uvm/create_wcow.go
+++ b/internal/uvm/create_wcow.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/Microsoft/go-winio"
 	"github.com/Microsoft/go-winio/pkg/guid"
-	"github.com/pkg/errors"
+
 	"go.opencensus.io/trace"
 
 	"github.com/Microsoft/hcsshim/internal/gcs"
@@ -305,7 +305,7 @@ func CreateWCOW(ctx context.Context, opts *OptionsWCOW) (_ *UtilityVM, err error
 	}()
 
 	if err := verifyOptions(ctx, opts); err != nil {
-		return nil, errors.Wrap(err, errBadUVMOpts.Error())
+		return nil, fmt.Errorf(errBadUVMOpts.Error()+": %w", err)
 	}
 
 	doc, err := prepareConfigDoc(ctx, uvm, opts)
@@ -314,7 +314,7 @@ func CreateWCOW(ctx context.Context, opts *OptionsWCOW) (_ *UtilityVM, err error
 	}
 
 	if err := wclayer.GrantVmAccess(ctx, uvm.id, opts.BootFiles.ScratchVHDPath); err != nil {
-		return nil, errors.Wrap(err, "failed to grant vm access to scratch")
+		return nil, fmt.Errorf("failed to grant vm access to scratch: %w", err)
 	}
 
 	doc.VirtualMachine.Devices.Scsi = map[string]hcsschema.Scsi{}

--- a/internal/uvm/share.go
+++ b/internal/uvm/share.go
@@ -11,14 +11,13 @@ import (
 	hcsschema "github.com/Microsoft/hcsshim/internal/hcs/schema2"
 	"github.com/Microsoft/hcsshim/internal/protocol/guestrequest"
 	"github.com/Microsoft/hcsshim/internal/protocol/guestresource"
-	"github.com/pkg/errors"
 )
 
 func (uvm *UtilityVM) AddVsmbAndGetSharePath(ctx context.Context, reqHostPath, reqUVMPath string, readOnly bool) (*VSMBShare, string, error) {
 	options := uvm.DefaultVSMBOptions(readOnly)
 	vsmbShare, err := uvm.AddVSMB(ctx, reqHostPath, options)
 	if err != nil {
-		return nil, "", errors.Wrapf(err, "failed to add mount as vSMB share to UVM")
+		return nil, "", fmt.Errorf("failed to add mount as vSMB share to UVM: %w", err)
 	}
 	defer func() {
 		if err != nil {
@@ -28,7 +27,7 @@ func (uvm *UtilityVM) AddVsmbAndGetSharePath(ctx context.Context, reqHostPath, r
 
 	sharePath, err := uvm.GetVSMBUvmPath(ctx, reqHostPath, readOnly)
 	if err != nil {
-		return nil, "", errors.Wrapf(err, "failed to get vsmb path")
+		return nil, "", fmt.Errorf("failed to get vsmb path: %w", err)
 	}
 
 	return vsmbShare, sharePath, nil

--- a/internal/uvm/stats.go
+++ b/internal/uvm/stats.go
@@ -4,11 +4,13 @@ package uvm
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/Microsoft/go-winio/pkg/guid"
 	"github.com/Microsoft/go-winio/pkg/process"
-	"github.com/pkg/errors"
+
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/windows"
 
@@ -79,7 +81,7 @@ func lookupVMMEM(ctx context.Context, vmID guid.GUID) (proc windows.Handle, err 
 
 	pids, err := process.EnumProcesses()
 	if err != nil {
-		return 0, errors.Wrap(err, "failed to enumerate processes")
+		return 0, fmt.Errorf("failed to enumerate processes: %w", err)
 	}
 	for _, pid := range pids {
 		p, err := checkProcess(ctx, pid, "vmmem", "NT VIRTUAL MACHINE", vmIDStr)

--- a/internal/uvm/vpmem.go
+++ b/internal/uvm/vpmem.go
@@ -4,10 +4,10 @@ package uvm
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
 	"github.com/Microsoft/hcsshim/internal/hcs/resourcepaths"
@@ -134,7 +134,7 @@ func (uvm *UtilityVM) addVPMemDefault(ctx context.Context, hostPath string) (_ s
 	}
 
 	if err := uvm.modify(ctx, modification); err != nil {
-		return "", errors.Errorf("uvm::addVPMemDefault: failed to modify utility VM configuration: %s", err)
+		return "", fmt.Errorf("uvm::addVPMemDefault: failed to modify utility VM configuration: %s", err)
 	}
 
 	uvm.vpmemDevicesDefault[deviceNumber] = newDefaultVPMemInfo(hostPath, uvmPath)
@@ -168,7 +168,7 @@ func (uvm *UtilityVM) removeVPMemDefault(ctx context.Context, hostPath string) e
 		},
 	}
 	if err := uvm.modify(ctx, modification); err != nil {
-		return errors.Errorf("failed to remove VPMEM %s from utility VM %s: %s", hostPath, uvm.id, err)
+		return fmt.Errorf("failed to remove VPMEM %s from utility VM %s: %s", hostPath, uvm.id, err)
 	}
 	log.G(ctx).WithFields(logrus.Fields{
 		"hostPath":     device.hostPath,

--- a/internal/verity/verity.go
+++ b/internal/verity/verity.go
@@ -9,7 +9,7 @@ import (
 	"github.com/Microsoft/hcsshim/ext4/tar2ext4"
 	"github.com/Microsoft/hcsshim/internal/log"
 	"github.com/Microsoft/hcsshim/internal/protocol/guestresource"
-	"github.com/pkg/errors"
+
 	"github.com/sirupsen/logrus"
 )
 
@@ -36,7 +36,7 @@ func ReadVeritySuperBlock(ctx context.Context, layerPath string) (*guestresource
 
 	dmvsb, err := dmverity.ReadDMVerityInfo(layerPath, ext4SizeInBytes)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to read dm-verity super block")
+		return nil, fmt.Errorf("failed to read dm-verity super block: %w", err)
 	}
 	log.G(ctx).WithFields(logrus.Fields{
 		"layerPath":     layerPath,

--- a/internal/vm/hcs/boot.go
+++ b/internal/vm/hcs/boot.go
@@ -3,9 +3,9 @@
 package hcs
 
 import (
+	"errors"
 	hcsschema "github.com/Microsoft/hcsshim/internal/hcs/schema2"
 	"github.com/Microsoft/hcsshim/osversion"
-	"github.com/pkg/errors"
 )
 
 func (uvmb *utilityVMBuilder) SetUEFIBoot(dir string, path string, args string) error {

--- a/internal/vm/hcs/builder.go
+++ b/internal/vm/hcs/builder.go
@@ -4,12 +4,12 @@ package hcs
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/Microsoft/hcsshim/internal/hcs"
 	hcsschema "github.com/Microsoft/hcsshim/internal/hcs/schema2"
 	"github.com/Microsoft/hcsshim/internal/schemaversion"
 	"github.com/Microsoft/hcsshim/internal/vm"
-	"github.com/pkg/errors"
 )
 
 var _ vm.UVMBuilder = &utilityVMBuilder{}
@@ -65,7 +65,7 @@ func NewUVMBuilder(id string, owner string, guestOS vm.GuestOS) (vm.UVMBuilder, 
 func (uvmb *utilityVMBuilder) Create(ctx context.Context) (_ vm.UVM, err error) {
 	cs, err := hcs.CreateComputeSystem(ctx, uvmb.id, uvmb.doc)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to create hcs compute system")
+		return nil, fmt.Errorf("failed to create hcs compute system: %w", err)
 	}
 
 	defer func() {

--- a/internal/vm/hcs/hcs.go
+++ b/internal/vm/hcs/hcs.go
@@ -4,13 +4,14 @@ package hcs
 
 import (
 	"context"
+	"fmt"
 	"sync"
 
 	"github.com/Microsoft/go-winio/pkg/guid"
 	"github.com/Microsoft/hcsshim/internal/hcs"
 	hcsschema "github.com/Microsoft/hcsshim/internal/hcs/schema2"
 	"github.com/Microsoft/hcsshim/internal/vm"
-	"github.com/pkg/errors"
+
 	"golang.org/x/sys/windows"
 )
 
@@ -33,28 +34,28 @@ func (uvm *utilityVM) ID() string {
 
 func (uvm *utilityVM) Start(ctx context.Context) (err error) {
 	if err := uvm.cs.Start(ctx); err != nil {
-		return errors.Wrap(err, "failed to start utility VM")
+		return fmt.Errorf("failed to start utility VM: %w", err)
 	}
 	return nil
 }
 
 func (uvm *utilityVM) Stop(ctx context.Context) error {
 	if err := uvm.cs.Terminate(ctx); err != nil {
-		return errors.Wrap(err, "failed to terminate utility VM")
+		return fmt.Errorf("failed to terminate utility VM: %w", err)
 	}
 	return nil
 }
 
 func (uvm *utilityVM) Pause(ctx context.Context) error {
 	if err := uvm.cs.Pause(ctx); err != nil {
-		return errors.Wrap(err, "failed to pause utility VM")
+		return fmt.Errorf("failed to pause utility VM: %w", err)
 	}
 	return nil
 }
 
 func (uvm *utilityVM) Resume(ctx context.Context) error {
 	if err := uvm.cs.Resume(ctx); err != nil {
-		return errors.Wrap(err, "failed to resume utility VM")
+		return fmt.Errorf("failed to resume utility VM: %w", err)
 	}
 	return nil
 }
@@ -64,7 +65,7 @@ func (uvm *utilityVM) Save(ctx context.Context) error {
 		SaveType: "AsTemplate",
 	}
 	if err := uvm.cs.Save(ctx, saveOptions); err != nil {
-		return errors.Wrap(err, "failed to save utility VM state")
+		return fmt.Errorf("failed to save utility VM state: %w", err)
 	}
 	return nil
 }

--- a/internal/vm/hcs/scsi.go
+++ b/internal/vm/hcs/scsi.go
@@ -4,10 +4,9 @@ package hcs
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
-
-	"github.com/pkg/errors"
 
 	"github.com/Microsoft/hcsshim/internal/hcs/resourcepaths"
 	hcsschema "github.com/Microsoft/hcsshim/internal/hcs/schema2"

--- a/internal/vm/hcs/serial.go
+++ b/internal/vm/hcs/serial.go
@@ -3,11 +3,11 @@
 package hcs
 
 import (
+	"errors"
 	"strconv"
 	"strings"
 
 	hcsschema "github.com/Microsoft/hcsshim/internal/hcs/schema2"
-	"github.com/pkg/errors"
 )
 
 func (uvmb *utilityVMBuilder) SetSerialConsole(port uint32, listenerPath string) error {

--- a/internal/vm/hcs/stats.go
+++ b/internal/vm/hcs/stats.go
@@ -4,6 +4,8 @@ package hcs
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/Microsoft/go-winio/pkg/guid"
@@ -12,7 +14,7 @@ import (
 	hcsschema "github.com/Microsoft/hcsshim/internal/hcs/schema2"
 	"github.com/Microsoft/hcsshim/internal/log"
 	"github.com/Microsoft/hcsshim/internal/vm"
-	"github.com/pkg/errors"
+
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/windows"
 )
@@ -81,7 +83,7 @@ func lookupVMMEM(ctx context.Context, vmID guid.GUID) (proc windows.Handle, err 
 
 	pids, err := process.EnumProcesses()
 	if err != nil {
-		return 0, errors.Wrap(err, "failed to enumerate processes")
+		return 0, fmt.Errorf("failed to enumerate processes: %w", err)
 	}
 	for _, pid := range pids {
 		p, err := checkProcess(ctx, pid, "vmmem", "NT VIRTUAL MACHINE", vmIDStr)

--- a/internal/vm/hcs/vmsocket.go
+++ b/internal/vm/hcs/vmsocket.go
@@ -4,12 +4,12 @@ package hcs
 
 import (
 	"context"
+	"errors"
 	"net"
 
 	"github.com/Microsoft/go-winio"
 	"github.com/Microsoft/go-winio/pkg/guid"
 	"github.com/Microsoft/hcsshim/internal/vm"
-	"github.com/pkg/errors"
 )
 
 func (uvm *utilityVM) VMSocketListen(ctx context.Context, listenType vm.VMSocketType, connID interface{}) (net.Listener, error) {

--- a/internal/vm/hcs/vpmem.go
+++ b/internal/vm/hcs/vpmem.go
@@ -4,10 +4,9 @@ package hcs
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
-
-	"github.com/pkg/errors"
 
 	"github.com/Microsoft/hcsshim/internal/hcs/resourcepaths"
 	hcsschema "github.com/Microsoft/hcsshim/internal/hcs/schema2"

--- a/internal/vm/remotevm/remotevm.go
+++ b/internal/vm/remotevm/remotevm.go
@@ -4,8 +4,8 @@ package remotevm
 
 import (
 	"context"
+	"fmt"
 
-	"github.com/pkg/errors"
 	"google.golang.org/protobuf/types/known/emptypb"
 
 	"github.com/Microsoft/hcsshim/internal/jobobject"
@@ -41,14 +41,14 @@ func (uvm *utilityVM) ID() string {
 func (uvm *utilityVM) Start(ctx context.Context) error {
 	// The expectation is the VM should be in a paused state after creation.
 	if _, err := uvm.client.ResumeVM(ctx, &emptypb.Empty{}); err != nil {
-		return errors.Wrap(err, "failed to start remote VM")
+		return fmt.Errorf("failed to start remote VM: %w", err)
 	}
 	return nil
 }
 
 func (uvm *utilityVM) Stop(ctx context.Context) error {
 	if _, err := uvm.client.TeardownVM(ctx, &emptypb.Empty{}); err != nil {
-		return errors.Wrap(err, "failed to stop remote VM")
+		return fmt.Errorf("failed to stop remote VM: %w", err)
 	}
 	return nil
 }
@@ -57,21 +57,21 @@ func (uvm *utilityVM) Wait() error {
 	_, err := uvm.client.WaitVM(context.Background(), &emptypb.Empty{})
 	if err != nil {
 		uvm.waitError = err
-		return errors.Wrap(err, "failed to wait on remote VM")
+		return fmt.Errorf("failed to wait on remote VM: %w", err)
 	}
 	return nil
 }
 
 func (uvm *utilityVM) Pause(ctx context.Context) error {
 	if _, err := uvm.client.PauseVM(ctx, &emptypb.Empty{}); err != nil {
-		return errors.Wrap(err, "failed to pause remote VM")
+		return fmt.Errorf("failed to pause remote VM: %w", err)
 	}
 	return nil
 }
 
 func (uvm *utilityVM) Resume(ctx context.Context) error {
 	if _, err := uvm.client.ResumeVM(ctx, &emptypb.Empty{}); err != nil {
-		return errors.Wrap(err, "failed to resume remote VM")
+		return fmt.Errorf("failed to resume remote VM: %w", err)
 	}
 	return nil
 }

--- a/internal/vm/remotevm/scsi.go
+++ b/internal/vm/remotevm/scsi.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/Microsoft/hcsshim/internal/vm"
 	"github.com/Microsoft/hcsshim/internal/vmservice"
-	"github.com/pkg/errors"
 )
 
 func getSCSIDiskType(typ vm.SCSIDiskType) (vmservice.DiskType, error) {
@@ -78,7 +77,7 @@ func (uvm *utilityVM) AddSCSIDisk(ctx context.Context, controller, lun uint32, p
 			},
 		},
 	); err != nil {
-		return errors.Wrap(err, "failed to add SCSI disk")
+		return fmt.Errorf("failed to add SCSI disk: %w", err)
 	}
 
 	return nil
@@ -99,7 +98,7 @@ func (uvm *utilityVM) RemoveSCSIDisk(ctx context.Context, controller, lun uint32
 			},
 		},
 	); err != nil {
-		return errors.Wrapf(err, "failed to remove SCSI disk %q", path)
+		return fmt.Errorf("failed to remove SCSI disk %q: %w", path, err)
 	}
 
 	return nil

--- a/internal/vm/remotevm/storage.go
+++ b/internal/vm/remotevm/storage.go
@@ -3,7 +3,7 @@
 package remotevm
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
 )
 
 func (uvmb *utilityVMBuilder) SetStorageQos(iopsMaximum int64, bandwidthMaximum int64) error {
@@ -12,7 +12,7 @@ func (uvmb *utilityVMBuilder) SetStorageQos(iopsMaximum int64, bandwidthMaximum 
 	// in HCS we can do the same here as we launch the server process in a job object.
 	if uvmb.job != nil {
 		if err := uvmb.job.SetIOLimit(bandwidthMaximum, iopsMaximum); err != nil {
-			return errors.Wrap(err, "failed to set storage qos values on remotevm process")
+			return fmt.Errorf("failed to set storage qos values on remotevm process: %w", err)
 		}
 	}
 

--- a/internal/wclayer/cim/registry.go
+++ b/internal/wclayer/cim/registry.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/Microsoft/hcsshim/internal/winapi"
 	"github.com/Microsoft/hcsshim/osversion"
-	"github.com/pkg/errors"
 )
 
 // mergeHive merges the hive located at parentHivePath with the hive located at deltaHivePath and stores
@@ -21,7 +20,7 @@ func mergeHive(parentHivePath, deltaHivePath, mergedHivePath string) (err error)
 	defer func() {
 		err2 := winapi.ORCloseHive(baseHive)
 		if err == nil {
-			err = errors.Wrap(err2, "failed to close base hive")
+			err = fmt.Errorf("failed to close base hive: %w", err2)
 		}
 	}()
 	if err := winapi.OROpenHive(deltaHivePath, &deltaHive); err != nil {
@@ -30,7 +29,7 @@ func mergeHive(parentHivePath, deltaHivePath, mergedHivePath string) (err error)
 	defer func() {
 		err2 := winapi.ORCloseHive(deltaHive)
 		if err == nil {
-			err = errors.Wrap(err2, "failed to close delta hive")
+			err = fmt.Errorf("failed to close delta hive: %w", err2)
 		}
 	}()
 	if err := winapi.ORMergeHives([]winapi.ORHKey{baseHive, deltaHive}, &mergedHive); err != nil {
@@ -39,7 +38,7 @@ func mergeHive(parentHivePath, deltaHivePath, mergedHivePath string) (err error)
 	defer func() {
 		err2 := winapi.ORCloseHive(mergedHive)
 		if err == nil {
-			err = errors.Wrap(err2, "failed to close merged hive")
+			err = fmt.Errorf("failed to close merged hive: %w", err2)
 		}
 	}()
 	if err := winapi.ORSaveHive(mergedHive, mergedHivePath, uint32(osversion.Get().MajorVersion), uint32(osversion.Get().MinorVersion)); err != nil {

--- a/internal/wclayer/converttobaselayer.go
+++ b/internal/wclayer/converttobaselayer.go
@@ -13,7 +13,7 @@ import (
 	"github.com/Microsoft/hcsshim/internal/oc"
 	"github.com/Microsoft/hcsshim/internal/safefile"
 	"github.com/Microsoft/hcsshim/internal/winapi"
-	"github.com/pkg/errors"
+
 	"go.opencensus.io/trace"
 	"golang.org/x/sys/windows"
 )
@@ -85,7 +85,7 @@ func ensureBaseLayer(root *os.File) (hasUtilityVM bool, err error) {
 
 	if !stat.Mode().IsDir() {
 		fullPath := filepath.Join(root.Name(), UtilityVMFilesPath)
-		return false, errors.Errorf("%s has unexpected file mode %s", fullPath, stat.Mode().String())
+		return false, fmt.Errorf("%s has unexpected file mode %s", fullPath, stat.Mode().String())
 	}
 
 	const bcdRelativePath = "EFI\\Microsoft\\Boot\\BCD"
@@ -97,12 +97,12 @@ func ensureBaseLayer(root *os.File) (hasUtilityVM bool, err error) {
 
 	stat, err = safefile.LstatRelative(bcdPath, root)
 	if err != nil {
-		return false, errors.Wrapf(err, "UtilityVM must contain '%s'", bcdRelativePath)
+		return false, fmt.Errorf("UtilityVM must contain %q: %w", bcdRelativePath, err)
 	}
 
 	if !stat.Mode().IsRegular() {
 		fullPath := filepath.Join(root.Name(), bcdPath)
-		return false, errors.Errorf("%s has unexpected file mode %s", fullPath, stat.Mode().String())
+		return false, fmt.Errorf("%s has unexpected file mode %s", fullPath, stat.Mode().String())
 	}
 
 	return true, nil
@@ -110,7 +110,6 @@ func ensureBaseLayer(root *os.File) (hasUtilityVM bool, err error) {
 
 func convertToBaseLayer(ctx context.Context, root *os.File) error {
 	hasUtilityVM, err := ensureBaseLayer(root)
-
 	if err != nil {
 		return err
 	}

--- a/pkg/cimfs/mount_cim.go
+++ b/pkg/cimfs/mount_cim.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/Microsoft/go-winio/pkg/guid"
 	"github.com/Microsoft/hcsshim/internal/winapi"
-	"github.com/pkg/errors"
 )
 
 type MountError struct {
@@ -46,7 +45,7 @@ func Unmount(volumePath string) error {
 	}
 
 	if !(strings.HasPrefix(volumePath, "\\\\?\\Volume{") && strings.HasSuffix(volumePath, "}\\")) {
-		return errors.Errorf("volume path %s is not in the expected format", volumePath)
+		return fmt.Errorf("volume path %s is not in the expected format", volumePath)
 	}
 
 	trimmedStr := strings.TrimPrefix(volumePath, "\\\\?\\Volume{")
@@ -54,7 +53,7 @@ func Unmount(volumePath string) error {
 
 	volGUID, err := guid.FromString(trimmedStr)
 	if err != nil {
-		return errors.Wrapf(err, "guid parsing failed for %s", trimmedStr)
+		return fmt.Errorf("guid parsing failed for %s: %w", trimmedStr, err)
 	}
 
 	if err := winapi.CimDismountImage(&volGUID); err != nil {

--- a/pkg/securitypolicy/regopolicy_test.go
+++ b/pkg/securitypolicy/regopolicy_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	_ "embed"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math/rand"
 	"sort"
@@ -21,7 +22,6 @@ import (
 	"github.com/blang/semver/v4"
 	"github.com/open-policy-agent/opa/rego"
 	oci "github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/pkg/errors"
 )
 
 const (

--- a/pkg/securitypolicy/securitypolicy.go
+++ b/pkg/securitypolicy/securitypolicy.go
@@ -5,6 +5,7 @@ import (
 	_ "embed"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"regexp"
 	"strconv"
@@ -13,7 +14,6 @@ import (
 
 	"github.com/Microsoft/hcsshim/internal/guestpath"
 	"github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/pkg/errors"
 )
 
 //go:embed framework.rego
@@ -143,7 +143,7 @@ func ExtractPolicyDecision(errorMessage string) (string, error) {
 	re := regexp.MustCompile(fmt.Sprintf(policyDecisionPattern, `(.*)`))
 	matches := re.FindStringSubmatch(errorMessage)
 	if len(matches) != 2 {
-		return "", errors.Errorf("unable to extract policy decision from error message: %s", errorMessage)
+		return "", fmt.Errorf("unable to extract policy decision from error message: %s", errorMessage)
 	}
 
 	errorBytes, err := base64.StdEncoding.DecodeString(matches[1])

--- a/pkg/securitypolicy/securitypolicyenforcer.go
+++ b/pkg/securitypolicy/securitypolicyenforcer.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"regexp"
 	"strconv"
@@ -18,7 +19,6 @@ import (
 
 	specInternal "github.com/Microsoft/hcsshim/internal/guest/spec"
 	"github.com/Microsoft/hcsshim/internal/guestpath"
-	"github.com/pkg/errors"
 )
 
 type createEnforcerFunc func(base64EncodedPolicy string, criMounts, criPrivilegedMounts []oci.Mount, maxErrorMessageLength int) (SecurityPolicyEnforcer, error)
@@ -107,14 +107,14 @@ func newSecurityPolicyFromBase64JSON(base64EncodedPolicy string) (*SecurityPolic
 	// we want to store a complex json object so.... base64 it is
 	jsonPolicy, err := base64.StdEncoding.DecodeString(base64EncodedPolicy)
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to decode policy from Base64 format")
+		return nil, fmt.Errorf("unable to decode policy from Base64 format: %w", err)
 	}
 
 	// json unmarshall the decoded to a SecurityPolicy
 	securityPolicy := new(SecurityPolicy)
 	err = json.Unmarshal(jsonPolicy, securityPolicy)
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to unmarshal JSON policy")
+		return nil, fmt.Errorf("unable to unmarshal JSON policy: %w", err)
 	}
 
 	return securityPolicy, nil

--- a/pkg/securitypolicy/securitypolicyenforcer_rego.go
+++ b/pkg/securitypolicy/securitypolicyenforcer_rego.go
@@ -8,6 +8,7 @@ import (
 	_ "embed"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -21,7 +22,6 @@ import (
 	rpi "github.com/Microsoft/hcsshim/internal/regopolicyinterpreter"
 	"github.com/opencontainers/runc/libcontainer/user"
 	oci "github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/pkg/errors"
 )
 
 const regoEnforcerName = "rego"
@@ -997,7 +997,7 @@ func getUser(passwdPath string, filter func(user.User) bool) (user.User, error) 
 		return user.User{}, err
 	}
 	if len(users) != 1 {
-		return user.User{}, errors.Errorf("expected exactly 1 user matched '%d'", len(users))
+		return user.User{}, fmt.Errorf("expected exactly 1 user matched '%d'", len(users))
 	}
 	return users[0], nil
 }
@@ -1008,7 +1008,7 @@ func getGroup(groupPath string, filter func(user.Group) bool) (user.Group, error
 		return user.Group{}, err
 	}
 	if len(groups) != 1 {
-		return user.Group{}, errors.Errorf("expected exactly 1 group matched '%d'", len(groups))
+		return user.Group{}, fmt.Errorf("expected exactly 1 group matched '%d'", len(groups))
 	}
 	return groups[0], nil
 }

--- a/test/cri-containerd/helpers/log.go
+++ b/test/cri-containerd/helpers/log.go
@@ -11,7 +11,6 @@ import (
 	"sync"
 
 	"github.com/Microsoft/go-winio"
-	"github.com/pkg/errors"
 )
 
 func main() {
@@ -31,24 +30,24 @@ func logContainerStdoutToFile() (err error) {
 	waitPipe := os.Getenv("CONTAINER_WAIT")
 
 	if sout, err = winio.DialPipeContext(ctx, soutPipe); err != nil {
-		return errors.Wrap(err, "couldn't open stdout pipe")
+		return fmt.Errorf("couldn't open stdout pipe: %w", err)
 	}
 	defer sout.Close()
 
 	// The only expected argument should be output file path
 	if len(os.Args[1:]) != 1 {
-		return errors.Errorf("Expected exactly 1 argument, got: %d", len(os.Args[1:]))
+		return fmt.Errorf("Expected exactly 1 argument, got: %d", len(os.Args[1:]))
 	}
 
 	var dest *os.File
 	destPath := os.Args[1]
 	if dest, err = os.Create(destPath); err != nil {
-		return errors.Wrap(err, "couldn't open destination file")
+		return fmt.Errorf("couldn't open destination file: %w", err)
 	}
 	defer dest.Close()
 
 	if wait, err = winio.DialPipeContext(ctx, waitPipe); err != nil {
-		return errors.Wrap(err, "couldn't open wait pipe")
+		return fmt.Errorf("couldn't open wait pipe: %w", err)
 	}
 	// Indicate that logging binary is ready to receive output
 	wait.Close()

--- a/test/cri-containerd/test-images/unordered_tar/tar_generator.go
+++ b/test/cri-containerd/test-images/unordered_tar/tar_generator.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-
-	"github.com/pkg/errors"
 )
 
 type tarContents struct {
@@ -32,11 +30,11 @@ func writeContentsToTar(tw *tar.Writer, contents []tarContents) error {
 			}
 		}
 		if err := tw.WriteHeader(hdr); err != nil {
-			return errors.Wrapf(err, "failed to write tar header for file: %s", file.path)
+			return fmt.Errorf("failed to write tar header for file: %s: %w", file.path, err)
 		}
 		if !isDir {
 			if _, err := tw.Write(file.body); err != nil {
-				return errors.Wrapf(err, "failed to write contents of file: %s", file.path)
+				return fmt.Errorf("failed to write contents of file: %s: %w", file.path, err)
 			}
 		}
 	}
@@ -75,14 +73,14 @@ func createUnorderedTars(dirPath string) ([]string, error) {
 		layerPath := filepath.Join(dirPath, fmt.Sprintf("tar%d.tar", i+1))
 		layerTar, err := os.Create(layerPath)
 		if err != nil {
-			return []string{}, errors.Wrapf(err, "failed to create tar at path: %s", layerPath)
+			return []string{}, fmt.Errorf("failed to create tar at path: %s: %w", layerPath, err)
 		}
 		defer layerTar.Close()
 
 		tw := tar.NewWriter(layerTar)
 		defer tw.Close()
 		if err = writeContentsToTar(tw, layer); err != nil {
-			return []string{}, errors.Wrapf(err, "failed to write tar contents for tar : %s", layerPath)
+			return []string{}, fmt.Errorf("failed to write tar contents for tar : %s: %w", layerPath, err)
 		}
 
 		generatedTars = append(generatedTars, layerPath)

--- a/test/go.mod
+++ b/test/go.mod
@@ -19,7 +19,6 @@ require (
 	github.com/opencontainers/image-spec v1.1.0
 	github.com/opencontainers/runtime-spec v1.2.0
 	github.com/opencontainers/runtime-tools v0.9.1-0.20221107090550-2e043c6bd626
-	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.9.3
 	github.com/urfave/cli/v2 v2.27.1
 	go.opencensus.io v0.24.0
@@ -92,6 +91,7 @@ require (
 	github.com/opencontainers/runc v1.1.14 // indirect
 	github.com/opencontainers/selinux v1.11.0 // indirect
 	github.com/pelletier/go-toml v1.9.5 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.20.2 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.55.0 // indirect

--- a/test/runhcs/e2e_matrix_test.go
+++ b/test/runhcs/e2e_matrix_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"os"
 	"os/exec"
@@ -23,7 +24,7 @@ import (
 	"github.com/Microsoft/hcsshim/test/pkg/require"
 	runc "github.com/containerd/go-runc"
 	"github.com/opencontainers/runtime-tools/generate"
-	"github.com/pkg/errors"
+
 	"golang.org/x/sync/errgroup"
 )
 
@@ -157,11 +158,11 @@ func getWindowsImageNameByVersion(t *testing.T, bv int) string {
 func readPidFile(path string) (int, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
-		return -1, errors.Wrap(err, "failed to read pidfile")
+		return -1, fmt.Errorf("failed to read pidfile: %w", err)
 	}
 	p, err := strconv.Atoi(string(data))
 	if err != nil {
-		return -1, errors.Wrap(err, "pidfile failed to parse pid")
+		return -1, fmt.Errorf("pidfile failed to parse pid: %w", err)
 	}
 	return p, nil
 }


### PR DESCRIPTION
Fixes: #1614 

The github.com/pkg/errors is mostly obsoleted since Go 1.13 introduced
%w-style error wrapping. It is also not maintained and is now archived
by the owner.

Some part of this change was done manually, and some changes were done
by using https://github.com/AkihiroSuda/go-wrap-to-percent-w tool.

In a few places this also:
 - changes '%s' or \"%s\" to %q;
 - removes extra context from the error message (such as, errors from os
   functions dealing with files do contain the file name already, and
   strconv.Atoi errors already contains the string which it failed to
   parse).

Note that there is a single place which uses StackTrace functionality of
pkg/errors, which is removed by this PR.

A few remaining users of pkg/errors vendored here (directly and
indirectly) are:
 - github.com/containerd/go-runc (needs to be bumped to v1.1.0);
 - github.com/microsoft/didx509go (needs https://github.com/microsoft/didx509go/pull/19);
 - github.com/docker/cli (needs https://github.com/docker/cli/issues/3618 fixed);
 - github.com/docker/docker (?)
 - github.com/linuxkit/virtsock (needs https://github.com/linuxkit/virtsock/pull/69 merged);
