### PR TITLE
Add build version block for pod CPU limits updating

### DIFF
--- a/internal/uvm/cpulimits_update.go
+++ b/internal/uvm/cpulimits_update.go
@@ -7,10 +7,16 @@ import (
 
 	"github.com/Microsoft/hcsshim/internal/hcs/resourcepaths"
 	hcsschema "github.com/Microsoft/hcsshim/internal/hcs/schema2"
+	"github.com/Microsoft/hcsshim/osversion"
+	"github.com/containerd/errdefs"
 )
 
 // UpdateCPULimits updates the CPU limits of the utility vm
 func (uvm *UtilityVM) UpdateCPULimits(ctx context.Context, limits *hcsschema.ProcessorLimits) error {
+	// Support for updating CPU limits was not added until 20H2 build
+	if osversion.Get().Build < osversion.V20H2 {
+		return errdefs.ErrNotImplemented
+	}
 	req := &hcsschema.ModifySettingRequest{
 		ResourcePath: resourcepaths.CPULimitsResourcePath,
 		Settings:     limits,

--- a/test/cri-containerd/pod_update_test.go
+++ b/test/cri-containerd/pod_update_test.go
@@ -10,9 +10,11 @@ import (
 	"testing"
 
 	"github.com/Microsoft/hcsshim/internal/memory"
+	"github.com/Microsoft/hcsshim/osversion"
 	"github.com/Microsoft/hcsshim/pkg/annotations"
 	"github.com/Microsoft/hcsshim/test/pkg/definitions/cpugroup"
 	"github.com/Microsoft/hcsshim/test/pkg/definitions/processorinfo"
+	"github.com/Microsoft/hcsshim/test/pkg/require"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
@@ -132,6 +134,7 @@ func Test_Pod_UpdateResources_Memory_PA(t *testing.T) {
 
 func Test_Pod_UpdateResources_CPUShares(t *testing.T) {
 	requireAnyFeature(t, featureWCOWHypervisor)
+	require.Build(t, osversion.V20H2)
 
 	type config struct {
 		name             string


### PR DESCRIPTION
Prevent test break by adding in a build version requirement when updating pod CPU limits. This feature was not added in HCS until 20H2. 