### PR TITLE
Fix go.mod to have the correct Go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Microsoft/hcsshim
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/Microsoft/cosesign1go v1.2.0

--- a/test/go.mod
+++ b/test/go.mod
@@ -1,6 +1,6 @@
 module github.com/Microsoft/hcsshim/test
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/Microsoft/go-winio v0.6.2


### PR DESCRIPTION
As of recent Go versions, specifying the go directive without a patch (e.g. 1.22) is no longer supported. Because go tries to download a matching toolchain if you're not already using one, it will try to download go toolchain version 1.22, which doesn't exist (1.22.0 does).

Fix the go.mod version to specify the full version with patch, 1.22.0.