### PR TITLE
osversion: Add new versions, fix compat bug, improve tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Microsoft/hcsshim
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/Microsoft/cosesign1go v1.2.0

--- a/osversion/platform_compat_windows.go
+++ b/osversion/platform_compat_windows.go
@@ -3,7 +3,8 @@ package osversion
 // List of stable ABI compliant ltsc releases
 // Note: List must be sorted in ascending order
 var compatLTSCReleases = []uint16{
-	V21H2Server,
+	LTSC2022,
+	LTSC2025,
 }
 
 // CheckHostAndContainerCompat checks if given host and container
@@ -20,16 +21,25 @@ func CheckHostAndContainerCompat(host, ctr OSVersion) bool {
 	}
 
 	// If host is < WS 2022, exact version match is required
-	if host.Build < V21H2Server {
+	if host.Build < LTSC2022 {
 		return host.Build == ctr.Build
 	}
 
-	var supportedLtscRelease uint16
+	// Find the latest LTSC version that is earlier than the host version.
+	// This is the earliest version of container that the host can run.
+	//
+	// If the host version is an LTSC, then it supports compatibility with
+	// everything from the previous LTSC up to itself, so we want supportedLTSCRelease
+	// to be the previous entry.
+	//
+	// If no match is found, then we know that the host is LTSC2022 exactly,
+	// since we already checked that it's not less than LTSC2022.
+	var supportedLTSCRelease uint16 = LTSC2022
 	for i := len(compatLTSCReleases) - 1; i >= 0; i-- {
-		if host.Build >= compatLTSCReleases[i] {
-			supportedLtscRelease = compatLTSCReleases[i]
+		if host.Build > compatLTSCReleases[i] {
+			supportedLTSCRelease = compatLTSCReleases[i]
 			break
 		}
 	}
-	return ctr.Build >= supportedLtscRelease && ctr.Build <= host.Build
+	return supportedLTSCRelease <= ctr.Build && ctr.Build <= host.Build
 }

--- a/osversion/platform_compat_windows_test.go
+++ b/osversion/platform_compat_windows_test.go
@@ -1,68 +1,86 @@
 package osversion
 
 import (
+	"fmt"
 	"testing"
 )
 
-// Test the platform compatibility of the different
-// OS Versions considering two ltsc container image
-// versions (ltsc2019, ltsc2022)
+// Test the platform compatibility of the different OS Versions
 func Test_PlatformCompat(t *testing.T) {
-	for testName, tc := range map[string]struct {
-		hostOs    uint16
-		ctrOs     uint16
+	for _, tc := range []struct {
+		hostOS    uint16
+		ctrOS     uint16
 		shouldRun bool
 	}{
-		"RS5Host_ltsc2019": {
-			hostOs:    RS5,
-			ctrOs:     RS5,
+		{
+			hostOS:    LTSC2019,
+			ctrOS:     LTSC2019,
 			shouldRun: true,
 		},
-		"RS5Host_ltsc2022": {
-			hostOs:    RS5,
-			ctrOs:     V21H2Server,
+		{
+			hostOS:    LTSC2019,
+			ctrOS:     LTSC2022,
 			shouldRun: false,
 		},
-		"WS2022Host_ltsc2019": {
-			hostOs:    V21H2Server,
-			ctrOs:     RS5,
+		{
+			hostOS:    LTSC2022,
+			ctrOS:     LTSC2019,
 			shouldRun: false,
 		},
-		"WS2022Host_ltsc2022": {
-			hostOs:    V21H2Server,
-			ctrOs:     V21H2Server,
+		{
+			hostOS:    LTSC2022,
+			ctrOS:     LTSC2022,
 			shouldRun: true,
 		},
-		"Wind11Host_ltsc2019": {
-			hostOs:    V22H2Win11,
-			ctrOs:     RS5,
+		{
+			hostOS:    V22H2Win11,
+			ctrOS:     LTSC2019,
 			shouldRun: false,
 		},
-		"Wind11Host_ltsc2022": {
-			hostOs:    V22H2Win11,
-			ctrOs:     V21H2Server,
+		{
+			hostOS:    V22H2Win11,
+			ctrOS:     LTSC2022,
+			shouldRun: true,
+		},
+		{
+			hostOS:    LTSC2025,
+			ctrOS:     LTSC2022,
+			shouldRun: true,
+		},
+		{
+			hostOS:    LTSC2022,
+			ctrOS:     LTSC2025,
+			shouldRun: false,
+		},
+		{
+			hostOS:    LTSC2022,
+			ctrOS:     V22H2Win11,
+			shouldRun: false,
+		},
+		{
+			hostOS:    LTSC2025,
+			ctrOS:     V22H2Win11,
 			shouldRun: true,
 		},
 	} {
-		// Check if ltsc2019/ltsc2022 guest images are compatible on
-		// the given host OS versions
-		//
-		hostOSVersion := OSVersion{
-			MajorVersion: 10,
-			MinorVersion: 0,
-			Build:        tc.hostOs,
-		}
-		ctrOSVersion := OSVersion{
-			MajorVersion: 10,
-			MinorVersion: 0,
-			Build:        tc.ctrOs,
-		}
-		if CheckHostAndContainerCompat(hostOSVersion, ctrOSVersion) != tc.shouldRun {
-			var expectedResultStr string
-			if !tc.shouldRun {
-				expectedResultStr = " NOT"
+		t.Run(fmt.Sprintf("Host_%d_Ctr_%d", tc.hostOS, tc.ctrOS), func(t *testing.T) {
+			hostOSVersion := OSVersion{
+				MajorVersion: 10,
+				MinorVersion: 0,
+				Build:        tc.hostOS,
 			}
-			t.Fatalf("Failed %v: host %v should%s be able to run guest %v", testName, tc.hostOs, expectedResultStr, tc.ctrOs)
-		}
+			ctrOSVersion := OSVersion{
+				MajorVersion: 10,
+				MinorVersion: 0,
+				Build:        tc.ctrOS,
+			}
+			if CheckHostAndContainerCompat(hostOSVersion, ctrOSVersion) != tc.shouldRun {
+				var expectedResultStr string
+				if !tc.shouldRun {
+					expectedResultStr = " NOT"
+				}
+				t.Fatalf("host %v should%s be able to run guest %v", tc.hostOS, expectedResultStr, tc.ctrOS)
+			}
+		})
 	}
 }

--- a/osversion/windowsbuilds.go
+++ b/osversion/windowsbuilds.go
@@ -82,6 +82,10 @@ const (
 	// V22H2Win11 corresponds to Windows 11 (2022 Update).
 	V22H2Win11 = 22621
 
+	// V23H2 is the 23H2 release in the Windows Server annual channel.
+	V23H2 = 25398
+
 	// Windows Server 2025 build 26100
 	V25H1Server = 26100
+	LTSC2025    = V25H1Server
 )

--- a/test/go.mod
+++ b/test/go.mod
@@ -1,6 +1,6 @@
 module github.com/Microsoft/hcsshim/test
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/Microsoft/go-winio v0.6.2


### PR DESCRIPTION
- Add V23H2 (annual channel) and LTSC2025 to the version list
- Use the LTSC build naming in the compat checks and tests, to make
  intent clearer
- Fix a bug in the compat check. A given LTSC release should be able to
  run everything from the previous LTSC up to itself
- Add new test cases, including for the fixed compat check bug
- Change the tests to use t.Run for each test case

Signed-off-by: Kevin Parsons <kevpar@microsoft.com>