### PR TITLE
Remove stats span

### DIFF
--- a/pkg/octtrpc/interceptor.go
+++ b/pkg/octtrpc/interceptor.go
@@ -100,7 +100,6 @@ func ServerInterceptor(opts ...Option) ttrpc.UnaryServerInterceptor {
 	}
 	return func(ctx context.Context, unmarshal ttrpc.Unmarshaler, info *ttrpc.UnaryServerInfo, method ttrpc.Method) (_ interface{}, err error) {
 		name := convertMethodName(info.FullMethod)
-
 		var span *trace.Span
 		opts := []trace.StartOption{trace.WithSampler(o.sampler), oc.WithServerSpanKind}
 		parent, ok := getParentSpanFromContext(ctx)


### PR DESCRIPTION
Stats calls are made quite often by customers and the spans created could flood the logs. This change is removing the spans for stats calls.

The following spans are being removed:

time="2024-11-22T06:19:59.305267800Z" level=info msg=Span duration="708.4µs" endTime="2024-11-22T06:19:59.305976200Z" name=containerd.task.v2.Task.Stats parentSpanID=0000000000000000 spanID=e9bfa06a09bb9548 spanKind=server startTime="2024-11-22T06:19:59.305267800Z" traceID=ddf4f2231ce67194bd833c15a4c73fcf
time="2024-11-22T06:19:59.304139100Z" level=info msg=Span duration=2.1059ms endTime="2024-11-22T06:19:59.306245000Z" name=Stats parentSpanID=30ddb65909c4d7f1 pod-id=83162ca3a00729c49df470140aab6a966c0e2950d4e7267eb488f203ac06cf19 spanID=914dea16815abd59 startTime="2024-11-22T06:19:59.304139100Z" tid=4b2c96383294ae1a2ae8d764fb4518c8b5dbbe1b745da379623aa30f154374ca traceID=a207fe1ca8efe6033aaa7ba74ae4fb5c
