### PR TITLE
Add support for HCN v2 endpoint and add unit tests

### DIFF
--- a/internal/annotations/annotations.go
+++ b/internal/annotations/annotations.go
@@ -48,4 +48,12 @@ const (
 	// UVMConsolePipe is the name of the named pipe that the UVM console is connected to. This works only for non-SNP
 	// scenario, for SNP use a debugger.
 	UVMConsolePipe = "io.microsoft.virtualmachine.console.pipe"
+
+	// NetworkingPolicyBasedRouting toggles on the ability to set policy based routing in the
+	// guest for LCOW.
+	//
+	// TODO(katiewasnothere): The goal of this annotation was to be used as a fallback if the
+	// work to support multiple custom network routes per adapter in LCOW breaks existing
+	// LCOW scenarios. Ideally, this annotation should be removed if no issues are found.
+	NetworkingPolicyBasedRouting = "io.microsoft.virtualmachine.lcow.network.policybasedrouting"
 )

--- a/internal/guest/network/netns.go
+++ b/internal/guest/network/netns.go
@@ -34,7 +34,7 @@ const (
 	ipv6GwDestination = "::/0"
 	ipv6EmptyGw       = "::"
 
-	unreachableErr = "network is unreachable"
+	unreachableErrStr = "network is unreachable"
 )
 
 // MoveInterfaceToNS moves the adapter with interface name `ifStr` to the network namespace
@@ -281,7 +281,7 @@ func configureLink(ctx context.Context,
 		if err := netlinkRouteAdd(&route); err != nil {
 			// unfortunately, netlink library doesn't have great error handling,
 			// so we have to rely on the string error here
-			if strings.Contains(err.Error(), unreachableErr) && gw != nil {
+			if strings.Contains(err.Error(), unreachableErrStr) && gw != nil {
 				// In the case that a gw is not part of the subnet we are setting gw for,
 				// a new addr containing this gw address needs to be added into the link to avoid getting
 				// unreachable error when adding this out-of-subnet gw route

--- a/internal/guest/network/netns_test.go
+++ b/internal/guest/network/netns_test.go
@@ -72,7 +72,7 @@ func unreachableNetlinkRouteAdd(count *int, link netlink.Link, expected []*testR
 		if err := f(route); err != nil {
 			return err
 		}
-		return fmt.Errorf(unreachableErr)
+		return fmt.Errorf(unreachableErrStr)
 	}
 }
 
@@ -169,7 +169,7 @@ func Test_configureLink_IPv4(t *testing.T) {
 		Routes: []guestresource.LCOWRoute{
 			{
 				NextHop:           "192.168.0.100",
-				DestinationPrefix: "0.0.0.0/0",
+				DestinationPrefix: ipv4GwDestination,
 			},
 		},
 	}
@@ -220,7 +220,7 @@ func Test_configureLink_EnableLowMetric_IPv4(t *testing.T) {
 		Routes: []guestresource.LCOWRoute{
 			{
 				NextHop:           "192.168.0.100",
-				DestinationPrefix: "0.0.0.0/0",
+				DestinationPrefix: ipv4GwDestination,
 			},
 		},
 		EnableLowMetric: true,
@@ -287,7 +287,7 @@ func Test_configureLink_IPv6(t *testing.T) {
 		Routes: []guestresource.LCOWRoute{
 			{
 				NextHop:           "9541:a2d4:f0f3:18ff:c868:26ce:e9c4:aaaa",
-				DestinationPrefix: "::/0",
+				DestinationPrefix: ipv6GwDestination,
 			},
 		},
 	}
@@ -338,7 +338,7 @@ func Test_configureLink_EnableLowMetric_IPv6(t *testing.T) {
 		Routes: []guestresource.LCOWRoute{
 			{
 				NextHop:           "9541:a2d4:f0f3:18ff:c868:26ce:e9c4:aaaa",
-				DestinationPrefix: "::/0",
+				DestinationPrefix: ipv6GwDestination,
 			},
 		},
 		EnableLowMetric: true,
@@ -411,11 +411,11 @@ func Test_configureLink_IPv4AndIPv6(t *testing.T) {
 		Routes: []guestresource.LCOWRoute{
 			{
 				NextHop:           "192.168.0.100",
-				DestinationPrefix: "0.0.0.0/0",
+				DestinationPrefix: ipv4GwDestination,
 			},
 			{
 				NextHop:           "9541:a2d4:f0f3:18ff:c868:26ce:e9c4:aaaa",
-				DestinationPrefix: "::/0",
+				DestinationPrefix: ipv6GwDestination,
 			},
 		},
 	}
@@ -538,7 +538,7 @@ func Test_configureLink_GatewayOutsideSubnet_IPv4(t *testing.T) {
 		Routes: []guestresource.LCOWRoute{
 			{
 				NextHop:           "10.0.0.2",
-				DestinationPrefix: "0.0.0.0/0",
+				DestinationPrefix: ipv4GwDestination,
 			},
 		},
 	}
@@ -578,7 +578,7 @@ func Test_configureLink_GatewayOutsideSubnet_IPv4(t *testing.T) {
 	netlinkAddrAdd = standardNetlinkAddrAdd(&addrAddCount, expectedAddr)
 
 	err := configureLink(ctx, link1, adapter)
-	if err == nil || !strings.Contains(err.Error(), unreachableErr) {
+	if err == nil || !strings.Contains(err.Error(), unreachableErrStr) {
 		t.Fatalf("expected an error from configureLink: %s", err)
 	}
 
@@ -604,7 +604,7 @@ func Test_configureLink_GatewayOutsideSubnet_IPv6(t *testing.T) {
 		Routes: []guestresource.LCOWRoute{
 			{
 				NextHop:           "9999:a2d4:f0f3:18ff:c868:26ce:e9c4:aaaa",
-				DestinationPrefix: "::/0",
+				DestinationPrefix: ipv6GwDestination,
 			},
 		},
 	}
@@ -644,7 +644,7 @@ func Test_configureLink_GatewayOutsideSubnet_IPv6(t *testing.T) {
 	netlinkAddrAdd = standardNetlinkAddrAdd(&addrAddCount, expectedAddr)
 
 	err := configureLink(ctx, link1, adapter)
-	if err == nil || !strings.Contains(err.Error(), unreachableErr) {
+	if err == nil || !strings.Contains(err.Error(), unreachableErrStr) {
 		t.Fatalf("expected an error from configureLink: %s", err)
 	}
 
@@ -669,12 +669,12 @@ func Test_configureLink_MultiRoute_IPv4(t *testing.T) {
 		},
 		Routes: []guestresource.LCOWRoute{
 			{
-				NextHop:           "0.0.0.0",
-				DestinationPrefix: "0.0.0.0/0",
+				NextHop:           ipv4EmptyGw,
+				DestinationPrefix: ipv4GwDestination,
 			},
 			{
 				NextHop:           "192.168.0.100",
-				DestinationPrefix: "0.0.0.0/0",
+				DestinationPrefix: ipv4GwDestination,
 			},
 			{
 				NextHop:           "192.168.0.5",
@@ -742,12 +742,12 @@ func Test_configureLink_MultiRoute_IPv6(t *testing.T) {
 		},
 		Routes: []guestresource.LCOWRoute{
 			{
-				NextHop:           "::",
-				DestinationPrefix: "::/0",
+				NextHop:           ipv6EmptyGw,
+				DestinationPrefix: ipv6GwDestination,
 			},
 			{
 				NextHop:           "9541:a2d4:f0f3:18ff:c868:26ce:e9c4:aaaa",
-				DestinationPrefix: "::/0",
+				DestinationPrefix: ipv6GwDestination,
 			},
 			{
 				NextHop:           "9541:a2d4:f0f3:18ff:c868:26ce:e9c4:cccc",

--- a/internal/guest/network/netns_test.go
+++ b/internal/guest/network/netns_test.go
@@ -1,0 +1,663 @@
+//go:build linux
+// +build linux
+
+package network
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net"
+	"strings"
+	"testing"
+
+	"github.com/Microsoft/hcsshim/internal/protocol/guestresource"
+	"github.com/vishvananda/netlink"
+)
+
+const (
+	ipv4TotalMaskLength = 32
+	ipv6TotalMaskLength = 128
+)
+
+type testRoute struct {
+	scope    netlink.Scope
+	dstIP    string
+	gw       string
+	priority int
+}
+
+type testAddr struct {
+	ip         string
+	prefixLen  int
+	maskLength int
+}
+
+type fakeLink struct {
+	attr *netlink.LinkAttrs
+}
+
+func (l *fakeLink) Attrs() *netlink.LinkAttrs {
+	return l.attr
+}
+
+func (l *fakeLink) Type() string {
+	return ""
+}
+
+func newFakeLink(name string, index int) *fakeLink {
+	attr := &netlink.LinkAttrs{
+		Name:  name,
+		Index: index,
+	}
+	return &fakeLink{
+		attr: attr,
+	}
+}
+
+var _ = (netlink.Link)(&fakeLink{})
+
+// unreachableNetlinkRouteAdd is a helper function that will always return that the
+// network is unreachable
+func unreachableNetlinkRouteAdd(count *int, link netlink.Link, expected []*testRoute) func(_ *netlink.Route) error {
+	return func(route *netlink.Route) error {
+		f := standardNetlinkRouteAdd(count, link, expected)
+		if err := f(route); err != nil {
+			return err
+		}
+		return fmt.Errorf(unreachableErr)
+	}
+}
+
+func standardNetlinkRouteAdd(count *int, link netlink.Link, expected []*testRoute) func(_ *netlink.Route) error {
+	return func(route *netlink.Route) error {
+		if *count >= len(expected) {
+			return fmt.Errorf("expected to call route add %d times, instead got %d", len(expected), *count)
+		}
+		exp := expected[*count]
+
+		if exp.scope != route.Scope {
+			return fmt.Errorf("expected scope %s, instead got %s", exp.scope, route.Scope)
+		}
+
+		if route.Gw == nil && exp.gw != "" {
+			return fmt.Errorf("expected to have gw set %s", exp.gw)
+		} else if route.Gw != nil && (exp.gw != route.Gw.String()) {
+			return fmt.Errorf("expected gw %s, instead got %s", exp.gw, route.Gw.String())
+		}
+
+		if route.Dst == nil && exp.dstIP != "" {
+			return fmt.Errorf("expected to have dst set %s", exp.dstIP)
+		} else if route.Dst != nil && (exp.dstIP != route.Dst.String()) {
+			return fmt.Errorf("expected dst %s, instead got %s", exp.dstIP, route.Dst.String())
+		}
+
+		if route.Priority != exp.priority {
+			return fmt.Errorf("expected to use metric %d, instead used %d", exp.priority, route.Priority)
+		}
+
+		if link.Attrs().Index != route.LinkIndex {
+			return fmt.Errorf("expected to get link index %d, instead got %d", link.Attrs().Index, route.LinkIndex)
+		}
+
+		*count++
+		return nil
+	}
+}
+
+func standardNetlinkAddrAdd(count *int, expected []*testAddr) func(_ netlink.Link, _ *netlink.Addr) error {
+	return func(link netlink.Link, addr *netlink.Addr) error {
+		if *count >= len(expected) {
+			return fmt.Errorf("expected to call addr add %d times, instead got %d", len(expected), *count)
+		}
+		exp := expected[*count]
+
+		if addr.IP.String() != exp.ip {
+			return fmt.Errorf("expected to add address %s, instead got %s", exp.ip, addr.IP.String())
+		}
+		expectedMask := net.CIDRMask(exp.prefixLen, exp.maskLength)
+		if !bytes.Equal(addr.Mask, expectedMask) {
+			return fmt.Errorf("expected mask to be %s, instead got %s", expectedMask, addr.Mask)
+		}
+		*count++
+		return nil
+	}
+}
+
+func Test_configureLink_IPv4(t *testing.T) {
+	ctx := context.Background()
+	link1 := newFakeLink("eth0", 0)
+	adapter := &guestresource.LCOWNetworkAdapter{
+		IPConfigs: []guestresource.LCOWIPConfig{
+			{
+				IPAddress:    "192.168.0.5",
+				PrefixLength: 24,
+			},
+		},
+		Routes: []guestresource.LCOWRoute{
+			{
+				NextHop:           "192.168.0.100",
+				DestinationPrefix: "0.0.0.0/0",
+			},
+		},
+	}
+	expectedRoutes := []*testRoute{
+		{
+			scope:    netlink.SCOPE_UNIVERSE,
+			gw:       "192.168.0.100",
+			priority: 0,
+		},
+	}
+	expectedAddr := []*testAddr{
+		{
+			ip:         "192.168.0.5",
+			prefixLen:  24,
+			maskLength: ipv4TotalMaskLength,
+		},
+	}
+
+	routeAddCount := 0
+	netlinkRouteAdd = standardNetlinkRouteAdd(&routeAddCount, link1, expectedRoutes)
+
+	addrAddCount := 0
+	netlinkAddrAdd = standardNetlinkAddrAdd(&addrAddCount, expectedAddr)
+
+	if err := configureLink(ctx, link1, adapter); err != nil {
+		t.Fatalf("configureLink: %s", err)
+	}
+
+	if routeAddCount != len(expectedRoutes) {
+		t.Fatalf("expected to call routeAdd %d times, instead called it %d times", len(expectedRoutes), routeAddCount)
+	}
+
+	if addrAddCount != len(expectedAddr) {
+		t.Fatalf("expected to call addrAdd %d times, instead called it %d times", len(expectedAddr), addrAddCount)
+	}
+}
+
+func Test_configureLink_IPv6(t *testing.T) {
+	ctx := context.Background()
+	link1 := newFakeLink("eth0", 0)
+	adapter := &guestresource.LCOWNetworkAdapter{
+		IPConfigs: []guestresource.LCOWIPConfig{
+			{
+				IPAddress:    "9541:a2d4:f0f3:18ff:c868:26ce:e9c4:30a6",
+				PrefixLength: 64,
+			},
+		},
+		Routes: []guestresource.LCOWRoute{
+			{
+				NextHop:           "9541:a2d4:f0f3:18ff:c868:26ce:e9c4:aaaa",
+				DestinationPrefix: "::/0",
+			},
+		},
+	}
+	expectedRoutes := []*testRoute{
+		{
+			scope:    netlink.SCOPE_UNIVERSE,
+			gw:       "9541:a2d4:f0f3:18ff:c868:26ce:e9c4:aaaa",
+			priority: 0,
+		},
+	}
+	expectedAddr := []*testAddr{
+		{
+			ip:         "9541:a2d4:f0f3:18ff:c868:26ce:e9c4:30a6",
+			prefixLen:  64,
+			maskLength: ipv6TotalMaskLength,
+		},
+	}
+
+	routeAddCount := 0
+	netlinkRouteAdd = standardNetlinkRouteAdd(&routeAddCount, link1, expectedRoutes)
+
+	addrAddCount := 0
+	netlinkAddrAdd = standardNetlinkAddrAdd(&addrAddCount, expectedAddr)
+
+	if err := configureLink(ctx, link1, adapter); err != nil {
+		t.Fatalf("configureLink: %s", err)
+	}
+
+	if routeAddCount != len(expectedRoutes) {
+		t.Fatalf("expected to call routeAdd %d times, instead called it %d times", len(expectedRoutes), routeAddCount)
+	}
+
+	if addrAddCount != len(expectedAddr) {
+		t.Fatalf("expected to call addrAdd %d times, instead called it %d times", len(expectedAddr), addrAddCount)
+	}
+}
+
+func Test_configureLink_IPv4AndIPv6(t *testing.T) {
+	ctx := context.Background()
+
+	link1 := newFakeLink("eth0", 1)
+
+	adapter := &guestresource.LCOWNetworkAdapter{
+		IPConfigs: []guestresource.LCOWIPConfig{
+			{
+				IPAddress:    "192.168.0.5",
+				PrefixLength: 24,
+			},
+			{
+				IPAddress:    "9541:a2d4:f0f3:18ff:c868:26ce:e9c4:30a6",
+				PrefixLength: 64,
+			},
+		},
+		Routes: []guestresource.LCOWRoute{
+			{
+				NextHop:           "192.168.0.100",
+				DestinationPrefix: "0.0.0.0/0",
+			},
+			{
+				NextHop:           "9541:a2d4:f0f3:18ff:c868:26ce:e9c4:aaaa",
+				DestinationPrefix: "::/0",
+			},
+		},
+	}
+	expectedRoutes := []*testRoute{
+		{
+			scope:    netlink.SCOPE_UNIVERSE,
+			gw:       "192.168.0.100",
+			priority: 0,
+		},
+		{
+			scope:    netlink.SCOPE_UNIVERSE,
+			gw:       "9541:a2d4:f0f3:18ff:c868:26ce:e9c4:aaaa",
+			priority: 0,
+		},
+	}
+	expectedAddr := []*testAddr{
+		{
+			ip:         "192.168.0.5",
+			prefixLen:  24,
+			maskLength: ipv4TotalMaskLength,
+		},
+		{
+			ip:         "9541:a2d4:f0f3:18ff:c868:26ce:e9c4:30a6",
+			prefixLen:  64,
+			maskLength: ipv6TotalMaskLength,
+		},
+	}
+
+	routeAddCount := 0
+	netlinkRouteAdd = standardNetlinkRouteAdd(&routeAddCount, link1, expectedRoutes)
+
+	addrAddCount := 0
+	netlinkAddrAdd = standardNetlinkAddrAdd(&addrAddCount, expectedAddr)
+
+	if err := configureLink(ctx, link1, adapter); err != nil {
+		t.Fatalf("configureLink: %s", err)
+	}
+
+	if routeAddCount != len(expectedRoutes) {
+		t.Fatalf("expected to call routeAdd %d times, instead called it %d times", len(expectedRoutes), routeAddCount)
+	}
+
+	if addrAddCount != len(expectedAddr) {
+		t.Fatalf("expected to call addrAdd %d times, instead called it %d times", len(expectedAddr), addrAddCount)
+	}
+}
+
+func Test_configureLink_No_Gateway_IPv4(t *testing.T) {
+	ctx := context.Background()
+
+	link1 := newFakeLink("eth0", 0)
+
+	adapter := &guestresource.LCOWNetworkAdapter{
+		IPConfigs: []guestresource.LCOWIPConfig{
+			{
+				IPAddress:    "192.168.0.5",
+				PrefixLength: 24,
+			},
+		},
+	}
+	expectedAddr := []*testAddr{
+		{
+			ip:         "192.168.0.5",
+			prefixLen:  24,
+			maskLength: ipv4TotalMaskLength,
+		},
+	}
+
+	addrAddCount := 0
+	netlinkAddrAdd = standardNetlinkAddrAdd(&addrAddCount, expectedAddr)
+	if err := configureLink(ctx, link1, adapter); err != nil {
+		t.Fatalf("configureLink: %s", err)
+	}
+
+	if addrAddCount != len(expectedAddr) {
+		t.Fatalf("expected to call addrAdd %d times, instead called it %d times", len(expectedAddr), addrAddCount)
+	}
+}
+
+func Test_configureLink_No_Gateway_IPv6(t *testing.T) {
+	ctx := context.Background()
+	link1 := newFakeLink("eth0", 0)
+	adapter := &guestresource.LCOWNetworkAdapter{
+		IPConfigs: []guestresource.LCOWIPConfig{
+			{
+				IPAddress:    "9541:a2d4:f0f3:18ff:c868:26ce:e9c4:30a6",
+				PrefixLength: 64,
+			},
+		},
+	}
+	expectedAddr := []*testAddr{
+		{
+			ip:         "9541:a2d4:f0f3:18ff:c868:26ce:e9c4:30a6",
+			prefixLen:  64,
+			maskLength: ipv6TotalMaskLength,
+		},
+	}
+
+	addrAddCount := 0
+	netlinkAddrAdd = standardNetlinkAddrAdd(&addrAddCount, expectedAddr)
+	if err := configureLink(ctx, link1, adapter); err != nil {
+		t.Fatalf("configureLink: %s", err)
+	}
+
+	if addrAddCount != len(expectedAddr) {
+		t.Fatalf("expected to call addrAdd %d times, instead called it %d times", len(expectedAddr), addrAddCount)
+	}
+}
+
+func Test_configureLink_GatewayOutsideSubnet_IPv4(t *testing.T) {
+	ctx := context.Background()
+	link1 := newFakeLink("eth0", 0)
+	adapter := &guestresource.LCOWNetworkAdapter{
+		IPConfigs: []guestresource.LCOWIPConfig{
+			{
+				IPAddress:    "192.168.0.5",
+				PrefixLength: 24,
+			},
+		},
+		Routes: []guestresource.LCOWRoute{
+			{
+				NextHop:           "10.0.0.2",
+				DestinationPrefix: "0.0.0.0/0",
+			},
+		},
+	}
+	expectedRoutes := []*testRoute{
+		{
+			scope:    netlink.SCOPE_UNIVERSE,
+			gw:       "10.0.0.2",
+			priority: 0,
+		},
+		{
+			// routeAdd should be called twice with the same content in this test
+			scope:    netlink.SCOPE_UNIVERSE,
+			gw:       "10.0.0.2",
+			priority: 0,
+		},
+	}
+	expectedAddr := []*testAddr{
+		{
+			ip:         "192.168.0.5",
+			prefixLen:  24,
+			maskLength: ipv4TotalMaskLength,
+		},
+		{
+			ip:         "10.0.0.2",
+			prefixLen:  ipv4TotalMaskLength,
+			maskLength: ipv4TotalMaskLength,
+		},
+	}
+
+	// since it isn't easy to change the definition of the netlinkRouteAdd per call,
+	// instead of checking for a success for this test case, we just check that the
+	// behavior we expect happens when we get the error message we expect.
+	routeAddCount := 0
+	netlinkRouteAdd = unreachableNetlinkRouteAdd(&routeAddCount, link1, expectedRoutes)
+
+	addrAddCount := 0
+	netlinkAddrAdd = standardNetlinkAddrAdd(&addrAddCount, expectedAddr)
+
+	err := configureLink(ctx, link1, adapter)
+	if err == nil || !strings.Contains(err.Error(), unreachableErr) {
+		t.Fatalf("expected an error from configureLink: %s", err)
+	}
+
+	if routeAddCount != len(expectedRoutes) {
+		t.Fatalf("expected to call routeAdd %d times, instead called it %d times", len(expectedRoutes), routeAddCount)
+	}
+
+	if addrAddCount != len(expectedAddr) {
+		t.Fatalf("expected to call addrAdd %d times, instead called it %d times", len(expectedAddr), addrAddCount)
+	}
+}
+
+func Test_configureLink_GatewayOutsideSubnet_IPv6(t *testing.T) {
+	ctx := context.Background()
+	link1 := newFakeLink("eth0", 0)
+	adapter := &guestresource.LCOWNetworkAdapter{
+		IPConfigs: []guestresource.LCOWIPConfig{
+			{
+				IPAddress:    "9541:a2d4:f0f3:18ff:c868:26ce:e9c4:30a6",
+				PrefixLength: 64,
+			},
+		},
+		Routes: []guestresource.LCOWRoute{
+			{
+				NextHop:           "9999:a2d4:f0f3:18ff:c868:26ce:e9c4:aaaa",
+				DestinationPrefix: "::/0",
+			},
+		},
+	}
+	expectedRoutes := []*testRoute{
+		{
+			scope:    netlink.SCOPE_UNIVERSE,
+			gw:       "9999:a2d4:f0f3:18ff:c868:26ce:e9c4:aaaa",
+			priority: 0,
+		},
+		{
+			// routeAdd should be called twice with the same content in this test
+			scope:    netlink.SCOPE_UNIVERSE,
+			gw:       "9999:a2d4:f0f3:18ff:c868:26ce:e9c4:aaaa",
+			priority: 0,
+		},
+	}
+	expectedAddr := []*testAddr{
+		{
+			ip:         "9541:a2d4:f0f3:18ff:c868:26ce:e9c4:30a6",
+			prefixLen:  64,
+			maskLength: ipv6TotalMaskLength,
+		},
+		{
+			ip:         "9999:a2d4:f0f3:18ff:c868:26ce:e9c4:aaaa",
+			prefixLen:  ipv6TotalMaskLength,
+			maskLength: ipv6TotalMaskLength,
+		},
+	}
+
+	// since it isn't easy to change the definition of the netlinkRouteAdd per call,
+	// instead of checking for a success for this test case, we just check that the
+	// behavior we expect happens when we get the error message we expect.
+	routeAddCount := 0
+	netlinkRouteAdd = unreachableNetlinkRouteAdd(&routeAddCount, link1, expectedRoutes)
+
+	addrAddCount := 0
+	netlinkAddrAdd = standardNetlinkAddrAdd(&addrAddCount, expectedAddr)
+
+	err := configureLink(ctx, link1, adapter)
+	if err == nil || !strings.Contains(err.Error(), unreachableErr) {
+		t.Fatalf("expected an error from configureLink: %s", err)
+	}
+
+	if routeAddCount != len(expectedRoutes) {
+		t.Fatalf("expected to call routeAdd %d times, instead called it %d times", len(expectedRoutes), routeAddCount)
+	}
+
+	if addrAddCount != len(expectedAddr) {
+		t.Fatalf("expected to call addrAdd %d times, instead called it %d times", len(expectedAddr), addrAddCount)
+	}
+}
+
+func Test_configureLink_MultiRoute_IPv4(t *testing.T) {
+	ctx := context.Background()
+	link1 := newFakeLink("eth0", 0)
+	adapter := &guestresource.LCOWNetworkAdapter{
+		IPConfigs: []guestresource.LCOWIPConfig{
+			{
+				IPAddress:    "192.168.0.5",
+				PrefixLength: 24,
+			},
+		},
+		Routes: []guestresource.LCOWRoute{
+			{
+				NextHop:           "0.0.0.0",
+				DestinationPrefix: "0.0.0.0/0",
+			},
+			{
+				NextHop:           "192.168.0.100",
+				DestinationPrefix: "0.0.0.0/0",
+			},
+			{
+				NextHop:           "192.168.0.5",
+				DestinationPrefix: "10.10.0.0/16",
+			},
+			{
+				DestinationPrefix: "10.0.0.0/16",
+			},
+		},
+	}
+	expectedRoutes := []*testRoute{
+		{
+			scope:    netlink.SCOPE_UNIVERSE,
+			gw:       "192.168.0.100",
+			priority: 0,
+		},
+		{
+			scope:    netlink.SCOPE_UNIVERSE,
+			gw:       "192.168.0.5",
+			dstIP:    "10.10.0.0/16",
+			priority: 0,
+		},
+		{
+			scope:    netlink.SCOPE_UNIVERSE,
+			dstIP:    "10.0.0.0/16",
+			priority: 0,
+		},
+	}
+	expectedAddr := []*testAddr{
+		{
+			ip:         "192.168.0.5",
+			prefixLen:  24,
+			maskLength: ipv4TotalMaskLength,
+		},
+	}
+
+	routeAddCount := 0
+	netlinkRouteAdd = standardNetlinkRouteAdd(&routeAddCount, link1, expectedRoutes)
+
+	addrAddCount := 0
+	netlinkAddrAdd = standardNetlinkAddrAdd(&addrAddCount, expectedAddr)
+
+	if err := configureLink(ctx, link1, adapter); err != nil {
+		t.Fatalf("configureLink: %s", err)
+	}
+
+	if routeAddCount != len(expectedRoutes) {
+		t.Fatalf("expected to call routeAdd %d times, instead called it %d times", len(expectedRoutes), routeAddCount)
+	}
+
+	if addrAddCount != len(expectedAddr) {
+		t.Fatalf("expected to call addrAdd %d times, instead called it %d times", len(expectedAddr), addrAddCount)
+	}
+}
+
+func Test_configureLink_MultiRoute_IPv6(t *testing.T) {
+	ctx := context.Background()
+	link1 := newFakeLink("eth0", 0)
+	adapter := &guestresource.LCOWNetworkAdapter{
+		IPConfigs: []guestresource.LCOWIPConfig{
+			{
+				IPAddress:    "9541:a2d4:f0f3:18ff:c868:26ce:e9c4:30a6",
+				PrefixLength: 64,
+			},
+		},
+		Routes: []guestresource.LCOWRoute{
+			{
+				NextHop:           "::",
+				DestinationPrefix: "::/0",
+			},
+			{
+				NextHop:           "9541:a2d4:f0f3:18ff:c868:26ce:e9c4:aaaa",
+				DestinationPrefix: "::/0",
+			},
+			{
+				NextHop:           "9541:a2d4:f0f3:18ff:c868:26ce:e9c4:cccc",
+				DestinationPrefix: "fc49:65e9:61e8:5aa7:9680:dd25:8ce8:c4f0/64",
+			},
+			{
+				DestinationPrefix: "25a6:6c50:5564:4a67:d7d3:6aa3:7e1f:9786/64",
+			},
+		},
+	}
+	expectedRoutes := []*testRoute{
+		{
+			scope:    netlink.SCOPE_UNIVERSE,
+			gw:       "9541:a2d4:f0f3:18ff:c868:26ce:e9c4:aaaa",
+			priority: 0,
+		},
+		{
+			scope:    netlink.SCOPE_UNIVERSE,
+			gw:       "9541:a2d4:f0f3:18ff:c868:26ce:e9c4:cccc",
+			dstIP:    "fc49:65e9:61e8:5aa7:9680:dd25:8ce8:c4f0/64",
+			priority: 0,
+		},
+		{
+			scope:    netlink.SCOPE_UNIVERSE,
+			dstIP:    "25a6:6c50:5564:4a67:d7d3:6aa3:7e1f:9786/64",
+			priority: 0,
+		},
+	}
+	expectedAddr := []*testAddr{
+		{
+			ip:         "9541:a2d4:f0f3:18ff:c868:26ce:e9c4:30a6",
+			prefixLen:  64,
+			maskLength: ipv6TotalMaskLength,
+		},
+	}
+
+	routeAddCount := 0
+	netlinkRouteAdd = standardNetlinkRouteAdd(&routeAddCount, link1, expectedRoutes)
+
+	addrAddCount := 0
+	netlinkAddrAdd = standardNetlinkAddrAdd(&addrAddCount, expectedAddr)
+
+	if err := configureLink(ctx, link1, adapter); err != nil {
+		t.Fatalf("configureLink: %s", err)
+	}
+
+	if routeAddCount != len(expectedRoutes) {
+		t.Fatalf("expected to call routeAdd %d times, instead called it %d times", len(expectedRoutes), routeAddCount)
+	}
+
+	if addrAddCount != len(expectedAddr) {
+		t.Fatalf("expected to call addrAdd %d times, instead called it %d times", len(expectedAddr), addrAddCount)
+	}
+}
+
+func Test_configureLink_Bad_Route_IPv4(t *testing.T) {
+	ctx := context.Background()
+	link1 := newFakeLink("eth0", 0)
+	adapter := &guestresource.LCOWNetworkAdapter{
+		IPConfigs: []guestresource.LCOWIPConfig{
+			{
+				IPAddress:    "192.168.0.5",
+				PrefixLength: 24,
+			},
+		},
+		Routes: []guestresource.LCOWRoute{
+			{
+				// this is a bad route, destination prefix cannot be empty.
+				// Default gateways should have a destination prefix of "0.0.0.0/0"
+				NextHop: "192.168.0.100",
+			},
+		},
+	}
+
+	err := configureLink(ctx, link1, adapter)
+	if err == nil {
+		t.Fatal("configureLink expected error due to badly formed route")
+	}
+}

--- a/internal/guest/runtime/hcsv2/network.go
+++ b/internal/guest/runtime/hcsv2/network.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/Microsoft/hcsshim/internal/guest/gcserr"
 	"github.com/Microsoft/hcsshim/internal/guest/network"
-	"github.com/Microsoft/hcsshim/internal/guest/prot"
 	"github.com/Microsoft/hcsshim/internal/oc"
 	"github.com/Microsoft/hcsshim/internal/protocol/guestresource"
 )
@@ -215,12 +214,7 @@ func (n *namespace) Sync(ctx context.Context) (err error) {
 	defer n.m.Unlock()
 
 	if n.pid != 0 {
-		for i, a := range n.nics {
-			// Lower the metric for anything but the first adapter
-			// TODO: remove when we correctly support assigning metrics to the default GWs
-			if i > 0 {
-				a.adapter.EnableLowMetric = true
-			}
+		for _, a := range n.nics {
 			err = a.assignToPid(ctx, n.pid)
 			if err != nil {
 				return err
@@ -252,18 +246,6 @@ func (nin *nicInNamespace) assignToPid(ctx context.Context, pid int) (err error)
 		trace.StringAttribute("ifname", nin.ifname),
 		trace.Int64Attribute("pid", int64(pid)))
 
-	v1Adapter := &prot.NetworkAdapter{
-		NatEnabled:           (nin.adapter.IPAddress != "") || (nin.adapter.IPv6Address != ""),
-		AllocatedIPAddress:   nin.adapter.IPAddress,
-		HostIPAddress:        nin.adapter.GatewayAddress,
-		HostIPPrefixLength:   nin.adapter.PrefixLength,
-		AllocatedIPv6Address: nin.adapter.IPv6Address,
-		HostIPv6Address:      nin.adapter.IPv6GatewayAddress,
-		HostIPv6PrefixLength: nin.adapter.IPv6PrefixLength,
-		EnableLowMetric:      nin.adapter.EnableLowMetric,
-		EncapOverhead:        nin.adapter.EncapOverhead,
-	}
-
 	if err := network.MoveInterfaceToNS(nin.ifname, pid); err != nil {
 		return errors.Wrapf(err, "failed to move interface %s to network namespace", nin.ifname)
 	}
@@ -276,7 +258,7 @@ func (nin *nicInNamespace) assignToPid(ctx context.Context, pid int) (err error)
 	defer ns.Close()
 
 	netNSCfg := func() error {
-		return network.NetNSConfig(ctx, nin.ifname, pid, v1Adapter)
+		return network.NetNSConfig(ctx, nin.ifname, pid, nin.adapter)
 	}
 
 	if err := network.DoInNetNS(ns, netNSCfg); err != nil {

--- a/internal/guest/runtime/hcsv2/network.go
+++ b/internal/guest/runtime/hcsv2/network.go
@@ -214,7 +214,10 @@ func (n *namespace) Sync(ctx context.Context) (err error) {
 	defer n.m.Unlock()
 
 	if n.pid != 0 {
-		for _, a := range n.nics {
+		for i, a := range n.nics {
+			if a.adapter.PolicyBasedRouting && i > 0 {
+				a.adapter.EnableLowMetric = true
+			}
 			err = a.assignToPid(ctx, n.pid)
 			if err != nil {
 				return err

--- a/internal/guest/runtime/hcsv2/network.go
+++ b/internal/guest/runtime/hcsv2/network.go
@@ -215,8 +215,8 @@ func (n *namespace) Sync(ctx context.Context) (err error) {
 
 	if n.pid != 0 {
 		for i, a := range n.nics {
-			if a.adapter.PolicyBasedRouting && i > 0 {
-				a.adapter.EnableLowMetric = true
+			if a.adapter.PolicyBasedRouting {
+				a.adapter.EnableLowMetric = (i > 0)
 			}
 			err = a.assignToPid(ctx, n.pid)
 			if err != nil {

--- a/internal/oci/uvm.go
+++ b/internal/oci/uvm.go
@@ -331,7 +331,7 @@ func SpecToUVMCreateOpts(ctx context.Context, s *specs.Spec, id, owner string) (
 
 		// Add devices on the spec to the UVM's options
 		lopts.AssignedDevices = parseDevices(ctx, s.Windows)
-
+		lopts.PolicyBasedRouting = ParseAnnotationsBool(ctx, s.Annotations, annotations.NetworkingPolicyBasedRouting, lopts.PolicyBasedRouting)
 		return lopts, nil
 	} else if IsWCOW(s) {
 		wopts := uvm.NewDefaultOptionsWCOW(id, owner)

--- a/internal/oci/uvm.go
+++ b/internal/oci/uvm.go
@@ -331,7 +331,7 @@ func SpecToUVMCreateOpts(ctx context.Context, s *specs.Spec, id, owner string) (
 
 		// Add devices on the spec to the UVM's options
 		lopts.AssignedDevices = parseDevices(ctx, s.Windows)
-		lopts.PolicyBasedRouting = ParseAnnotationsBool(ctx, s.Annotations, annotations.NetworkingPolicyBasedRouting, lopts.PolicyBasedRouting)
+		lopts.PolicyBasedRouting = ParseAnnotationsBool(ctx, s.Annotations, iannotations.NetworkingPolicyBasedRouting, lopts.PolicyBasedRouting)
 		return lopts, nil
 	} else if IsWCOW(s) {
 		wopts := uvm.NewDefaultOptionsWCOW(id, owner)

--- a/internal/protocol/guestresource/resources.go
+++ b/internal/protocol/guestresource/resources.go
@@ -151,20 +151,26 @@ type LCOWMappedVPCIDevice struct {
 // LCOWNetworkAdapter represents a network interface and its associated
 // configuration in a namespace.
 type LCOWNetworkAdapter struct {
-	NamespaceID        string `json:",omitempty"`
-	ID                 string `json:",omitempty"`
-	MacAddress         string `json:",omitempty"`
-	IPAddress          string `json:",omitempty"`
-	PrefixLength       uint8  `json:",omitempty"`
-	GatewayAddress     string `json:",omitempty"`
-	IPv6Address        string `json:",omitempty"`
-	IPv6PrefixLength   uint8  `json:",omitempty"`
-	IPv6GatewayAddress string `json:",omitempty"`
-	DNSSuffix          string `json:",omitempty"`
-	DNSServerList      string `json:",omitempty"`
-	EnableLowMetric    bool   `json:",omitempty"`
-	EncapOverhead      uint16 `json:",omitempty"`
-	VPCIAssigned       bool   `json:",omitempty"`
+	NamespaceID   string         `json:",omitempty"`
+	ID            string         `json:",omitempty"`
+	MacAddress    string         `json:",omitempty"`
+	DNSSuffix     string         `json:",omitempty"`
+	DNSServerList string         `json:",omitempty"`
+	EncapOverhead uint16         `json:",omitempty"`
+	VPCIAssigned  bool           `json:",omitempty"`
+	IPConfigs     []LCOWIPConfig `json:",omitempty"`
+	Routes        []LCOWRoute    `json:",omitempty"`
+}
+
+type LCOWIPConfig struct {
+	IPAddress    string `json:",omitempty"`
+	PrefixLength uint8  `json:",omitempty"`
+}
+
+type LCOWRoute struct {
+	NextHop           string `json:",omitempty"`
+	DestinationPrefix string `json:",omitempty"`
+	Metric            uint16 `json:",omitempty"`
 }
 
 type LCOWContainerConstraints struct {

--- a/internal/protocol/guestresource/resources.go
+++ b/internal/protocol/guestresource/resources.go
@@ -160,6 +160,12 @@ type LCOWNetworkAdapter struct {
 	VPCIAssigned  bool           `json:",omitempty"`
 	IPConfigs     []LCOWIPConfig `json:",omitempty"`
 	Routes        []LCOWRoute    `json:",omitempty"`
+	// PolicyBasedRouting determines if we should use old policy based routing in the
+	// guest when configuring the endpoint.
+	PolicyBasedRouting bool `json:",omitempty"`
+	// EnableLowMetric is ONLY used by the guest when PolicyBasedRouting is set to
+	// indicate which endpoints should be added with a low metric (higher number).
+	EnableLowMetric bool `json:",omitempty"`
 }
 
 type LCOWIPConfig struct {

--- a/internal/uvm/create_lcow.go
+++ b/internal/uvm/create_lcow.go
@@ -133,6 +133,7 @@ type OptionsLCOW struct {
 	HclEnabled              *bool                // Whether to enable the host compatibility layer
 	ExtraVSockPorts         []uint32             // Extra vsock ports to allow
 	AssignedDevices         []VPCIDeviceID       // AssignedDevices are devices to add on pod boot
+	PolicyBasedRouting      bool                 // Whether we should use policy based routing when configuring net interfaces in guest
 }
 
 // defaultLCOWOSBootFilesPath returns the default path used to locate the LCOW
@@ -931,6 +932,7 @@ func CreateLCOW(ctx context.Context, opts *OptionsLCOW) (_ *UtilityVM, err error
 		encryptScratch:          opts.EnableScratchEncryption,
 		noWritableFileShares:    opts.NoWritableFileShares,
 		confidentialUVMOptions:  opts.ConfidentialOptions,
+		policyBasedRouting:      opts.PolicyBasedRouting,
 	}
 
 	defer func() {

--- a/internal/uvm/network.go
+++ b/internal/uvm/network.go
@@ -555,7 +555,7 @@ func getNetworkModifyRequest(adapterID string, requestType guestrequest.RequestT
 
 // convertToLCOWReq converts the HCN endpoint type to the guestresource.LCOWNetworkAdapter type that is
 // passed to the GCS for a request.
-func convertToLCOWReq(id string, endpoint *hcn.HostComputeEndpoint) (*guestresource.LCOWNetworkAdapter, error) {
+func convertToLCOWReq(id string, endpoint *hcn.HostComputeEndpoint, policyBasedRouting bool) (*guestresource.LCOWNetworkAdapter, error) {
 	req := &guestresource.LCOWNetworkAdapter{
 		NamespaceID: endpoint.HostComputeNamespace,
 		ID:          id,
@@ -597,6 +597,8 @@ func convertToLCOWReq(id string, endpoint *hcn.HostComputeEndpoint) (*guestresou
 			req.EncapOverhead = settings.Overhead
 		}
 	}
+
+	req.PolicyBasedRouting = policyBasedRouting
 
 	return req, nil
 }
@@ -640,7 +642,7 @@ func (uvm *UtilityVM) addNIC(ctx context.Context, id string, endpoint *hcn.HostC
 				nil),
 		}
 	} else {
-		s, err := convertToLCOWReq(id, endpoint)
+		s, err := convertToLCOWReq(id, endpoint, uvm.policyBasedRouting)
 		if err != nil {
 			return err
 		}

--- a/internal/uvm/network.go
+++ b/internal/uvm/network.go
@@ -4,6 +4,7 @@ package uvm
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"slices"
@@ -38,8 +39,8 @@ var (
 	ErrNICNotFound = errors.New("NIC not found in network namespace")
 )
 
-func sortEndpoints(endpoints []*hns.HNSEndpoint) {
-	cmp := func(a, b *hns.HNSEndpoint) int {
+func sortEndpoints(endpoints []*hcn.HostComputeEndpoint) {
+	cmp := func(a, b *hcn.HostComputeEndpoint) int {
 		if strings.HasSuffix(a.Name, "eth0") {
 			return -1
 		}
@@ -59,7 +60,7 @@ func (uvm *UtilityVM) SetupNetworkNamespace(ctx context.Context, nsid string) er
 	nsidInsideUVM := nsid
 
 	// Query endpoints with actual nsid
-	endpoints, err := GetNamespaceEndpoints(ctx, nsid)
+	endpoints, err := GetHCNNamespaceEndpoints(ctx, nsid)
 	if err != nil {
 		return err
 	}
@@ -92,22 +93,22 @@ func (uvm *UtilityVM) SetupNetworkNamespace(ctx context.Context, nsid string) er
 	return nil
 }
 
-// GetNamespaceEndpoints gets all endpoints in `netNS`
-func GetNamespaceEndpoints(ctx context.Context, netNS string) ([]*hns.HNSEndpoint, error) {
-	op := "uvm::GetNamespaceEndpoints"
+// GetHCNNamespaceEndpoints gets all endpoints in `netNS` with the HCN v2 API
+func GetHCNNamespaceEndpoints(ctx context.Context, netNS string) ([]*hcn.HostComputeEndpoint, error) {
+	op := "uvm::GetHCNNamespaceEndpoints"
 	l := log.G(ctx).WithField("netns-id", netNS)
 	l.Debug(op + " - Begin")
 	defer func() {
 		l.Debug(op + " - End")
 	}()
 
-	ids, err := hns.GetNamespaceEndpoints(netNS)
+	ids, err := hcn.GetNamespaceEndpointIds(netNS)
 	if err != nil {
 		return nil, err
 	}
-	var endpoints []*hns.HNSEndpoint
+	var endpoints []*hcn.HostComputeEndpoint
 	for _, id := range ids {
-		endpoint, err := hns.GetHNSEndpointByID(id)
+		endpoint, err := hcn.GetEndpointByID(id)
 		if err != nil {
 			return nil, err
 		}
@@ -382,13 +383,18 @@ func (uvm *UtilityVM) AddNetNSByID(ctx context.Context, id string) error {
 //
 // If no network namespace matches `id` returns `ErrNetNSNotFound`.
 func (uvm *UtilityVM) AddEndpointToNSWithID(ctx context.Context, nsID, nicID string, endpoint *hns.HNSEndpoint) error {
+	// get the v2 endpoint
+	endpointV2, err := hcn.GetEndpointByID(endpoint.Id)
+	if err != nil {
+		return err
+	}
 	uvm.m.Lock()
 	defer uvm.m.Unlock()
 	ns, ok := uvm.namespaces[nsID]
 	if !ok {
 		return ErrNetNSNotFound
 	}
-	if _, ok := ns.nics[endpoint.Id]; !ok {
+	if _, ok := ns.nics[endpointV2.Id]; !ok {
 		if nicID == "" {
 			id, err := guid.NewV4()
 			if err != nil {
@@ -396,12 +402,12 @@ func (uvm *UtilityVM) AddEndpointToNSWithID(ctx context.Context, nsID, nicID str
 			}
 			nicID = id.String()
 		}
-		if err := uvm.addNIC(ctx, nicID, endpoint); err != nil {
+		if err := uvm.addNIC(ctx, nicID, endpointV2); err != nil {
 			return err
 		}
-		ns.nics[endpoint.Id] = &nicInfo{
+		ns.nics[endpointV2.Id] = &nicInfo{
 			ID:       nicID,
-			Endpoint: endpoint,
+			Endpoint: endpointV2,
 		}
 	}
 	return nil
@@ -412,7 +418,7 @@ func (uvm *UtilityVM) AddEndpointToNSWithID(ctx context.Context, nsID, nicID str
 // added endpoints.
 //
 // If no network namespace matches `id` returns `ErrNetNSNotFound`.
-func (uvm *UtilityVM) AddEndpointsToNS(ctx context.Context, id string, endpoints []*hns.HNSEndpoint) error {
+func (uvm *UtilityVM) AddEndpointsToNS(ctx context.Context, id string, endpoints []*hcn.HostComputeEndpoint) error {
 	uvm.m.Lock()
 	defer uvm.m.Unlock()
 
@@ -547,8 +553,56 @@ func getNetworkModifyRequest(adapterID string, requestType guestrequest.RequestT
 	}
 }
 
+// convertToLCOWReq converts the HCN endpoint type to the guestresource.LCOWNetworkAdapter type that is
+// passed to the GCS for a request.
+func convertToLCOWReq(id string, endpoint *hcn.HostComputeEndpoint) (*guestresource.LCOWNetworkAdapter, error) {
+	req := &guestresource.LCOWNetworkAdapter{
+		NamespaceID: endpoint.HostComputeNamespace,
+		ID:          id,
+		MacAddress:  endpoint.MacAddress,
+	}
+
+	for _, i := range endpoint.IpConfigurations {
+		ipConfig := guestresource.LCOWIPConfig{
+			IPAddress:    i.IpAddress,
+			PrefixLength: i.PrefixLength,
+		}
+		if req.IPConfigs == nil {
+			req.IPConfigs = make([]guestresource.LCOWIPConfig, 0)
+		}
+		req.IPConfigs = append(req.IPConfigs, ipConfig)
+	}
+
+	for _, r := range endpoint.Routes {
+		if req.Routes == nil {
+			req.Routes = make([]guestresource.LCOWRoute, 0)
+		}
+		newRoute := guestresource.LCOWRoute{
+			DestinationPrefix: r.DestinationPrefix,
+			NextHop:           r.NextHop,
+			Metric:            r.Metric,
+		}
+		req.Routes = append(req.Routes, newRoute)
+	}
+
+	req.DNSSuffix = endpoint.Dns.Domain
+	req.DNSServerList = strings.Join(endpoint.Dns.ServerList, ",")
+
+	for _, p := range endpoint.Policies {
+		if p.Type == hcn.EncapOverhead {
+			var settings hcn.EncapOverheadEndpointPolicySetting
+			if err := json.Unmarshal(p.Settings, &settings); err != nil {
+				return nil, fmt.Errorf("unmarshal encap overhead policy setting: %w", err)
+			}
+			req.EncapOverhead = settings.Overhead
+		}
+	}
+
+	return req, nil
+}
+
 // addNIC adds a nic to the Utility VM.
-func (uvm *UtilityVM) addNIC(ctx context.Context, id string, endpoint *hns.HNSEndpoint) error {
+func (uvm *UtilityVM) addNIC(ctx context.Context, id string, endpoint *hcn.HostComputeEndpoint) error {
 	// First a pre-add. This is a guest-only request and is only done on Windows.
 	if uvm.operatingSystem == "windows" {
 		preAddRequest := hcsschema.ModifySettingRequest{
@@ -586,31 +640,12 @@ func (uvm *UtilityVM) addNIC(ctx context.Context, id string, endpoint *hns.HNSEn
 				nil),
 		}
 	} else {
+		s, err := convertToLCOWReq(id, endpoint)
+		if err != nil {
+			return err
+		}
+
 		// Verify this version of LCOW supports Network HotAdd
-		s := &guestresource.LCOWNetworkAdapter{
-			NamespaceID:     endpoint.Namespace.ID,
-			ID:              id,
-			MacAddress:      endpoint.MacAddress,
-			IPAddress:       endpoint.IPAddress.String(),
-			PrefixLength:    endpoint.PrefixLength,
-			GatewayAddress:  endpoint.GatewayAddress,
-			DNSSuffix:       endpoint.DNSSuffix,
-			DNSServerList:   endpoint.DNSServerList,
-			EnableLowMetric: endpoint.EnableLowMetric,
-			EncapOverhead:   endpoint.EncapOverhead,
-		}
-		if v6 := endpoint.IPv6Address.To16(); v6 != nil && !v6.IsUnspecified() {
-			// if the address is empty or invalid, endpoint.IPv6Address.String will be "<nil>"
-			// since we should be guranteed an IPv4, but not a v6, skip invalid v6 address
-			s.IPv6Address = v6.String()
-			s.IPv6PrefixLength = endpoint.IPv6PrefixLength
-			s.IPv6GatewayAddress = endpoint.GatewayAddressV6
-			log.G(ctx).WithFields(logrus.Fields{
-				"ip":           s.IPAddress,
-				"prefixLength": s.IPv6PrefixLength,
-				"gateway":      s.IPv6GatewayAddress,
-			}).Debug("adding IPv6 settings")
-		}
 		if uvm.isNetworkNamespaceSupported() {
 			request.GuestRequest = guestrequest.ModificationRequest{
 				ResourceType: guestresource.ResourceTypeNetwork,
@@ -627,7 +662,7 @@ func (uvm *UtilityVM) addNIC(ctx context.Context, id string, endpoint *hns.HNSEn
 	return nil
 }
 
-func (uvm *UtilityVM) removeNIC(ctx context.Context, id string, endpoint *hns.HNSEndpoint) error {
+func (uvm *UtilityVM) removeNIC(ctx context.Context, id string, endpoint *hcn.HostComputeEndpoint) error {
 	request := hcsschema.ModifySettingRequest{
 		RequestType:  guestrequest.RequestTypeRemove,
 		ResourcePath: fmt.Sprintf(resourcepaths.NetworkResourceFormat, id),
@@ -652,7 +687,7 @@ func (uvm *UtilityVM) removeNIC(ctx context.Context, id string, endpoint *hns.HN
 				ResourceType: guestresource.ResourceTypeNetwork,
 				RequestType:  guestrequest.RequestTypeRemove,
 				Settings: &guestresource.LCOWNetworkAdapter{
-					NamespaceID: endpoint.Namespace.ID,
+					NamespaceID: endpoint.HostComputeNamespace,
 					ID:          endpoint.Id,
 				},
 			}

--- a/internal/uvm/network.go
+++ b/internal/uvm/network.go
@@ -560,6 +560,8 @@ func convertToLCOWReq(id string, endpoint *hcn.HostComputeEndpoint, policyBasedR
 		NamespaceID: endpoint.HostComputeNamespace,
 		ID:          id,
 		MacAddress:  endpoint.MacAddress,
+		IPConfigs:   make([]guestresource.LCOWIPConfig, 0, len(endpoint.IpConfigurations)),
+		Routes:      make([]guestresource.LCOWRoute, 0, len(endpoint.Routes)),
 	}
 
 	for _, i := range endpoint.IpConfigurations {
@@ -567,16 +569,10 @@ func convertToLCOWReq(id string, endpoint *hcn.HostComputeEndpoint, policyBasedR
 			IPAddress:    i.IpAddress,
 			PrefixLength: i.PrefixLength,
 		}
-		if req.IPConfigs == nil {
-			req.IPConfigs = make([]guestresource.LCOWIPConfig, 0)
-		}
 		req.IPConfigs = append(req.IPConfigs, ipConfig)
 	}
 
 	for _, r := range endpoint.Routes {
-		if req.Routes == nil {
-			req.Routes = make([]guestresource.LCOWRoute, 0)
-		}
 		newRoute := guestresource.LCOWRoute{
 			DestinationPrefix: r.DestinationPrefix,
 			NextHop:           r.NextHop,

--- a/internal/uvm/network_test.go
+++ b/internal/uvm/network_test.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/Microsoft/hcsshim/internal/hns"
+	"github.com/Microsoft/hcsshim/hcn"
 )
 
 func Test_SortEndpoints(t *testing.T) {
@@ -50,9 +50,9 @@ func Test_SortEndpoints(t *testing.T) {
 	}
 	for i, test := range tests {
 		t.Run(fmt.Sprint(t.Name(), i), func(st *testing.T) {
-			endpoints := []*hns.HNSEndpoint{}
+			endpoints := []*hcn.HostComputeEndpoint{}
 			for _, n := range test.endpointNames {
-				e := &hns.HNSEndpoint{
+				e := &hcn.HostComputeEndpoint{
 					Name: n,
 				}
 				endpoints = append(endpoints, e)

--- a/internal/uvm/types.go
+++ b/internal/uvm/types.go
@@ -11,9 +11,9 @@ import (
 	"github.com/Microsoft/go-winio/pkg/guid"
 	"golang.org/x/sys/windows"
 
+	"github.com/Microsoft/hcsshim/hcn"
 	"github.com/Microsoft/hcsshim/internal/gcs"
 	"github.com/Microsoft/hcsshim/internal/hcs"
-	"github.com/Microsoft/hcsshim/internal/hns"
 	"github.com/Microsoft/hcsshim/internal/uvm/scsi"
 )
 
@@ -25,7 +25,7 @@ import (
 
 type nicInfo struct {
 	ID       string
-	Endpoint *hns.HNSEndpoint
+	Endpoint *hcn.HostComputeEndpoint
 }
 
 type namespaceInfo struct {

--- a/internal/uvm/types.go
+++ b/internal/uvm/types.go
@@ -139,6 +139,9 @@ type UtilityVM struct {
 
 	// confidentialUVMOptions hold confidential UVM specific options
 	confidentialUVMOptions *ConfidentialOptions
+
+	// LCOW only. Indicates whether to use policy based routing when configuring net interfaces in the guest.
+	policyBasedRouting bool
 }
 
 func (uvm *UtilityVM) ScratchEncryptionEnabled() bool {

--- a/pkg/annotations/annotations.go
+++ b/pkg/annotations/annotations.go
@@ -343,6 +343,11 @@ const (
 	// number of memory blocks at slice index 1, etc.
 	// This should be used for explicit vNUMA topology.
 	NumaCountOfMemoryBlocks = "io.microsoft.virtualmachine.computetopology.numa.count-of-memory-blocks"
+
+	// NetworkingPolicyBasedRouting toggles on the ability to set naive policy based routing
+	// in the guest for LCOW. This support should either be extended or removed in the near
+	// future based on customer experience.
+	NetworkingPolicyBasedRouting = "io.microsoft.virtualmachine.lcow.network.policybasedrouting"
 )
 
 // AnnotationExpansions maps annotations that will be expanded into an array of

--- a/pkg/annotations/annotations.go
+++ b/pkg/annotations/annotations.go
@@ -343,11 +343,6 @@ const (
 	// number of memory blocks at slice index 1, etc.
 	// This should be used for explicit vNUMA topology.
 	NumaCountOfMemoryBlocks = "io.microsoft.virtualmachine.computetopology.numa.count-of-memory-blocks"
-
-	// NetworkingPolicyBasedRouting toggles on the ability to set naive policy based routing
-	// in the guest for LCOW. This support should either be extended or removed in the near
-	// future based on customer experience.
-	NetworkingPolicyBasedRouting = "io.microsoft.virtualmachine.lcow.network.policybasedrouting"
 )
 
 // AnnotationExpansions maps annotations that will be expanded into an array of


### PR DESCRIPTION
- switch to HCN v2 endpoint API by default 
- Support parsing routes in GCS when we setup the network interfaces
- [breaking] update gcs bridge LCOW network adapter type with new fields that better align with v2 endpoint
- Add unit tests for new GCS side changes
- Add support for the legacy policy based routing with the new endpoint type 
The motivation for this change was to support adding custom routes on interfaces. However, the v1 endpoint implementation does not have this support. Therefore, we needed to move to the V2 implementation.