### PR TITLE
Use abs path to testing binary

### DIFF
--- a/test/functional/hvsock_test.go
+++ b/test/functional/hvsock_test.go
@@ -1140,8 +1140,8 @@ func goBlockT[T any](f func() T) <-chan T {
 
 // reExecSelfShareUVM shares the current testing binary directly into the specified uVM,
 //
-// This assumes that binary will be run directly on a uVM, and not from within a container.
-// For the later case, see [reExecSelfCmd].
+// This assumes that the binary will be run directly on a uVM, and not from within a container.
+// For the latter case, see [reExecSelfCmd].
 //
 // See [util.ReExecSelfGuestPath] for information on generating the guest path.
 func reExecSelfShareUVM(ctx context.Context, tb testing.TB, vm *uvm.UtilityVM, base string) string {

--- a/test/internal/util/reexec_windows.go
+++ b/test/internal/util/reexec_windows.go
@@ -21,7 +21,7 @@ func ReExecSelfGuestPath(ctx context.Context, tb testing.TB, base string) (strin
 	tb.Helper()
 
 	if base == "" {
-		base = `C:\`
+		base = ReExecDefaultGuestPathBase
 	}
 
 	self := TestingBinaryPath(ctx, tb)

--- a/test/internal/util/reexec_windows.go
+++ b/test/internal/util/reexec_windows.go
@@ -1,0 +1,29 @@
+//go:build windows
+
+package util
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+)
+
+// windows only because TestingBinaryPath is Windows only as well, and the default path is `C:\`
+
+// Default path to share the current testing binary under.
+const ReExecDefaultGuestPathBase = `C:\`
+
+// ReExecSelfGuestPath returns the path to the current testing binary, as well as the
+// path should be shared (under the path specified by base).
+//
+// If base is empty, [ReExecDefaultGuestPathBase] will be used.
+func ReExecSelfGuestPath(ctx context.Context, tb testing.TB, base string) (string, string) {
+	tb.Helper()
+
+	if base == "" {
+		base = `C:\`
+	}
+
+	self := TestingBinaryPath(ctx, tb)
+	return self, filepath.Join(base, filepath.Base(self))
+}

--- a/test/internal/util/util_windows.go
+++ b/test/internal/util/util_windows.go
@@ -4,7 +4,12 @@ package util
 
 import (
 	"context"
+	"fmt"
 	"os"
+	"sync"
+	"testing"
+
+	"github.com/Microsoft/go-winio/pkg/fs"
 
 	"github.com/Microsoft/hcsshim/internal/wclayer"
 )
@@ -16,4 +21,26 @@ func DestroyLayer(ctx context.Context, p string) (err error) {
 		return nil
 	}
 	return repeat(func() error { return wclayer.DestroyLayer(ctx, p) }, RemoveAttempts, RemoveWait)
+}
+
+// executablePathOnce returns the current testing binary image
+var executablePathOnce = sync.OnceValues(func() (string, error) {
+	// use [os.Executable] over `os.Args[0]` to make sure path is absolute
+	// as always, this shouldn't really fail, but just to be safe...
+	p, err := os.Executable()
+	if err != nil {
+		return "", fmt.Errorf("retrieve executable path: %w", err)
+	}
+	// just to be safe (and address the comments on [os.Executable]), resolve the path
+	return fs.ResolvePath(p)
+})
+
+func TestingBinaryPath(_ context.Context, tb testing.TB) string {
+	tb.Helper()
+
+	p, err := executablePathOnce()
+	if err != nil {
+		tb.Fatalf("could not get testing binary path: %v", err)
+	}
+	return p
 }


### PR DESCRIPTION
Use the full path to the `functional.test.exe` binary when sharing into the uVM for the `TestHVSock_*` test cases in
`test\functional\hvsock_test.go` to prevent vSMB share issues.

Otherwise, `os.Args[0]` will return the path that the tests were run with (e.g., `.\functional.test.exe`), which can cause vSMB to fail with `The parameter is incorrect.` (likely because it cannot find the current file).