### PR TITLE
Fix duplicate artifact name in github CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -390,7 +390,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: ${{ github.event_name == 'pull_request' }}
         with:
-          name: test_binaries_${{ matrix.os }}
+          name: test_binaries_${{ matrix.name }}
           path: |
             test/containerd-shim-runhcs-v1.test.exe
             test/cri-containerd.test.exe


### PR DESCRIPTION
This PR fixes a bug that broke the `test-windows` step in the CI. The `matrix.os` was previously removed and not replaced. 

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL393-R393): Updated the `name` field for the uploaded artifact to use `matrix.name` instead of `matrix.os`.