### PR TITLE
github-actions: update lint action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.54
+          version: v1.64
           args: >-
             --verbose
             --max-issues-per-linter=0
@@ -45,6 +45,7 @@ jobs:
             --timeout=10m
             --config=${{ github.workspace }}/.golangci.yml
           working-directory: ${{ github.workspace }}/${{ matrix.root }}
+          only-new-issues: true
         env:
           GOOS: ${{ matrix.goos }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,6 @@ jobs:
             --timeout=10m
             --config=${{ github.workspace }}/.golangci.yml
           working-directory: ${{ github.workspace }}/${{ matrix.root }}
-          only-new-issues: true
         env:
           GOOS: ${{ matrix.goos }}
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,9 +5,6 @@ run:
     - admin
     - functional
     - integration
-  skip-dirs:
-    # paths are relative to module root
-    - cri-containerd/test-images
 
 linters:
   enable:
@@ -34,13 +31,15 @@ linters-settings:
       # struct order is often for Win32 compat
       # also, ignore pointer bytes/GC issues for now until performance becomes an issue
       - fieldalignment
-    check-shadowing: true
 
   stylecheck:
     # https://staticcheck.io/docs/checks
     checks: ["all"]
 
 issues:
+  exclude-dirs:
+    # paths are relative to module root
+    - cri-containerd/test-images
   exclude-rules:
     # err is very often shadowed in nested scopes
     - linters:

--- a/hcn/hcnerrors.go
+++ b/hcn/hcnerrors.go
@@ -39,7 +39,7 @@ func checkForErrors(methodName string, hr error, resultBuffer *uint16) error {
 
 	if errorFound {
 		returnError := new(hr, methodName, result)
-		logrus.Debugf(returnError.Error()) // HCN errors logged for debugging.
+		logrus.Debug(returnError.Error()) // HCN errors logged for debugging.
 		return returnError
 	}
 

--- a/internal/exec/exec.go
+++ b/internal/exec/exec.go
@@ -175,7 +175,7 @@ func (e *Exec) Start() error {
 	pSec := &windows.SecurityAttributes{Length: uint32(unsafe.Sizeof(zeroSec)), InheritHandle: 1}
 	tSec := &windows.SecurityAttributes{Length: uint32(unsafe.Sizeof(zeroSec)), InheritHandle: 1}
 
-	siEx.ProcThreadAttributeList = attrList.List() //nolint:govet // unusedwrite: ProcThreadAttributeList will be read in syscall
+	siEx.ProcThreadAttributeList = attrList.List()
 	siEx.Cb = uint32(unsafe.Sizeof(*siEx))
 	if e.execConfig.token != 0 {
 		err = windows.CreateProcessAsUser(

--- a/internal/guest/gcserr/errors.go
+++ b/internal/guest/gcserr/errors.go
@@ -73,11 +73,11 @@ func BaseStackTrace(e error) errors.StackTrace {
 	cause := e
 	var tracer StackTracer
 	for cause != nil {
-		serr, ok := cause.(StackTracer) //nolint:errorlint
+		serr, ok := cause.(StackTracer)
 		if ok {
 			tracer = serr
 		}
-		cerr, ok := cause.(causer) //nolint:errorlint
+		cerr, ok := cause.(causer)
 		if !ok {
 			break
 		}
@@ -132,7 +132,7 @@ func (e *wrappingHresultError) StackTrace() errors.StackTrace {
 	type stackTracer interface {
 		StackTrace() errors.StackTrace
 	}
-	serr, ok := e.Cause().(stackTracer) //nolint:errorlint
+	serr, ok := e.Cause().(stackTracer)
 	if !ok {
 		return nil
 	}
@@ -167,11 +167,11 @@ func GetHresult(e error) (Hresult, error) {
 	}
 	cause := e
 	for cause != nil {
-		herr, ok := cause.(hresulter) //nolint:errorlint
+		herr, ok := cause.(hresulter)
 		if ok {
 			return herr.Hresult(), nil
 		}
-		cerr, ok := cause.(causer) //nolint:errorlint
+		cerr, ok := cause.(causer)
 		if !ok {
 			break
 		}

--- a/internal/guest/network/netns_test.go
+++ b/internal/guest/network/netns_test.go
@@ -6,6 +6,7 @@ package network
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"strings"
@@ -72,7 +73,7 @@ func unreachableNetlinkRouteAdd(count *int, link netlink.Link, expected []*testR
 		if err := f(route); err != nil {
 			return err
 		}
-		return fmt.Errorf(unreachableErrStr)
+		return errors.New(unreachableErrStr)
 	}
 }
 

--- a/internal/hcs/process.go
+++ b/internal/hcs/process.go
@@ -63,10 +63,10 @@ func (process *Process) SystemID() string {
 }
 
 func (process *Process) processSignalResult(ctx context.Context, err error) (bool, error) {
-	switch err { //nolint:errorlint
-	case nil:
+	if err == nil {
 		return true, nil
-	case ErrVmcomputeOperationInvalidState, ErrComputeSystemDoesNotExist, ErrElementNotFound:
+	}
+	if errors.Is(err, ErrVmcomputeOperationInvalidState) || errors.Is(err, ErrComputeSystemDoesNotExist) || errors.Is(err, ErrElementNotFound) {
 		if !process.stopped() {
 			// The process should be gone, but we have not received the notification.
 			// After a second, force unblock the process wait to work around a possible
@@ -82,9 +82,8 @@ func (process *Process) processSignalResult(ctx context.Context, err error) (boo
 			}()
 		}
 		return false, nil
-	default:
-		return false, err
 	}
+	return false, nil
 }
 
 // Signal signals the process with `options`.

--- a/internal/hns/hnsaccelnet.go
+++ b/internal/hns/hnsaccelnet.go
@@ -47,7 +47,7 @@ func (nnvManagementMacList *HNSNnvManagementMacList) Set() (*HNSNnvManagementMac
 func GetNnvManagementMacAddressList() (*HNSNnvManagementMacList, error) {
 	operation := "Get"
 	title := "hcsshim::nnvManagementMacList::" + operation
-	logrus.Debugf(title)
+	logrus.Debug(title)
 	return HNSNnvManagementMacRequest("GET", "", "")
 }
 
@@ -55,6 +55,6 @@ func GetNnvManagementMacAddressList() (*HNSNnvManagementMacList, error) {
 func DeleteNnvManagementMacAddressList() (*HNSNnvManagementMacList, error) {
 	operation := "Delete"
 	title := "hcsshim::nnvManagementMacList::" + operation
-	logrus.Debugf(title)
+	logrus.Debug(title)
 	return HNSNnvManagementMacRequest("DELETE", "", "")
 }

--- a/internal/regopolicyinterpreter/regopolicyinterpreter.go
+++ b/internal/regopolicyinterpreter/regopolicyinterpreter.go
@@ -543,7 +543,7 @@ func (r *RegoPolicyInterpreter) query(rule string, input map[string]interface{})
 	resultSet, err := query.Eval(ctx)
 	output := buf.String()
 
-	r.logInfo(output)
+	r.logInfo("%s", output)
 
 	return resultSet, err
 }

--- a/internal/vmcompute/vmcompute.go
+++ b/internal/vmcompute/vmcompute.go
@@ -104,7 +104,7 @@ func execute(ctx gcontext.Context, timeout time.Duration, f func() error) error 
 	}()
 	select {
 	case <-ctx.Done():
-		if ctx.Err() == gcontext.DeadlineExceeded { //nolint:errorlint
+		if ctx.Err() == gcontext.DeadlineExceeded {
 			log.G(ctx).WithField(logfields.Timeout, trueTimeout).
 				Warning("Syscall did not complete within operation timeout. This may indicate a platform issue. " +
 					"If it appears to be making no forward progress, obtain the stacks and see if there is a syscall " +


### PR DESCRIPTION
seems like something broke with newer golang versions.

Update golangci-lint version and set `only-new-issues` to `true`.