### PR TITLE
Add missing GetCurrentThreadCompartmentId

### DIFF
--- a/hcn/hcn.go
+++ b/hcn/hcn.go
@@ -15,6 +15,7 @@ import (
 /// HNS V1 API
 
 //sys SetCurrentThreadCompartmentId(compartmentId uint32) (hr error) = iphlpapi.SetCurrentThreadCompartmentId
+//sys GetCurrentThreadCompartmentId() (compartmentId uint32) = iphlpapi.GetCurrentThreadCompartmentId
 //sys _hnsCall(method string, path string, object string, response **uint16) (hr error) = vmcompute.HNSCall?
 
 /// HCN V2 API

--- a/hcn/zsyscall_windows.go
+++ b/hcn/zsyscall_windows.go
@@ -77,6 +77,7 @@ var (
 	procHcnQueryNetworkProperties      = modcomputenetwork.NewProc("HcnQueryNetworkProperties")
 	procHcnQuerySdnRouteProperties     = modcomputenetwork.NewProc("HcnQuerySdnRouteProperties")
 	procSetCurrentThreadCompartmentId  = modiphlpapi.NewProc("SetCurrentThreadCompartmentId")
+	procGetCurrentThreadCompartmentId = modiphlpapi.NewProc("GetCurrentThreadCompartmentId")
 	procHNSCall                        = modvmcompute.NewProc("HNSCall")
 )
 
@@ -793,6 +794,12 @@ func SetCurrentThreadCompartmentId(compartmentId uint32) (hr error) {
 		}
 		hr = syscall.Errno(r0)
 	}
+	return
+}
+
+func GetCurrentThreadCompartmentId() (compartmentId uint32) {
+	r0, _, _ := syscall.SyscallN(procGetCurrentThreadCompartmentId.Addr())
+	compartmentId = uint32(r0)
 	return
 }
 

--- a/hcn/zsyscall_windows.go
+++ b/hcn/zsyscall_windows.go
@@ -76,8 +76,8 @@ var (
 	procHcnQueryNamespaceProperties    = modcomputenetwork.NewProc("HcnQueryNamespaceProperties")
 	procHcnQueryNetworkProperties      = modcomputenetwork.NewProc("HcnQueryNetworkProperties")
 	procHcnQuerySdnRouteProperties     = modcomputenetwork.NewProc("HcnQuerySdnRouteProperties")
+	procGetCurrentThreadCompartmentId  = modiphlpapi.NewProc("GetCurrentThreadCompartmentId")
 	procSetCurrentThreadCompartmentId  = modiphlpapi.NewProc("SetCurrentThreadCompartmentId")
-	procGetCurrentThreadCompartmentId = modiphlpapi.NewProc("GetCurrentThreadCompartmentId")
 	procHNSCall                        = modvmcompute.NewProc("HNSCall")
 )
 
@@ -786,6 +786,12 @@ func _hcnQueryRouteProperties(route hcnRoute, query *uint16, properties **uint16
 	return
 }
 
+func GetCurrentThreadCompartmentId() (compartmentId uint32) {
+	r0, _, _ := syscall.SyscallN(procGetCurrentThreadCompartmentId.Addr())
+	compartmentId = uint32(r0)
+	return
+}
+
 func SetCurrentThreadCompartmentId(compartmentId uint32) (hr error) {
 	r0, _, _ := syscall.SyscallN(procSetCurrentThreadCompartmentId.Addr(), uintptr(compartmentId))
 	if int32(r0) < 0 {
@@ -794,12 +800,6 @@ func SetCurrentThreadCompartmentId(compartmentId uint32) (hr error) {
 		}
 		hr = syscall.Errno(r0)
 	}
-	return
-}
-
-func GetCurrentThreadCompartmentId() (compartmentId uint32) {
-	r0, _, _ := syscall.SyscallN(procGetCurrentThreadCompartmentId.Addr())
-	compartmentId = uint32(r0)
 	return
 }
 

--- a/hcsshim.go
+++ b/hcsshim.go
@@ -14,6 +14,7 @@ import (
 //go:generate go run github.com/Microsoft/go-winio/tools/mkwinsyscall -output zsyscall_windows.go hcsshim.go
 
 //sys SetCurrentThreadCompartmentId(compartmentId uint32) (hr error) = iphlpapi.SetCurrentThreadCompartmentId
+//sys GetCurrentThreadCompartmentId() (compartmentId uint32) = iphlpapi.GetCurrentThreadCompartmentId
 
 const (
 	// Specific user-visible exit codes

--- a/zsyscall_windows.go
+++ b/zsyscall_windows.go
@@ -39,8 +39,15 @@ func errnoErr(e syscall.Errno) error {
 var (
 	modiphlpapi = windows.NewLazySystemDLL("iphlpapi.dll")
 
+	procGetCurrentThreadCompartmentId = modiphlpapi.NewProc("GetCurrentThreadCompartmentId")
 	procSetCurrentThreadCompartmentId = modiphlpapi.NewProc("SetCurrentThreadCompartmentId")
 )
+
+func GetCurrentThreadCompartmentId() (compartmentId uint32) {
+	r0, _, _ := syscall.SyscallN(procGetCurrentThreadCompartmentId.Addr())
+	compartmentId = uint32(r0)
+	return
+}
 
 func SetCurrentThreadCompartmentId(compartmentId uint32) (hr error) {
 	r0, _, _ := syscall.SyscallN(procSetCurrentThreadCompartmentId.Addr(), uintptr(compartmentId))


### PR DESCRIPTION
I'm working on a container networking project and noticed this function was missing. I took a stab at adding it, but let me know if changes (or a different approach) is needed.