### PR TITLE
Synchronize organization name with other Go modules

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/Microsoft/hcsshim
+module github.com/microsoft/hcsshim
 
 go 1.22.0
 


### PR DESCRIPTION
Other modules in the organization use lowercase. Due to the difference in case, some proprietary build systems cannot install the hcsshim package if other Microsoft modules are already installed.