### PR TITLE
Tool for extracting UtilityVM files from a container layer into a CIM

### DIFF
--- a/cmd/mkuvmcim/main.go
+++ b/cmd/mkuvmcim/main.go
@@ -1,0 +1,47 @@
+//go:build windows
+// +build windows
+
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/Microsoft/hcsshim/pkg/extractuvm"
+)
+
+func run() error {
+	var (
+		layerTar string
+		destPath string
+	)
+
+	flag.StringVar(&layerTar, "layer", "", "Path to the gzipped layer tar")
+	flag.StringVar(&destPath, "dest", "", "Path to the destination directory")
+	flag.Parse()
+
+	if layerTar == "" || destPath == "" {
+		flag.Usage()
+		return fmt.Errorf("both -layer and -dest flags are required")
+	}
+
+	// 5 minutes should be more than enough to extract all the files
+	ctx, cancelFunc := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancelFunc()
+
+	_, err := extractuvm.MakeUtilityVMCIMFromTar(ctx, layerTar, destPath)
+	if err != nil {
+		return fmt.Errorf("failed to create UVM CIM: %w", err)
+	}
+	return nil
+}
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintf(os.Stderr, "%s\n", err)
+		os.Exit(1)
+	}
+}

--- a/pkg/extractuvm/bcim.go
+++ b/pkg/extractuvm/bcim.go
@@ -1,0 +1,208 @@
+//go:build windows
+// +build windows
+
+package extractuvm
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+
+	"github.com/Microsoft/hcsshim/pkg/cimfs"
+)
+
+const (
+	LevelTrace = slog.Level(-8)
+)
+
+func MakeUtilityVMCIMFromTar(ctx context.Context, tarPath, destPath string) (_ *cimfs.BlockCIM, err error) {
+	slog.InfoContext(ctx, "Extracting UtilityVM files from tar", "tarPath", tarPath, "destPath", destPath)
+
+	tarFile, err := os.Open(tarPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open layer tar: %w", err)
+	}
+	defer tarFile.Close()
+
+	err = os.MkdirAll(destPath, 0755)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create destination directory: %w", err)
+	}
+
+	uvmCIM := &cimfs.BlockCIM{
+		Type:      cimfs.BlockCIMTypeSingleFile,
+		BlockPath: filepath.Join(destPath, "boot.bcim"),
+		CimName:   "boot.cim",
+	}
+
+	w, err := newUVMCIMWriter(uvmCIM)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create block CIM writer: %w", err)
+	}
+	defer func() {
+		cErr := w.Close(ctx)
+		if err == nil {
+			err = cErr
+		}
+	}()
+
+	if err = extractUtilityVMFilesFromTar(ctx, tarFile, w); err != nil {
+		return nil, fmt.Errorf("failed to extract UVM layer: %w", err)
+	}
+	return uvmCIM, nil
+}
+
+// extractUtilityVMFilesFromTar writes all the files in the tar under the
+// `UitilityVM/Files` directory into the CIM.  For windows container image layer tarballs,
+// there is complex web of hardlinks between the files under `Files` &
+// `UtilityVM/Files`. To correctly handle this when extracting UtilityVM files this code
+// makes following assumptions based on the way windows layer tarballs are currently
+// structured:
+// 1. If tar iteration comes across a file of type `TypeLink`, the target that this link points to MUST have already been iterated over.
+// 2. When iterating over the tarball, `Files` directory tree always comes before the `UtilityVM/Files` directory.
+// 3. There are hardlinks under `UtilityVM/Files` that point to files under `Files` but not vice versa.
+// 4. Since this routine is supposed to be used on a base layer tarball, it doesn't expect any whiteout files in the tarball.
+// 5. Files of type `TypeSymlink` are not generally used windows base layers and so the code errors out if it sees such files. Same is the case for files with alternate data streams.
+// 6. There are no directories under `UtilityVM/Files` that are hardlinks to directories under `Files`. Only files can be hardlinks.
+func extractUtilityVMFilesFromTar(ctx context.Context, tarFile *os.File, w *uvmCIMWriter) error {
+	gr, err := gzip.NewReader(tarFile)
+	if err != nil {
+		return fmt.Errorf("failed to get gzip reader: %w", err)
+	}
+	defer gr.Close()
+
+	tr := tar.NewReader(gr)
+
+	// General approach:
+	// Iterate over each file in the tar one by one. If we see a file that is under
+	// `UtilityVM/Files`: If it is a standard file or a directory add it to the CIM
+	// directly.
+	// If it is a link, check the target of the link:
+	// - If the target is not under `UtilityVM/Files`, save it so that we can copy the
+	// target file under at the path of this link.
+	// - If the target is also under UtilityVM/Files save it for later addition (we
+	// can't add the link yet because the target itself could be another link, so we
+	// need to wait until all link targets are resolved and added to the CIM).
+
+	linksToAdd := []*pendingLink{}
+	// a map of all the files seen in the tar - this is used to resolve nested links
+	tarContents := make(map[string]*tar.Header)
+	// a map of all files that we need to copy inside the UtilityVM directory from the
+	// outside because there are hardlinks to it inside the UtilityVM directory.
+	// There could be multiple links under UtilityVM/Files that end up directly or
+	// indirectly pointing to the same target. So we may have to copy the same file at
+	// multiple locations.
+	// TODO (ambarve): avoid these multiple copies by only copying once and then
+	// adding hardlinks.
+	copies := make(map[string][]string)
+
+	for {
+		hdr, err := tr.Next()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return fmt.Errorf("tar read failed: %w", err)
+		}
+
+		if err = validateFileType(hdr); err != nil {
+			return err
+		}
+
+		tarContents[hdr.Name] = hdr
+
+		if !hasUtilityVMFilesPrefix(hdr.Name) {
+			continue
+		}
+
+		// At this point we either have a standard file or a link file that is
+		// under the UtilityVM\Files directory.
+		if hdr.Typeflag == tar.TypeLink {
+			if !hasUtilityVMFilesPrefix(hdr.Linkname) {
+				// link points to a file outside the UtilityVM\Files
+				// directory we need to copy this file, but first resolve
+				// the link
+				resolvedTarget, err := resolveLink(tarContents, hdr.Linkname)
+				if err != nil {
+					return fmt.Errorf("failed to resolve link's [%s] target [%s]: %w", hdr.Name, hdr.Linkname, err)
+				}
+				copies[resolvedTarget] = append(copies[resolvedTarget], hdr.Name)
+				slog.Log(ctx, LevelTrace, "adding to list of pending copies", "src", resolvedTarget, "dest", hdr.Name)
+			} else {
+				linksToAdd = append(linksToAdd, &pendingLink{
+					name:   hdr.Name,
+					target: hdr.Linkname,
+				})
+				slog.Log(ctx, LevelTrace, "adding to list of pending links", "link", hdr.Name, "target", hdr.Linkname)
+			}
+			continue
+		}
+		if err = w.Add(hdr, tr, false); err != nil {
+			return fmt.Errorf("failed add UtilityVM standard file [%s]: %w", hdr.Name, err)
+		}
+		slog.Log(ctx, LevelTrace, "added standard file", "path", hdr.Name)
+	}
+	// close the current gzip reader before making a new one
+	if err = gr.Close(); err != nil {
+		return fmt.Errorf("failed to close gzip reader after first iteration: %w", err)
+	}
+
+	// reiterate tar and add copies
+	if _, err = tarFile.Seek(0, 0); err != nil {
+		return fmt.Errorf("failed to reset file offset: %w", err)
+	}
+
+	gr, err = gzip.NewReader(tarFile)
+	if err != nil {
+		return fmt.Errorf("failed to get gzip reader: %w", err)
+	}
+	defer gr.Close()
+	tr = tar.NewReader(gr)
+
+	for {
+		hdr, err := tr.Next()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return fmt.Errorf("tar read failed: %w", err)
+		}
+
+		dsts, ok := copies[hdr.Name]
+		if !ok {
+			continue
+		}
+
+		if !hasFilesPrefix(hdr.Name) {
+			return fmt.Errorf("copy src file doesn't have expected prefix: [%s]", hdr.Name)
+		}
+
+		for i, dst := range dsts {
+			if i == 0 {
+				dHdr := *hdr
+				dHdr.Name = dst
+				// copy the first one, next will be links to the first
+				if err = w.Add(&dHdr, tr, true); err != nil {
+					return fmt.Errorf("failed to copy resolved link target [%s]: %w", hdr.Name, err)
+				}
+			} else {
+				if err = w.AddLink(dst, dsts[0], true); err != nil {
+					return fmt.Errorf("failed to add links to copied file [%s]: %w", dst, err)
+				}
+			}
+		}
+	}
+
+	for _, pl := range linksToAdd {
+		if err = w.AddLink(pl.name, pl.target, false); err != nil {
+			return fmt.Errorf("failed to add link from [%s] to [%s]: %w", pl.name, pl.target, err)
+		}
+	}
+	return nil
+}

--- a/pkg/extractuvm/bcim_test.go
+++ b/pkg/extractuvm/bcim_test.go
@@ -1,0 +1,237 @@
+//go:build windows
+// +build windows
+
+package extractuvm
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Microsoft/go-winio/pkg/guid"
+	"github.com/Microsoft/hcsshim/pkg/cimfs"
+)
+
+// A simple tuple type used to hold information about a file/directory that is created
+// during a test.
+type testFile struct {
+	hdr          *tar.Header
+	fileContents []byte
+}
+
+// compareContent takes in path to a directory (which is usually a volume at which a CIM is
+// mounted) and ensures that every file/directory in the `testContents` shows up exactly
+// as it is under that directory.
+func compareContent(t *testing.T, root string, testContents []testFile) {
+	t.Helper()
+
+	for _, ft := range testContents {
+		ftPath := filepath.Join(root, ft.hdr.Name)
+		if ft.hdr.Typeflag == tar.TypeDir {
+			_, err := os.Stat(ftPath)
+			if err != nil {
+				t.Fatalf("stat directory %s from cim: %s", ftPath, err)
+			}
+		} else {
+			f, err := os.Open(filepath.Join(root, ft.hdr.Name))
+			if err != nil {
+				t.Fatalf("open file %s: %s", ftPath, err)
+			}
+			defer f.Close()
+
+			// it is a file - read contents
+			fileContents, err := io.ReadAll(f)
+			if err != nil {
+				t.Fatalf("failure while reading file %s from cim: %s", ftPath, err)
+			} else if !bytes.Equal(fileContents, ft.fileContents) {
+				t.Fatalf("contents of file %s don't match", ftPath)
+			}
+		}
+	}
+}
+
+func mountBlockCIM(t *testing.T, bCIM *cimfs.BlockCIM, mountFlags uint32) string {
+	t.Helper()
+	// mount and read the contents of the cim
+	volumeGUID, err := guid.NewV4()
+	if err != nil {
+		t.Fatalf("generate cim mount GUID: %s", err)
+	}
+
+	mountvol, err := cimfs.Mount(filepath.Join(bCIM.BlockPath, bCIM.CimName), volumeGUID, mountFlags)
+	if err != nil {
+		t.Fatalf("mount cim : %s", err)
+	}
+	t.Cleanup(func() {
+		if err := cimfs.Unmount(mountvol); err != nil {
+			t.Logf("CIM unmount failed: %s", err)
+		}
+	})
+	return mountvol
+}
+
+func makeGzipTar(t *testing.T, contents []testFile) string {
+	t.Helper()
+
+	// Create a temporary file to hold the tar
+	dir := t.TempDir()
+	tarPath := filepath.Join(dir, "test.tar.gz")
+
+	// open the tar file for writing
+	tarFile, err := os.Create(tarPath)
+	if err != nil {
+		t.Fatalf("failed to create tar file: %v", err)
+	}
+	defer tarFile.Close()
+
+	// Create a gzip writer
+	gzipWriter := gzip.NewWriter(tarFile)
+	defer gzipWriter.Close()
+
+	// Create a tar writer
+	tarWriter := tar.NewWriter(gzipWriter)
+	defer tarWriter.Close()
+
+	for _, item := range contents {
+		err = tarWriter.WriteHeader(item.hdr)
+		if err != nil {
+			t.Fatalf("failed to write dir header: %v", err)
+		}
+		if item.hdr.Typeflag == tar.TypeReg {
+			_, err = tarWriter.Write(item.fileContents)
+			if err != nil {
+				t.Fatalf("failed to write file contents: %v", err)
+			}
+		}
+	}
+
+	err = tarWriter.Close()
+	if err != nil {
+		t.Fatalf("failed to close tar writer: %v", err)
+	}
+
+	err = gzipWriter.Close()
+	if err != nil {
+		t.Fatalf("failed to close gzip writer: %v", err)
+	}
+	return tarPath
+}
+
+func extractAndVerifyTarToCIM(t *testing.T, tarContents []testFile, contentsToVerify []testFile) {
+	t.Helper()
+
+	if testing.Verbose() {
+		originalLogger := slog.Default()
+		defer func() {
+			// Reset log level after test
+			slog.SetDefault(originalLogger)
+		}()
+
+		slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
+			Level: LevelTrace,
+		})))
+	}
+
+	tarPath := makeGzipTar(t, tarContents)
+
+	// Create a temporary directory to extract the tar contents
+	destDir := t.TempDir()
+
+	// Call the function to extract the tar contents
+	uvmCIM, err := MakeUtilityVMCIMFromTar(context.Background(), tarPath, destDir)
+	if err != nil {
+		t.Fatalf("failed to extract tar contents: %v", err)
+	}
+	mountedCIMVolume := mountBlockCIM(t, uvmCIM, cimfs.CimMountSingleFileCim)
+	compareContent(t, mountedCIMVolume, contentsToVerify)
+}
+
+func TestTarUtilityVMExtract(t *testing.T) {
+	if !cimfs.IsBlockCimSupported() {
+		t.Skip("block CIMs are not supported on this build")
+	}
+
+	tarContents := []testFile{
+		{
+			fileContents: []byte("F1"),
+			hdr: &tar.Header{
+				Name:     "Files\\f1.txt",
+				Size:     2,
+				Typeflag: tar.TypeReg,
+			},
+		},
+		{
+			fileContents: []byte("F2"),
+			hdr: &tar.Header{
+				Name:     "Files\\f2.txt",
+				Size:     2,
+				Typeflag: tar.TypeReg,
+			},
+		},
+		{
+			// Standard file under UtilityVM\Files directory
+			hdr: &tar.Header{
+				Name:     "UtilityVM\\Files",
+				Typeflag: tar.TypeDir,
+			},
+		},
+		{
+			fileContents: []byte("U"),
+			hdr: &tar.Header{
+				Name:     "UtilityVM\\Files\\u.txt",
+				Size:     1,
+				Typeflag: tar.TypeReg,
+			},
+		},
+		{
+			// Link under UtilityVM\Files pointing to a file under Files
+			hdr: &tar.Header{
+				Name:     "UtilityVM\\Files\\ul1.txt",
+				Linkname: "Files\\f1.txt",
+				Typeflag: tar.TypeLink,
+			},
+		},
+		{
+			// Link under UtilityVM\Files pointing to a file also under UtilityVM\Files
+			hdr: &tar.Header{
+				Name:     "UtilityVM\\Files\\ul2.txt",
+				Linkname: "UtilityVM\\Files\\u.txt",
+				Typeflag: tar.TypeLink,
+			},
+			fileContents: nil, // No content for links
+		},
+	}
+
+	extractedContents := []testFile{
+		{
+			fileContents: []byte("U"),
+			hdr: &tar.Header{
+				Name:     "u.txt",
+				Size:     1,
+				Typeflag: tar.TypeReg,
+			},
+		},
+		{
+			// Link under UtilityVM\Files pointing to a file under Files
+			fileContents: []byte("F1"),
+			hdr: &tar.Header{
+				Name: "ul1.txt",
+				Size: 2,
+			},
+		},
+		{
+			fileContents: []byte("U"),
+			hdr: &tar.Header{
+				Name: "ul2.txt",
+				Size: 1,
+			},
+		},
+	}
+	extractAndVerifyTarToCIM(t, tarContents, extractedContents)
+}

--- a/pkg/extractuvm/utils.go
+++ b/pkg/extractuvm/utils.go
@@ -1,0 +1,73 @@
+//go:build windows
+// +build windows
+
+package extractuvm
+
+import (
+	"archive/tar"
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"github.com/Microsoft/hcsshim/internal/wclayer"
+	"github.com/Microsoft/hcsshim/pkg/ociwclayer"
+)
+
+type pendingLink struct {
+	name   string
+	target string
+}
+
+func resolveLink(files map[string]*tar.Header, target string) (string, error) {
+	var (
+		resolvedFile *tar.Header
+		hasFile      bool
+	)
+	for {
+		if resolvedFile, hasFile = files[target]; !hasFile {
+			return "", os.ErrNotExist
+		} else if resolvedFile.Typeflag == tar.TypeReg {
+			break
+		} else if resolvedFile.Typeflag == tar.TypeLink {
+			target = resolvedFile.Linkname
+		} else {
+			return "", fmt.Errorf("resolved link [%s] to invalid type: %d", target, resolvedFile.Typeflag)
+		}
+	}
+	return resolvedFile.Name, nil
+}
+
+func hasUtilityVMFilesPrefix(path string) bool {
+	// When iterating the tar, file paths show up with forward slash (`/`), however,
+	// constants in wclayer use backward slash (`\`) So we have this special function to always combine with `/`
+	// Also, note that the ending slash is considered to be a part of the prefix, otherwise just `UtilityVM\Files` would
+	// return true, but that directory shouldn't be included
+	return strings.HasPrefix(filepath.ToSlash(path), filepath.ToSlash(wclayer.UtilityVMFilesPath+`\`))
+}
+
+func hasFilesPrefix(path string) bool {
+	// When iterating the tar, file paths show up with forward slash (`/`), however,
+	// constants in wclayer use backward slash (`\`) So we have this special function to always combine with `/`
+	// Also, note that the ending slash is considered to be a part of the prefix, otherwise just `UtilityVM\Files` would
+	// return true, but that directory shouldn't be included
+	return strings.HasPrefix(filepath.ToSlash(path), filepath.ToSlash("Files"+`\`))
+}
+
+func cutUtilityVMFilesPrefix(path string) string {
+	return strings.TrimPrefix(filepath.ToSlash(path), filepath.ToSlash(wclayer.UtilityVMFilesPath+`\`))
+}
+
+func validateFileType(hdr *tar.Header) error {
+	if strings.HasPrefix(path.Base(hdr.Name), ociwclayer.WhiteoutPrefix) {
+		return fmt.Errorf("found unexpected whiteout file [%s] in the base tar", hdr.Name)
+	}
+	if strings.Contains(hdr.Name, ":") {
+		return fmt.Errorf("found unexpected alternate data stream file [%s] in the base tar", hdr.Name)
+	}
+	if hdr.Typeflag == tar.TypeSymlink {
+		return fmt.Errorf("found unexpected symlink [%s] in the base tar", hdr.Name)
+	}
+	return nil
+}

--- a/pkg/extractuvm/uvm_cim_writer.go
+++ b/pkg/extractuvm/uvm_cim_writer.go
@@ -1,0 +1,126 @@
+//go:build windows
+// +build windows
+
+package extractuvm
+
+import (
+	"archive/tar"
+	"context"
+	"fmt"
+	"io"
+	"path/filepath"
+	"strings"
+
+	"github.com/Microsoft/go-winio"
+	"github.com/Microsoft/go-winio/backuptar"
+	"github.com/Microsoft/hcsshim/pkg/cimfs"
+	"golang.org/x/sys/windows"
+)
+
+// handles the task of writing all `UtilityVM/Files/*` files into a CIM. Removes the
+// `UtilityVM/Files` prefix from the file path before adding it to the CIM.
+type uvmCIMWriter struct {
+	cimWriter  *cimfs.CimFsWriter
+	layerCIM   *cimfs.BlockCIM
+	filesAdded map[string]struct{}
+}
+
+func newUVMCIMWriter(l *cimfs.BlockCIM) (*uvmCIMWriter, error) {
+	cim, err := cimfs.CreateBlockCIM(l.BlockPath, l.CimName, l.Type)
+	if err != nil {
+		return nil, fmt.Errorf("error in creating a new cim: %w", err)
+	}
+	return &uvmCIMWriter{
+		cimWriter:  cim,
+		layerCIM:   l,
+		filesAdded: make(map[string]struct{}),
+	}, nil
+}
+
+func (u *uvmCIMWriter) ensureParents(path string) error {
+	if hasUtilityVMFilesPrefix(path) {
+		return fmt.Errorf("unexpected `UtilityVM/Files` prefix in the path `%s`", path)
+	}
+
+	elems := strings.Split(filepath.ToSlash(path), "/")
+	currPath := ""
+	for _, e := range elems[:len(elems)-1] {
+		currPath = filepath.ToSlash(filepath.Join(currPath, e))
+		if _, ok := u.filesAdded[currPath]; !ok {
+			info := &winio.FileBasicInfo{
+				FileAttributes: windows.FILE_ATTRIBUTE_DIRECTORY,
+			}
+			u.filesAdded[currPath] = struct{}{}
+			err := u.cimWriter.AddFile(filepath.FromSlash(currPath), info, 0, nil, nil, nil)
+			if err != nil {
+				return fmt.Errorf("failed to ensure parent dir `%s`: %w", currPath, err)
+			}
+		}
+	}
+	return nil
+}
+
+// Add adds a file to the layer with given metadata.
+func (u *uvmCIMWriter) Add(hdr *tar.Header, tr io.Reader, ensureParents bool) error {
+	if !hasUtilityVMFilesPrefix(hdr.Name) {
+		return fmt.Errorf("expected `UtilityVM/Files` prefix in the path `%s`", hdr.Name)
+	}
+
+	name, fileSize, fileInfo, err := backuptar.FileInfoFromHeader(hdr)
+	if err != nil {
+		return err
+	}
+	sddl, err := backuptar.SecurityDescriptorFromTarHeader(hdr)
+	if err != nil {
+		return err
+	}
+	eadata, err := backuptar.ExtendedAttributesFromTarHeader(hdr)
+	if err != nil {
+		return err
+	}
+
+	// we don't expect any valid reparse points here. remove the flag and pass nil byte array
+	var reparse []byte
+	fileInfo.FileAttributes &^= uint32(windows.FILE_ATTRIBUTE_REPARSE_POINT)
+
+	name = cutUtilityVMFilesPrefix(name)
+
+	if ensureParents {
+		if err = u.ensureParents(name); err != nil {
+			return fmt.Errorf("failed to ensure parents: %w", err)
+		}
+	}
+	if err = u.cimWriter.AddFile(filepath.FromSlash(name), fileInfo, fileSize, sddl, eadata, reparse); err != nil {
+		return err
+	}
+	u.filesAdded[name] = struct{}{}
+
+	if hdr.Typeflag == tar.TypeReg {
+		if _, err := io.Copy(u.cimWriter, tr); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// AddLink adds a hard link to the layer. The target must already have been added.
+func (u *uvmCIMWriter) AddLink(name string, target string, ensureParents bool) error {
+	if !hasUtilityVMFilesPrefix(name) {
+		return fmt.Errorf("expected `UtilityVM/Files` prefix in the path `%s`", name)
+	}
+	if !hasUtilityVMFilesPrefix(target) {
+		return fmt.Errorf("expected `UtilityVM/Files` prefix in the path `%s`", target)
+
+	}
+	name = cutUtilityVMFilesPrefix(name)
+	target = cutUtilityVMFilesPrefix(target)
+	if err := u.cimWriter.AddLink(filepath.FromSlash(target), filepath.FromSlash(name)); err != nil {
+		return fmt.Errorf("failed to add link [%s] to target [%s]: %w", name, target, err)
+	}
+	u.filesAdded[name] = struct{}{}
+	return nil
+}
+
+func (u *uvmCIMWriter) Close(ctx context.Context) error {
+	return u.cimWriter.Close()
+}

--- a/test/functional/make_uvm_cim_test.go
+++ b/test/functional/make_uvm_cim_test.go
@@ -1,0 +1,233 @@
+//go:build windows && functional
+// +build windows,functional
+
+package functional
+
+import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/Microsoft/go-winio/pkg/guid"
+	"github.com/Microsoft/hcsshim/pkg/cimfs"
+	"github.com/Microsoft/hcsshim/pkg/extractuvm"
+	"github.com/google/go-containerregistry/pkg/crane"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+)
+
+func compareFiles(t *testing.T, file1, file2 string) (bool, error) {
+	t.Helper()
+
+	file1, err := filepath.EvalSymlinks(file1)
+	if err != nil {
+		return false, err
+	}
+
+	file2, err = filepath.EvalSymlinks(file2)
+	if err != nil {
+		return false, err
+	}
+
+	// Get file info for both files
+	info1, err := os.Stat(file1)
+	if err != nil {
+		return false, err
+	}
+	info2, err := os.Stat(file2)
+	if err != nil {
+		return false, err
+	}
+
+	// Only compare file sizes for now
+	return info1.Size() == info2.Size(), nil
+}
+
+func compareDirs(t *testing.T, dir1, dir2 string) {
+	t.Helper()
+
+	var differences []string
+	var onlyInDir1 []string
+	var onlyInDir2 []string
+
+	// Walk through the first directory
+	err := filepath.Walk(dir1, func(path1 string, info1 os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		// Construct the corresponding path in the second directory
+		relativePath := strings.TrimPrefix(path1, dir1)
+		path2 := filepath.Join(dir2, relativePath)
+
+		_, err = os.Stat(path2)
+		if os.IsNotExist(err) {
+			onlyInDir1 = append(onlyInDir1, relativePath)
+			return nil
+		} else if err != nil {
+			return err
+		}
+
+		// If the file exists in both directories, compare it
+		if info1.IsDir() {
+			// Skip directories, we don't compare their contents here
+			return nil
+		}
+
+		isIdentical, err := compareFiles(t, path1, path2)
+		if err != nil {
+			return err
+		}
+		if !isIdentical {
+			differences = append(differences, relativePath)
+		}
+		return nil
+	})
+
+	if err != nil {
+		t.Fatalf("comparison failed: %s", err)
+	}
+
+	// Walk through the second directory to find files that are not in the first directory
+	err = filepath.Walk(dir2, func(path2 string, info2 os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		// Construct the corresponding path in the first directory
+		relativePath := strings.TrimPrefix(path2, dir2)
+		path1 := filepath.Join(dir1, relativePath)
+
+		_, err = os.Stat(path1)
+		if os.IsNotExist(err) {
+			onlyInDir2 = append(onlyInDir2, relativePath)
+		} else if err != nil {
+			return err
+		}
+		return nil
+	})
+
+	if err != nil {
+		t.Fatalf("comparison failed: %s", err)
+	}
+
+	failed := false
+	// Output results
+	if len(differences) > 0 {
+		failed = true
+		t.Log("Files that differ in size between the directories:")
+		for _, diff := range differences {
+			t.Log(diff)
+		}
+	}
+
+	if len(onlyInDir1) > 0 {
+		failed = true
+		t.Logf("Files/directories only in %s:", dir1)
+		for _, item := range onlyInDir1 {
+			t.Log(item)
+		}
+	}
+
+	if len(onlyInDir2) > 0 {
+		failed = true
+		t.Logf("Files/directories only in %s:", dir2)
+		for _, item := range onlyInDir2 {
+			t.Log(item)
+		}
+	}
+
+	if failed {
+		t.Fatalf("directories not identical!")
+	}
+}
+
+func saveLayerTar(t *testing.T, layer v1.Layer, savePath string) {
+	t.Helper()
+
+	// Open a file to write the layer content
+	outputFile, err := os.Create(savePath)
+	if err != nil {
+		t.Fatalf("creating tarball file %s: %s", savePath, err)
+	}
+	defer outputFile.Close()
+
+	// Get a reader for the layer
+	layerReader, err := layer.Compressed()
+	if err != nil {
+		t.Fatalf("getting reader for layer: %s", err)
+	}
+	defer layerReader.Close()
+
+	// Copy the layer content to the file
+	if _, err := io.Copy(outputFile, layerReader); err != nil {
+		t.Fatalf("failed to write layer to file: %s", err)
+	}
+}
+
+func mountBlockCIM(t *testing.T, bCIM *cimfs.BlockCIM, mountFlags uint32) string {
+	t.Helper()
+	// mount and read the contents of the cim
+	volumeGUID, err := guid.NewV4()
+	if err != nil {
+		t.Fatalf("generate cim mount GUID: %s", err)
+	}
+
+	mountvol, err := cimfs.Mount(filepath.Join(bCIM.BlockPath, bCIM.CimName), volumeGUID, mountFlags)
+	if err != nil {
+		t.Fatalf("mount cim : %s", err)
+	}
+	t.Cleanup(func() {
+		if err := cimfs.Unmount(mountvol); err != nil {
+			t.Logf("CIM unmount failed: %s", err)
+		}
+	})
+	return mountvol
+}
+
+// TestCompareUtilityVMCIM compares generated UtilityVM CIM's contents against the WCIFS based layer and ensures that they match.
+func TestCompareUtilityVMCIM(t *testing.T) {
+	if !cimfs.IsBlockCimSupported() {
+		t.Skip("block CIMs are not supported on this build")
+	}
+
+	// extract image locally using default WCIFS based layers
+	nanoserverLayers := windowsImageLayers(context.TODO(), t)
+
+	// download the nanoserver base layer tarball
+	wcowImages, err := wcowImagePathsOnce()
+	if err != nil {
+		t.Fatalf("failed to get wcow images: %s", err)
+	}
+
+	img, err := crane.Pull(wcowImages.nanoserver.Image, crane.WithPlatform(&v1.Platform{
+		OS: wcowImages.nanoserver.Platform, Architecture: runtime.GOARCH,
+	}))
+	if err != nil {
+		t.Fatalf("failed to pull nanoserver image: %s", err)
+	}
+
+	layers, err := img.Layers()
+	if err != nil {
+		t.Fatalf("failed to get image layers: %s", err)
+	}
+
+	layerTarPath := filepath.Join(t.TempDir(), "nanoserver_base.tar")
+	// nanoserver has only 1 layer
+	saveLayerTar(t, layers[0], layerTarPath)
+
+	// use the tarball to extract out the UtilityVM layer
+	extractPath := t.TempDir()
+	uvmCIM, err := extractuvm.MakeUtilityVMCIMFromTar(context.Background(), layerTarPath, extractPath)
+	if err != nil {
+		t.Fatalf("failed to make UtilityVM CIM: %s", err)
+	}
+
+	mountvol := mountBlockCIM(t, uvmCIM, cimfs.CimMountSingleFileCim)
+
+	compareDirs(t, filepath.Join(nanoserverLayers[0], "UtilityVM\\Files"), mountvol)
+
+}


### PR DESCRIPTION
This commit adds a new tool that can take a valid Windows container image tarball and extracts all the UtilityVM files from that tarball into a block CIM. The end result should be a block CIM that has all the files necessary to successfully boot & run a UtilityVM.