### PR TITLE
Add `rootfs.exe` tool to merge tar image layers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.9.3
 	github.com/urfave/cli v1.22.15
+	github.com/urfave/cli/v2 v2.27.5
 	github.com/vishvananda/netlink v1.3.0
 	github.com/vishvananda/netns v0.0.4
 	go.etcd.io/bbolt v1.3.10
@@ -54,7 +55,7 @@ require (
 	github.com/containerd/log v0.1.0 // indirect
 	github.com/containerd/stargz-snapshotter/estargz v0.14.3 // indirect
 	github.com/coreos/go-systemd/v22 v22.5.0 // indirect
-	github.com/cpuguy83/go-md2man/v2 v2.0.4 // indirect
+	github.com/cpuguy83/go-md2man/v2 v2.0.5 // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0 // indirect
 	github.com/docker/cli v24.0.0+incompatible // indirect
 	github.com/docker/distribution v2.8.3+incompatible // indirect
@@ -101,6 +102,7 @@ require (
 	github.com/x448/float16 v0.8.4 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
+	github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1 // indirect
 	github.com/yashtewari/glob-intersection v0.2.0 // indirect
 	go.opentelemetry.io/otel v1.31.0 // indirect
 	go.opentelemetry.io/otel/metric v1.31.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -63,8 +63,9 @@ github.com/containerd/typeurl/v2 v2.2.0/go.mod h1:8XOOxnyatxSWuG8OfsZXVnAF4iZfed
 github.com/coreos/go-systemd/v22 v22.5.0 h1:RrqgGjYQKalulkV8NGVIfkXQf6YYmOyiJKk8iXXhfZs=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
-github.com/cpuguy83/go-md2man/v2 v2.0.4 h1:wfIWP927BUkWJb2NmU/kNDYIBTh/ziUX91+lVfRxZq4=
 github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
+github.com/cpuguy83/go-md2man/v2 v2.0.5 h1:ZtcqGrnekaHpVLArFSe4HK5DoKx1T0rq2DwVB0alcyc=
+github.com/cpuguy83/go-md2man/v2 v2.0.5/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -259,6 +260,8 @@ github.com/tchap/go-patricia/v2 v2.3.1/go.mod h1:VZRHKAb53DLaG+nA9EaYYiaEx6YztwD
 github.com/urfave/cli v1.22.12/go.mod h1:sSBEIC79qR6OvcmsD4U3KABeOTxDqQtdDnaFuUN30b8=
 github.com/urfave/cli v1.22.15 h1:nuqt+pdC/KqswQKhETJjo7pvn/k4xMUxgW6liI7XpnM=
 github.com/urfave/cli v1.22.15/go.mod h1:wSan1hmo5zeyLGBjRJbzRTNk8gwoYa2B9n4q9dmRIc0=
+github.com/urfave/cli/v2 v2.27.5 h1:WoHEJLdsXr6dDWoJgMq/CboDmyY/8HMMH1fTECbih+w=
+github.com/urfave/cli/v2 v2.27.5/go.mod h1:3Sevf16NykTbInEnD0yKkjDAeZDS0A6bzhBH5hrMvTQ=
 github.com/vbatts/tar-split v0.11.3 h1:hLFqsOLQ1SsppQNTMpkpPXClLDfC2A3Zgy9OUU+RVck=
 github.com/vbatts/tar-split v0.11.3/go.mod h1:9QlHN18E+fEH7RdG+QAJJcuya3rqT7eXSTY7wGrAokY=
 github.com/veraison/go-cose v1.1.0 h1:AalPS4VGiKavpAzIlBjrn7bhqXiXi4jbMYY/2+UC+4o=
@@ -273,6 +276,8 @@ github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb h1:zGWFAtiMc
 github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 h1:EzJWgHovont7NscjpAxXsDA8S8BMYve8Y5+7cuRE7R0=
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
+github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1 h1:gEOO8jv9F4OT7lGCjxCBTO/36wtF6j2nSip77qHd4x4=
+github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1/go.mod h1:Ohn+xnUBiLI6FVj/9LpzZWtj1/D6lUovWYBkxHVV3aM=
 github.com/yashtewari/glob-intersection v0.2.0 h1:8iuHdN88yYuCzCdjt0gDe+6bAhUwBeEWqThExu54RFg=
 github.com/yashtewari/glob-intersection v0.2.0/go.mod h1:LK7pIC3piUjovexikBbJ26Yml7g8xa5bsjfx2v1fwok=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/internal/tools/rootfs/main.go
+++ b/internal/tools/rootfs/main.go
@@ -14,7 +14,12 @@ import (
 	"github.com/Microsoft/hcsshim/internal/oc"
 )
 
-// TODO: tests ...............
+// TODO: add tests for:
+// - general functionality (Windows + Linux)
+// - adding `./` prefix
+// - adding `/` suffix
+// - overriding UID and GUID
+// TODO: output CPIO archive?
 
 func main() {
 	logrus.SetFormatter(&logrus.TextFormatter{FullTimestamp: true})
@@ -71,18 +76,4 @@ func run() error {
 	}
 
 	return app.Run(args)
-}
-
-// TODO: output CPIO archive
-
-// see 	"github.com/u-root/mkuimage/cpio".fs_windows.go
-type tarRecorder struct {
-	inumber uint64
-}
-
-func newTarRecorder() *tarRecorder { return &tarRecorder{inumber: 2} }
-
-func (r *tarRecorder) inode() uint64 {
-	r.inumber++
-	return r.inumber - 1
 }

--- a/internal/tools/rootfs/main.go
+++ b/internal/tools/rootfs/main.go
@@ -1,0 +1,88 @@
+// Tool to merge Windows and Linux rootfs.tar(.gz) and delta.tar (or other files) into
+// a unified rootfs (gzipped) TAR.
+
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/sirupsen/logrus"
+	"github.com/urfave/cli/v2"
+	"go.opencensus.io/trace"
+
+	"github.com/Microsoft/hcsshim/internal/oc"
+)
+
+// TODO: tests ...............
+
+func main() {
+	logrus.SetFormatter(&logrus.TextFormatter{FullTimestamp: true})
+
+	trace.ApplyConfig(trace.Config{DefaultSampler: oc.DefaultSampler})
+	trace.RegisterExporter(&oc.LogrusExporter{})
+
+	if err := run(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	args := os.Args
+
+	mergeCommand, err := newMergeCommand()
+	if err != nil {
+		return fmt.Errorf("could not create merge command: %w", err)
+	}
+
+	app := &cli.App{
+		Name:  "rootfs",
+		Usage: "manipulate rootfs tar(.gz) files",
+
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:    "log-level",
+				Aliases: []string{"lvl"},
+				Usage:   "logging `level`",
+				Value:   logrus.StandardLogger().Level.String(),
+				Action: func(_ *cli.Context, s string) error {
+					lvl, err := logrus.ParseLevel(s)
+					if err == nil {
+						logrus.SetLevel(lvl)
+					}
+					return err
+				},
+			},
+		},
+
+		Commands: []*cli.Command{
+			mergeCommand,
+		},
+		DefaultCommand: mergeCommand.Name,
+		ExitErrHandler: func(ctx *cli.Context, err error) {
+			if err != nil {
+				logrus.WithFields(logrus.Fields{
+					logrus.ErrorKey: err,
+					"command":       fmt.Sprintf("%#+v", args),
+				}).Error(ctx.App.Name + " failed")
+			}
+		},
+	}
+
+	return app.Run(args)
+}
+
+// TODO: output CPIO archive
+
+// see 	"github.com/u-root/mkuimage/cpio".fs_windows.go
+type tarRecorder struct {
+	inumber uint64
+}
+
+func newTarRecorder() *tarRecorder { return &tarRecorder{inumber: 2} }
+
+func (r *tarRecorder) inode() uint64 {
+	r.inumber++
+	return r.inumber - 1
+}

--- a/internal/tools/rootfs/merge.go
+++ b/internal/tools/rootfs/merge.go
@@ -1,0 +1,445 @@
+// Tool to merge Windows and Linux rootfs.tar(.gz) and delta.tar (or other files) into
+// a unified rootfs (gzipped) TAR.
+
+package main
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/tarball"
+	"github.com/google/go-containerregistry/pkg/v1/types"
+	"github.com/sirupsen/logrus"
+	"github.com/urfave/cli/v2"
+)
+
+// Note:
+// file modification time when booting from initrd.img is the uVM boot time,
+// since the kernel creates a rootfs (ramfs or tempfs) filesystem, instead of using the
+// cpio archive directly.
+//
+// for rootfs.vhd, it is the original time as provided by the original tarball, since
+// the VHD has an already-formatted (ext4) filesystem on it
+//
+// for the rootfs.vhd and intermediary tar and cpio archives, if they are created after
+// extracting files to disk, the modification time for directories and symlinks will be
+// the extraction date (and not the original date from the source).
+
+type mergeCommand struct {
+	// Append a `/` to directory names to be consistent with what GNU and BSD tar does.
+	TrailingSlash bool
+	// Set file and directory owner user and group ID to 0 (root) and remove user and group name.
+	OverrideOwner bool
+	// Prepend `./` to all paths.
+	RelativePathPrefix bool
+	// Override the tar header format.
+	OverrideTarFormat tar.Format
+
+	// Target OS
+	OS osType
+
+	// Paths to merge
+	Paths []string
+
+	// Compress output file
+	GZIP bool
+	// Destination tar file
+	Dest cli.Path
+}
+
+func newMergeCommand() (*cli.Command, error) {
+	c := &mergeCommand{
+		OverrideTarFormat: tar.FormatPAX,
+	}
+
+	cmd := &cli.Command{
+		Name:    "merge",
+		Aliases: []string{"m"},
+		Usage:   "merge together multiple layer tarballs",
+		Description: strings.ReplaceAll(
+			`Merge (tar) layers without needing to extract and combine them on the file system.
+This allows preserving file properties (e.g., creation date, owner user and group) which could
+be changed by extraction.`, "\n", " "),
+		Args:      true,
+		ArgsUsage: "layers...",
+		Flags: []cli.Flag{
+			&cli.PathFlag{
+				Name:     "output",
+				Aliases:  []string{"o"},
+				Usage:    "output tarball `file`",
+				Required: true,
+				Action: func(_ *cli.Context, p cli.Path) (err error) {
+					c.Dest, err = outputFilePath(p)
+					return
+				},
+			},
+			&cli.BoolFlag{
+				Name:        "trailing-slash",
+				Usage:       "append a trailing slash (/) to directories",
+				Destination: &c.TrailingSlash,
+			},
+			&cli.BoolFlag{
+				Name:        "override-owner",
+				Usage:       "set file owner UID and GID to 0",
+				Destination: &c.OverrideOwner,
+			},
+			&cli.BoolFlag{
+				Name:        "relative-prefix",
+				Usage:       "prefix all file paths with './'",
+				Destination: &c.RelativePathPrefix,
+			},
+			&cli.BoolFlag{
+				Name:        "gzip",
+				Aliases:     []string{"z"},
+				Usage:       "gzip compress output tarball",
+				Destination: &c.GZIP,
+			},
+			&cli.StringFlag{
+				Name:  "os",
+				Usage: "target OS for the resulting rootfs",
+				Value: string(linuxOS),
+				Action: func(_ *cli.Context, s string) (err error) {
+					c.OS, err = parseOSType(s)
+					return
+				},
+			},
+		},
+
+		Before: func(cCtx *cli.Context) (err error) {
+			args := cCtx.Args()
+			if args.Len() < 1 {
+				return fmt.Errorf("no layers specified")
+			}
+
+			c.Paths = make([]string, 0, args.Len())
+			for _, s := range args.Slice() {
+				p, err := filepath.Abs(s)
+				if err != nil {
+					return fmt.Errorf("invalid layer file path %q: %w", s, err)
+				}
+				c.Paths = append(c.Paths, p)
+			}
+
+			return nil
+		},
+
+		Action: c.run,
+	}
+	return cmd, nil
+}
+
+// basically crane (github.com/google/go-containerregistry/cmd/crane) append and export
+func (c *mergeCommand) run(_ *cli.Context) error {
+	logrus.WithFields(logrus.Fields{
+		"trailing-slash":  c.TrailingSlash,
+		"override-owner":  c.OverrideOwner,
+		"relative-prefix": c.RelativePathPrefix,
+		"override-format": c.OverrideTarFormat.String(),
+		"os":              string(c.OS),
+		"layers":          strings.Join(c.Paths, ", "),
+		"gzip":            c.GZIP,
+		"output":          c.Dest,
+	}).Info("merging layers")
+
+	layers := make([]v1.Layer, 0, len(c.Paths))
+	for _, p := range c.Paths {
+		l, err := tarball.LayerFromFile(p, tarball.WithMediaType(types.OCILayer))
+		if err != nil {
+			return fmt.Errorf("create layer from %q: %w", p, err)
+		}
+		layers = append(layers, l)
+	}
+
+	var wc io.WriteCloser
+	wc, err := os.Create(c.Dest)
+	if err != nil {
+		return fmt.Errorf("create output file %q: %w", c.Dest, err)
+	}
+	defer wc.Close()
+
+	if c.GZIP {
+		wc = gzip.NewWriter(wc)
+		defer wc.Close()
+	}
+
+	logrus.Trace("append layers to empty OCI image")
+	if err := c.mergeLayers(wc, layers); err != nil {
+		return fmt.Errorf("write merged layers to %q: %w", c.Dest, err)
+	}
+
+	logrus.WithFields(logrus.Fields{
+		"output": c.Dest,
+		"layers": c.Paths,
+	}).Info("merged layer tarball")
+	return nil
+}
+
+// merge combines multiple tar filesystems (image layers) together, and writes the result to w.
+//
+// Adapted from [containerregistry extract], with several key differences:
+//   - operate on layers directly, without needing intermediary image
+//   - use [path] for path maniputlation instead of [filepath], so files are handled consistently on Windows and Linux
+//   - allow overriding non-root (non-0) file ownership, which may have been copied during tar creation
+//   - allow appending a trailing slash to directories, similar to GNU and BSD tar(.exe)
+//   - allow prepending a leading `./` to all files
+//
+// [containerregistry extract]: https://github.com/google/go-containerregistry/blob/a07d1cab8700a9875699d2e7052f47acec30399d/pkg/v1/mutate/mutate.go#L264
+func (c *mergeCommand) mergeLayers(w io.Writer, layers []v1.Layer) error {
+	tw := tar.NewWriter(w)
+	defer tw.Close()
+
+	// track the files we've seen before
+	fileMap := make(map[string]bool)
+
+	stats := layerWriteStats{}
+	defer func() {
+		logrus.WithFields(logrus.Fields{
+			"total-files":            stats.totalFiles(),
+			"files":                  stats.numFiles,
+			"directories":            stats.numDir,
+			"hard-links":             stats.numHard,
+			"sym-links":              stats.numSym,
+			"other-files":            stats.numOther,
+			"trailing-slash-appends": stats.numTrailing,
+			"relative-path-preprend": stats.numRelPrepend,
+			"owner-overrides":        stats.numOwnerOverride,
+			"format-overrides":       stats.numFormatOverride,
+		}).Debug("finished processing image layers")
+	}()
+
+	// iterate through the layers in reverse order because it makes handling
+	// whiteout layers more efficient, since we can just keep track of the removed
+	// files as we see .wh. layers and ignore those in previous layers.
+	for i := len(layers) - 1; i >= 0; i-- {
+		layer := layers[i]
+		if err := c.writeLayer(tw, &stats, fileMap, layer); err != nil {
+			return err
+		}
+	}
+	return nil
+
+}
+
+// append the tar layer to w.
+//
+// based off of:
+//   - https://github.com/google/go-containerregistry/blob/a07d1cab8700a9875699d2e7052f47acec30399d/pkg/v1/mutate/mutate.go#L264
+func (c *mergeCommand) writeLayer(
+	tw *tar.Writer,
+	stats *layerWriteStats,
+	fileMap map[string]bool,
+	layer v1.Layer,
+) error {
+	const whiteoutPrefix = ".wh."
+
+	r, err := layer.Uncompressed()
+	if err != nil {
+		return fmt.Errorf("uncompressing layer contents: %w", err)
+	}
+	defer r.Close()
+	tr := tar.NewReader(r)
+
+	for {
+		header, err := tr.Next()
+		switch {
+		case errors.Is(err, io.EOF):
+			return nil
+		case err != nil:
+			return fmt.Errorf("reading layer tar: %w", err)
+		}
+
+		entry := logrus.WithFields(logrus.Fields{
+			"directory": header.FileInfo().IsDir(),
+			"name":      header.Name,
+		})
+
+		header.Name = c.normalize(header.Name)
+		basename := path.Base(header.Name)
+		dirname := path.Dir(header.Name)
+		tombstone := strings.HasPrefix(basename, whiteoutPrefix)
+		if tombstone {
+			basename = basename[len(whiteoutPrefix):]
+		}
+
+		// check if we have seen value before
+		// if we're checking a directory, don't filepath.Join names
+		var name string
+		if header.Typeflag == tar.TypeDir {
+			name = header.Name
+		} else {
+			name = path.Join(dirname, basename)
+		}
+
+		if _, ok := fileMap[name]; ok {
+			continue
+		}
+
+		// check for a whited out parent directory
+		if inWhiteoutDir(fileMap, name) {
+			continue
+		}
+
+		//
+		// update header (as needed)
+		//
+
+		if c.RelativePathPrefix && !(strings.HasPrefix(header.Name, `./`) || (c.OS == windowsOS && strings.HasPrefix(header.Name, `.\`))) {
+			stats.numRelPrepend++
+			entry.Trace("prepend relative path specifier to path")
+
+			header.Name = `./` + header.Name
+		}
+
+		switch header.Typeflag {
+		case tar.TypeReg:
+			stats.numFiles++
+		case tar.TypeDir:
+			stats.numDir++
+
+			if c.TrailingSlash && !(strings.HasSuffix(header.Name, `/`) || (c.OS == windowsOS && strings.HasSuffix(header.Name, `\`))) {
+				stats.numTrailing++
+				entry.Trace("append trailing slash to directory name")
+
+				header.Name += `/`
+			}
+		case tar.TypeLink:
+			stats.numHard++
+		case tar.TypeSymlink:
+			stats.numSym++
+		default:
+			stats.numOther++
+		}
+
+		if c.OverrideOwner && (header.Gid != 0 || header.Gname != "" || header.Uid != 0 || header.Uname != "") {
+			stats.numOwnerOverride++
+			entry.WithFields(logrus.Fields{
+				"group":     header.Gid,
+				"groupname": header.Gname,
+				"user":      header.Uid,
+				"username":  header.Uname,
+			}).Trace("set user and group ownership to 0 (root)")
+
+			header.Gid = 0
+			header.Uid = 0
+			header.Gname = ""
+			header.Uname = ""
+		}
+
+		if c.OverrideTarFormat != tar.FormatUnknown && header.Format != c.OverrideTarFormat {
+			stats.numFormatOverride++
+			entry.WithFields(logrus.Fields{
+				"format":   header.Format.String(),
+				"override": c.OverrideTarFormat.String(),
+			}).Trace("override tar format")
+
+			header.Format = c.OverrideTarFormat
+		}
+
+		// mark file as handled. non-directory implicitly tombstones
+		// any entries with a matching (or child) name
+		fileMap[name] = tombstone || !(header.Typeflag == tar.TypeDir)
+		if !tombstone {
+			if err := tw.WriteHeader(header); err != nil {
+				return fmt.Errorf("write %q header: %w", header.Name, err)
+			}
+			if header.Size > 0 {
+				if _, err := io.CopyN(tw, tr, header.Size); err != nil {
+					return fmt.Errorf("write %q contents: %w", header.Name, err)
+				}
+			}
+		}
+	}
+}
+
+// normalize names to avoid duplicates by calling [path.Clean], then removing leading and trailing slashes
+func (c *mergeCommand) normalize(p string) string {
+	// don't use [filepath.Clean], since that converts to "\" to "/" on Windows, which breaks Linux images
+	cs := "/"
+	if c.OS == windowsOS {
+		cs += `\`
+	}
+	// triming trailing "/" should be redundant, but needed for "\" in Windows layers
+	return strings.Trim(path.Clean(p), cs)
+}
+
+// based off of:
+//   - https://github.com/google/go-containerregistry/blob/a07d1cab8700a9875699d2e7052f47acec30399d/pkg/v1/mutate/mutate.go#L264
+func inWhiteoutDir(fileMap map[string]bool, file string) bool {
+	for {
+		if file == "" {
+			break
+		}
+		dirname := path.Dir(file)
+		if file == dirname {
+			break
+		}
+		if val, ok := fileMap[dirname]; ok && val {
+			return true
+		}
+		file = dirname
+	}
+	return false
+}
+
+func outputFilePath(s string) (string, error) {
+	p, err := filepath.Abs(s)
+	if err != nil {
+		return "", fmt.Errorf("invalid output file path %q: %w", s, err)
+	}
+
+	entry := logrus.WithField("output", p)
+	// if path is a (normal) file, it'll be silently overwritten
+	if st, err := os.Stat(p); err == nil {
+		if st.IsDir() {
+			return "", fmt.Errorf("output file %q is a directory", p)
+		} else {
+			entry.Warn("existing output file will be overwritten")
+		}
+	} else if !os.IsNotExist(err) {
+		// something weird happened, warn and hope the error goes away when we create it
+		entry.WithError(err).Warn("unable to stat")
+	}
+
+	entry.Debug("using output path")
+	return p, nil
+}
+
+// statistics seen when merging layers
+type layerWriteStats struct {
+	numTrailing       int
+	numOwnerOverride  int
+	numFormatOverride int
+	numRelPrepend     int
+	numFiles          int
+	numDir            int
+	numHard           int
+	numSym            int
+	numOther          int
+}
+
+func (x *layerWriteStats) totalFiles() int {
+	return x.numFiles + x.numDir + x.numHard + x.numSym + x.numOther
+}
+
+type osType string
+
+const (
+	windowsOS = osType("windows")
+	linuxOS   = osType("linux")
+)
+
+func parseOSType(s string) (t osType, _ error) {
+	switch t = osType(strings.ToLower(strings.TrimSpace(s))); t {
+	case windowsOS, linuxOS:
+		return t, nil
+	}
+	return t, fmt.Errorf("unknown OS type: %s", s)
+}

--- a/internal/tools/rootfs/merge.go
+++ b/internal/tools/rootfs/merge.go
@@ -287,9 +287,7 @@ func (c *mergeCommand) writeLayer(
 			continue
 		}
 
-		//
 		// update header (as needed)
-		//
 
 		if c.RelativePathPrefix && !(strings.HasPrefix(header.Name, `./`) || (c.OS == windowsOS && strings.HasPrefix(header.Name, `.\`))) {
 			stats.numRelPrepend++

--- a/test/functional/main_test.go
+++ b/test/functional/main_test.go
@@ -41,6 +41,8 @@ import (
 	testuvm "github.com/Microsoft/hcsshim/test/pkg/uvm"
 )
 
+// TODO(go1.24): use [(*"testing".B).Loop()] instead of `for i := 0; i < b.N; i++ { }`
+
 // owner field for uVMs.
 const hcsOwner = "hcsshim-functional-tests"
 

--- a/test/go.mod
+++ b/test/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/opencontainers/runtime-tools v0.9.1-0.20221107090550-2e043c6bd626
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.9.3
-	github.com/urfave/cli/v2 v2.27.1
+	github.com/urfave/cli/v2 v2.27.5
 	go.opencensus.io v0.24.0
 	golang.org/x/sync v0.13.0
 	golang.org/x/sys v0.32.0
@@ -49,7 +49,7 @@ require (
 	github.com/containerd/stargz-snapshotter/estargz v0.15.1 // indirect
 	github.com/containerd/typeurl/v2 v2.2.0 // indirect
 	github.com/coreos/go-systemd/v22 v22.5.0 // indirect
-	github.com/cpuguy83/go-md2man/v2 v2.0.4 // indirect
+	github.com/cpuguy83/go-md2man/v2 v2.0.5 // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0 // indirect
 	github.com/distribution/reference v0.6.0 // indirect
 	github.com/docker/cli v24.0.0+incompatible // indirect
@@ -108,7 +108,7 @@ require (
 	github.com/x448/float16 v0.8.4 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
-	github.com/xrash/smetrics v0.0.0-20240312152122-5f08fbb34913 // indirect
+	github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1 // indirect
 	github.com/yashtewari/glob-intersection v0.2.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.53.0 // indirect
 	go.opentelemetry.io/otel v1.31.0 // indirect

--- a/test/go.sum
+++ b/test/go.sum
@@ -63,8 +63,8 @@ github.com/containerd/typeurl/v2 v2.2.0 h1:6NBDbQzr7I5LHgp34xAXYF5DOTQDn05X58lsP
 github.com/containerd/typeurl/v2 v2.2.0/go.mod h1:8XOOxnyatxSWuG8OfsZXVnAF4iZfedjS/8UHSPJnX4g=
 github.com/coreos/go-systemd/v22 v22.5.0 h1:RrqgGjYQKalulkV8NGVIfkXQf6YYmOyiJKk8iXXhfZs=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
-github.com/cpuguy83/go-md2man/v2 v2.0.4 h1:wfIWP927BUkWJb2NmU/kNDYIBTh/ziUX91+lVfRxZq4=
-github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
+github.com/cpuguy83/go-md2man/v2 v2.0.5 h1:ZtcqGrnekaHpVLArFSe4HK5DoKx1T0rq2DwVB0alcyc=
+github.com/cpuguy83/go-md2man/v2 v2.0.5/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -278,8 +278,8 @@ github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG
 github.com/tchap/go-patricia/v2 v2.3.1 h1:6rQp39lgIYZ+MHmdEq4xzuk1t7OdC35z/xm0BGhTkes=
 github.com/tchap/go-patricia/v2 v2.3.1/go.mod h1:VZRHKAb53DLaG+nA9EaYYiaEx6YztwDlLElMsnSHD4k=
 github.com/urfave/cli v1.19.1/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
-github.com/urfave/cli/v2 v2.27.1 h1:8xSQ6szndafKVRmfyeUMxkNUJQMjL1F2zmsZ+qHpfho=
-github.com/urfave/cli/v2 v2.27.1/go.mod h1:8qnjx1vcq5s2/wpsqoZFndg2CE5tNFyrTvS6SinrnYQ=
+github.com/urfave/cli/v2 v2.27.5 h1:WoHEJLdsXr6dDWoJgMq/CboDmyY/8HMMH1fTECbih+w=
+github.com/urfave/cli/v2 v2.27.5/go.mod h1:3Sevf16NykTbInEnD0yKkjDAeZDS0A6bzhBH5hrMvTQ=
 github.com/vbatts/tar-split v0.11.5 h1:3bHCTIheBm1qFTcgh9oPu+nNBtX+XJIupG/vacinCts=
 github.com/vbatts/tar-split v0.11.5/go.mod h1:yZbwRsSeGjusneWgA781EKej9HF8vme8okylkAeNKLk=
 github.com/veraison/go-cose v1.1.0 h1:AalPS4VGiKavpAzIlBjrn7bhqXiXi4jbMYY/2+UC+4o=
@@ -297,8 +297,8 @@ github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 h1:EzJWgHo
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
 github.com/xeipuuv/gojsonschema v1.2.0 h1:LhYJRs+L4fBtjZUfuSZIKGeVu0QRy8e5Xi7D17UxZ74=
 github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=
-github.com/xrash/smetrics v0.0.0-20240312152122-5f08fbb34913 h1:+qGGcbkzsfDQNPPe9UDgpxAWQrhbbBXOYJFQDq/dtJw=
-github.com/xrash/smetrics v0.0.0-20240312152122-5f08fbb34913/go.mod h1:4aEEwZQutDLsQv2Deui4iYQ6DWTxR14g6m8Wv88+Xqk=
+github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1 h1:gEOO8jv9F4OT7lGCjxCBTO/36wtF6j2nSip77qHd4x4=
+github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1/go.mod h1:Ohn+xnUBiLI6FVj/9LpzZWtj1/D6lUovWYBkxHVV3aM=
 github.com/yashtewari/glob-intersection v0.2.0 h1:8iuHdN88yYuCzCdjt0gDe+6bAhUwBeEWqThExu54RFg=
 github.com/yashtewari/glob-intersection v0.2.0/go.mod h1:LK7pIC3piUjovexikBbJ26Yml7g8xa5bsjfx2v1fwok=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/test/internal/util/util.go
+++ b/test/internal/util/util.go
@@ -155,6 +155,12 @@ func repeat(f func() error, n int, d time.Duration) (err error) {
 	return err
 }
 
+// TODO(go1.24): use [TB.Context]
+// See:
+//  - https://tip.golang.org/doc/go1.24#testingpkgtesting
+//  - https://pkg.go.dev/testing@master#T.Context
+//  - https://pkg.go.dev/testing@master#TB
+
 // Context creates a [context.Context] that uses the testing.Deadline minus a small grace period (if applicable)
 // and the cancellation to the testing cleanup.
 //

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -2,6 +2,11 @@
 
 package tools
 
+// TODO(go1.24): use tools directive in go.mod
+// See:
+//  - https://github.com/golang/go/issues/48429
+//  - https://go.googlesource.com/proposal/+/54d6775ff71ccbc00c276db2a4e4841d67011cf4/design/48429-go-tool-modules.md
+
 import (
 	// protobuf/gRPC/ttrpc generation
 	_ "github.com/containerd/protobuild"

--- a/vendor/github.com/cpuguy83/go-md2man/v2/md2man/debug.go
+++ b/vendor/github.com/cpuguy83/go-md2man/v2/md2man/debug.go
@@ -1,0 +1,62 @@
+package md2man
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/russross/blackfriday/v2"
+)
+
+func fmtListFlags(flags blackfriday.ListType) string {
+	knownFlags := []struct {
+		name string
+		flag blackfriday.ListType
+	}{
+		{"ListTypeOrdered", blackfriday.ListTypeOrdered},
+		{"ListTypeDefinition", blackfriday.ListTypeDefinition},
+		{"ListTypeTerm", blackfriday.ListTypeTerm},
+		{"ListItemContainsBlock", blackfriday.ListItemContainsBlock},
+		{"ListItemBeginningOfList", blackfriday.ListItemBeginningOfList},
+		{"ListItemEndOfList", blackfriday.ListItemEndOfList},
+	}
+
+	var f []string
+	for _, kf := range knownFlags {
+		if flags&kf.flag != 0 {
+			f = append(f, kf.name)
+			flags &^= kf.flag
+		}
+	}
+	if flags != 0 {
+		f = append(f, fmt.Sprintf("Unknown(%#x)", flags))
+	}
+	return strings.Join(f, "|")
+}
+
+type debugDecorator struct {
+	blackfriday.Renderer
+}
+
+func depth(node *blackfriday.Node) int {
+	d := 0
+	for n := node.Parent; n != nil; n = n.Parent {
+		d++
+	}
+	return d
+}
+
+func (d *debugDecorator) RenderNode(w io.Writer, node *blackfriday.Node, entering bool) blackfriday.WalkStatus {
+	fmt.Fprintf(os.Stderr, "%s%s %v %v\n",
+		strings.Repeat("  ", depth(node)),
+		map[bool]string{true: "+", false: "-"}[entering],
+		node,
+		fmtListFlags(node.ListFlags))
+	var b strings.Builder
+	status := d.Renderer.RenderNode(io.MultiWriter(&b, w), node, entering)
+	if b.Len() > 0 {
+		fmt.Fprintf(os.Stderr, ">> %q\n", b.String())
+	}
+	return status
+}

--- a/vendor/github.com/cpuguy83/go-md2man/v2/md2man/md2man.go
+++ b/vendor/github.com/cpuguy83/go-md2man/v2/md2man/md2man.go
@@ -1,16 +1,23 @@
 package md2man
 
 import (
+	"os"
+	"strconv"
+
 	"github.com/russross/blackfriday/v2"
 )
 
 // Render converts a markdown document into a roff formatted document.
 func Render(doc []byte) []byte {
 	renderer := NewRoffRenderer()
+	var r blackfriday.Renderer = renderer
+	if v, _ := strconv.ParseBool(os.Getenv("MD2MAN_DEBUG")); v {
+		r = &debugDecorator{Renderer: r}
+	}
 
 	return blackfriday.Run(doc,
 		[]blackfriday.Option{
-			blackfriday.WithRenderer(renderer),
+			blackfriday.WithRenderer(r),
 			blackfriday.WithExtensions(renderer.GetExtensions()),
 		}...)
 }

--- a/vendor/github.com/cpuguy83/go-md2man/v2/md2man/roff.go
+++ b/vendor/github.com/cpuguy83/go-md2man/v2/md2man/roff.go
@@ -14,10 +14,8 @@ import (
 // roffRenderer implements the blackfriday.Renderer interface for creating
 // roff format (manpages) from markdown text
 type roffRenderer struct {
-	extensions   blackfriday.Extensions
 	listCounters []int
 	firstHeader  bool
-	firstDD      bool
 	listDepth    int
 }
 
@@ -43,7 +41,7 @@ const (
 	quoteTag          = "\n.PP\n.RS\n"
 	quoteCloseTag     = "\n.RE\n"
 	listTag           = "\n.RS\n"
-	listCloseTag      = "\n.RE\n"
+	listCloseTag      = ".RE\n"
 	dtTag             = "\n.TP\n"
 	dd2Tag            = "\n"
 	tableStart        = "\n.TS\nallbox;\n"
@@ -56,23 +54,18 @@ const (
 // NewRoffRenderer creates a new blackfriday Renderer for generating roff documents
 // from markdown
 func NewRoffRenderer() *roffRenderer { // nolint: golint
-	var extensions blackfriday.Extensions
-
-	extensions |= blackfriday.NoIntraEmphasis
-	extensions |= blackfriday.Tables
-	extensions |= blackfriday.FencedCode
-	extensions |= blackfriday.SpaceHeadings
-	extensions |= blackfriday.Footnotes
-	extensions |= blackfriday.Titleblock
-	extensions |= blackfriday.DefinitionLists
-	return &roffRenderer{
-		extensions: extensions,
-	}
+	return &roffRenderer{}
 }
 
 // GetExtensions returns the list of extensions used by this renderer implementation
-func (r *roffRenderer) GetExtensions() blackfriday.Extensions {
-	return r.extensions
+func (*roffRenderer) GetExtensions() blackfriday.Extensions {
+	return blackfriday.NoIntraEmphasis |
+		blackfriday.Tables |
+		blackfriday.FencedCode |
+		blackfriday.SpaceHeadings |
+		blackfriday.Footnotes |
+		blackfriday.Titleblock |
+		blackfriday.DefinitionLists
 }
 
 // RenderHeader handles outputting the header at document start
@@ -103,7 +96,23 @@ func (r *roffRenderer) RenderNode(w io.Writer, node *blackfriday.Node, entering 
 
 	switch node.Type {
 	case blackfriday.Text:
-		escapeSpecialChars(w, node.Literal)
+		// Special case: format the NAME section as required for proper whatis parsing.
+		// Refer to the lexgrog(1) and groff_man(7) manual pages for details.
+		if node.Parent != nil &&
+			node.Parent.Type == blackfriday.Paragraph &&
+			node.Parent.Prev != nil &&
+			node.Parent.Prev.Type == blackfriday.Heading &&
+			node.Parent.Prev.FirstChild != nil &&
+			bytes.EqualFold(node.Parent.Prev.FirstChild.Literal, []byte("NAME")) {
+			before, after, found := bytes.Cut(node.Literal, []byte(" - "))
+			escapeSpecialChars(w, before)
+			if found {
+				out(w, ` \- `)
+				escapeSpecialChars(w, after)
+			}
+		} else {
+			escapeSpecialChars(w, node.Literal)
+		}
 	case blackfriday.Softbreak:
 		out(w, crTag)
 	case blackfriday.Hardbreak:
@@ -141,14 +150,25 @@ func (r *roffRenderer) RenderNode(w io.Writer, node *blackfriday.Node, entering 
 	case blackfriday.Document:
 		break
 	case blackfriday.Paragraph:
-		// roff .PP markers break lists
-		if r.listDepth > 0 {
-			return blackfriday.GoToNext
-		}
 		if entering {
-			out(w, paraTag)
+			if r.listDepth > 0 {
+				// roff .PP markers break lists
+				if node.Prev != nil { // continued paragraph
+					if node.Prev.Type == blackfriday.List && node.Prev.ListFlags&blackfriday.ListTypeDefinition == 0 {
+						out(w, ".IP\n")
+					} else {
+						out(w, crTag)
+					}
+				}
+			} else if node.Prev != nil && node.Prev.Type == blackfriday.Heading {
+				out(w, crTag)
+			} else {
+				out(w, paraTag)
+			}
 		} else {
-			out(w, crTag)
+			if node.Next == nil || node.Next.Type != blackfriday.List {
+				out(w, crTag)
+			}
 		}
 	case blackfriday.BlockQuote:
 		if entering {
@@ -211,6 +231,10 @@ func (r *roffRenderer) handleHeading(w io.Writer, node *blackfriday.Node, enteri
 func (r *roffRenderer) handleList(w io.Writer, node *blackfriday.Node, entering bool) {
 	openTag := listTag
 	closeTag := listCloseTag
+	if (entering && r.listDepth == 0) || (!entering && r.listDepth == 1) {
+		openTag = crTag
+		closeTag = ""
+	}
 	if node.ListFlags&blackfriday.ListTypeDefinition != 0 {
 		// tags for definition lists handled within Item node
 		openTag = ""
@@ -239,23 +263,25 @@ func (r *roffRenderer) handleItem(w io.Writer, node *blackfriday.Node, entering 
 		} else if node.ListFlags&blackfriday.ListTypeTerm != 0 {
 			// DT (definition term): line just before DD (see below).
 			out(w, dtTag)
-			r.firstDD = true
 		} else if node.ListFlags&blackfriday.ListTypeDefinition != 0 {
 			// DD (definition description): line that starts with ": ".
 			//
 			// We have to distinguish between the first DD and the
 			// subsequent ones, as there should be no vertical
 			// whitespace between the DT and the first DD.
-			if r.firstDD {
-				r.firstDD = false
-			} else {
-				out(w, dd2Tag)
+			if node.Prev != nil && node.Prev.ListFlags&(blackfriday.ListTypeTerm|blackfriday.ListTypeDefinition) == blackfriday.ListTypeDefinition {
+				if node.Prev.Type == blackfriday.Item &&
+					node.Prev.LastChild != nil &&
+					node.Prev.LastChild.Type == blackfriday.List &&
+					node.Prev.LastChild.ListFlags&blackfriday.ListTypeDefinition == 0 {
+					out(w, ".IP\n")
+				} else {
+					out(w, dd2Tag)
+				}
 			}
 		} else {
 			out(w, ".IP \\(bu 2\n")
 		}
-	} else {
-		out(w, "\n")
 	}
 }
 

--- a/vendor/github.com/urfave/cli/v2/.flake8
+++ b/vendor/github.com/urfave/cli/v2/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 120

--- a/vendor/github.com/urfave/cli/v2/.gitignore
+++ b/vendor/github.com/urfave/cli/v2/.gitignore
@@ -1,0 +1,14 @@
+*.coverprofile
+*.exe
+*.orig
+.*envrc
+.envrc
+.idea
+# goimports is installed here if not available
+/.local/
+/site/
+coverage.txt
+internal/*/built-example
+vendor
+/cmd/urfave-cli-genflags/urfave-cli-genflags
+*.exe

--- a/vendor/github.com/urfave/cli/v2/.golangci.yaml
+++ b/vendor/github.com/urfave/cli/v2/.golangci.yaml
@@ -1,0 +1,4 @@
+# https://golangci-lint.run/usage/configuration/
+linters:
+  enable:
+    - misspell

--- a/vendor/github.com/urfave/cli/v2/CODE_OF_CONDUCT.md
+++ b/vendor/github.com/urfave/cli/v2/CODE_OF_CONDUCT.md
@@ -1,0 +1,75 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of experience,
+education, socio-economic status, nationality, personal appearance, race,
+religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting urfave-governance@googlegroups.com, a members-only group
+that is world-postable. All complaints will be reviewed and investigated and
+will result in a response that is deemed necessary and appropriate to the
+circumstances. The project team is obligated to maintain confidentiality with
+regard to the reporter of an incident. Further details of specific enforcement
+policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+

--- a/vendor/github.com/urfave/cli/v2/LICENSE
+++ b/vendor/github.com/urfave/cli/v2/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 urfave/cli maintainers
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/urfave/cli/v2/Makefile
+++ b/vendor/github.com/urfave/cli/v2/Makefile
@@ -1,0 +1,26 @@
+# NOTE: this Makefile is meant to provide a simplified entry point for humans to
+# run all of the critical steps to verify one's changes are harmonious in
+# nature. Keeping target bodies to one line each and abstaining from make magic
+# are very important so that maintainers and contributors can focus their
+# attention on files that are primarily Go.
+
+GO_RUN_BUILD := go run internal/build/build.go
+
+.PHONY: all
+all: generate vet test check-binary-size gfmrun yamlfmt v2diff
+
+# NOTE: this is a special catch-all rule to run any of the commands
+# defined in internal/build/build.go with optional arguments passed
+# via GFLAGS (global flags) and FLAGS (command-specific flags), e.g.:
+#
+#   $ make test GFLAGS='--packages cli'
+%:
+	$(GO_RUN_BUILD) $(GFLAGS) $* $(FLAGS)
+
+.PHONY: docs
+docs:
+	mkdocs build
+
+.PHONY: serve-docs
+serve-docs:
+	mkdocs serve

--- a/vendor/github.com/urfave/cli/v2/README.md
+++ b/vendor/github.com/urfave/cli/v2/README.md
@@ -1,0 +1,19 @@
+# cli
+
+[![Run Tests](https://github.com/urfave/cli/actions/workflows/cli.yml/badge.svg?branch=v2-maint)](https://github.com/urfave/cli/actions/workflows/cli.yml)
+[![Go Reference](https://pkg.go.dev/badge/github.com/urfave/cli/v2.svg)](https://pkg.go.dev/github.com/urfave/cli/v2)
+[![Go Report Card](https://goreportcard.com/badge/github.com/urfave/cli/v2)](https://goreportcard.com/report/github.com/urfave/cli/v2)
+[![codecov](https://codecov.io/gh/urfave/cli/branch/v2-maint/graph/badge.svg?token=t9YGWLh05g)](https://app.codecov.io/gh/urfave/cli/tree/v2-maint)
+
+cli is a simple, fast, and fun package for building command line apps in Go. The
+goal is to enable developers to write fast and distributable command line
+applications in an expressive way.
+
+## Documentation
+
+More documentation is available in [`./docs`](./docs) or the hosted
+documentation site at <https://cli.urfave.org>.
+
+## License
+
+See [`LICENSE`](./LICENSE)

--- a/vendor/github.com/urfave/cli/v2/app.go
+++ b/vendor/github.com/urfave/cli/v2/app.go
@@ -1,0 +1,536 @@
+package cli
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+const suggestDidYouMeanTemplate = "Did you mean %q?"
+
+var (
+	changeLogURL            = "https://github.com/urfave/cli/blob/main/docs/CHANGELOG.md"
+	appActionDeprecationURL = fmt.Sprintf("%s#deprecated-cli-app-action-signature", changeLogURL)
+	contactSysadmin         = "This is an error in the application.  Please contact the distributor of this application if this is not you."
+	errInvalidActionType    = NewExitError("ERROR invalid Action type. "+
+		fmt.Sprintf("Must be `func(*Context`)` or `func(*Context) error).  %s", contactSysadmin)+
+		fmt.Sprintf("See %s", appActionDeprecationURL), 2)
+	ignoreFlagPrefix = "test." // this is to ignore test flags when adding flags from other packages
+
+	SuggestFlag               SuggestFlagFunc    = nil // initialized in suggestions.go unless built with urfave_cli_no_suggest
+	SuggestCommand            SuggestCommandFunc = nil // initialized in suggestions.go unless built with urfave_cli_no_suggest
+	SuggestDidYouMeanTemplate string             = suggestDidYouMeanTemplate
+)
+
+// App is the main structure of a cli application. It is recommended that
+// an app be created with the cli.NewApp() function
+type App struct {
+	// The name of the program. Defaults to path.Base(os.Args[0])
+	Name string
+	// Full name of command for help, defaults to Name
+	HelpName string
+	// Description of the program.
+	Usage string
+	// Text to override the USAGE section of help
+	UsageText string
+	// Whether this command supports arguments
+	Args bool
+	// Description of the program argument format.
+	ArgsUsage string
+	// Version of the program
+	Version string
+	// Description of the program
+	Description string
+	// DefaultCommand is the (optional) name of a command
+	// to run if no command names are passed as CLI arguments.
+	DefaultCommand string
+	// List of commands to execute
+	Commands []*Command
+	// List of flags to parse
+	Flags []Flag
+	// Boolean to enable bash completion commands
+	EnableBashCompletion bool
+	// Boolean to hide built-in help command and help flag
+	HideHelp bool
+	// Boolean to hide built-in help command but keep help flag.
+	// Ignored if HideHelp is true.
+	HideHelpCommand bool
+	// Boolean to hide built-in version flag and the VERSION section of help
+	HideVersion bool
+	// categories contains the categorized commands and is populated on app startup
+	categories CommandCategories
+	// flagCategories contains the categorized flags and is populated on app startup
+	flagCategories FlagCategories
+	// An action to execute when the shell completion flag is set
+	BashComplete BashCompleteFunc
+	// An action to execute before any subcommands are run, but after the context is ready
+	// If a non-nil error is returned, no subcommands are run
+	Before BeforeFunc
+	// An action to execute after any subcommands are run, but after the subcommand has finished
+	// It is run even if Action() panics
+	After AfterFunc
+	// The action to execute when no subcommands are specified
+	Action ActionFunc
+	// Execute this function if the proper command cannot be found
+	CommandNotFound CommandNotFoundFunc
+	// Execute this function if a usage error occurs
+	OnUsageError OnUsageErrorFunc
+	// Execute this function when an invalid flag is accessed from the context
+	InvalidFlagAccessHandler InvalidFlagAccessFunc
+	// Compilation date
+	Compiled time.Time
+	// List of all authors who contributed
+	Authors []*Author
+	// Copyright of the binary if any
+	Copyright string
+	// Reader reader to write input to (useful for tests)
+	Reader io.Reader
+	// Writer writer to write output to
+	Writer io.Writer
+	// ErrWriter writes error output
+	ErrWriter io.Writer
+	// ExitErrHandler processes any error encountered while running an App before
+	// it is returned to the caller. If no function is provided, HandleExitCoder
+	// is used as the default behavior.
+	ExitErrHandler ExitErrHandlerFunc
+	// Other custom info
+	Metadata map[string]interface{}
+	// Carries a function which returns app specific info.
+	ExtraInfo func() map[string]string
+	// CustomAppHelpTemplate the text template for app help topic.
+	// cli.go uses text/template to render templates. You can
+	// render custom help text by setting this variable.
+	CustomAppHelpTemplate string
+	// SliceFlagSeparator is used to customize the separator for SliceFlag, the default is ","
+	SliceFlagSeparator string
+	// DisableSliceFlagSeparator is used to disable SliceFlagSeparator, the default is false
+	DisableSliceFlagSeparator bool
+	// Boolean to enable short-option handling so user can combine several
+	// single-character bool arguments into one
+	// i.e. foobar -o -v -> foobar -ov
+	UseShortOptionHandling bool
+	// Enable suggestions for commands and flags
+	Suggest bool
+	// Allows global flags set by libraries which use flag.XXXVar(...) directly
+	// to be parsed through this library
+	AllowExtFlags bool
+	// Treat all flags as normal arguments if true
+	SkipFlagParsing bool
+
+	didSetup  bool
+	separator separatorSpec
+
+	rootCommand *Command
+}
+
+type SuggestFlagFunc func(flags []Flag, provided string, hideHelp bool) string
+
+type SuggestCommandFunc func(commands []*Command, provided string) string
+
+// Tries to find out when this binary was compiled.
+// Returns the current time if it fails to find it.
+func compileTime() time.Time {
+	info, err := os.Stat(os.Args[0])
+	if err != nil {
+		return time.Now()
+	}
+	return info.ModTime()
+}
+
+// NewApp creates a new cli Application with some reasonable defaults for Name,
+// Usage, Version and Action.
+func NewApp() *App {
+	return &App{
+		Name:         filepath.Base(os.Args[0]),
+		Usage:        "A new cli application",
+		UsageText:    "",
+		BashComplete: DefaultAppComplete,
+		Action:       helpCommand.Action,
+		Compiled:     compileTime(),
+		Reader:       os.Stdin,
+		Writer:       os.Stdout,
+		ErrWriter:    os.Stderr,
+	}
+}
+
+// Setup runs initialization code to ensure all data structures are ready for
+// `Run` or inspection prior to `Run`.  It is internally called by `Run`, but
+// will return early if setup has already happened.
+func (a *App) Setup() {
+	if a.didSetup {
+		return
+	}
+
+	a.didSetup = true
+
+	if a.Name == "" {
+		a.Name = filepath.Base(os.Args[0])
+	}
+
+	if a.HelpName == "" {
+		a.HelpName = a.Name
+	}
+
+	if a.Usage == "" {
+		a.Usage = "A new cli application"
+	}
+
+	if a.Version == "" {
+		a.HideVersion = true
+	}
+
+	if a.BashComplete == nil {
+		a.BashComplete = DefaultAppComplete
+	}
+
+	if a.Action == nil {
+		a.Action = helpCommand.Action
+	}
+
+	if a.Compiled == (time.Time{}) {
+		a.Compiled = compileTime()
+	}
+
+	if a.Reader == nil {
+		a.Reader = os.Stdin
+	}
+
+	if a.Writer == nil {
+		a.Writer = os.Stdout
+	}
+
+	if a.ErrWriter == nil {
+		a.ErrWriter = os.Stderr
+	}
+
+	if a.AllowExtFlags {
+		// add global flags added by other packages
+		flag.VisitAll(func(f *flag.Flag) {
+			// skip test flags
+			if !strings.HasPrefix(f.Name, ignoreFlagPrefix) {
+				a.Flags = append(a.Flags, &extFlag{f})
+			}
+		})
+	}
+
+	if len(a.SliceFlagSeparator) != 0 {
+		a.separator.customized = true
+		a.separator.sep = a.SliceFlagSeparator
+	}
+
+	if a.DisableSliceFlagSeparator {
+		a.separator.customized = true
+		a.separator.disabled = true
+	}
+
+	for _, c := range a.Commands {
+		cname := c.Name
+		if c.HelpName != "" {
+			cname = c.HelpName
+		}
+		c.separator = a.separator
+		c.HelpName = fmt.Sprintf("%s %s", a.HelpName, cname)
+		c.flagCategories = newFlagCategoriesFromFlags(c.Flags)
+	}
+
+	if a.Command(helpCommand.Name) == nil && !a.HideHelp {
+		if !a.HideHelpCommand {
+			a.appendCommand(helpCommand)
+		}
+
+		if HelpFlag != nil {
+			a.appendFlag(HelpFlag)
+		}
+	}
+
+	if !a.HideVersion {
+		a.appendFlag(VersionFlag)
+	}
+
+	a.categories = newCommandCategories()
+	for _, command := range a.Commands {
+		a.categories.AddCommand(command.Category, command)
+	}
+	sort.Sort(a.categories.(*commandCategories))
+
+	a.flagCategories = newFlagCategoriesFromFlags(a.Flags)
+
+	if a.Metadata == nil {
+		a.Metadata = make(map[string]interface{})
+	}
+}
+
+func (a *App) newRootCommand() *Command {
+	return &Command{
+		Name:                   a.Name,
+		Usage:                  a.Usage,
+		UsageText:              a.UsageText,
+		Description:            a.Description,
+		ArgsUsage:              a.ArgsUsage,
+		BashComplete:           a.BashComplete,
+		Before:                 a.Before,
+		After:                  a.After,
+		Action:                 a.Action,
+		OnUsageError:           a.OnUsageError,
+		Subcommands:            a.Commands,
+		Flags:                  a.Flags,
+		flagCategories:         a.flagCategories,
+		HideHelp:               a.HideHelp,
+		HideHelpCommand:        a.HideHelpCommand,
+		UseShortOptionHandling: a.UseShortOptionHandling,
+		HelpName:               a.HelpName,
+		CustomHelpTemplate:     a.CustomAppHelpTemplate,
+		categories:             a.categories,
+		SkipFlagParsing:        a.SkipFlagParsing,
+		isRoot:                 true,
+		separator:              a.separator,
+	}
+}
+
+func (a *App) newFlagSet() (*flag.FlagSet, error) {
+	return flagSet(a.Name, a.Flags, a.separator)
+}
+
+func (a *App) useShortOptionHandling() bool {
+	return a.UseShortOptionHandling
+}
+
+// Run is the entry point to the cli app. Parses the arguments slice and routes
+// to the proper flag/args combination
+func (a *App) Run(arguments []string) (err error) {
+	return a.RunContext(context.Background(), arguments)
+}
+
+// RunContext is like Run except it takes a Context that will be
+// passed to its commands and sub-commands. Through this, you can
+// propagate timeouts and cancellation requests
+func (a *App) RunContext(ctx context.Context, arguments []string) (err error) {
+	a.Setup()
+
+	// handle the completion flag separately from the flagset since
+	// completion could be attempted after a flag, but before its value was put
+	// on the command line. this causes the flagset to interpret the completion
+	// flag name as the value of the flag before it which is undesirable
+	// note that we can only do this because the shell autocomplete function
+	// always appends the completion flag at the end of the command
+	shellComplete, arguments := checkShellCompleteFlag(a, arguments)
+
+	cCtx := NewContext(a, nil, &Context{Context: ctx})
+	cCtx.shellComplete = shellComplete
+
+	a.rootCommand = a.newRootCommand()
+	cCtx.Command = a.rootCommand
+
+	if err := checkDuplicatedCmds(a.rootCommand); err != nil {
+		return err
+	}
+	return a.rootCommand.Run(cCtx, arguments...)
+}
+
+// RunAsSubcommand is for legacy/compatibility purposes only. New code should only
+// use App.RunContext. This function is slated to be removed in v3.
+func (a *App) RunAsSubcommand(ctx *Context) (err error) {
+	a.Setup()
+
+	cCtx := NewContext(a, nil, ctx)
+	cCtx.shellComplete = ctx.shellComplete
+
+	a.rootCommand = a.newRootCommand()
+	cCtx.Command = a.rootCommand
+
+	return a.rootCommand.Run(cCtx, ctx.Args().Slice()...)
+}
+
+func (a *App) suggestFlagFromError(err error, command string) (string, error) {
+	flag, parseErr := flagFromError(err)
+	if parseErr != nil {
+		return "", err
+	}
+
+	flags := a.Flags
+	hideHelp := a.HideHelp
+	if command != "" {
+		cmd := a.Command(command)
+		if cmd == nil {
+			return "", err
+		}
+		flags = cmd.Flags
+		hideHelp = hideHelp || cmd.HideHelp
+	}
+
+	if SuggestFlag == nil {
+		return "", err
+	}
+	suggestion := SuggestFlag(flags, flag, hideHelp)
+	if len(suggestion) == 0 {
+		return "", err
+	}
+
+	return fmt.Sprintf(SuggestDidYouMeanTemplate+"\n\n", suggestion), nil
+}
+
+// RunAndExitOnError calls .Run() and exits non-zero if an error was returned
+//
+// Deprecated: instead you should return an error that fulfills cli.ExitCoder
+// to cli.App.Run. This will cause the application to exit with the given error
+// code in the cli.ExitCoder
+func (a *App) RunAndExitOnError() {
+	if err := a.Run(os.Args); err != nil {
+		_, _ = fmt.Fprintln(a.ErrWriter, err)
+		OsExiter(1)
+	}
+}
+
+// Command returns the named command on App. Returns nil if the command does not exist
+func (a *App) Command(name string) *Command {
+	for _, c := range a.Commands {
+		if c.HasName(name) {
+			return c
+		}
+	}
+
+	return nil
+}
+
+// VisibleCategories returns a slice of categories and commands that are
+// Hidden=false
+func (a *App) VisibleCategories() []CommandCategory {
+	ret := []CommandCategory{}
+	for _, category := range a.categories.Categories() {
+		if visible := func() CommandCategory {
+			if len(category.VisibleCommands()) > 0 {
+				return category
+			}
+			return nil
+		}(); visible != nil {
+			ret = append(ret, visible)
+		}
+	}
+	return ret
+}
+
+// VisibleCommands returns a slice of the Commands with Hidden=false
+func (a *App) VisibleCommands() []*Command {
+	var ret []*Command
+	for _, command := range a.Commands {
+		if !command.Hidden {
+			ret = append(ret, command)
+		}
+	}
+	return ret
+}
+
+// VisibleFlagCategories returns a slice containing all the categories with the flags they contain
+func (a *App) VisibleFlagCategories() []VisibleFlagCategory {
+	if a.flagCategories == nil {
+		return []VisibleFlagCategory{}
+	}
+	return a.flagCategories.VisibleCategories()
+}
+
+// VisibleFlags returns a slice of the Flags with Hidden=false
+func (a *App) VisibleFlags() []Flag {
+	return visibleFlags(a.Flags)
+}
+
+func (a *App) appendFlag(fl Flag) {
+	if !hasFlag(a.Flags, fl) {
+		a.Flags = append(a.Flags, fl)
+	}
+}
+
+func (a *App) appendCommand(c *Command) {
+	if !hasCommand(a.Commands, c) {
+		a.Commands = append(a.Commands, c)
+	}
+}
+
+func (a *App) handleExitCoder(cCtx *Context, err error) {
+	if a.ExitErrHandler != nil {
+		a.ExitErrHandler(cCtx, err)
+	} else {
+		HandleExitCoder(err)
+	}
+}
+
+func (a *App) argsWithDefaultCommand(oldArgs Args) Args {
+	if a.DefaultCommand != "" {
+		rawArgs := append([]string{a.DefaultCommand}, oldArgs.Slice()...)
+		newArgs := args(rawArgs)
+
+		return &newArgs
+	}
+
+	return oldArgs
+}
+
+func runFlagActions(c *Context, fs []Flag) error {
+	for _, f := range fs {
+		isSet := false
+		for _, name := range f.Names() {
+			if c.IsSet(name) {
+				isSet = true
+				break
+			}
+		}
+		if isSet {
+			if af, ok := f.(ActionableFlag); ok {
+				if err := af.RunAction(c); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// Author represents someone who has contributed to a cli project.
+type Author struct {
+	Name  string // The Authors name
+	Email string // The Authors email
+}
+
+// String makes Author comply to the Stringer interface, to allow an easy print in the templating process
+func (a *Author) String() string {
+	e := ""
+	if a.Email != "" {
+		e = " <" + a.Email + ">"
+	}
+
+	return fmt.Sprintf("%v%v", a.Name, e)
+}
+
+// HandleAction attempts to figure out which Action signature was used.  If
+// it's an ActionFunc or a func with the legacy signature for Action, the func
+// is run!
+func HandleAction(action interface{}, cCtx *Context) (err error) {
+	switch a := action.(type) {
+	case ActionFunc:
+		return a(cCtx)
+	case func(*Context) error:
+		return a(cCtx)
+	case func(*Context): // deprecated function signature
+		a(cCtx)
+		return nil
+	}
+
+	return errInvalidActionType
+}
+
+func checkStringSliceIncludes(want string, sSlice []string) bool {
+	found := false
+	for _, s := range sSlice {
+		if want == s {
+			found = true
+			break
+		}
+	}
+
+	return found
+}

--- a/vendor/github.com/urfave/cli/v2/args.go
+++ b/vendor/github.com/urfave/cli/v2/args.go
@@ -1,0 +1,54 @@
+package cli
+
+type Args interface {
+	// Get returns the nth argument, or else a blank string
+	Get(n int) string
+	// First returns the first argument, or else a blank string
+	First() string
+	// Tail returns the rest of the arguments (not the first one)
+	// or else an empty string slice
+	Tail() []string
+	// Len returns the length of the wrapped slice
+	Len() int
+	// Present checks if there are any arguments present
+	Present() bool
+	// Slice returns a copy of the internal slice
+	Slice() []string
+}
+
+type args []string
+
+func (a *args) Get(n int) string {
+	if len(*a) > n {
+		return (*a)[n]
+	}
+	return ""
+}
+
+func (a *args) First() string {
+	return a.Get(0)
+}
+
+func (a *args) Tail() []string {
+	if a.Len() >= 2 {
+		tail := []string((*a)[1:])
+		ret := make([]string, len(tail))
+		copy(ret, tail)
+		return ret
+	}
+	return []string{}
+}
+
+func (a *args) Len() int {
+	return len(*a)
+}
+
+func (a *args) Present() bool {
+	return a.Len() != 0
+}
+
+func (a *args) Slice() []string {
+	ret := make([]string, len(*a))
+	copy(ret, *a)
+	return ret
+}

--- a/vendor/github.com/urfave/cli/v2/category.go
+++ b/vendor/github.com/urfave/cli/v2/category.go
@@ -1,0 +1,186 @@
+package cli
+
+import "sort"
+
+// CommandCategories interface allows for category manipulation
+type CommandCategories interface {
+	// AddCommand adds a command to a category, creating a new category if necessary.
+	AddCommand(category string, command *Command)
+	// Categories returns a slice of categories sorted by name
+	Categories() []CommandCategory
+}
+
+type commandCategories []*commandCategory
+
+func newCommandCategories() CommandCategories {
+	ret := commandCategories([]*commandCategory{})
+	return &ret
+}
+
+func (c *commandCategories) Less(i, j int) bool {
+	return lexicographicLess((*c)[i].Name(), (*c)[j].Name())
+}
+
+func (c *commandCategories) Len() int {
+	return len(*c)
+}
+
+func (c *commandCategories) Swap(i, j int) {
+	(*c)[i], (*c)[j] = (*c)[j], (*c)[i]
+}
+
+func (c *commandCategories) AddCommand(category string, command *Command) {
+	for _, commandCategory := range []*commandCategory(*c) {
+		if commandCategory.name == category {
+			commandCategory.commands = append(commandCategory.commands, command)
+			return
+		}
+	}
+	newVal := append(*c,
+		&commandCategory{name: category, commands: []*Command{command}})
+	*c = newVal
+}
+
+func (c *commandCategories) Categories() []CommandCategory {
+	ret := make([]CommandCategory, len(*c))
+	for i, cat := range *c {
+		ret[i] = cat
+	}
+	return ret
+}
+
+// CommandCategory is a category containing commands.
+type CommandCategory interface {
+	// Name returns the category name string
+	Name() string
+	// VisibleCommands returns a slice of the Commands with Hidden=false
+	VisibleCommands() []*Command
+}
+
+type commandCategory struct {
+	name     string
+	commands []*Command
+}
+
+func (c *commandCategory) Name() string {
+	return c.name
+}
+
+func (c *commandCategory) VisibleCommands() []*Command {
+	if c.commands == nil {
+		c.commands = []*Command{}
+	}
+
+	var ret []*Command
+	for _, command := range c.commands {
+		if !command.Hidden {
+			ret = append(ret, command)
+		}
+	}
+	return ret
+}
+
+// FlagCategories interface allows for category manipulation
+type FlagCategories interface {
+	// AddFlags adds a flag to a category, creating a new category if necessary.
+	AddFlag(category string, fl Flag)
+	// VisibleCategories returns a slice of visible flag categories sorted by name
+	VisibleCategories() []VisibleFlagCategory
+}
+
+type defaultFlagCategories struct {
+	m map[string]*defaultVisibleFlagCategory
+}
+
+func newFlagCategories() FlagCategories {
+	return &defaultFlagCategories{
+		m: map[string]*defaultVisibleFlagCategory{},
+	}
+}
+
+func newFlagCategoriesFromFlags(fs []Flag) FlagCategories {
+	fc := newFlagCategories()
+
+	var categorized bool
+	for _, fl := range fs {
+		if cf, ok := fl.(CategorizableFlag); ok {
+			if cat := cf.GetCategory(); cat != "" && cf.IsVisible() {
+				fc.AddFlag(cat, cf)
+				categorized = true
+			}
+		}
+	}
+
+	if categorized {
+		for _, fl := range fs {
+			if cf, ok := fl.(CategorizableFlag); ok {
+				if cf.GetCategory() == "" && cf.IsVisible() {
+					fc.AddFlag("", fl)
+				}
+			}
+		}
+	}
+
+	return fc
+}
+
+func (f *defaultFlagCategories) AddFlag(category string, fl Flag) {
+	if _, ok := f.m[category]; !ok {
+		f.m[category] = &defaultVisibleFlagCategory{name: category, m: map[string]Flag{}}
+	}
+
+	f.m[category].m[fl.String()] = fl
+}
+
+func (f *defaultFlagCategories) VisibleCategories() []VisibleFlagCategory {
+	catNames := []string{}
+	for name := range f.m {
+		catNames = append(catNames, name)
+	}
+
+	sort.Strings(catNames)
+
+	ret := make([]VisibleFlagCategory, len(catNames))
+	for i, name := range catNames {
+		ret[i] = f.m[name]
+	}
+
+	return ret
+}
+
+// VisibleFlagCategory is a category containing flags.
+type VisibleFlagCategory interface {
+	// Name returns the category name string
+	Name() string
+	// Flags returns a slice of VisibleFlag sorted by name
+	Flags() []VisibleFlag
+}
+
+type defaultVisibleFlagCategory struct {
+	name string
+	m    map[string]Flag
+}
+
+func (fc *defaultVisibleFlagCategory) Name() string {
+	return fc.name
+}
+
+func (fc *defaultVisibleFlagCategory) Flags() []VisibleFlag {
+	vfNames := []string{}
+	for flName, fl := range fc.m {
+		if vf, ok := fl.(VisibleFlag); ok {
+			if vf.IsVisible() {
+				vfNames = append(vfNames, flName)
+			}
+		}
+	}
+
+	sort.Strings(vfNames)
+
+	ret := make([]VisibleFlag, len(vfNames))
+	for i, flName := range vfNames {
+		ret[i] = fc.m[flName].(VisibleFlag)
+	}
+
+	return ret
+}

--- a/vendor/github.com/urfave/cli/v2/cli.go
+++ b/vendor/github.com/urfave/cli/v2/cli.go
@@ -1,0 +1,25 @@
+// Package cli provides a minimal framework for creating and organizing command line
+// Go applications. cli is designed to be easy to understand and write, the most simple
+// cli application can be written as follows:
+//
+//	func main() {
+//		(&cli.App{}).Run(os.Args)
+//	}
+//
+// Of course this application does not do much, so let's make this an actual application:
+//
+//	func main() {
+//		app := &cli.App{
+//	  		Name: "greet",
+//	  		Usage: "say a greeting",
+//	  		Action: func(c *cli.Context) error {
+//	  			fmt.Println("Greetings")
+//	  			return nil
+//	  		},
+//		}
+//
+//		app.Run(os.Args)
+//	}
+package cli
+
+//go:generate make -C cmd/urfave-cli-genflags run

--- a/vendor/github.com/urfave/cli/v2/command.go
+++ b/vendor/github.com/urfave/cli/v2/command.go
@@ -1,0 +1,421 @@
+package cli
+
+import (
+	"flag"
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+)
+
+// Command is a subcommand for a cli.App.
+type Command struct {
+	// The name of the command
+	Name string
+	// A list of aliases for the command
+	Aliases []string
+	// A short description of the usage of this command
+	Usage string
+	// Custom text to show on USAGE section of help
+	UsageText string
+	// A longer explanation of how the command works
+	Description string
+	// Whether this command supports arguments
+	Args bool
+	// A short description of the arguments of this command
+	ArgsUsage string
+	// The category the command is part of
+	Category string
+	// The function to call when checking for bash command completions
+	BashComplete BashCompleteFunc
+	// An action to execute before any sub-subcommands are run, but after the context is ready
+	// If a non-nil error is returned, no sub-subcommands are run
+	Before BeforeFunc
+	// An action to execute after any subcommands are run, but after the subcommand has finished
+	// It is run even if Action() panics
+	After AfterFunc
+	// The function to call when this command is invoked
+	Action ActionFunc
+	// Execute this function if a usage error occurs.
+	OnUsageError OnUsageErrorFunc
+	// List of child commands
+	Subcommands []*Command
+	// List of flags to parse
+	Flags          []Flag
+	flagCategories FlagCategories
+	// Treat all flags as normal arguments if true
+	SkipFlagParsing bool
+	// Boolean to hide built-in help command and help flag
+	HideHelp bool
+	// Boolean to hide built-in help command but keep help flag
+	// Ignored if HideHelp is true.
+	HideHelpCommand bool
+	// Boolean to hide this command from help or completion
+	Hidden bool
+	// Boolean to enable short-option handling so user can combine several
+	// single-character bool arguments into one
+	// i.e. foobar -o -v -> foobar -ov
+	UseShortOptionHandling bool
+
+	// Full name of command for help, defaults to full command name, including parent commands.
+	HelpName        string
+	commandNamePath []string
+
+	// CustomHelpTemplate the text template for the command help topic.
+	// cli.go uses text/template to render templates. You can
+	// render custom help text by setting this variable.
+	CustomHelpTemplate string
+
+	// categories contains the categorized commands and is populated on app startup
+	categories CommandCategories
+
+	// if this is a root "special" command
+	isRoot bool
+
+	separator separatorSpec
+}
+
+type Commands []*Command
+
+type CommandsByName []*Command
+
+func (c CommandsByName) Len() int {
+	return len(c)
+}
+
+func (c CommandsByName) Less(i, j int) bool {
+	return lexicographicLess(c[i].Name, c[j].Name)
+}
+
+func (c CommandsByName) Swap(i, j int) {
+	c[i], c[j] = c[j], c[i]
+}
+
+// FullName returns the full name of the command.
+// For subcommands this ensures that parent commands are part of the command path
+func (c *Command) FullName() string {
+	if c.commandNamePath == nil {
+		return c.Name
+	}
+	return strings.Join(c.commandNamePath, " ")
+}
+
+func (cmd *Command) Command(name string) *Command {
+	for _, c := range cmd.Subcommands {
+		if c.HasName(name) {
+			return c
+		}
+	}
+
+	return nil
+}
+
+func (c *Command) setup(ctx *Context) {
+	if c.Command(helpCommand.Name) == nil && !c.HideHelp {
+		if !c.HideHelpCommand {
+			c.Subcommands = append(c.Subcommands, helpCommand)
+		}
+	}
+
+	if !c.HideHelp && HelpFlag != nil {
+		// append help to flags
+		c.appendFlag(HelpFlag)
+	}
+
+	if ctx.App.UseShortOptionHandling {
+		c.UseShortOptionHandling = true
+	}
+
+	c.categories = newCommandCategories()
+	for _, command := range c.Subcommands {
+		c.categories.AddCommand(command.Category, command)
+	}
+	sort.Sort(c.categories.(*commandCategories))
+
+	for _, scmd := range c.Subcommands {
+		if scmd.HelpName == "" {
+			scmd.HelpName = fmt.Sprintf("%s %s", c.HelpName, scmd.Name)
+		}
+		scmd.separator = c.separator
+	}
+
+	if c.BashComplete == nil {
+		c.BashComplete = DefaultCompleteWithFlags(c)
+	}
+}
+
+func (c *Command) Run(cCtx *Context, arguments ...string) (err error) {
+
+	if !c.isRoot {
+		c.setup(cCtx)
+		if err := checkDuplicatedCmds(c); err != nil {
+			return err
+		}
+	}
+
+	a := args(arguments)
+	set, err := c.parseFlags(&a, cCtx.shellComplete)
+	cCtx.flagSet = set
+
+	if checkCompletions(cCtx) {
+		return nil
+	}
+
+	if err != nil {
+		if c.OnUsageError != nil {
+			err = c.OnUsageError(cCtx, err, !c.isRoot)
+			cCtx.App.handleExitCoder(cCtx, err)
+			return err
+		}
+		_, _ = fmt.Fprintf(cCtx.App.Writer, "%s %s\n\n", "Incorrect Usage:", err.Error())
+		if cCtx.App.Suggest {
+			if suggestion, err := c.suggestFlagFromError(err, ""); err == nil {
+				fmt.Fprintf(cCtx.App.Writer, "%s", suggestion)
+			}
+		}
+		if !c.HideHelp {
+			if c.isRoot {
+				_ = ShowAppHelp(cCtx)
+			} else {
+				_ = ShowCommandHelp(cCtx.parentContext, c.Name)
+			}
+		}
+		return err
+	}
+
+	if checkHelp(cCtx) {
+		return helpCommand.Action(cCtx)
+	}
+
+	if c.isRoot && !cCtx.App.HideVersion && checkVersion(cCtx) {
+		ShowVersion(cCtx)
+		return nil
+	}
+
+	if c.After != nil && !cCtx.shellComplete {
+		defer func() {
+			afterErr := c.After(cCtx)
+			if afterErr != nil {
+				cCtx.App.handleExitCoder(cCtx, err)
+				if err != nil {
+					err = newMultiError(err, afterErr)
+				} else {
+					err = afterErr
+				}
+			}
+		}()
+	}
+
+	cerr := cCtx.checkRequiredFlags(c.Flags)
+	if cerr != nil {
+		_ = helpCommand.Action(cCtx)
+		return cerr
+	}
+
+	if c.Before != nil && !cCtx.shellComplete {
+		beforeErr := c.Before(cCtx)
+		if beforeErr != nil {
+			cCtx.App.handleExitCoder(cCtx, beforeErr)
+			err = beforeErr
+			return err
+		}
+	}
+
+	if err = runFlagActions(cCtx, c.Flags); err != nil {
+		return err
+	}
+
+	var cmd *Command
+	args := cCtx.Args()
+	if args.Present() {
+		name := args.First()
+		cmd = c.Command(name)
+		if cmd == nil {
+			hasDefault := cCtx.App.DefaultCommand != ""
+			isFlagName := checkStringSliceIncludes(name, cCtx.FlagNames())
+
+			var (
+				isDefaultSubcommand   = false
+				defaultHasSubcommands = false
+			)
+
+			if hasDefault {
+				dc := cCtx.App.Command(cCtx.App.DefaultCommand)
+				defaultHasSubcommands = len(dc.Subcommands) > 0
+				for _, dcSub := range dc.Subcommands {
+					if checkStringSliceIncludes(name, dcSub.Names()) {
+						isDefaultSubcommand = true
+						break
+					}
+				}
+			}
+
+			if isFlagName || (hasDefault && (defaultHasSubcommands && isDefaultSubcommand)) {
+				argsWithDefault := cCtx.App.argsWithDefaultCommand(args)
+				if !reflect.DeepEqual(args, argsWithDefault) {
+					cmd = cCtx.App.rootCommand.Command(argsWithDefault.First())
+				}
+			}
+		}
+	} else if c.isRoot && cCtx.App.DefaultCommand != "" {
+		if dc := cCtx.App.Command(cCtx.App.DefaultCommand); dc != c {
+			cmd = dc
+		}
+	}
+
+	if cmd != nil {
+		newcCtx := NewContext(cCtx.App, nil, cCtx)
+		newcCtx.Command = cmd
+		return cmd.Run(newcCtx, cCtx.Args().Slice()...)
+	}
+
+	if c.Action == nil {
+		c.Action = helpCommand.Action
+	}
+
+	err = c.Action(cCtx)
+
+	cCtx.App.handleExitCoder(cCtx, err)
+	return err
+}
+
+func (c *Command) newFlagSet() (*flag.FlagSet, error) {
+	return flagSet(c.Name, c.Flags, c.separator)
+}
+
+func (c *Command) useShortOptionHandling() bool {
+	return c.UseShortOptionHandling
+}
+
+func (c *Command) suggestFlagFromError(err error, command string) (string, error) {
+	flag, parseErr := flagFromError(err)
+	if parseErr != nil {
+		return "", err
+	}
+
+	flags := c.Flags
+	hideHelp := c.HideHelp
+	if command != "" {
+		cmd := c.Command(command)
+		if cmd == nil {
+			return "", err
+		}
+		flags = cmd.Flags
+		hideHelp = hideHelp || cmd.HideHelp
+	}
+
+	suggestion := SuggestFlag(flags, flag, hideHelp)
+	if len(suggestion) == 0 {
+		return "", err
+	}
+
+	return fmt.Sprintf(SuggestDidYouMeanTemplate, suggestion) + "\n\n", nil
+}
+
+func (c *Command) parseFlags(args Args, shellComplete bool) (*flag.FlagSet, error) {
+	set, err := c.newFlagSet()
+	if err != nil {
+		return nil, err
+	}
+
+	if c.SkipFlagParsing {
+		return set, set.Parse(append([]string{"--"}, args.Tail()...))
+	}
+
+	err = parseIter(set, c, args.Tail(), shellComplete)
+	if err != nil {
+		return nil, err
+	}
+
+	err = normalizeFlags(c.Flags, set)
+	if err != nil {
+		return nil, err
+	}
+
+	return set, nil
+}
+
+// Names returns the names including short names and aliases.
+func (c *Command) Names() []string {
+	return append([]string{c.Name}, c.Aliases...)
+}
+
+// HasName returns true if Command.Name matches given name
+func (c *Command) HasName(name string) bool {
+	for _, n := range c.Names() {
+		if n == name {
+			return true
+		}
+	}
+	return false
+}
+
+// VisibleCategories returns a slice of categories and commands that are
+// Hidden=false
+func (c *Command) VisibleCategories() []CommandCategory {
+	ret := []CommandCategory{}
+	for _, category := range c.categories.Categories() {
+		if visible := func() CommandCategory {
+			if len(category.VisibleCommands()) > 0 {
+				return category
+			}
+			return nil
+		}(); visible != nil {
+			ret = append(ret, visible)
+		}
+	}
+	return ret
+}
+
+// VisibleCommands returns a slice of the Commands with Hidden=false
+func (c *Command) VisibleCommands() []*Command {
+	var ret []*Command
+	for _, command := range c.Subcommands {
+		if !command.Hidden {
+			ret = append(ret, command)
+		}
+	}
+	return ret
+}
+
+// VisibleFlagCategories returns a slice containing all the visible flag categories with the flags they contain
+func (c *Command) VisibleFlagCategories() []VisibleFlagCategory {
+	if c.flagCategories == nil {
+		c.flagCategories = newFlagCategoriesFromFlags(c.Flags)
+	}
+	return c.flagCategories.VisibleCategories()
+}
+
+// VisibleFlags returns a slice of the Flags with Hidden=false
+func (c *Command) VisibleFlags() []Flag {
+	return visibleFlags(c.Flags)
+}
+
+func (c *Command) appendFlag(fl Flag) {
+	if !hasFlag(c.Flags, fl) {
+		c.Flags = append(c.Flags, fl)
+	}
+}
+
+func hasCommand(commands []*Command, command *Command) bool {
+	for _, existing := range commands {
+		if command == existing {
+			return true
+		}
+	}
+
+	return false
+}
+
+func checkDuplicatedCmds(parent *Command) error {
+	seen := make(map[string]struct{})
+	for _, c := range parent.Subcommands {
+		for _, name := range c.Names() {
+			if _, exists := seen[name]; exists {
+				return fmt.Errorf("parent command [%s] has duplicated subcommand name or alias: %s", parent.Name, name)
+			}
+			seen[name] = struct{}{}
+		}
+	}
+	return nil
+}

--- a/vendor/github.com/urfave/cli/v2/context.go
+++ b/vendor/github.com/urfave/cli/v2/context.go
@@ -1,0 +1,272 @@
+package cli
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"strings"
+)
+
+// Context is a type that is passed through to
+// each Handler action in a cli application. Context
+// can be used to retrieve context-specific args and
+// parsed command-line options.
+type Context struct {
+	context.Context
+	App           *App
+	Command       *Command
+	shellComplete bool
+	flagSet       *flag.FlagSet
+	parentContext *Context
+}
+
+// NewContext creates a new context. For use in when invoking an App or Command action.
+func NewContext(app *App, set *flag.FlagSet, parentCtx *Context) *Context {
+	c := &Context{App: app, flagSet: set, parentContext: parentCtx}
+	if parentCtx != nil {
+		c.Context = parentCtx.Context
+		c.shellComplete = parentCtx.shellComplete
+		if parentCtx.flagSet == nil {
+			parentCtx.flagSet = &flag.FlagSet{}
+		}
+	}
+
+	c.Command = &Command{}
+
+	if c.Context == nil {
+		c.Context = context.Background()
+	}
+
+	return c
+}
+
+// NumFlags returns the number of flags set
+func (cCtx *Context) NumFlags() int {
+	return cCtx.flagSet.NFlag()
+}
+
+// Set sets a context flag to a value.
+func (cCtx *Context) Set(name, value string) error {
+	if fs := cCtx.lookupFlagSet(name); fs != nil {
+		return fs.Set(name, value)
+	}
+
+	return fmt.Errorf("no such flag -%s", name)
+}
+
+// IsSet determines if the flag was actually set
+func (cCtx *Context) IsSet(name string) bool {
+
+	if fs := cCtx.lookupFlagSet(name); fs != nil {
+		isSet := false
+		fs.Visit(func(f *flag.Flag) {
+			if f.Name == name {
+				isSet = true
+			}
+		})
+		if isSet {
+			return true
+		}
+
+		f := cCtx.lookupFlag(name)
+		if f == nil {
+			return false
+		}
+
+		if f.IsSet() {
+			return true
+		}
+
+		// now redo flagset search on aliases
+		aliases := f.Names()
+		fs.Visit(func(f *flag.Flag) {
+			for _, alias := range aliases {
+				if f.Name == alias {
+					isSet = true
+				}
+			}
+		})
+
+		if isSet {
+			return true
+		}
+	}
+
+	return false
+}
+
+// LocalFlagNames returns a slice of flag names used in this context.
+func (cCtx *Context) LocalFlagNames() []string {
+	var names []string
+	cCtx.flagSet.Visit(makeFlagNameVisitor(&names))
+	// Check the flags which have been set via env or file
+	if cCtx.Command != nil && cCtx.Command.Flags != nil {
+		for _, f := range cCtx.Command.Flags {
+			if f.IsSet() {
+				names = append(names, f.Names()...)
+			}
+		}
+	}
+
+	// Sort out the duplicates since flag could be set via multiple
+	// paths
+	m := map[string]struct{}{}
+	var unames []string
+	for _, name := range names {
+		if _, ok := m[name]; !ok {
+			m[name] = struct{}{}
+			unames = append(unames, name)
+		}
+	}
+
+	return unames
+}
+
+// FlagNames returns a slice of flag names used by the this context and all of
+// its parent contexts.
+func (cCtx *Context) FlagNames() []string {
+	var names []string
+	for _, pCtx := range cCtx.Lineage() {
+		names = append(names, pCtx.LocalFlagNames()...)
+	}
+	return names
+}
+
+// Lineage returns *this* context and all of its ancestor contexts in order from
+// child to parent
+func (cCtx *Context) Lineage() []*Context {
+	var lineage []*Context
+
+	for cur := cCtx; cur != nil; cur = cur.parentContext {
+		lineage = append(lineage, cur)
+	}
+
+	return lineage
+}
+
+// Count returns the num of occurrences of this flag
+func (cCtx *Context) Count(name string) int {
+	if fs := cCtx.lookupFlagSet(name); fs != nil {
+		if cf, ok := fs.Lookup(name).Value.(Countable); ok {
+			return cf.Count()
+		}
+	}
+	return 0
+}
+
+// Value returns the value of the flag corresponding to `name`
+func (cCtx *Context) Value(name string) interface{} {
+	if fs := cCtx.lookupFlagSet(name); fs != nil {
+		return fs.Lookup(name).Value.(flag.Getter).Get()
+	}
+	return nil
+}
+
+// Args returns the command line arguments associated with the context.
+func (cCtx *Context) Args() Args {
+	ret := args(cCtx.flagSet.Args())
+	return &ret
+}
+
+// NArg returns the number of the command line arguments.
+func (cCtx *Context) NArg() int {
+	return cCtx.Args().Len()
+}
+
+func (cCtx *Context) lookupFlag(name string) Flag {
+	for _, c := range cCtx.Lineage() {
+		if c.Command == nil {
+			continue
+		}
+
+		for _, f := range c.Command.Flags {
+			for _, n := range f.Names() {
+				if n == name {
+					return f
+				}
+			}
+		}
+	}
+
+	if cCtx.App != nil {
+		for _, f := range cCtx.App.Flags {
+			for _, n := range f.Names() {
+				if n == name {
+					return f
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func (cCtx *Context) lookupFlagSet(name string) *flag.FlagSet {
+	for _, c := range cCtx.Lineage() {
+		if c.flagSet == nil {
+			continue
+		}
+		if f := c.flagSet.Lookup(name); f != nil {
+			return c.flagSet
+		}
+	}
+	cCtx.onInvalidFlag(name)
+	return nil
+}
+
+func (cCtx *Context) checkRequiredFlags(flags []Flag) requiredFlagsErr {
+	var missingFlags []string
+	for _, f := range flags {
+		if rf, ok := f.(RequiredFlag); ok && rf.IsRequired() {
+			var flagPresent bool
+			var flagName string
+
+			flagNames := f.Names()
+			flagName = flagNames[0]
+
+			for _, key := range flagNames {
+				if cCtx.IsSet(strings.TrimSpace(key)) {
+					flagPresent = true
+				}
+			}
+
+			if !flagPresent && flagName != "" {
+				missingFlags = append(missingFlags, flagName)
+			}
+		}
+	}
+
+	if len(missingFlags) != 0 {
+		return &errRequiredFlags{missingFlags: missingFlags}
+	}
+
+	return nil
+}
+
+func (cCtx *Context) onInvalidFlag(name string) {
+	for cCtx != nil {
+		if cCtx.App != nil && cCtx.App.InvalidFlagAccessHandler != nil {
+			cCtx.App.InvalidFlagAccessHandler(cCtx, name)
+			break
+		}
+		cCtx = cCtx.parentContext
+	}
+}
+
+func makeFlagNameVisitor(names *[]string) func(*flag.Flag) {
+	return func(f *flag.Flag) {
+		nameParts := strings.Split(f.Name, ",")
+		name := strings.TrimSpace(nameParts[0])
+
+		for _, part := range nameParts {
+			part = strings.TrimSpace(part)
+			if len(part) > len(name) {
+				name = part
+			}
+		}
+
+		if name != "" {
+			*names = append(*names, name)
+		}
+	}
+}

--- a/vendor/github.com/urfave/cli/v2/docs.go
+++ b/vendor/github.com/urfave/cli/v2/docs.go
@@ -1,0 +1,203 @@
+//go:build !urfave_cli_no_docs
+// +build !urfave_cli_no_docs
+
+package cli
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+	"text/template"
+
+	"github.com/cpuguy83/go-md2man/v2/md2man"
+)
+
+// ToMarkdown creates a markdown string for the `*App`
+// The function errors if either parsing or writing of the string fails.
+func (a *App) ToMarkdown() (string, error) {
+	var w bytes.Buffer
+	if err := a.writeDocTemplate(&w, 0); err != nil {
+		return "", err
+	}
+	return w.String(), nil
+}
+
+// ToMan creates a man page string with section number for the `*App`
+// The function errors if either parsing or writing of the string fails.
+func (a *App) ToManWithSection(sectionNumber int) (string, error) {
+	var w bytes.Buffer
+	if err := a.writeDocTemplate(&w, sectionNumber); err != nil {
+		return "", err
+	}
+	man := md2man.Render(w.Bytes())
+	return string(man), nil
+}
+
+// ToMan creates a man page string for the `*App`
+// The function errors if either parsing or writing of the string fails.
+func (a *App) ToMan() (string, error) {
+	man, err := a.ToManWithSection(8)
+	return man, err
+}
+
+type cliTemplate struct {
+	App          *App
+	SectionNum   int
+	Commands     []string
+	GlobalArgs   []string
+	SynopsisArgs []string
+}
+
+func (a *App) writeDocTemplate(w io.Writer, sectionNum int) error {
+	const name = "cli"
+	t, err := template.New(name).Parse(MarkdownDocTemplate)
+	if err != nil {
+		return err
+	}
+	return t.ExecuteTemplate(w, name, &cliTemplate{
+		App:          a,
+		SectionNum:   sectionNum,
+		Commands:     prepareCommands(a.Commands, 0),
+		GlobalArgs:   prepareArgsWithValues(a.VisibleFlags()),
+		SynopsisArgs: prepareArgsSynopsis(a.VisibleFlags()),
+	})
+}
+
+func prepareCommands(commands []*Command, level int) []string {
+	var coms []string
+	for _, command := range commands {
+		if command.Hidden {
+			continue
+		}
+
+		usageText := prepareUsageText(command)
+
+		usage := prepareUsage(command, usageText)
+
+		prepared := fmt.Sprintf("%s %s\n\n%s%s",
+			strings.Repeat("#", level+2),
+			strings.Join(command.Names(), ", "),
+			usage,
+			usageText,
+		)
+
+		flags := prepareArgsWithValues(command.VisibleFlags())
+		if len(flags) > 0 {
+			prepared += fmt.Sprintf("\n%s", strings.Join(flags, "\n"))
+		}
+
+		coms = append(coms, prepared)
+
+		// recursively iterate subcommands
+		if len(command.Subcommands) > 0 {
+			coms = append(
+				coms,
+				prepareCommands(command.Subcommands, level+1)...,
+			)
+		}
+	}
+
+	return coms
+}
+
+func prepareArgsWithValues(flags []Flag) []string {
+	return prepareFlags(flags, ", ", "**", "**", `""`, true)
+}
+
+func prepareArgsSynopsis(flags []Flag) []string {
+	return prepareFlags(flags, "|", "[", "]", "[value]", false)
+}
+
+func prepareFlags(
+	flags []Flag,
+	sep, opener, closer, value string,
+	addDetails bool,
+) []string {
+	args := []string{}
+	for _, f := range flags {
+		flag, ok := f.(DocGenerationFlag)
+		if !ok {
+			continue
+		}
+		modifiedArg := opener
+
+		for _, s := range flag.Names() {
+			trimmed := strings.TrimSpace(s)
+			if len(modifiedArg) > len(opener) {
+				modifiedArg += sep
+			}
+			if len(trimmed) > 1 {
+				modifiedArg += fmt.Sprintf("--%s", trimmed)
+			} else {
+				modifiedArg += fmt.Sprintf("-%s", trimmed)
+			}
+		}
+		modifiedArg += closer
+		if flag.TakesValue() {
+			modifiedArg += fmt.Sprintf("=%s", value)
+		}
+
+		if addDetails {
+			modifiedArg += flagDetails(flag)
+		}
+
+		args = append(args, modifiedArg+"\n")
+
+	}
+	sort.Strings(args)
+	return args
+}
+
+// flagDetails returns a string containing the flags metadata
+func flagDetails(flag DocGenerationFlag) string {
+	description := flag.GetUsage()
+	if flag.TakesValue() {
+		defaultText := flag.GetDefaultText()
+		if defaultText == "" {
+			defaultText = flag.GetValue()
+		}
+		if defaultText != "" {
+			description += " (default: " + defaultText + ")"
+		}
+	}
+	return ": " + description
+}
+
+func prepareUsageText(command *Command) string {
+	if command.UsageText == "" {
+		return ""
+	}
+
+	// Remove leading and trailing newlines
+	preparedUsageText := strings.Trim(command.UsageText, "\n")
+
+	var usageText string
+	if strings.Contains(preparedUsageText, "\n") {
+		// Format multi-line string as a code block using the 4 space schema to allow for embedded markdown such
+		// that it will not break the continuous code block.
+		for _, ln := range strings.Split(preparedUsageText, "\n") {
+			usageText += fmt.Sprintf("    %s\n", ln)
+		}
+	} else {
+		// Style a single line as a note
+		usageText = fmt.Sprintf(">%s\n", preparedUsageText)
+	}
+
+	return usageText
+}
+
+func prepareUsage(command *Command, usageText string) string {
+	if command.Usage == "" {
+		return ""
+	}
+
+	usage := command.Usage + "\n"
+	// Add a newline to the Usage IFF there is a UsageText
+	if usageText != "" {
+		usage += "\n"
+	}
+
+	return usage
+}

--- a/vendor/github.com/urfave/cli/v2/errors.go
+++ b/vendor/github.com/urfave/cli/v2/errors.go
@@ -1,0 +1,178 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+// OsExiter is the function used when the app exits. If not set defaults to os.Exit.
+var OsExiter = os.Exit
+
+// ErrWriter is used to write errors to the user. This can be anything
+// implementing the io.Writer interface and defaults to os.Stderr.
+var ErrWriter io.Writer = os.Stderr
+
+// MultiError is an error that wraps multiple errors.
+type MultiError interface {
+	error
+	Errors() []error
+}
+
+// newMultiError creates a new MultiError. Pass in one or more errors.
+func newMultiError(err ...error) MultiError {
+	ret := multiError(err)
+	return &ret
+}
+
+type multiError []error
+
+// Error implements the error interface.
+func (m *multiError) Error() string {
+	errs := make([]string, len(*m))
+	for i, err := range *m {
+		errs[i] = err.Error()
+	}
+
+	return strings.Join(errs, "\n")
+}
+
+// Errors returns a copy of the errors slice
+func (m *multiError) Errors() []error {
+	errs := make([]error, len(*m))
+	for _, err := range *m {
+		errs = append(errs, err)
+	}
+	return errs
+}
+
+type requiredFlagsErr interface {
+	error
+	getMissingFlags() []string
+}
+
+type errRequiredFlags struct {
+	missingFlags []string
+}
+
+func (e *errRequiredFlags) Error() string {
+	numberOfMissingFlags := len(e.missingFlags)
+	if numberOfMissingFlags == 1 {
+		return fmt.Sprintf("Required flag %q not set", e.missingFlags[0])
+	}
+	joinedMissingFlags := strings.Join(e.missingFlags, ", ")
+	return fmt.Sprintf("Required flags %q not set", joinedMissingFlags)
+}
+
+func (e *errRequiredFlags) getMissingFlags() []string {
+	return e.missingFlags
+}
+
+// ErrorFormatter is the interface that will suitably format the error output
+type ErrorFormatter interface {
+	Format(s fmt.State, verb rune)
+}
+
+// ExitCoder is the interface checked by `App` and `Command` for a custom exit
+// code
+type ExitCoder interface {
+	error
+	ExitCode() int
+}
+
+type exitError struct {
+	exitCode int
+	err      error
+}
+
+// NewExitError calls Exit to create a new ExitCoder.
+//
+// Deprecated: This function is a duplicate of Exit and will eventually be removed.
+func NewExitError(message interface{}, exitCode int) ExitCoder {
+	return Exit(message, exitCode)
+}
+
+// Exit wraps a message and exit code into an error, which by default is
+// handled with a call to os.Exit during default error handling.
+//
+// This is the simplest way to trigger a non-zero exit code for an App without
+// having to call os.Exit manually. During testing, this behavior can be avoided
+// by overriding the ExitErrHandler function on an App or the package-global
+// OsExiter function.
+func Exit(message interface{}, exitCode int) ExitCoder {
+	var err error
+
+	switch e := message.(type) {
+	case ErrorFormatter:
+		err = fmt.Errorf("%+v", message)
+	case error:
+		err = e
+	default:
+		err = fmt.Errorf("%+v", message)
+	}
+
+	return &exitError{
+		err:      err,
+		exitCode: exitCode,
+	}
+}
+
+func (ee *exitError) Error() string {
+	return ee.err.Error()
+}
+
+func (ee *exitError) ExitCode() int {
+	return ee.exitCode
+}
+
+func (ee *exitError) Unwrap() error {
+	return ee.err
+}
+
+// HandleExitCoder handles errors implementing ExitCoder by printing their
+// message and calling OsExiter with the given exit code.
+//
+// If the given error instead implements MultiError, each error will be checked
+// for the ExitCoder interface, and OsExiter will be called with the last exit
+// code found, or exit code 1 if no ExitCoder is found.
+//
+// This function is the default error-handling behavior for an App.
+func HandleExitCoder(err error) {
+	if err == nil {
+		return
+	}
+
+	if exitErr, ok := err.(ExitCoder); ok {
+		if err.Error() != "" {
+			if _, ok := exitErr.(ErrorFormatter); ok {
+				_, _ = fmt.Fprintf(ErrWriter, "%+v\n", err)
+			} else {
+				_, _ = fmt.Fprintln(ErrWriter, err)
+			}
+		}
+		OsExiter(exitErr.ExitCode())
+		return
+	}
+
+	if multiErr, ok := err.(MultiError); ok {
+		code := handleMultiError(multiErr)
+		OsExiter(code)
+		return
+	}
+}
+
+func handleMultiError(multiErr MultiError) int {
+	code := 1
+	for _, merr := range multiErr.Errors() {
+		if multiErr2, ok := merr.(MultiError); ok {
+			code = handleMultiError(multiErr2)
+		} else if merr != nil {
+			fmt.Fprintln(ErrWriter, merr)
+			if exitErr, ok := merr.(ExitCoder); ok {
+				code = exitErr.ExitCode()
+			}
+		}
+	}
+	return code
+}

--- a/vendor/github.com/urfave/cli/v2/fish.go
+++ b/vendor/github.com/urfave/cli/v2/fish.go
@@ -1,0 +1,196 @@
+package cli
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"strings"
+	"text/template"
+)
+
+// ToFishCompletion creates a fish completion string for the `*App`
+// The function errors if either parsing or writing of the string fails.
+func (a *App) ToFishCompletion() (string, error) {
+	var w bytes.Buffer
+	if err := a.writeFishCompletionTemplate(&w); err != nil {
+		return "", err
+	}
+	return w.String(), nil
+}
+
+type fishCompletionTemplate struct {
+	App         *App
+	Completions []string
+	AllCommands []string
+}
+
+func (a *App) writeFishCompletionTemplate(w io.Writer) error {
+	const name = "cli"
+	t, err := template.New(name).Parse(FishCompletionTemplate)
+	if err != nil {
+		return err
+	}
+	allCommands := []string{}
+
+	// Add global flags
+	completions := a.prepareFishFlags(a.VisibleFlags(), allCommands)
+
+	// Add help flag
+	if !a.HideHelp {
+		completions = append(
+			completions,
+			a.prepareFishFlags([]Flag{HelpFlag}, allCommands)...,
+		)
+	}
+
+	// Add version flag
+	if !a.HideVersion {
+		completions = append(
+			completions,
+			a.prepareFishFlags([]Flag{VersionFlag}, allCommands)...,
+		)
+	}
+
+	// Add commands and their flags
+	completions = append(
+		completions,
+		a.prepareFishCommands(a.VisibleCommands(), &allCommands, []string{})...,
+	)
+
+	return t.ExecuteTemplate(w, name, &fishCompletionTemplate{
+		App:         a,
+		Completions: completions,
+		AllCommands: allCommands,
+	})
+}
+
+func (a *App) prepareFishCommands(commands []*Command, allCommands *[]string, previousCommands []string) []string {
+	completions := []string{}
+	for _, command := range commands {
+		if command.Hidden {
+			continue
+		}
+
+		var completion strings.Builder
+		completion.WriteString(fmt.Sprintf(
+			"complete -r -c %s -n '%s' -a '%s'",
+			a.Name,
+			a.fishSubcommandHelper(previousCommands),
+			strings.Join(command.Names(), " "),
+		))
+
+		if command.Usage != "" {
+			completion.WriteString(fmt.Sprintf(" -d '%s'",
+				escapeSingleQuotes(command.Usage)))
+		}
+
+		if !command.HideHelp {
+			completions = append(
+				completions,
+				a.prepareFishFlags([]Flag{HelpFlag}, command.Names())...,
+			)
+		}
+
+		*allCommands = append(*allCommands, command.Names()...)
+		completions = append(completions, completion.String())
+		completions = append(
+			completions,
+			a.prepareFishFlags(command.VisibleFlags(), command.Names())...,
+		)
+
+		// recursively iterate subcommands
+		if len(command.Subcommands) > 0 {
+			completions = append(
+				completions,
+				a.prepareFishCommands(
+					command.Subcommands, allCommands, command.Names(),
+				)...,
+			)
+		}
+	}
+
+	return completions
+}
+
+func (a *App) prepareFishFlags(flags []Flag, previousCommands []string) []string {
+	completions := []string{}
+	for _, f := range flags {
+		flag, ok := f.(DocGenerationFlag)
+		if !ok {
+			continue
+		}
+
+		completion := &strings.Builder{}
+		completion.WriteString(fmt.Sprintf(
+			"complete -c %s -n '%s'",
+			a.Name,
+			a.fishSubcommandHelper(previousCommands),
+		))
+
+		fishAddFileFlag(f, completion)
+
+		for idx, opt := range flag.Names() {
+			if idx == 0 {
+				completion.WriteString(fmt.Sprintf(
+					" -l %s", strings.TrimSpace(opt),
+				))
+			} else {
+				completion.WriteString(fmt.Sprintf(
+					" -s %s", strings.TrimSpace(opt),
+				))
+
+			}
+		}
+
+		if flag.TakesValue() {
+			completion.WriteString(" -r")
+		}
+
+		if flag.GetUsage() != "" {
+			completion.WriteString(fmt.Sprintf(" -d '%s'",
+				escapeSingleQuotes(flag.GetUsage())))
+		}
+
+		completions = append(completions, completion.String())
+	}
+
+	return completions
+}
+
+func fishAddFileFlag(flag Flag, completion *strings.Builder) {
+	switch f := flag.(type) {
+	case *GenericFlag:
+		if f.TakesFile {
+			return
+		}
+	case *StringFlag:
+		if f.TakesFile {
+			return
+		}
+	case *StringSliceFlag:
+		if f.TakesFile {
+			return
+		}
+	case *PathFlag:
+		if f.TakesFile {
+			return
+		}
+	}
+	completion.WriteString(" -f")
+}
+
+func (a *App) fishSubcommandHelper(allCommands []string) string {
+	fishHelper := fmt.Sprintf("__fish_%s_no_subcommand", a.Name)
+	if len(allCommands) > 0 {
+		fishHelper = fmt.Sprintf(
+			"__fish_seen_subcommand_from %s",
+			strings.Join(allCommands, " "),
+		)
+	}
+	return fishHelper
+
+}
+
+func escapeSingleQuotes(input string) string {
+	return strings.Replace(input, `'`, `\'`, -1)
+}

--- a/vendor/github.com/urfave/cli/v2/flag-spec.yaml
+++ b/vendor/github.com/urfave/cli/v2/flag-spec.yaml
@@ -1,0 +1,131 @@
+# NOTE: this file is used by the tool defined in
+# ./cmd/urfave-cli-genflags/main.go which uses the
+# `Spec` type that maps to this file structure.
+flag_types:
+  bool:
+    struct_fields:
+      - name: Count
+        type: int
+        pointer: true
+      - name: DisableDefaultText
+        type: bool
+      - name: Action
+        type: "func(*Context, bool) error"
+  float64:
+    struct_fields:
+      - name: Action
+        type: "func(*Context, float64) error"
+  Float64Slice:
+    value_pointer: true
+    skip_interfaces:
+      - fmt.Stringer
+    struct_fields:
+      - name: separator
+        type: separatorSpec
+      - name: Action
+        type: "func(*Context, []float64) error"
+  int:
+    struct_fields:
+      - name: Base
+        type: int
+      - name: Action
+        type: "func(*Context, int) error"
+  IntSlice:
+    value_pointer: true
+    skip_interfaces:
+      - fmt.Stringer
+    struct_fields:
+      - name: separator
+        type: separatorSpec
+      - name: Action
+        type: "func(*Context, []int) error"
+  int64:
+    struct_fields:
+      - name: Base
+        type: int
+      - name: Action
+        type: "func(*Context, int64) error"
+  Int64Slice:
+    value_pointer: true
+    skip_interfaces:
+      - fmt.Stringer
+    struct_fields:
+      - name: separator
+        type: separatorSpec
+      - name: Action
+        type: "func(*Context, []int64) error"
+  uint:
+    struct_fields:
+      - name: Base
+        type: int
+      - name: Action
+        type: "func(*Context, uint) error"
+  UintSlice:
+    value_pointer: true
+    skip_interfaces:
+      - fmt.Stringer
+    struct_fields:
+      - name: separator
+        type: separatorSpec
+      - name: Action
+        type: "func(*Context, []uint) error"
+  uint64:
+    struct_fields:
+      - name: Base
+        type: int
+      - name: Action
+        type: "func(*Context, uint64) error"
+  Uint64Slice:
+    value_pointer: true
+    skip_interfaces:
+      - fmt.Stringer
+    struct_fields:
+      - name: separator
+        type: separatorSpec
+      - name: Action
+        type: "func(*Context, []uint64) error"
+  string:
+    struct_fields:
+      - name: TakesFile
+        type: bool
+      - name: Action
+        type: "func(*Context, string) error"
+  StringSlice:
+    value_pointer: true
+    skip_interfaces:
+      - fmt.Stringer
+    struct_fields:
+      - name: separator
+        type: separatorSpec
+      - name: TakesFile
+        type: bool
+      - name: Action
+        type: "func(*Context, []string) error"
+      - name: KeepSpace
+        type: bool
+  time.Duration:
+    struct_fields:
+      - name: Action
+        type: "func(*Context, time.Duration) error"
+  Timestamp:
+    value_pointer: true
+    struct_fields:
+      - name: Layout
+        type: string
+      - name: Timezone
+        type: "*time.Location"
+      - name: Action
+        type: "func(*Context, *time.Time) error"
+  Generic:
+    no_destination_pointer: true
+    struct_fields:
+      - name: TakesFile
+        type: bool
+      - name: Action
+        type: "func(*Context, interface{}) error"
+  Path:
+    struct_fields:
+      - name: TakesFile
+        type: bool
+      - name: Action
+        type: "func(*Context, Path) error"

--- a/vendor/github.com/urfave/cli/v2/flag.go
+++ b/vendor/github.com/urfave/cli/v2/flag.go
@@ -1,0 +1,419 @@
+package cli
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"regexp"
+	"runtime"
+	"strings"
+	"syscall"
+	"time"
+)
+
+const defaultPlaceholder = "value"
+
+const (
+	defaultSliceFlagSeparator = ","
+	disableSliceFlagSeparator = false
+)
+
+var (
+	slPfx = fmt.Sprintf("sl:::%d:::", time.Now().UTC().UnixNano())
+
+	commaWhitespace = regexp.MustCompile("[, ]+.*")
+)
+
+// BashCompletionFlag enables bash-completion for all commands and subcommands
+var BashCompletionFlag Flag = &BoolFlag{
+	Name:   "generate-bash-completion",
+	Hidden: true,
+}
+
+// VersionFlag prints the version for the application
+var VersionFlag Flag = &BoolFlag{
+	Name:               "version",
+	Aliases:            []string{"v"},
+	Usage:              "print the version",
+	DisableDefaultText: true,
+}
+
+// HelpFlag prints the help for all commands and subcommands.
+// Set to nil to disable the flag.  The subcommand
+// will still be added unless HideHelp or HideHelpCommand is set to true.
+var HelpFlag Flag = &BoolFlag{
+	Name:               "help",
+	Aliases:            []string{"h"},
+	Usage:              "show help",
+	DisableDefaultText: true,
+}
+
+// FlagStringer converts a flag definition to a string. This is used by help
+// to display a flag.
+var FlagStringer FlagStringFunc = stringifyFlag
+
+// Serializer is used to circumvent the limitations of flag.FlagSet.Set
+type Serializer interface {
+	Serialize() string
+}
+
+// FlagNamePrefixer converts a full flag name and its placeholder into the help
+// message flag prefix. This is used by the default FlagStringer.
+var FlagNamePrefixer FlagNamePrefixFunc = prefixedNames
+
+// FlagEnvHinter annotates flag help message with the environment variable
+// details. This is used by the default FlagStringer.
+var FlagEnvHinter FlagEnvHintFunc = withEnvHint
+
+// FlagFileHinter annotates flag help message with the environment variable
+// details. This is used by the default FlagStringer.
+var FlagFileHinter FlagFileHintFunc = withFileHint
+
+// FlagsByName is a slice of Flag.
+type FlagsByName []Flag
+
+func (f FlagsByName) Len() int {
+	return len(f)
+}
+
+func (f FlagsByName) Less(i, j int) bool {
+	if len(f[j].Names()) == 0 {
+		return false
+	} else if len(f[i].Names()) == 0 {
+		return true
+	}
+	return lexicographicLess(f[i].Names()[0], f[j].Names()[0])
+}
+
+func (f FlagsByName) Swap(i, j int) {
+	f[i], f[j] = f[j], f[i]
+}
+
+// ActionableFlag is an interface that wraps Flag interface and RunAction operation.
+type ActionableFlag interface {
+	Flag
+	RunAction(*Context) error
+}
+
+// Flag is a common interface related to parsing flags in cli.
+// For more advanced flag parsing techniques, it is recommended that
+// this interface be implemented.
+type Flag interface {
+	fmt.Stringer
+	// Apply Flag settings to the given flag set
+	Apply(*flag.FlagSet) error
+	Names() []string
+	IsSet() bool
+}
+
+// RequiredFlag is an interface that allows us to mark flags as required
+// it allows flags required flags to be backwards compatible with the Flag interface
+type RequiredFlag interface {
+	Flag
+
+	IsRequired() bool
+}
+
+// DocGenerationFlag is an interface that allows documentation generation for the flag
+type DocGenerationFlag interface {
+	Flag
+
+	// TakesValue returns true if the flag takes a value, otherwise false
+	TakesValue() bool
+
+	// GetUsage returns the usage string for the flag
+	GetUsage() string
+
+	// GetValue returns the flags value as string representation and an empty
+	// string if the flag takes no value at all.
+	GetValue() string
+
+	// GetDefaultText returns the default text for this flag
+	GetDefaultText() string
+
+	// GetEnvVars returns the env vars for this flag
+	GetEnvVars() []string
+}
+
+// DocGenerationSliceFlag extends DocGenerationFlag for slice-based flags.
+type DocGenerationSliceFlag interface {
+	DocGenerationFlag
+
+	// IsSliceFlag returns true for flags that can be given multiple times.
+	IsSliceFlag() bool
+}
+
+// VisibleFlag is an interface that allows to check if a flag is visible
+type VisibleFlag interface {
+	Flag
+
+	// IsVisible returns true if the flag is not hidden, otherwise false
+	IsVisible() bool
+}
+
+// CategorizableFlag is an interface that allows us to potentially
+// use a flag in a categorized representation.
+type CategorizableFlag interface {
+	VisibleFlag
+
+	GetCategory() string
+}
+
+// Countable is an interface to enable detection of flag values which support
+// repetitive flags
+type Countable interface {
+	Count() int
+}
+
+func flagSet(name string, flags []Flag, spec separatorSpec) (*flag.FlagSet, error) {
+	set := flag.NewFlagSet(name, flag.ContinueOnError)
+
+	for _, f := range flags {
+		if c, ok := f.(customizedSeparator); ok {
+			c.WithSeparatorSpec(spec)
+		}
+		if err := f.Apply(set); err != nil {
+			return nil, err
+		}
+	}
+	set.SetOutput(io.Discard)
+	return set, nil
+}
+
+func copyFlag(name string, ff *flag.Flag, set *flag.FlagSet) {
+	switch ff.Value.(type) {
+	case Serializer:
+		_ = set.Set(name, ff.Value.(Serializer).Serialize())
+	default:
+		_ = set.Set(name, ff.Value.String())
+	}
+}
+
+func normalizeFlags(flags []Flag, set *flag.FlagSet) error {
+	visited := make(map[string]bool)
+	set.Visit(func(f *flag.Flag) {
+		visited[f.Name] = true
+	})
+	for _, f := range flags {
+		parts := f.Names()
+		if len(parts) == 1 {
+			continue
+		}
+		var ff *flag.Flag
+		for _, name := range parts {
+			name = strings.Trim(name, " ")
+			if visited[name] {
+				if ff != nil {
+					return errors.New("Cannot use two forms of the same flag: " + name + " " + ff.Name)
+				}
+				ff = set.Lookup(name)
+			}
+		}
+		if ff == nil {
+			continue
+		}
+		for _, name := range parts {
+			name = strings.Trim(name, " ")
+			if !visited[name] {
+				copyFlag(name, ff, set)
+			}
+		}
+	}
+	return nil
+}
+
+func visibleFlags(fl []Flag) []Flag {
+	var visible []Flag
+	for _, f := range fl {
+		if vf, ok := f.(VisibleFlag); ok && vf.IsVisible() {
+			visible = append(visible, f)
+		}
+	}
+	return visible
+}
+
+func prefixFor(name string) (prefix string) {
+	if len(name) == 1 {
+		prefix = "-"
+	} else {
+		prefix = "--"
+	}
+
+	return
+}
+
+// Returns the placeholder, if any, and the unquoted usage string.
+func unquoteUsage(usage string) (string, string) {
+	for i := 0; i < len(usage); i++ {
+		if usage[i] == '`' {
+			for j := i + 1; j < len(usage); j++ {
+				if usage[j] == '`' {
+					name := usage[i+1 : j]
+					usage = usage[:i] + name + usage[j+1:]
+					return name, usage
+				}
+			}
+			break
+		}
+	}
+	return "", usage
+}
+
+func prefixedNames(names []string, placeholder string) string {
+	var prefixed string
+	for i, name := range names {
+		if name == "" {
+			continue
+		}
+
+		prefixed += prefixFor(name) + name
+		if placeholder != "" {
+			prefixed += " " + placeholder
+		}
+		if i < len(names)-1 {
+			prefixed += ", "
+		}
+	}
+	return prefixed
+}
+
+func envFormat(envVars []string, prefix, sep, suffix string) string {
+	if len(envVars) > 0 {
+		return fmt.Sprintf(" [%s%s%s]", prefix, strings.Join(envVars, sep), suffix)
+	}
+	return ""
+}
+
+func defaultEnvFormat(envVars []string) string {
+	return envFormat(envVars, "$", ", $", "")
+}
+
+func withEnvHint(envVars []string, str string) string {
+	envText := ""
+	if runtime.GOOS != "windows" || os.Getenv("PSHOME") != "" {
+		envText = defaultEnvFormat(envVars)
+	} else {
+		envText = envFormat(envVars, "%", "%, %", "%")
+	}
+	return str + envText
+}
+
+func FlagNames(name string, aliases []string) []string {
+	var ret []string
+
+	for _, part := range append([]string{name}, aliases...) {
+		// v1 -> v2 migration warning zone:
+		// Strip off anything after the first found comma or space, which
+		// *hopefully* makes it a tiny bit more obvious that unexpected behavior is
+		// caused by using the v1 form of stringly typed "Name".
+		ret = append(ret, commaWhitespace.ReplaceAllString(part, ""))
+	}
+
+	return ret
+}
+
+func withFileHint(filePath, str string) string {
+	fileText := ""
+	if filePath != "" {
+		fileText = fmt.Sprintf(" [%s]", filePath)
+	}
+	return str + fileText
+}
+
+func formatDefault(format string) string {
+	return " (default: " + format + ")"
+}
+
+func stringifyFlag(f Flag) string {
+	// enforce DocGeneration interface on flags to avoid reflection
+	df, ok := f.(DocGenerationFlag)
+	if !ok {
+		return ""
+	}
+
+	placeholder, usage := unquoteUsage(df.GetUsage())
+	needsPlaceholder := df.TakesValue()
+
+	if needsPlaceholder && placeholder == "" {
+		placeholder = defaultPlaceholder
+	}
+
+	defaultValueString := ""
+
+	// set default text for all flags except bool flags
+	// for bool flags display default text if DisableDefaultText is not
+	// set
+	if bf, ok := f.(*BoolFlag); !ok || !bf.DisableDefaultText {
+		if s := df.GetDefaultText(); s != "" {
+			defaultValueString = fmt.Sprintf(formatDefault("%s"), s)
+		}
+	}
+
+	usageWithDefault := strings.TrimSpace(usage + defaultValueString)
+
+	pn := prefixedNames(df.Names(), placeholder)
+	sliceFlag, ok := f.(DocGenerationSliceFlag)
+	if ok && sliceFlag.IsSliceFlag() {
+		pn = pn + " [ " + pn + " ]"
+	}
+
+	return withEnvHint(df.GetEnvVars(), fmt.Sprintf("%s\t%s", pn, usageWithDefault))
+}
+
+func hasFlag(flags []Flag, fl Flag) bool {
+	for _, existing := range flags {
+		if fl == existing {
+			return true
+		}
+	}
+
+	return false
+}
+
+// Return the first value from a list of environment variables and files
+// (which may or may not exist), a description of where the value was found,
+// and a boolean which is true if a value was found.
+func flagFromEnvOrFile(envVars []string, filePath string) (value string, fromWhere string, found bool) {
+	for _, envVar := range envVars {
+		envVar = strings.TrimSpace(envVar)
+		if value, found := syscall.Getenv(envVar); found {
+			return value, fmt.Sprintf("environment variable %q", envVar), true
+		}
+	}
+	for _, fileVar := range strings.Split(filePath, ",") {
+		if fileVar != "" {
+			if data, err := os.ReadFile(fileVar); err == nil {
+				return string(data), fmt.Sprintf("file %q", filePath), true
+			}
+		}
+	}
+	return "", "", false
+}
+
+type customizedSeparator interface {
+	WithSeparatorSpec(separatorSpec)
+}
+
+type separatorSpec struct {
+	sep        string
+	disabled   bool
+	customized bool
+}
+
+func (s separatorSpec) flagSplitMultiValues(val string) []string {
+	var (
+		disabled bool   = s.disabled
+		sep      string = s.sep
+	)
+	if !s.customized {
+		disabled = disableSliceFlagSeparator
+		sep = defaultSliceFlagSeparator
+	}
+	if disabled {
+		return []string{val}
+	}
+
+	return strings.Split(val, sep)
+}

--- a/vendor/github.com/urfave/cli/v2/flag_bool.go
+++ b/vendor/github.com/urfave/cli/v2/flag_bool.go
@@ -1,0 +1,178 @@
+package cli
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"strconv"
+)
+
+// boolValue needs to implement the boolFlag internal interface in flag
+// to be able to capture bool fields and values
+//
+//	type boolFlag interface {
+//		  Value
+//		  IsBoolFlag() bool
+//	}
+type boolValue struct {
+	destination *bool
+	count       *int
+}
+
+func newBoolValue(val bool, p *bool, count *int) *boolValue {
+	*p = val
+	return &boolValue{
+		destination: p,
+		count:       count,
+	}
+}
+
+func (b *boolValue) Set(s string) error {
+	v, err := strconv.ParseBool(s)
+	if err != nil {
+		err = errors.New("parse error")
+		return err
+	}
+	*b.destination = v
+	if b.count != nil {
+		*b.count = *b.count + 1
+	}
+	return err
+}
+
+func (b *boolValue) Get() interface{} { return *b.destination }
+
+func (b *boolValue) String() string {
+	if b.destination != nil {
+		return strconv.FormatBool(*b.destination)
+	}
+	return strconv.FormatBool(false)
+}
+
+func (b *boolValue) IsBoolFlag() bool { return true }
+
+func (b *boolValue) Count() int {
+	if b.count != nil && *b.count > 0 {
+		return *b.count
+	}
+	return 0
+}
+
+// TakesValue returns true of the flag takes a value, otherwise false
+func (f *BoolFlag) TakesValue() bool {
+	return false
+}
+
+// GetUsage returns the usage string for the flag
+func (f *BoolFlag) GetUsage() string {
+	return f.Usage
+}
+
+// GetCategory returns the category for the flag
+func (f *BoolFlag) GetCategory() string {
+	return f.Category
+}
+
+// GetValue returns the flags value as string representation and an empty
+// string if the flag takes no value at all.
+func (f *BoolFlag) GetValue() string {
+	return ""
+}
+
+// GetDefaultText returns the default text for this flag
+func (f *BoolFlag) GetDefaultText() string {
+	if f.DefaultText != "" {
+		return f.DefaultText
+	}
+	if f.defaultValueSet {
+		return fmt.Sprintf("%v", f.defaultValue)
+	}
+	return fmt.Sprintf("%v", f.Value)
+}
+
+// GetEnvVars returns the env vars for this flag
+func (f *BoolFlag) GetEnvVars() []string {
+	return f.EnvVars
+}
+
+// RunAction executes flag action if set
+func (f *BoolFlag) RunAction(c *Context) error {
+	if f.Action != nil {
+		return f.Action(c, c.Bool(f.Name))
+	}
+
+	return nil
+}
+
+// Apply populates the flag given the flag set and environment
+func (f *BoolFlag) Apply(set *flag.FlagSet) error {
+	// set default value so that environment wont be able to overwrite it
+	f.defaultValue = f.Value
+	f.defaultValueSet = true
+
+	if val, source, found := flagFromEnvOrFile(f.EnvVars, f.FilePath); found {
+		if val != "" {
+			valBool, err := strconv.ParseBool(val)
+
+			if err != nil {
+				return fmt.Errorf("could not parse %q as bool value from %s for flag %s: %s", val, source, f.Name, err)
+			}
+
+			f.Value = valBool
+		} else {
+			// empty value implies that the env is defined but set to empty string, we have to assume that this is
+			// what the user wants. If user doesnt want this then the env needs to be deleted or the flag removed from
+			// file
+			f.Value = false
+		}
+		f.HasBeenSet = true
+	}
+
+	count := f.Count
+	dest := f.Destination
+
+	if count == nil {
+		count = new(int)
+	}
+
+	// since count will be incremented for each alias as well
+	// subtract number of aliases from overall count
+	*count -= len(f.Aliases)
+
+	if dest == nil {
+		dest = new(bool)
+	}
+
+	for _, name := range f.Names() {
+		value := newBoolValue(f.Value, dest, count)
+		set.Var(value, name, f.Usage)
+	}
+
+	return nil
+}
+
+// Get returns the flag’s value in the given Context.
+func (f *BoolFlag) Get(ctx *Context) bool {
+	return ctx.Bool(f.Name)
+}
+
+// Bool looks up the value of a local BoolFlag, returns
+// false if not found
+func (cCtx *Context) Bool(name string) bool {
+	if fs := cCtx.lookupFlagSet(name); fs != nil {
+		return lookupBool(name, fs)
+	}
+	return false
+}
+
+func lookupBool(name string, set *flag.FlagSet) bool {
+	f := set.Lookup(name)
+	if f != nil {
+		parsed, err := strconv.ParseBool(f.Value.String())
+		if err != nil {
+			return false
+		}
+		return parsed
+	}
+	return false
+}

--- a/vendor/github.com/urfave/cli/v2/flag_duration.go
+++ b/vendor/github.com/urfave/cli/v2/flag_duration.go
@@ -1,0 +1,108 @@
+package cli
+
+import (
+	"flag"
+	"fmt"
+	"time"
+)
+
+// TakesValue returns true of the flag takes a value, otherwise false
+func (f *DurationFlag) TakesValue() bool {
+	return true
+}
+
+// GetUsage returns the usage string for the flag
+func (f *DurationFlag) GetUsage() string {
+	return f.Usage
+}
+
+// GetCategory returns the category for the flag
+func (f *DurationFlag) GetCategory() string {
+	return f.Category
+}
+
+// GetValue returns the flags value as string representation and an empty
+// string if the flag takes no value at all.
+func (f *DurationFlag) GetValue() string {
+	return f.Value.String()
+}
+
+// GetDefaultText returns the default text for this flag
+func (f *DurationFlag) GetDefaultText() string {
+	if f.DefaultText != "" {
+		return f.DefaultText
+	}
+	if f.defaultValueSet {
+		return f.defaultValue.String()
+	}
+	return f.Value.String()
+}
+
+// GetEnvVars returns the env vars for this flag
+func (f *DurationFlag) GetEnvVars() []string {
+	return f.EnvVars
+}
+
+// Apply populates the flag given the flag set and environment
+func (f *DurationFlag) Apply(set *flag.FlagSet) error {
+	// set default value so that environment wont be able to overwrite it
+	f.defaultValue = f.Value
+	f.defaultValueSet = true
+
+	if val, source, found := flagFromEnvOrFile(f.EnvVars, f.FilePath); found {
+		if val != "" {
+			valDuration, err := time.ParseDuration(val)
+
+			if err != nil {
+				return fmt.Errorf("could not parse %q as duration value from %s for flag %s: %s", val, source, f.Name, err)
+			}
+
+			f.Value = valDuration
+			f.HasBeenSet = true
+		}
+	}
+
+	for _, name := range f.Names() {
+		if f.Destination != nil {
+			set.DurationVar(f.Destination, name, f.Value, f.Usage)
+			continue
+		}
+		set.Duration(name, f.Value, f.Usage)
+	}
+	return nil
+}
+
+// Get returns the flag’s value in the given Context.
+func (f *DurationFlag) Get(ctx *Context) time.Duration {
+	return ctx.Duration(f.Name)
+}
+
+// RunAction executes flag action if set
+func (f *DurationFlag) RunAction(c *Context) error {
+	if f.Action != nil {
+		return f.Action(c, c.Duration(f.Name))
+	}
+
+	return nil
+}
+
+// Duration looks up the value of a local DurationFlag, returns
+// 0 if not found
+func (cCtx *Context) Duration(name string) time.Duration {
+	if fs := cCtx.lookupFlagSet(name); fs != nil {
+		return lookupDuration(name, fs)
+	}
+	return 0
+}
+
+func lookupDuration(name string, set *flag.FlagSet) time.Duration {
+	f := set.Lookup(name)
+	if f != nil {
+		parsed, err := time.ParseDuration(f.Value.String())
+		if err != nil {
+			return 0
+		}
+		return parsed
+	}
+	return 0
+}

--- a/vendor/github.com/urfave/cli/v2/flag_ext.go
+++ b/vendor/github.com/urfave/cli/v2/flag_ext.go
@@ -1,0 +1,48 @@
+package cli
+
+import "flag"
+
+type extFlag struct {
+	f *flag.Flag
+}
+
+func (e *extFlag) Apply(fs *flag.FlagSet) error {
+	fs.Var(e.f.Value, e.f.Name, e.f.Usage)
+	return nil
+}
+
+func (e *extFlag) Names() []string {
+	return []string{e.f.Name}
+}
+
+func (e *extFlag) IsSet() bool {
+	return false
+}
+
+func (e *extFlag) String() string {
+	return FlagStringer(e)
+}
+
+func (e *extFlag) IsVisible() bool {
+	return true
+}
+
+func (e *extFlag) TakesValue() bool {
+	return false
+}
+
+func (e *extFlag) GetUsage() string {
+	return e.f.Usage
+}
+
+func (e *extFlag) GetValue() string {
+	return e.f.Value.String()
+}
+
+func (e *extFlag) GetDefaultText() string {
+	return e.f.DefValue
+}
+
+func (e *extFlag) GetEnvVars() []string {
+	return nil
+}

--- a/vendor/github.com/urfave/cli/v2/flag_float64.go
+++ b/vendor/github.com/urfave/cli/v2/flag_float64.go
@@ -1,0 +1,107 @@
+package cli
+
+import (
+	"flag"
+	"fmt"
+	"strconv"
+)
+
+// TakesValue returns true of the flag takes a value, otherwise false
+func (f *Float64Flag) TakesValue() bool {
+	return true
+}
+
+// GetUsage returns the usage string for the flag
+func (f *Float64Flag) GetUsage() string {
+	return f.Usage
+}
+
+// GetCategory returns the category for the flag
+func (f *Float64Flag) GetCategory() string {
+	return f.Category
+}
+
+// GetValue returns the flags value as string representation and an empty
+// string if the flag takes no value at all.
+func (f *Float64Flag) GetValue() string {
+	return fmt.Sprintf("%v", f.Value)
+}
+
+// GetDefaultText returns the default text for this flag
+func (f *Float64Flag) GetDefaultText() string {
+	if f.DefaultText != "" {
+		return f.DefaultText
+	}
+	if f.defaultValueSet {
+		return fmt.Sprintf("%v", f.defaultValue)
+	}
+	return fmt.Sprintf("%v", f.Value)
+}
+
+// GetEnvVars returns the env vars for this flag
+func (f *Float64Flag) GetEnvVars() []string {
+	return f.EnvVars
+}
+
+// Apply populates the flag given the flag set and environment
+func (f *Float64Flag) Apply(set *flag.FlagSet) error {
+	f.defaultValue = f.Value
+	f.defaultValueSet = true
+
+	if val, source, found := flagFromEnvOrFile(f.EnvVars, f.FilePath); found {
+		if val != "" {
+			valFloat, err := strconv.ParseFloat(val, 64)
+			if err != nil {
+				return fmt.Errorf("could not parse %q as float64 value from %s for flag %s: %s", val, source, f.Name, err)
+			}
+
+			f.Value = valFloat
+			f.HasBeenSet = true
+		}
+	}
+
+	for _, name := range f.Names() {
+		if f.Destination != nil {
+			set.Float64Var(f.Destination, name, f.Value, f.Usage)
+			continue
+		}
+		set.Float64(name, f.Value, f.Usage)
+	}
+
+	return nil
+}
+
+// Get returns the flag’s value in the given Context.
+func (f *Float64Flag) Get(ctx *Context) float64 {
+	return ctx.Float64(f.Name)
+}
+
+// RunAction executes flag action if set
+func (f *Float64Flag) RunAction(c *Context) error {
+	if f.Action != nil {
+		return f.Action(c, c.Float64(f.Name))
+	}
+
+	return nil
+}
+
+// Float64 looks up the value of a local Float64Flag, returns
+// 0 if not found
+func (cCtx *Context) Float64(name string) float64 {
+	if fs := cCtx.lookupFlagSet(name); fs != nil {
+		return lookupFloat64(name, fs)
+	}
+	return 0
+}
+
+func lookupFloat64(name string, set *flag.FlagSet) float64 {
+	f := set.Lookup(name)
+	if f != nil {
+		parsed, err := strconv.ParseFloat(f.Value.String(), 64)
+		if err != nil {
+			return 0
+		}
+		return parsed
+	}
+	return 0
+}

--- a/vendor/github.com/urfave/cli/v2/flag_float64_slice.go
+++ b/vendor/github.com/urfave/cli/v2/flag_float64_slice.go
@@ -1,0 +1,216 @@
+package cli
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// Float64Slice wraps []float64 to satisfy flag.Value
+type Float64Slice struct {
+	slice      []float64
+	separator  separatorSpec
+	hasBeenSet bool
+}
+
+// NewFloat64Slice makes a *Float64Slice with default values
+func NewFloat64Slice(defaults ...float64) *Float64Slice {
+	return &Float64Slice{slice: append([]float64{}, defaults...)}
+}
+
+// clone allocate a copy of self object
+func (f *Float64Slice) clone() *Float64Slice {
+	n := &Float64Slice{
+		slice:      make([]float64, len(f.slice)),
+		hasBeenSet: f.hasBeenSet,
+	}
+	copy(n.slice, f.slice)
+	return n
+}
+
+func (f *Float64Slice) WithSeparatorSpec(spec separatorSpec) {
+	f.separator = spec
+}
+
+// Set parses the value into a float64 and appends it to the list of values
+func (f *Float64Slice) Set(value string) error {
+	if !f.hasBeenSet {
+		f.slice = []float64{}
+		f.hasBeenSet = true
+	}
+
+	if strings.HasPrefix(value, slPfx) {
+		// Deserializing assumes overwrite
+		_ = json.Unmarshal([]byte(strings.Replace(value, slPfx, "", 1)), &f.slice)
+		f.hasBeenSet = true
+		return nil
+	}
+
+	for _, s := range f.separator.flagSplitMultiValues(value) {
+		tmp, err := strconv.ParseFloat(strings.TrimSpace(s), 64)
+		if err != nil {
+			return err
+		}
+
+		f.slice = append(f.slice, tmp)
+	}
+	return nil
+}
+
+// String returns a readable representation of this value (for usage defaults)
+func (f *Float64Slice) String() string {
+	v := f.slice
+	if v == nil {
+		// treat nil the same as zero length non-nil
+		v = make([]float64, 0)
+	}
+	return fmt.Sprintf("%#v", v)
+}
+
+// Serialize allows Float64Slice to fulfill Serializer
+func (f *Float64Slice) Serialize() string {
+	jsonBytes, _ := json.Marshal(f.slice)
+	return fmt.Sprintf("%s%s", slPfx, string(jsonBytes))
+}
+
+// Value returns the slice of float64s set by this flag
+func (f *Float64Slice) Value() []float64 {
+	return f.slice
+}
+
+// Get returns the slice of float64s set by this flag
+func (f *Float64Slice) Get() interface{} {
+	return *f
+}
+
+// String returns a readable representation of this value
+// (for usage defaults)
+func (f *Float64SliceFlag) String() string {
+	return FlagStringer(f)
+}
+
+// TakesValue returns true if the flag takes a value, otherwise false
+func (f *Float64SliceFlag) TakesValue() bool {
+	return true
+}
+
+// GetUsage returns the usage string for the flag
+func (f *Float64SliceFlag) GetUsage() string {
+	return f.Usage
+}
+
+// GetCategory returns the category for the flag
+func (f *Float64SliceFlag) GetCategory() string {
+	return f.Category
+}
+
+// GetValue returns the flags value as string representation and an empty
+// string if the flag takes no value at all.
+func (f *Float64SliceFlag) GetValue() string {
+	var defaultVals []string
+	if f.Value != nil && len(f.Value.Value()) > 0 {
+		for _, i := range f.Value.Value() {
+			defaultVals = append(defaultVals, strings.TrimRight(strings.TrimRight(fmt.Sprintf("%f", i), "0"), "."))
+		}
+	}
+	return strings.Join(defaultVals, ", ")
+}
+
+// GetDefaultText returns the default text for this flag
+func (f *Float64SliceFlag) GetDefaultText() string {
+	if f.DefaultText != "" {
+		return f.DefaultText
+	}
+	return f.GetValue()
+}
+
+// GetEnvVars returns the env vars for this flag
+func (f *Float64SliceFlag) GetEnvVars() []string {
+	return f.EnvVars
+}
+
+// IsSliceFlag implements DocGenerationSliceFlag.
+func (f *Float64SliceFlag) IsSliceFlag() bool {
+	return true
+}
+
+// Apply populates the flag given the flag set and environment
+func (f *Float64SliceFlag) Apply(set *flag.FlagSet) error {
+	// apply any default
+	if f.Destination != nil && f.Value != nil {
+		f.Destination.slice = make([]float64, len(f.Value.slice))
+		copy(f.Destination.slice, f.Value.slice)
+	}
+
+	// resolve setValue (what we will assign to the set)
+	var setValue *Float64Slice
+	switch {
+	case f.Destination != nil:
+		setValue = f.Destination
+	case f.Value != nil:
+		setValue = f.Value.clone()
+	default:
+		setValue = new(Float64Slice)
+		setValue.WithSeparatorSpec(f.separator)
+	}
+
+	if val, source, found := flagFromEnvOrFile(f.EnvVars, f.FilePath); found {
+		if val != "" {
+			for _, s := range f.separator.flagSplitMultiValues(val) {
+				if err := setValue.Set(strings.TrimSpace(s)); err != nil {
+					return fmt.Errorf("could not parse %q as float64 slice value from %s for flag %s: %s", val, source, f.Name, err)
+				}
+			}
+
+			// Set this to false so that we reset the slice if we then set values from
+			// flags that have already been set by the environment.
+			setValue.hasBeenSet = false
+			f.HasBeenSet = true
+		}
+	}
+
+	for _, name := range f.Names() {
+		set.Var(setValue, name, f.Usage)
+	}
+
+	return nil
+}
+
+func (f *Float64SliceFlag) WithSeparatorSpec(spec separatorSpec) {
+	f.separator = spec
+}
+
+// Get returns the flag’s value in the given Context.
+func (f *Float64SliceFlag) Get(ctx *Context) []float64 {
+	return ctx.Float64Slice(f.Name)
+}
+
+// RunAction executes flag action if set
+func (f *Float64SliceFlag) RunAction(c *Context) error {
+	if f.Action != nil {
+		return f.Action(c, c.Float64Slice(f.Name))
+	}
+
+	return nil
+}
+
+// Float64Slice looks up the value of a local Float64SliceFlag, returns
+// nil if not found
+func (cCtx *Context) Float64Slice(name string) []float64 {
+	if fs := cCtx.lookupFlagSet(name); fs != nil {
+		return lookupFloat64Slice(name, fs)
+	}
+	return nil
+}
+
+func lookupFloat64Slice(name string, set *flag.FlagSet) []float64 {
+	f := set.Lookup(name)
+	if f != nil {
+		if slice, ok := unwrapFlagValue(f.Value).(*Float64Slice); ok {
+			return slice.Value()
+		}
+	}
+	return nil
+}

--- a/vendor/github.com/urfave/cli/v2/flag_generic.go
+++ b/vendor/github.com/urfave/cli/v2/flag_generic.go
@@ -1,0 +1,131 @@
+package cli
+
+import (
+	"flag"
+	"fmt"
+)
+
+// Generic is a generic parseable type identified by a specific flag
+type Generic interface {
+	Set(value string) error
+	String() string
+}
+
+type stringGeneric struct {
+	value string
+}
+
+func (s *stringGeneric) Set(value string) error {
+	s.value = value
+	return nil
+}
+
+func (s *stringGeneric) String() string {
+	return s.value
+}
+
+// TakesValue returns true of the flag takes a value, otherwise false
+func (f *GenericFlag) TakesValue() bool {
+	return true
+}
+
+// GetUsage returns the usage string for the flag
+func (f *GenericFlag) GetUsage() string {
+	return f.Usage
+}
+
+// GetCategory returns the category for the flag
+func (f *GenericFlag) GetCategory() string {
+	return f.Category
+}
+
+// GetValue returns the flags value as string representation and an empty
+// string if the flag takes no value at all.
+func (f *GenericFlag) GetValue() string {
+	if f.Value != nil {
+		return f.Value.String()
+	}
+	return ""
+}
+
+// GetDefaultText returns the default text for this flag
+func (f *GenericFlag) GetDefaultText() string {
+	if f.DefaultText != "" {
+		return f.DefaultText
+	}
+	val := f.Value
+	if f.defaultValueSet {
+		val = f.defaultValue
+	}
+
+	if val != nil {
+		return val.String()
+	}
+
+	return ""
+}
+
+// GetEnvVars returns the env vars for this flag
+func (f *GenericFlag) GetEnvVars() []string {
+	return f.EnvVars
+}
+
+// Apply takes the flagset and calls Set on the generic flag with the value
+// provided by the user for parsing by the flag
+func (f *GenericFlag) Apply(set *flag.FlagSet) error {
+	// set default value so that environment wont be able to overwrite it
+	if f.Value != nil {
+		f.defaultValue = &stringGeneric{value: f.Value.String()}
+		f.defaultValueSet = true
+	}
+
+	if val, source, found := flagFromEnvOrFile(f.EnvVars, f.FilePath); found {
+		if val != "" {
+			if err := f.Value.Set(val); err != nil {
+				return fmt.Errorf("could not parse %q from %s as value for flag %s: %s", val, source, f.Name, err)
+			}
+
+			f.HasBeenSet = true
+		}
+	}
+
+	for _, name := range f.Names() {
+		if f.Destination != nil {
+			set.Var(f.Destination, name, f.Usage)
+			continue
+		}
+		set.Var(f.Value, name, f.Usage)
+	}
+
+	return nil
+}
+
+// Get returns the flag’s value in the given Context.
+func (f *GenericFlag) Get(ctx *Context) interface{} {
+	return ctx.Generic(f.Name)
+}
+
+// RunAction executes flag action if set
+func (f *GenericFlag) RunAction(c *Context) error {
+	if f.Action != nil {
+		return f.Action(c, c.Generic(f.Name))
+	}
+
+	return nil
+}
+
+// Generic looks up the value of a local GenericFlag, returns
+// nil if not found
+func (cCtx *Context) Generic(name string) interface{} {
+	if fs := cCtx.lookupFlagSet(name); fs != nil {
+		return lookupGeneric(name, fs)
+	}
+	return nil
+}
+
+func lookupGeneric(name string, set *flag.FlagSet) interface{} {
+	if f := set.Lookup(name); f != nil {
+		return f.Value
+	}
+	return nil
+}

--- a/vendor/github.com/urfave/cli/v2/flag_int.go
+++ b/vendor/github.com/urfave/cli/v2/flag_int.go
@@ -1,0 +1,109 @@
+package cli
+
+import (
+	"flag"
+	"fmt"
+	"strconv"
+)
+
+// TakesValue returns true of the flag takes a value, otherwise false
+func (f *IntFlag) TakesValue() bool {
+	return true
+}
+
+// GetUsage returns the usage string for the flag
+func (f *IntFlag) GetUsage() string {
+	return f.Usage
+}
+
+// GetCategory returns the category for the flag
+func (f *IntFlag) GetCategory() string {
+	return f.Category
+}
+
+// GetValue returns the flags value as string representation and an empty
+// string if the flag takes no value at all.
+func (f *IntFlag) GetValue() string {
+	return fmt.Sprintf("%d", f.Value)
+}
+
+// GetDefaultText returns the default text for this flag
+func (f *IntFlag) GetDefaultText() string {
+	if f.DefaultText != "" {
+		return f.DefaultText
+	}
+	if f.defaultValueSet {
+		return fmt.Sprintf("%d", f.defaultValue)
+	}
+	return fmt.Sprintf("%d", f.Value)
+}
+
+// GetEnvVars returns the env vars for this flag
+func (f *IntFlag) GetEnvVars() []string {
+	return f.EnvVars
+}
+
+// Apply populates the flag given the flag set and environment
+func (f *IntFlag) Apply(set *flag.FlagSet) error {
+	// set default value so that environment wont be able to overwrite it
+	f.defaultValue = f.Value
+	f.defaultValueSet = true
+
+	if val, source, found := flagFromEnvOrFile(f.EnvVars, f.FilePath); found {
+		if val != "" {
+			valInt, err := strconv.ParseInt(val, f.Base, 64)
+
+			if err != nil {
+				return fmt.Errorf("could not parse %q as int value from %s for flag %s: %s", val, source, f.Name, err)
+			}
+
+			f.Value = int(valInt)
+			f.HasBeenSet = true
+		}
+	}
+
+	for _, name := range f.Names() {
+		if f.Destination != nil {
+			set.IntVar(f.Destination, name, f.Value, f.Usage)
+			continue
+		}
+		set.Int(name, f.Value, f.Usage)
+	}
+
+	return nil
+}
+
+// Get returns the flag’s value in the given Context.
+func (f *IntFlag) Get(ctx *Context) int {
+	return ctx.Int(f.Name)
+}
+
+// RunAction executes flag action if set
+func (f *IntFlag) RunAction(c *Context) error {
+	if f.Action != nil {
+		return f.Action(c, c.Int(f.Name))
+	}
+
+	return nil
+}
+
+// Int looks up the value of a local IntFlag, returns
+// 0 if not found
+func (cCtx *Context) Int(name string) int {
+	if fs := cCtx.lookupFlagSet(name); fs != nil {
+		return lookupInt(name, fs)
+	}
+	return 0
+}
+
+func lookupInt(name string, set *flag.FlagSet) int {
+	f := set.Lookup(name)
+	if f != nil {
+		parsed, err := strconv.ParseInt(f.Value.String(), 0, 64)
+		if err != nil {
+			return 0
+		}
+		return int(parsed)
+	}
+	return 0
+}

--- a/vendor/github.com/urfave/cli/v2/flag_int64.go
+++ b/vendor/github.com/urfave/cli/v2/flag_int64.go
@@ -1,0 +1,108 @@
+package cli
+
+import (
+	"flag"
+	"fmt"
+	"strconv"
+)
+
+// TakesValue returns true of the flag takes a value, otherwise false
+func (f *Int64Flag) TakesValue() bool {
+	return true
+}
+
+// GetUsage returns the usage string for the flag
+func (f *Int64Flag) GetUsage() string {
+	return f.Usage
+}
+
+// GetCategory returns the category for the flag
+func (f *Int64Flag) GetCategory() string {
+	return f.Category
+}
+
+// GetValue returns the flags value as string representation and an empty
+// string if the flag takes no value at all.
+func (f *Int64Flag) GetValue() string {
+	return fmt.Sprintf("%d", f.Value)
+}
+
+// GetDefaultText returns the default text for this flag
+func (f *Int64Flag) GetDefaultText() string {
+	if f.DefaultText != "" {
+		return f.DefaultText
+	}
+	if f.defaultValueSet {
+		return fmt.Sprintf("%d", f.defaultValue)
+	}
+	return fmt.Sprintf("%d", f.Value)
+}
+
+// GetEnvVars returns the env vars for this flag
+func (f *Int64Flag) GetEnvVars() []string {
+	return f.EnvVars
+}
+
+// Apply populates the flag given the flag set and environment
+func (f *Int64Flag) Apply(set *flag.FlagSet) error {
+	// set default value so that environment wont be able to overwrite it
+	f.defaultValue = f.Value
+	f.defaultValueSet = true
+
+	if val, source, found := flagFromEnvOrFile(f.EnvVars, f.FilePath); found {
+		if val != "" {
+			valInt, err := strconv.ParseInt(val, f.Base, 64)
+
+			if err != nil {
+				return fmt.Errorf("could not parse %q as int value from %s for flag %s: %s", val, source, f.Name, err)
+			}
+
+			f.Value = valInt
+			f.HasBeenSet = true
+		}
+	}
+
+	for _, name := range f.Names() {
+		if f.Destination != nil {
+			set.Int64Var(f.Destination, name, f.Value, f.Usage)
+			continue
+		}
+		set.Int64(name, f.Value, f.Usage)
+	}
+	return nil
+}
+
+// Get returns the flag’s value in the given Context.
+func (f *Int64Flag) Get(ctx *Context) int64 {
+	return ctx.Int64(f.Name)
+}
+
+// RunAction executes flag action if set
+func (f *Int64Flag) RunAction(c *Context) error {
+	if f.Action != nil {
+		return f.Action(c, c.Int64(f.Name))
+	}
+
+	return nil
+}
+
+// Int64 looks up the value of a local Int64Flag, returns
+// 0 if not found
+func (cCtx *Context) Int64(name string) int64 {
+	if fs := cCtx.lookupFlagSet(name); fs != nil {
+		return lookupInt64(name, fs)
+	}
+	return 0
+}
+
+func lookupInt64(name string, set *flag.FlagSet) int64 {
+	f := set.Lookup(name)
+	if f != nil {
+		parsed, err := strconv.ParseInt(f.Value.String(), 0, 64)
+		if err != nil {
+			return 0
+		}
+		return parsed
+	}
+	return 0
+}

--- a/vendor/github.com/urfave/cli/v2/flag_int64_slice.go
+++ b/vendor/github.com/urfave/cli/v2/flag_int64_slice.go
@@ -1,0 +1,215 @@
+package cli
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// Int64Slice wraps []int64 to satisfy flag.Value
+type Int64Slice struct {
+	slice      []int64
+	separator  separatorSpec
+	hasBeenSet bool
+}
+
+// NewInt64Slice makes an *Int64Slice with default values
+func NewInt64Slice(defaults ...int64) *Int64Slice {
+	return &Int64Slice{slice: append([]int64{}, defaults...)}
+}
+
+// clone allocate a copy of self object
+func (i *Int64Slice) clone() *Int64Slice {
+	n := &Int64Slice{
+		slice:      make([]int64, len(i.slice)),
+		hasBeenSet: i.hasBeenSet,
+	}
+	copy(n.slice, i.slice)
+	return n
+}
+
+func (i *Int64Slice) WithSeparatorSpec(spec separatorSpec) {
+	i.separator = spec
+}
+
+// Set parses the value into an integer and appends it to the list of values
+func (i *Int64Slice) Set(value string) error {
+	if !i.hasBeenSet {
+		i.slice = []int64{}
+		i.hasBeenSet = true
+	}
+
+	if strings.HasPrefix(value, slPfx) {
+		// Deserializing assumes overwrite
+		_ = json.Unmarshal([]byte(strings.Replace(value, slPfx, "", 1)), &i.slice)
+		i.hasBeenSet = true
+		return nil
+	}
+
+	for _, s := range i.separator.flagSplitMultiValues(value) {
+		tmp, err := strconv.ParseInt(strings.TrimSpace(s), 0, 64)
+		if err != nil {
+			return err
+		}
+
+		i.slice = append(i.slice, tmp)
+	}
+
+	return nil
+}
+
+// String returns a readable representation of this value (for usage defaults)
+func (i *Int64Slice) String() string {
+	v := i.slice
+	if v == nil {
+		// treat nil the same as zero length non-nil
+		v = make([]int64, 0)
+	}
+	return fmt.Sprintf("%#v", v)
+}
+
+// Serialize allows Int64Slice to fulfill Serializer
+func (i *Int64Slice) Serialize() string {
+	jsonBytes, _ := json.Marshal(i.slice)
+	return fmt.Sprintf("%s%s", slPfx, string(jsonBytes))
+}
+
+// Value returns the slice of ints set by this flag
+func (i *Int64Slice) Value() []int64 {
+	return i.slice
+}
+
+// Get returns the slice of ints set by this flag
+func (i *Int64Slice) Get() interface{} {
+	return *i
+}
+
+// String returns a readable representation of this value
+// (for usage defaults)
+func (f *Int64SliceFlag) String() string {
+	return FlagStringer(f)
+}
+
+// TakesValue returns true of the flag takes a value, otherwise false
+func (f *Int64SliceFlag) TakesValue() bool {
+	return true
+}
+
+// GetUsage returns the usage string for the flag
+func (f *Int64SliceFlag) GetUsage() string {
+	return f.Usage
+}
+
+// GetCategory returns the category for the flag
+func (f *Int64SliceFlag) GetCategory() string {
+	return f.Category
+}
+
+// GetValue returns the flags value as string representation and an empty
+// string if the flag takes no value at all.
+func (f *Int64SliceFlag) GetValue() string {
+	var defaultVals []string
+	if f.Value != nil && len(f.Value.Value()) > 0 {
+		for _, i := range f.Value.Value() {
+			defaultVals = append(defaultVals, strconv.FormatInt(i, 10))
+		}
+	}
+	return strings.Join(defaultVals, ", ")
+}
+
+// GetDefaultText returns the default text for this flag
+func (f *Int64SliceFlag) GetDefaultText() string {
+	if f.DefaultText != "" {
+		return f.DefaultText
+	}
+	return f.GetValue()
+}
+
+// GetEnvVars returns the env vars for this flag
+func (f *Int64SliceFlag) GetEnvVars() []string {
+	return f.EnvVars
+}
+
+// IsSliceFlag implements DocGenerationSliceFlag.
+func (f *Int64SliceFlag) IsSliceFlag() bool {
+	return true
+}
+
+// Apply populates the flag given the flag set and environment
+func (f *Int64SliceFlag) Apply(set *flag.FlagSet) error {
+	// apply any default
+	if f.Destination != nil && f.Value != nil {
+		f.Destination.slice = make([]int64, len(f.Value.slice))
+		copy(f.Destination.slice, f.Value.slice)
+	}
+
+	// resolve setValue (what we will assign to the set)
+	var setValue *Int64Slice
+	switch {
+	case f.Destination != nil:
+		setValue = f.Destination
+	case f.Value != nil:
+		setValue = f.Value.clone()
+	default:
+		setValue = new(Int64Slice)
+		setValue.WithSeparatorSpec(f.separator)
+	}
+
+	if val, source, ok := flagFromEnvOrFile(f.EnvVars, f.FilePath); ok && val != "" {
+		for _, s := range f.separator.flagSplitMultiValues(val) {
+			if err := setValue.Set(strings.TrimSpace(s)); err != nil {
+				return fmt.Errorf("could not parse %q as int64 slice value from %s for flag %s: %s", val, source, f.Name, err)
+			}
+		}
+
+		// Set this to false so that we reset the slice if we then set values from
+		// flags that have already been set by the environment.
+		setValue.hasBeenSet = false
+		f.HasBeenSet = true
+	}
+
+	for _, name := range f.Names() {
+		set.Var(setValue, name, f.Usage)
+	}
+
+	return nil
+}
+
+func (f *Int64SliceFlag) WithSeparatorSpec(spec separatorSpec) {
+	f.separator = spec
+}
+
+// Get returns the flag’s value in the given Context.
+func (f *Int64SliceFlag) Get(ctx *Context) []int64 {
+	return ctx.Int64Slice(f.Name)
+}
+
+// RunAction executes flag action if set
+func (f *Int64SliceFlag) RunAction(c *Context) error {
+	if f.Action != nil {
+		return f.Action(c, c.Int64Slice(f.Name))
+	}
+
+	return nil
+}
+
+// Int64Slice looks up the value of a local Int64SliceFlag, returns
+// nil if not found
+func (cCtx *Context) Int64Slice(name string) []int64 {
+	if fs := cCtx.lookupFlagSet(name); fs != nil {
+		return lookupInt64Slice(name, fs)
+	}
+	return nil
+}
+
+func lookupInt64Slice(name string, set *flag.FlagSet) []int64 {
+	f := set.Lookup(name)
+	if f != nil {
+		if slice, ok := unwrapFlagValue(f.Value).(*Int64Slice); ok {
+			return slice.Value()
+		}
+	}
+	return nil
+}

--- a/vendor/github.com/urfave/cli/v2/flag_int_slice.go
+++ b/vendor/github.com/urfave/cli/v2/flag_int_slice.go
@@ -1,0 +1,226 @@
+package cli
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// IntSlice wraps []int to satisfy flag.Value
+type IntSlice struct {
+	slice      []int
+	separator  separatorSpec
+	hasBeenSet bool
+}
+
+// NewIntSlice makes an *IntSlice with default values
+func NewIntSlice(defaults ...int) *IntSlice {
+	return &IntSlice{slice: append([]int{}, defaults...)}
+}
+
+// clone allocate a copy of self object
+func (i *IntSlice) clone() *IntSlice {
+	n := &IntSlice{
+		slice:      make([]int, len(i.slice)),
+		hasBeenSet: i.hasBeenSet,
+	}
+	copy(n.slice, i.slice)
+	return n
+}
+
+// TODO: Consistently have specific Set function for Int64 and Float64 ?
+// SetInt directly adds an integer to the list of values
+func (i *IntSlice) SetInt(value int) {
+	if !i.hasBeenSet {
+		i.slice = []int{}
+		i.hasBeenSet = true
+	}
+
+	i.slice = append(i.slice, value)
+}
+
+func (i *IntSlice) WithSeparatorSpec(spec separatorSpec) {
+	i.separator = spec
+}
+
+// Set parses the value into an integer and appends it to the list of values
+func (i *IntSlice) Set(value string) error {
+	if !i.hasBeenSet {
+		i.slice = []int{}
+		i.hasBeenSet = true
+	}
+
+	if strings.HasPrefix(value, slPfx) {
+		// Deserializing assumes overwrite
+		_ = json.Unmarshal([]byte(strings.Replace(value, slPfx, "", 1)), &i.slice)
+		i.hasBeenSet = true
+		return nil
+	}
+
+	for _, s := range i.separator.flagSplitMultiValues(value) {
+		tmp, err := strconv.ParseInt(strings.TrimSpace(s), 0, 64)
+		if err != nil {
+			return err
+		}
+
+		i.slice = append(i.slice, int(tmp))
+	}
+
+	return nil
+}
+
+// String returns a readable representation of this value (for usage defaults)
+func (i *IntSlice) String() string {
+	v := i.slice
+	if v == nil {
+		// treat nil the same as zero length non-nil
+		v = make([]int, 0)
+	}
+	return fmt.Sprintf("%#v", v)
+}
+
+// Serialize allows IntSlice to fulfill Serializer
+func (i *IntSlice) Serialize() string {
+	jsonBytes, _ := json.Marshal(i.slice)
+	return fmt.Sprintf("%s%s", slPfx, string(jsonBytes))
+}
+
+// Value returns the slice of ints set by this flag
+func (i *IntSlice) Value() []int {
+	return i.slice
+}
+
+// Get returns the slice of ints set by this flag
+func (i *IntSlice) Get() interface{} {
+	return *i
+}
+
+// String returns a readable representation of this value
+// (for usage defaults)
+func (f *IntSliceFlag) String() string {
+	return FlagStringer(f)
+}
+
+// TakesValue returns true of the flag takes a value, otherwise false
+func (f *IntSliceFlag) TakesValue() bool {
+	return true
+}
+
+// GetUsage returns the usage string for the flag
+func (f *IntSliceFlag) GetUsage() string {
+	return f.Usage
+}
+
+// GetCategory returns the category for the flag
+func (f *IntSliceFlag) GetCategory() string {
+	return f.Category
+}
+
+// GetValue returns the flags value as string representation and an empty
+// string if the flag takes no value at all.
+func (f *IntSliceFlag) GetValue() string {
+	var defaultVals []string
+	if f.Value != nil && len(f.Value.Value()) > 0 {
+		for _, i := range f.Value.Value() {
+			defaultVals = append(defaultVals, strconv.Itoa(i))
+		}
+	}
+	return strings.Join(defaultVals, ", ")
+}
+
+// GetDefaultText returns the default text for this flag
+func (f *IntSliceFlag) GetDefaultText() string {
+	if f.DefaultText != "" {
+		return f.DefaultText
+	}
+	return f.GetValue()
+}
+
+// GetEnvVars returns the env vars for this flag
+func (f *IntSliceFlag) GetEnvVars() []string {
+	return f.EnvVars
+}
+
+// IsSliceFlag implements DocGenerationSliceFlag.
+func (f *IntSliceFlag) IsSliceFlag() bool {
+	return true
+}
+
+// Apply populates the flag given the flag set and environment
+func (f *IntSliceFlag) Apply(set *flag.FlagSet) error {
+	// apply any default
+	if f.Destination != nil && f.Value != nil {
+		f.Destination.slice = make([]int, len(f.Value.slice))
+		copy(f.Destination.slice, f.Value.slice)
+	}
+
+	// resolve setValue (what we will assign to the set)
+	var setValue *IntSlice
+	switch {
+	case f.Destination != nil:
+		setValue = f.Destination
+	case f.Value != nil:
+		setValue = f.Value.clone()
+	default:
+		setValue = new(IntSlice)
+		setValue.WithSeparatorSpec(f.separator)
+	}
+
+	if val, source, ok := flagFromEnvOrFile(f.EnvVars, f.FilePath); ok && val != "" {
+		for _, s := range f.separator.flagSplitMultiValues(val) {
+			if err := setValue.Set(strings.TrimSpace(s)); err != nil {
+				return fmt.Errorf("could not parse %q as int slice value from %s for flag %s: %s", val, source, f.Name, err)
+			}
+		}
+
+		// Set this to false so that we reset the slice if we then set values from
+		// flags that have already been set by the environment.
+		setValue.hasBeenSet = false
+		f.HasBeenSet = true
+	}
+
+	for _, name := range f.Names() {
+		set.Var(setValue, name, f.Usage)
+	}
+
+	return nil
+}
+
+func (f *IntSliceFlag) WithSeparatorSpec(spec separatorSpec) {
+	f.separator = spec
+}
+
+// Get returns the flag’s value in the given Context.
+func (f *IntSliceFlag) Get(ctx *Context) []int {
+	return ctx.IntSlice(f.Name)
+}
+
+// RunAction executes flag action if set
+func (f *IntSliceFlag) RunAction(c *Context) error {
+	if f.Action != nil {
+		return f.Action(c, c.IntSlice(f.Name))
+	}
+
+	return nil
+}
+
+// IntSlice looks up the value of a local IntSliceFlag, returns
+// nil if not found
+func (cCtx *Context) IntSlice(name string) []int {
+	if fs := cCtx.lookupFlagSet(name); fs != nil {
+		return lookupIntSlice(name, fs)
+	}
+	return nil
+}
+
+func lookupIntSlice(name string, set *flag.FlagSet) []int {
+	f := set.Lookup(name)
+	if f != nil {
+		if slice, ok := unwrapFlagValue(f.Value).(*IntSlice); ok {
+			return slice.Value()
+		}
+	}
+	return nil
+}

--- a/vendor/github.com/urfave/cli/v2/flag_path.go
+++ b/vendor/github.com/urfave/cli/v2/flag_path.go
@@ -1,0 +1,102 @@
+package cli
+
+import (
+	"flag"
+	"fmt"
+)
+
+type Path = string
+
+// TakesValue returns true of the flag takes a value, otherwise false
+func (f *PathFlag) TakesValue() bool {
+	return true
+}
+
+// GetUsage returns the usage string for the flag
+func (f *PathFlag) GetUsage() string {
+	return f.Usage
+}
+
+// GetCategory returns the category for the flag
+func (f *PathFlag) GetCategory() string {
+	return f.Category
+}
+
+// GetValue returns the flags value as string representation and an empty
+// string if the flag takes no value at all.
+func (f *PathFlag) GetValue() string {
+	return f.Value
+}
+
+// GetDefaultText returns the default text for this flag
+func (f *PathFlag) GetDefaultText() string {
+	if f.DefaultText != "" {
+		return f.DefaultText
+	}
+	val := f.Value
+	if f.defaultValueSet {
+		val = f.defaultValue
+	}
+	if val == "" {
+		return val
+	}
+	return fmt.Sprintf("%q", val)
+}
+
+// GetEnvVars returns the env vars for this flag
+func (f *PathFlag) GetEnvVars() []string {
+	return f.EnvVars
+}
+
+// Apply populates the flag given the flag set and environment
+func (f *PathFlag) Apply(set *flag.FlagSet) error {
+	// set default value so that environment wont be able to overwrite it
+	f.defaultValue = f.Value
+	f.defaultValueSet = true
+
+	if val, _, found := flagFromEnvOrFile(f.EnvVars, f.FilePath); found {
+		f.Value = val
+		f.HasBeenSet = true
+	}
+
+	for _, name := range f.Names() {
+		if f.Destination != nil {
+			set.StringVar(f.Destination, name, f.Value, f.Usage)
+			continue
+		}
+		set.String(name, f.Value, f.Usage)
+	}
+
+	return nil
+}
+
+// Get returns the flag’s value in the given Context.
+func (f *PathFlag) Get(ctx *Context) string {
+	return ctx.Path(f.Name)
+}
+
+// RunAction executes flag action if set
+func (f *PathFlag) RunAction(c *Context) error {
+	if f.Action != nil {
+		return f.Action(c, c.Path(f.Name))
+	}
+
+	return nil
+}
+
+// Path looks up the value of a local PathFlag, returns
+// "" if not found
+func (cCtx *Context) Path(name string) string {
+	if fs := cCtx.lookupFlagSet(name); fs != nil {
+		return lookupPath(name, fs)
+	}
+
+	return ""
+}
+
+func lookupPath(name string, set *flag.FlagSet) string {
+	if f := set.Lookup(name); f != nil {
+		return f.Value.String()
+	}
+	return ""
+}

--- a/vendor/github.com/urfave/cli/v2/flag_string.go
+++ b/vendor/github.com/urfave/cli/v2/flag_string.go
@@ -1,0 +1,100 @@
+package cli
+
+import (
+	"flag"
+	"fmt"
+)
+
+// TakesValue returns true of the flag takes a value, otherwise false
+func (f *StringFlag) TakesValue() bool {
+	return true
+}
+
+// GetUsage returns the usage string for the flag
+func (f *StringFlag) GetUsage() string {
+	return f.Usage
+}
+
+// GetCategory returns the category for the flag
+func (f *StringFlag) GetCategory() string {
+	return f.Category
+}
+
+// GetValue returns the flags value as string representation and an empty
+// string if the flag takes no value at all.
+func (f *StringFlag) GetValue() string {
+	return f.Value
+}
+
+// GetDefaultText returns the default text for this flag
+func (f *StringFlag) GetDefaultText() string {
+	if f.DefaultText != "" {
+		return f.DefaultText
+	}
+	val := f.Value
+	if f.defaultValueSet {
+		val = f.defaultValue
+	}
+
+	if val == "" {
+		return val
+	}
+	return fmt.Sprintf("%q", val)
+}
+
+// GetEnvVars returns the env vars for this flag
+func (f *StringFlag) GetEnvVars() []string {
+	return f.EnvVars
+}
+
+// Apply populates the flag given the flag set and environment
+func (f *StringFlag) Apply(set *flag.FlagSet) error {
+	// set default value so that environment wont be able to overwrite it
+	f.defaultValue = f.Value
+	f.defaultValueSet = true
+
+	if val, _, found := flagFromEnvOrFile(f.EnvVars, f.FilePath); found {
+		f.Value = val
+		f.HasBeenSet = true
+	}
+
+	for _, name := range f.Names() {
+		if f.Destination != nil {
+			set.StringVar(f.Destination, name, f.Value, f.Usage)
+			continue
+		}
+		set.String(name, f.Value, f.Usage)
+	}
+
+	return nil
+}
+
+// Get returns the flag’s value in the given Context.
+func (f *StringFlag) Get(ctx *Context) string {
+	return ctx.String(f.Name)
+}
+
+// RunAction executes flag action if set
+func (f *StringFlag) RunAction(c *Context) error {
+	if f.Action != nil {
+		return f.Action(c, c.String(f.Name))
+	}
+
+	return nil
+}
+
+// String looks up the value of a local StringFlag, returns
+// "" if not found
+func (cCtx *Context) String(name string) string {
+	if fs := cCtx.lookupFlagSet(name); fs != nil {
+		return lookupString(name, fs)
+	}
+	return ""
+}
+
+func lookupString(name string, set *flag.FlagSet) string {
+	if f := set.Lookup(name); f != nil {
+		return f.Value.String()
+	}
+	return ""
+}

--- a/vendor/github.com/urfave/cli/v2/flag_string_slice.go
+++ b/vendor/github.com/urfave/cli/v2/flag_string_slice.go
@@ -1,0 +1,216 @@
+package cli
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// StringSlice wraps a []string to satisfy flag.Value
+type StringSlice struct {
+	slice      []string
+	separator  separatorSpec
+	hasBeenSet bool
+	keepSpace  bool
+}
+
+// NewStringSlice creates a *StringSlice with default values
+func NewStringSlice(defaults ...string) *StringSlice {
+	return &StringSlice{slice: append([]string{}, defaults...)}
+}
+
+// clone allocate a copy of self object
+func (s *StringSlice) clone() *StringSlice {
+	n := &StringSlice{
+		slice:      make([]string, len(s.slice)),
+		hasBeenSet: s.hasBeenSet,
+	}
+	copy(n.slice, s.slice)
+	return n
+}
+
+// Set appends the string value to the list of values
+func (s *StringSlice) Set(value string) error {
+	if !s.hasBeenSet {
+		s.slice = []string{}
+		s.hasBeenSet = true
+	}
+
+	if strings.HasPrefix(value, slPfx) {
+		// Deserializing assumes overwrite
+		_ = json.Unmarshal([]byte(strings.Replace(value, slPfx, "", 1)), &s.slice)
+		s.hasBeenSet = true
+		return nil
+	}
+
+	for _, t := range s.separator.flagSplitMultiValues(value) {
+		if !s.keepSpace {
+			t = strings.TrimSpace(t)
+		}
+		s.slice = append(s.slice, t)
+	}
+
+	return nil
+}
+
+func (s *StringSlice) WithSeparatorSpec(spec separatorSpec) {
+	s.separator = spec
+}
+
+// String returns a readable representation of this value (for usage defaults)
+func (s *StringSlice) String() string {
+	return fmt.Sprintf("%s", s.slice)
+}
+
+// Serialize allows StringSlice to fulfill Serializer
+func (s *StringSlice) Serialize() string {
+	jsonBytes, _ := json.Marshal(s.slice)
+	return fmt.Sprintf("%s%s", slPfx, string(jsonBytes))
+}
+
+// Value returns the slice of strings set by this flag
+func (s *StringSlice) Value() []string {
+	return s.slice
+}
+
+// Get returns the slice of strings set by this flag
+func (s *StringSlice) Get() interface{} {
+	return *s
+}
+
+// String returns a readable representation of this value
+// (for usage defaults)
+func (f *StringSliceFlag) String() string {
+	return FlagStringer(f)
+}
+
+// TakesValue returns true of the flag takes a value, otherwise false
+func (f *StringSliceFlag) TakesValue() bool {
+	return true
+}
+
+// GetUsage returns the usage string for the flag
+func (f *StringSliceFlag) GetUsage() string {
+	return f.Usage
+}
+
+// GetCategory returns the category for the flag
+func (f *StringSliceFlag) GetCategory() string {
+	return f.Category
+}
+
+// GetValue returns the flags value as string representation and an empty
+// string if the flag takes no value at all.
+func (f *StringSliceFlag) GetValue() string {
+	var defaultVals []string
+	if f.Value != nil && len(f.Value.Value()) > 0 {
+		for _, s := range f.Value.Value() {
+			if len(s) > 0 {
+				defaultVals = append(defaultVals, strconv.Quote(s))
+			}
+		}
+	}
+	return strings.Join(defaultVals, ", ")
+}
+
+// GetDefaultText returns the default text for this flag
+func (f *StringSliceFlag) GetDefaultText() string {
+	if f.DefaultText != "" {
+		return f.DefaultText
+	}
+	return f.GetValue()
+}
+
+// GetEnvVars returns the env vars for this flag
+func (f *StringSliceFlag) GetEnvVars() []string {
+	return f.EnvVars
+}
+
+// IsSliceFlag implements DocGenerationSliceFlag.
+func (f *StringSliceFlag) IsSliceFlag() bool {
+	return true
+}
+
+// Apply populates the flag given the flag set and environment
+func (f *StringSliceFlag) Apply(set *flag.FlagSet) error {
+	// apply any default
+	if f.Destination != nil && f.Value != nil {
+		f.Destination.slice = make([]string, len(f.Value.slice))
+		copy(f.Destination.slice, f.Value.slice)
+	}
+
+	// resolve setValue (what we will assign to the set)
+	var setValue *StringSlice
+	switch {
+	case f.Destination != nil:
+		setValue = f.Destination
+	case f.Value != nil:
+		setValue = f.Value.clone()
+	default:
+		setValue = new(StringSlice)
+		setValue.WithSeparatorSpec(f.separator)
+	}
+
+	setValue.keepSpace = f.KeepSpace
+
+	if val, source, found := flagFromEnvOrFile(f.EnvVars, f.FilePath); found {
+		for _, s := range f.separator.flagSplitMultiValues(val) {
+			if !f.KeepSpace {
+				s = strings.TrimSpace(s)
+			}
+			if err := setValue.Set(s); err != nil {
+				return fmt.Errorf("could not parse %q as string value from %s for flag %s: %s", val, source, f.Name, err)
+			}
+		}
+
+		// Set this to false so that we reset the slice if we then set values from
+		// flags that have already been set by the environment.
+		setValue.hasBeenSet = false
+		f.HasBeenSet = true
+	}
+
+	for _, name := range f.Names() {
+		set.Var(setValue, name, f.Usage)
+	}
+
+	return nil
+}
+
+func (f *StringSliceFlag) WithSeparatorSpec(spec separatorSpec) {
+	f.separator = spec
+}
+
+// Get returns the flag’s value in the given Context.
+func (f *StringSliceFlag) Get(ctx *Context) []string {
+	return ctx.StringSlice(f.Name)
+}
+
+// RunAction executes flag action if set
+func (f *StringSliceFlag) RunAction(c *Context) error {
+	if f.Action != nil {
+		return f.Action(c, c.StringSlice(f.Name))
+	}
+
+	return nil
+}
+
+// StringSlice looks up the value of a local StringSliceFlag, returns
+// nil if not found
+func (cCtx *Context) StringSlice(name string) []string {
+	if fs := cCtx.lookupFlagSet(name); fs != nil {
+		return lookupStringSlice(name, fs)
+	}
+	return nil
+}
+
+func lookupStringSlice(name string, set *flag.FlagSet) []string {
+	f := set.Lookup(name)
+	if f != nil {
+		if slice, ok := unwrapFlagValue(f.Value).(*StringSlice); ok {
+			return slice.Value()
+		}
+	}
+	return nil
+}

--- a/vendor/github.com/urfave/cli/v2/flag_timestamp.go
+++ b/vendor/github.com/urfave/cli/v2/flag_timestamp.go
@@ -1,0 +1,205 @@
+package cli
+
+import (
+	"flag"
+	"fmt"
+	"time"
+)
+
+// Timestamp wrap to satisfy golang's flag interface.
+type Timestamp struct {
+	timestamp  *time.Time
+	hasBeenSet bool
+	layout     string
+	location   *time.Location
+}
+
+// Timestamp constructor
+func NewTimestamp(timestamp time.Time) *Timestamp {
+	return &Timestamp{timestamp: &timestamp}
+}
+
+// Set the timestamp value directly
+func (t *Timestamp) SetTimestamp(value time.Time) {
+	if !t.hasBeenSet {
+		t.timestamp = &value
+		t.hasBeenSet = true
+	}
+}
+
+// Set the timestamp string layout for future parsing
+func (t *Timestamp) SetLayout(layout string) {
+	t.layout = layout
+}
+
+// Set perceived timezone of the to-be parsed time string
+func (t *Timestamp) SetLocation(loc *time.Location) {
+	t.location = loc
+}
+
+// Parses the string value to timestamp
+func (t *Timestamp) Set(value string) error {
+	var timestamp time.Time
+	var err error
+
+	if t.location != nil {
+		timestamp, err = time.ParseInLocation(t.layout, value, t.location)
+	} else {
+		timestamp, err = time.Parse(t.layout, value)
+	}
+
+	if err != nil {
+		return err
+	}
+
+	t.timestamp = &timestamp
+	t.hasBeenSet = true
+	return nil
+}
+
+// String returns a readable representation of this value (for usage defaults)
+func (t *Timestamp) String() string {
+	return fmt.Sprintf("%#v", t.timestamp)
+}
+
+// Value returns the timestamp value stored in the flag
+func (t *Timestamp) Value() *time.Time {
+	return t.timestamp
+}
+
+// Get returns the flag structure
+func (t *Timestamp) Get() interface{} {
+	return *t
+}
+
+// clone timestamp
+func (t *Timestamp) clone() *Timestamp {
+	tc := &Timestamp{
+		timestamp:  nil,
+		hasBeenSet: t.hasBeenSet,
+		layout:     t.layout,
+		location:   nil,
+	}
+	if t.timestamp != nil {
+		tts := *t.timestamp
+		tc.timestamp = &tts
+	}
+	if t.location != nil {
+		loc := *t.location
+		tc.location = &loc
+	}
+	return tc
+}
+
+// TakesValue returns true of the flag takes a value, otherwise false
+func (f *TimestampFlag) TakesValue() bool {
+	return true
+}
+
+// GetUsage returns the usage string for the flag
+func (f *TimestampFlag) GetUsage() string {
+	return f.Usage
+}
+
+// GetCategory returns the category for the flag
+func (f *TimestampFlag) GetCategory() string {
+	return f.Category
+}
+
+// GetValue returns the flags value as string representation and an empty
+// string if the flag takes no value at all.
+func (f *TimestampFlag) GetValue() string {
+	if f.Value != nil && f.Value.timestamp != nil {
+		return f.Value.timestamp.String()
+	}
+	return ""
+}
+
+// GetDefaultText returns the default text for this flag
+func (f *TimestampFlag) GetDefaultText() string {
+	if f.DefaultText != "" {
+		return f.DefaultText
+	}
+	val := f.Value
+	if f.defaultValueSet {
+		val = f.defaultValue
+	}
+
+	if val != nil && val.timestamp != nil {
+		return val.timestamp.String()
+	}
+
+	return ""
+}
+
+// GetEnvVars returns the env vars for this flag
+func (f *TimestampFlag) GetEnvVars() []string {
+	return f.EnvVars
+}
+
+// Apply populates the flag given the flag set and environment
+func (f *TimestampFlag) Apply(set *flag.FlagSet) error {
+	if f.Layout == "" {
+		return fmt.Errorf("timestamp Layout is required")
+	}
+	if f.Value == nil {
+		f.Value = &Timestamp{}
+	}
+	f.Value.SetLayout(f.Layout)
+	f.Value.SetLocation(f.Timezone)
+
+	f.defaultValue = f.Value.clone()
+	f.defaultValueSet = true
+
+	if val, source, found := flagFromEnvOrFile(f.EnvVars, f.FilePath); found {
+		if err := f.Value.Set(val); err != nil {
+			return fmt.Errorf("could not parse %q as timestamp value from %s for flag %s: %s", val, source, f.Name, err)
+		}
+		f.HasBeenSet = true
+	}
+
+	if f.Destination != nil {
+		*f.Destination = *f.Value
+	}
+
+	for _, name := range f.Names() {
+		if f.Destination != nil {
+			set.Var(f.Destination, name, f.Usage)
+			continue
+		}
+
+		set.Var(f.Value, name, f.Usage)
+	}
+	return nil
+}
+
+// Get returns the flag’s value in the given Context.
+func (f *TimestampFlag) Get(ctx *Context) *time.Time {
+	return ctx.Timestamp(f.Name)
+}
+
+// RunAction executes flag action if set
+func (f *TimestampFlag) RunAction(c *Context) error {
+	if f.Action != nil {
+		return f.Action(c, c.Timestamp(f.Name))
+	}
+
+	return nil
+}
+
+// Timestamp gets the timestamp from a flag name
+func (cCtx *Context) Timestamp(name string) *time.Time {
+	if fs := cCtx.lookupFlagSet(name); fs != nil {
+		return lookupTimestamp(name, fs)
+	}
+	return nil
+}
+
+// Fetches the timestamp value from the local timestampWrap
+func lookupTimestamp(name string, set *flag.FlagSet) *time.Time {
+	f := set.Lookup(name)
+	if f != nil {
+		return (f.Value.(*Timestamp)).Value()
+	}
+	return nil
+}

--- a/vendor/github.com/urfave/cli/v2/flag_uint.go
+++ b/vendor/github.com/urfave/cli/v2/flag_uint.go
@@ -1,0 +1,108 @@
+package cli
+
+import (
+	"flag"
+	"fmt"
+	"strconv"
+)
+
+// TakesValue returns true of the flag takes a value, otherwise false
+func (f *UintFlag) TakesValue() bool {
+	return true
+}
+
+// GetUsage returns the usage string for the flag
+func (f *UintFlag) GetUsage() string {
+	return f.Usage
+}
+
+// GetCategory returns the category for the flag
+func (f *UintFlag) GetCategory() string {
+	return f.Category
+}
+
+// Apply populates the flag given the flag set and environment
+func (f *UintFlag) Apply(set *flag.FlagSet) error {
+	// set default value so that environment wont be able to overwrite it
+	f.defaultValue = f.Value
+	f.defaultValueSet = true
+
+	if val, source, found := flagFromEnvOrFile(f.EnvVars, f.FilePath); found {
+		if val != "" {
+			valInt, err := strconv.ParseUint(val, f.Base, 64)
+			if err != nil {
+				return fmt.Errorf("could not parse %q as uint value from %s for flag %s: %s", val, source, f.Name, err)
+			}
+
+			f.Value = uint(valInt)
+			f.HasBeenSet = true
+		}
+	}
+
+	for _, name := range f.Names() {
+		if f.Destination != nil {
+			set.UintVar(f.Destination, name, f.Value, f.Usage)
+			continue
+		}
+		set.Uint(name, f.Value, f.Usage)
+	}
+
+	return nil
+}
+
+// RunAction executes flag action if set
+func (f *UintFlag) RunAction(c *Context) error {
+	if f.Action != nil {
+		return f.Action(c, c.Uint(f.Name))
+	}
+
+	return nil
+}
+
+// GetValue returns the flags value as string representation and an empty
+// string if the flag takes no value at all.
+func (f *UintFlag) GetValue() string {
+	return fmt.Sprintf("%d", f.Value)
+}
+
+// GetDefaultText returns the default text for this flag
+func (f *UintFlag) GetDefaultText() string {
+	if f.DefaultText != "" {
+		return f.DefaultText
+	}
+	if f.defaultValueSet {
+		return fmt.Sprintf("%d", f.defaultValue)
+	}
+	return fmt.Sprintf("%d", f.Value)
+}
+
+// GetEnvVars returns the env vars for this flag
+func (f *UintFlag) GetEnvVars() []string {
+	return f.EnvVars
+}
+
+// Get returns the flag’s value in the given Context.
+func (f *UintFlag) Get(ctx *Context) uint {
+	return ctx.Uint(f.Name)
+}
+
+// Uint looks up the value of a local UintFlag, returns
+// 0 if not found
+func (cCtx *Context) Uint(name string) uint {
+	if fs := cCtx.lookupFlagSet(name); fs != nil {
+		return lookupUint(name, fs)
+	}
+	return 0
+}
+
+func lookupUint(name string, set *flag.FlagSet) uint {
+	f := set.Lookup(name)
+	if f != nil {
+		parsed, err := strconv.ParseUint(f.Value.String(), 0, 64)
+		if err != nil {
+			return 0
+		}
+		return uint(parsed)
+	}
+	return 0
+}

--- a/vendor/github.com/urfave/cli/v2/flag_uint64.go
+++ b/vendor/github.com/urfave/cli/v2/flag_uint64.go
@@ -1,0 +1,108 @@
+package cli
+
+import (
+	"flag"
+	"fmt"
+	"strconv"
+)
+
+// TakesValue returns true of the flag takes a value, otherwise false
+func (f *Uint64Flag) TakesValue() bool {
+	return true
+}
+
+// GetUsage returns the usage string for the flag
+func (f *Uint64Flag) GetUsage() string {
+	return f.Usage
+}
+
+// GetCategory returns the category for the flag
+func (f *Uint64Flag) GetCategory() string {
+	return f.Category
+}
+
+// Apply populates the flag given the flag set and environment
+func (f *Uint64Flag) Apply(set *flag.FlagSet) error {
+	// set default value so that environment wont be able to overwrite it
+	f.defaultValue = f.Value
+	f.defaultValueSet = true
+
+	if val, source, found := flagFromEnvOrFile(f.EnvVars, f.FilePath); found {
+		if val != "" {
+			valInt, err := strconv.ParseUint(val, f.Base, 64)
+			if err != nil {
+				return fmt.Errorf("could not parse %q as uint64 value from %s for flag %s: %s", val, source, f.Name, err)
+			}
+
+			f.Value = valInt
+			f.HasBeenSet = true
+		}
+	}
+
+	for _, name := range f.Names() {
+		if f.Destination != nil {
+			set.Uint64Var(f.Destination, name, f.Value, f.Usage)
+			continue
+		}
+		set.Uint64(name, f.Value, f.Usage)
+	}
+
+	return nil
+}
+
+// RunAction executes flag action if set
+func (f *Uint64Flag) RunAction(c *Context) error {
+	if f.Action != nil {
+		return f.Action(c, c.Uint64(f.Name))
+	}
+
+	return nil
+}
+
+// GetValue returns the flags value as string representation and an empty
+// string if the flag takes no value at all.
+func (f *Uint64Flag) GetValue() string {
+	return fmt.Sprintf("%d", f.Value)
+}
+
+// GetDefaultText returns the default text for this flag
+func (f *Uint64Flag) GetDefaultText() string {
+	if f.DefaultText != "" {
+		return f.DefaultText
+	}
+	if f.defaultValueSet {
+		return fmt.Sprintf("%d", f.defaultValue)
+	}
+	return fmt.Sprintf("%d", f.Value)
+}
+
+// GetEnvVars returns the env vars for this flag
+func (f *Uint64Flag) GetEnvVars() []string {
+	return f.EnvVars
+}
+
+// Get returns the flag’s value in the given Context.
+func (f *Uint64Flag) Get(ctx *Context) uint64 {
+	return ctx.Uint64(f.Name)
+}
+
+// Uint64 looks up the value of a local Uint64Flag, returns
+// 0 if not found
+func (cCtx *Context) Uint64(name string) uint64 {
+	if fs := cCtx.lookupFlagSet(name); fs != nil {
+		return lookupUint64(name, fs)
+	}
+	return 0
+}
+
+func lookupUint64(name string, set *flag.FlagSet) uint64 {
+	f := set.Lookup(name)
+	if f != nil {
+		parsed, err := strconv.ParseUint(f.Value.String(), 0, 64)
+		if err != nil {
+			return 0
+		}
+		return parsed
+	}
+	return 0
+}

--- a/vendor/github.com/urfave/cli/v2/flag_uint64_slice.go
+++ b/vendor/github.com/urfave/cli/v2/flag_uint64_slice.go
@@ -1,0 +1,219 @@
+package cli
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// Uint64Slice wraps []int64 to satisfy flag.Value
+type Uint64Slice struct {
+	slice      []uint64
+	separator  separatorSpec
+	hasBeenSet bool
+}
+
+// NewUint64Slice makes an *Uint64Slice with default values
+func NewUint64Slice(defaults ...uint64) *Uint64Slice {
+	return &Uint64Slice{slice: append([]uint64{}, defaults...)}
+}
+
+// clone allocate a copy of self object
+func (i *Uint64Slice) clone() *Uint64Slice {
+	n := &Uint64Slice{
+		slice:      make([]uint64, len(i.slice)),
+		hasBeenSet: i.hasBeenSet,
+	}
+	copy(n.slice, i.slice)
+	return n
+}
+
+// Set parses the value into an integer and appends it to the list of values
+func (i *Uint64Slice) Set(value string) error {
+	if !i.hasBeenSet {
+		i.slice = []uint64{}
+		i.hasBeenSet = true
+	}
+
+	if strings.HasPrefix(value, slPfx) {
+		// Deserializing assumes overwrite
+		_ = json.Unmarshal([]byte(strings.Replace(value, slPfx, "", 1)), &i.slice)
+		i.hasBeenSet = true
+		return nil
+	}
+
+	for _, s := range i.separator.flagSplitMultiValues(value) {
+		tmp, err := strconv.ParseUint(strings.TrimSpace(s), 0, 64)
+		if err != nil {
+			return err
+		}
+
+		i.slice = append(i.slice, tmp)
+	}
+
+	return nil
+}
+
+func (i *Uint64Slice) WithSeparatorSpec(spec separatorSpec) {
+	i.separator = spec
+}
+
+// String returns a readable representation of this value (for usage defaults)
+func (i *Uint64Slice) String() string {
+	v := i.slice
+	if v == nil {
+		// treat nil the same as zero length non-nil
+		v = make([]uint64, 0)
+	}
+	str := fmt.Sprintf("%d", v)
+	str = strings.Replace(str, " ", ", ", -1)
+	str = strings.Replace(str, "[", "{", -1)
+	str = strings.Replace(str, "]", "}", -1)
+	return fmt.Sprintf("[]uint64%s", str)
+}
+
+// Serialize allows Uint64Slice to fulfill Serializer
+func (i *Uint64Slice) Serialize() string {
+	jsonBytes, _ := json.Marshal(i.slice)
+	return fmt.Sprintf("%s%s", slPfx, string(jsonBytes))
+}
+
+// Value returns the slice of ints set by this flag
+func (i *Uint64Slice) Value() []uint64 {
+	return i.slice
+}
+
+// Get returns the slice of ints set by this flag
+func (i *Uint64Slice) Get() interface{} {
+	return *i
+}
+
+// String returns a readable representation of this value
+// (for usage defaults)
+func (f *Uint64SliceFlag) String() string {
+	return FlagStringer(f)
+}
+
+// TakesValue returns true of the flag takes a value, otherwise false
+func (f *Uint64SliceFlag) TakesValue() bool {
+	return true
+}
+
+// GetUsage returns the usage string for the flag
+func (f *Uint64SliceFlag) GetUsage() string {
+	return f.Usage
+}
+
+// GetCategory returns the category for the flag
+func (f *Uint64SliceFlag) GetCategory() string {
+	return f.Category
+}
+
+// GetValue returns the flags value as string representation and an empty
+// string if the flag takes no value at all.
+func (f *Uint64SliceFlag) GetValue() string {
+	var defaultVals []string
+	if f.Value != nil && len(f.Value.Value()) > 0 {
+		for _, i := range f.Value.Value() {
+			defaultVals = append(defaultVals, strconv.FormatUint(i, 10))
+		}
+	}
+	return strings.Join(defaultVals, ", ")
+}
+
+// GetDefaultText returns the default text for this flag
+func (f *Uint64SliceFlag) GetDefaultText() string {
+	if f.DefaultText != "" {
+		return f.DefaultText
+	}
+	return f.GetValue()
+}
+
+// GetEnvVars returns the env vars for this flag
+func (f *Uint64SliceFlag) GetEnvVars() []string {
+	return f.EnvVars
+}
+
+// IsSliceFlag implements DocGenerationSliceFlag.
+func (f *Uint64SliceFlag) IsSliceFlag() bool {
+	return true
+}
+
+// Apply populates the flag given the flag set and environment
+func (f *Uint64SliceFlag) Apply(set *flag.FlagSet) error {
+	// apply any default
+	if f.Destination != nil && f.Value != nil {
+		f.Destination.slice = make([]uint64, len(f.Value.slice))
+		copy(f.Destination.slice, f.Value.slice)
+	}
+
+	// resolve setValue (what we will assign to the set)
+	var setValue *Uint64Slice
+	switch {
+	case f.Destination != nil:
+		setValue = f.Destination
+	case f.Value != nil:
+		setValue = f.Value.clone()
+	default:
+		setValue = new(Uint64Slice)
+		setValue.WithSeparatorSpec(f.separator)
+	}
+
+	if val, source, ok := flagFromEnvOrFile(f.EnvVars, f.FilePath); ok && val != "" {
+		for _, s := range f.separator.flagSplitMultiValues(val) {
+			if err := setValue.Set(strings.TrimSpace(s)); err != nil {
+				return fmt.Errorf("could not parse %q as uint64 slice value from %s for flag %s: %s", val, source, f.Name, err)
+			}
+		}
+
+		// Set this to false so that we reset the slice if we then set values from
+		// flags that have already been set by the environment.
+		setValue.hasBeenSet = false
+		f.HasBeenSet = true
+	}
+
+	for _, name := range f.Names() {
+		set.Var(setValue, name, f.Usage)
+	}
+
+	return nil
+}
+
+func (f *Uint64SliceFlag) WithSeparatorSpec(spec separatorSpec) {
+	f.separator = spec
+}
+
+// Get returns the flag’s value in the given Context.
+func (f *Uint64SliceFlag) Get(ctx *Context) []uint64 {
+	return ctx.Uint64Slice(f.Name)
+}
+
+// RunAction executes flag action if set
+func (f *Uint64SliceFlag) RunAction(c *Context) error {
+	if f.Action != nil {
+		return f.Action(c, c.Uint64Slice(f.Name))
+	}
+
+	return nil
+}
+
+// Uint64Slice looks up the value of a local Uint64SliceFlag, returns
+// nil if not found
+func (cCtx *Context) Uint64Slice(name string) []uint64 {
+	if fs := cCtx.lookupFlagSet(name); fs != nil {
+		return lookupUint64Slice(name, fs)
+	}
+	return nil
+}
+
+func lookupUint64Slice(name string, set *flag.FlagSet) []uint64 {
+	f := set.Lookup(name)
+	if f != nil {
+		if slice, ok := unwrapFlagValue(f.Value).(*Uint64Slice); ok {
+			return slice.Value()
+		}
+	}
+	return nil
+}

--- a/vendor/github.com/urfave/cli/v2/flag_uint_slice.go
+++ b/vendor/github.com/urfave/cli/v2/flag_uint_slice.go
@@ -1,0 +1,230 @@
+package cli
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// UintSlice wraps []int to satisfy flag.Value
+type UintSlice struct {
+	slice      []uint
+	separator  separatorSpec
+	hasBeenSet bool
+}
+
+// NewUintSlice makes an *UintSlice with default values
+func NewUintSlice(defaults ...uint) *UintSlice {
+	return &UintSlice{slice: append([]uint{}, defaults...)}
+}
+
+// clone allocate a copy of self object
+func (i *UintSlice) clone() *UintSlice {
+	n := &UintSlice{
+		slice:      make([]uint, len(i.slice)),
+		hasBeenSet: i.hasBeenSet,
+	}
+	copy(n.slice, i.slice)
+	return n
+}
+
+// TODO: Consistently have specific Set function for Int64 and Float64 ?
+// SetInt directly adds an integer to the list of values
+func (i *UintSlice) SetUint(value uint) {
+	if !i.hasBeenSet {
+		i.slice = []uint{}
+		i.hasBeenSet = true
+	}
+
+	i.slice = append(i.slice, value)
+}
+
+// Set parses the value into an integer and appends it to the list of values
+func (i *UintSlice) Set(value string) error {
+	if !i.hasBeenSet {
+		i.slice = []uint{}
+		i.hasBeenSet = true
+	}
+
+	if strings.HasPrefix(value, slPfx) {
+		// Deserializing assumes overwrite
+		_ = json.Unmarshal([]byte(strings.Replace(value, slPfx, "", 1)), &i.slice)
+		i.hasBeenSet = true
+		return nil
+	}
+
+	for _, s := range i.separator.flagSplitMultiValues(value) {
+		tmp, err := strconv.ParseUint(strings.TrimSpace(s), 0, 32)
+		if err != nil {
+			return err
+		}
+
+		i.slice = append(i.slice, uint(tmp))
+	}
+
+	return nil
+}
+
+func (i *UintSlice) WithSeparatorSpec(spec separatorSpec) {
+	i.separator = spec
+}
+
+// String returns a readable representation of this value (for usage defaults)
+func (i *UintSlice) String() string {
+	v := i.slice
+	if v == nil {
+		// treat nil the same as zero length non-nil
+		v = make([]uint, 0)
+	}
+	str := fmt.Sprintf("%d", v)
+	str = strings.Replace(str, " ", ", ", -1)
+	str = strings.Replace(str, "[", "{", -1)
+	str = strings.Replace(str, "]", "}", -1)
+	return fmt.Sprintf("[]uint%s", str)
+}
+
+// Serialize allows UintSlice to fulfill Serializer
+func (i *UintSlice) Serialize() string {
+	jsonBytes, _ := json.Marshal(i.slice)
+	return fmt.Sprintf("%s%s", slPfx, string(jsonBytes))
+}
+
+// Value returns the slice of ints set by this flag
+func (i *UintSlice) Value() []uint {
+	return i.slice
+}
+
+// Get returns the slice of ints set by this flag
+func (i *UintSlice) Get() interface{} {
+	return *i
+}
+
+// String returns a readable representation of this value
+// (for usage defaults)
+func (f *UintSliceFlag) String() string {
+	return FlagStringer(f)
+}
+
+// TakesValue returns true of the flag takes a value, otherwise false
+func (f *UintSliceFlag) TakesValue() bool {
+	return true
+}
+
+// GetUsage returns the usage string for the flag
+func (f *UintSliceFlag) GetUsage() string {
+	return f.Usage
+}
+
+// GetCategory returns the category for the flag
+func (f *UintSliceFlag) GetCategory() string {
+	return f.Category
+}
+
+// GetValue returns the flags value as string representation and an empty
+// string if the flag takes no value at all.
+func (f *UintSliceFlag) GetValue() string {
+	var defaultVals []string
+	if f.Value != nil && len(f.Value.Value()) > 0 {
+		for _, i := range f.Value.Value() {
+			defaultVals = append(defaultVals, strconv.FormatUint(uint64(i), 10))
+		}
+	}
+	return strings.Join(defaultVals, ", ")
+}
+
+// GetDefaultText returns the default text for this flag
+func (f *UintSliceFlag) GetDefaultText() string {
+	if f.DefaultText != "" {
+		return f.DefaultText
+	}
+	return f.GetValue()
+}
+
+// GetEnvVars returns the env vars for this flag
+func (f *UintSliceFlag) GetEnvVars() []string {
+	return f.EnvVars
+}
+
+// IsSliceFlag implements DocGenerationSliceFlag.
+func (f *UintSliceFlag) IsSliceFlag() bool {
+	return true
+}
+
+// Apply populates the flag given the flag set and environment
+func (f *UintSliceFlag) Apply(set *flag.FlagSet) error {
+	// apply any default
+	if f.Destination != nil && f.Value != nil {
+		f.Destination.slice = make([]uint, len(f.Value.slice))
+		copy(f.Destination.slice, f.Value.slice)
+	}
+
+	// resolve setValue (what we will assign to the set)
+	var setValue *UintSlice
+	switch {
+	case f.Destination != nil:
+		setValue = f.Destination
+	case f.Value != nil:
+		setValue = f.Value.clone()
+	default:
+		setValue = new(UintSlice)
+		setValue.WithSeparatorSpec(f.separator)
+	}
+
+	if val, source, ok := flagFromEnvOrFile(f.EnvVars, f.FilePath); ok && val != "" {
+		for _, s := range f.separator.flagSplitMultiValues(val) {
+			if err := setValue.Set(strings.TrimSpace(s)); err != nil {
+				return fmt.Errorf("could not parse %q as uint slice value from %s for flag %s: %s", val, source, f.Name, err)
+			}
+		}
+
+		// Set this to false so that we reset the slice if we then set values from
+		// flags that have already been set by the environment.
+		setValue.hasBeenSet = false
+		f.HasBeenSet = true
+	}
+
+	for _, name := range f.Names() {
+		set.Var(setValue, name, f.Usage)
+	}
+
+	return nil
+}
+
+func (f *UintSliceFlag) WithSeparatorSpec(spec separatorSpec) {
+	f.separator = spec
+}
+
+// Get returns the flag’s value in the given Context.
+func (f *UintSliceFlag) Get(ctx *Context) []uint {
+	return ctx.UintSlice(f.Name)
+}
+
+// RunAction executes flag action if set
+func (f *UintSliceFlag) RunAction(c *Context) error {
+	if f.Action != nil {
+		return f.Action(c, c.UintSlice(f.Name))
+	}
+
+	return nil
+}
+
+// UintSlice looks up the value of a local UintSliceFlag, returns
+// nil if not found
+func (cCtx *Context) UintSlice(name string) []uint {
+	if fs := cCtx.lookupFlagSet(name); fs != nil {
+		return lookupUintSlice(name, fs)
+	}
+	return nil
+}
+
+func lookupUintSlice(name string, set *flag.FlagSet) []uint {
+	f := set.Lookup(name)
+	if f != nil {
+		if slice, ok := unwrapFlagValue(f.Value).(*UintSlice); ok {
+			return slice.Value()
+		}
+	}
+	return nil
+}

--- a/vendor/github.com/urfave/cli/v2/funcs.go
+++ b/vendor/github.com/urfave/cli/v2/funcs.go
@@ -1,0 +1,47 @@
+package cli
+
+// BashCompleteFunc is an action to execute when the shell completion flag is set
+type BashCompleteFunc func(*Context)
+
+// BeforeFunc is an action to execute before any subcommands are run, but after
+// the context is ready if a non-nil error is returned, no subcommands are run
+type BeforeFunc func(*Context) error
+
+// AfterFunc is an action to execute after any subcommands are run, but after the
+// subcommand has finished it is run even if Action() panics
+type AfterFunc func(*Context) error
+
+// ActionFunc is the action to execute when no subcommands are specified
+type ActionFunc func(*Context) error
+
+// CommandNotFoundFunc is executed if the proper command cannot be found
+type CommandNotFoundFunc func(*Context, string)
+
+// OnUsageErrorFunc is executed if a usage error occurs. This is useful for displaying
+// customized usage error messages.  This function is able to replace the
+// original error messages.  If this function is not set, the "Incorrect usage"
+// is displayed and the execution is interrupted.
+type OnUsageErrorFunc func(cCtx *Context, err error, isSubcommand bool) error
+
+// InvalidFlagAccessFunc is executed when an invalid flag is accessed from the context.
+type InvalidFlagAccessFunc func(*Context, string)
+
+// ExitErrHandlerFunc is executed if provided in order to handle exitError values
+// returned by Actions and Before/After functions.
+type ExitErrHandlerFunc func(cCtx *Context, err error)
+
+// FlagStringFunc is used by the help generation to display a flag, which is
+// expected to be a single line.
+type FlagStringFunc func(Flag) string
+
+// FlagNamePrefixFunc is used by the default FlagStringFunc to create prefix
+// text for a flag's full name.
+type FlagNamePrefixFunc func(fullName []string, placeholder string) string
+
+// FlagEnvHintFunc is used by the default FlagStringFunc to annotate flag help
+// with the environment variable details.
+type FlagEnvHintFunc func(envVars []string, str string) string
+
+// FlagFileHintFunc is used by the default FlagStringFunc to annotate flag help
+// with the file path details.
+type FlagFileHintFunc func(filePath, str string) string

--- a/vendor/github.com/urfave/cli/v2/godoc-current.txt
+++ b/vendor/github.com/urfave/cli/v2/godoc-current.txt
@@ -1,0 +1,2724 @@
+package cli // import "github.com/urfave/cli/v2"
+
+Package cli provides a minimal framework for creating and organizing command
+line Go applications. cli is designed to be easy to understand and write,
+the most simple cli application can be written as follows:
+
+    func main() {
+    	(&cli.App{}).Run(os.Args)
+    }
+
+Of course this application does not do much, so let's make this an actual
+application:
+
+    func main() {
+    	app := &cli.App{
+      		Name: "greet",
+      		Usage: "say a greeting",
+      		Action: func(c *cli.Context) error {
+      			fmt.Println("Greetings")
+      			return nil
+      		},
+    	}
+
+    	app.Run(os.Args)
+    }
+
+VARIABLES
+
+var (
+	SuggestFlag               SuggestFlagFunc    = nil // initialized in suggestions.go unless built with urfave_cli_no_suggest
+	SuggestCommand            SuggestCommandFunc = nil // initialized in suggestions.go unless built with urfave_cli_no_suggest
+	SuggestDidYouMeanTemplate string             = suggestDidYouMeanTemplate
+)
+var AppHelpTemplate = `NAME:
+   {{template "helpNameTemplate" .}}
+
+USAGE:
+   {{if .UsageText}}{{wrap .UsageText 3}}{{else}}{{.HelpName}} {{if .VisibleFlags}}[global options]{{end}}{{if .Commands}} command [command options]{{end}}{{if .ArgsUsage}} {{.ArgsUsage}}{{else}}{{if .Args}} [arguments...]{{end}}{{end}}{{end}}{{if .Version}}{{if not .HideVersion}}
+
+VERSION:
+   {{.Version}}{{end}}{{end}}{{if .Description}}
+
+DESCRIPTION:
+   {{template "descriptionTemplate" .}}{{end}}
+{{- if len .Authors}}
+
+AUTHOR{{template "authorsTemplate" .}}{{end}}{{if .VisibleCommands}}
+
+COMMANDS:{{template "visibleCommandCategoryTemplate" .}}{{end}}{{if .VisibleFlagCategories}}
+
+GLOBAL OPTIONS:{{template "visibleFlagCategoryTemplate" .}}{{else if .VisibleFlags}}
+
+GLOBAL OPTIONS:{{template "visibleFlagTemplate" .}}{{end}}{{if .Copyright}}
+
+COPYRIGHT:
+   {{template "copyrightTemplate" .}}{{end}}
+`
+    AppHelpTemplate is the text template for the Default help topic. cli.go
+    uses text/template to render templates. You can render custom help text by
+    setting this variable.
+
+var CommandHelpTemplate = `NAME:
+   {{template "helpNameTemplate" .}}
+
+USAGE:
+   {{template "usageTemplate" .}}{{if .Category}}
+
+CATEGORY:
+   {{.Category}}{{end}}{{if .Description}}
+
+DESCRIPTION:
+   {{template "descriptionTemplate" .}}{{end}}{{if .VisibleFlagCategories}}
+
+OPTIONS:{{template "visibleFlagCategoryTemplate" .}}{{else if .VisibleFlags}}
+
+OPTIONS:{{template "visibleFlagTemplate" .}}{{end}}
+`
+    CommandHelpTemplate is the text template for the command help topic. cli.go
+    uses text/template to render templates. You can render custom help text by
+    setting this variable.
+
+var ErrWriter io.Writer = os.Stderr
+    ErrWriter is used to write errors to the user. This can be anything
+    implementing the io.Writer interface and defaults to os.Stderr.
+
+var FishCompletionTemplate = `# {{ .App.Name }} fish shell completion
+
+function __fish_{{ .App.Name }}_no_subcommand --description 'Test if there has been any subcommand yet'
+    for i in (commandline -opc)
+        if contains -- $i{{ range $v := .AllCommands }} {{ $v }}{{ end }}
+            return 1
+        end
+    end
+    return 0
+end
+
+{{ range $v := .Completions }}{{ $v }}
+{{ end }}`
+var MarkdownDocTemplate = `{{if gt .SectionNum 0}}% {{ .App.Name }} {{ .SectionNum }}
+
+{{end}}# NAME
+
+{{ .App.Name }}{{ if .App.Usage }} - {{ .App.Usage }}{{ end }}
+
+# SYNOPSIS
+
+{{ .App.Name }}
+{{ if .SynopsisArgs }}
+` + "```" + `
+{{ range $v := .SynopsisArgs }}{{ $v }}{{ end }}` + "```" + `
+{{ end }}{{ if .App.Description }}
+# DESCRIPTION
+
+{{ .App.Description }}
+{{ end }}
+**Usage**:
+
+` + "```" + `{{ if .App.UsageText }}
+{{ .App.UsageText }}
+{{ else }}
+{{ .App.Name }} [GLOBAL OPTIONS] command [COMMAND OPTIONS] [ARGUMENTS...]
+{{ end }}` + "```" + `
+{{ if .GlobalArgs }}
+# GLOBAL OPTIONS
+{{ range $v := .GlobalArgs }}
+{{ $v }}{{ end }}
+{{ end }}{{ if .Commands }}
+# COMMANDS
+{{ range $v := .Commands }}
+{{ $v }}{{ end }}{{ end }}`
+var OsExiter = os.Exit
+    OsExiter is the function used when the app exits. If not set defaults to
+    os.Exit.
+
+var SubcommandHelpTemplate = `NAME:
+   {{template "helpNameTemplate" .}}
+
+USAGE:
+   {{if .UsageText}}{{wrap .UsageText 3}}{{else}}{{.HelpName}} {{if .VisibleFlags}}command [command options]{{end}}{{if .ArgsUsage}} {{.ArgsUsage}}{{else}}{{if .Args}} [arguments...]{{end}}{{end}}{{end}}{{if .Description}}
+
+DESCRIPTION:
+   {{template "descriptionTemplate" .}}{{end}}{{if .VisibleCommands}}
+
+COMMANDS:{{template "visibleCommandCategoryTemplate" .}}{{end}}{{if .VisibleFlagCategories}}
+
+OPTIONS:{{template "visibleFlagCategoryTemplate" .}}{{else if .VisibleFlags}}
+
+OPTIONS:{{template "visibleFlagTemplate" .}}{{end}}
+`
+    SubcommandHelpTemplate is the text template for the subcommand help topic.
+    cli.go uses text/template to render templates. You can render custom help
+    text by setting this variable.
+
+var VersionPrinter = printVersion
+    VersionPrinter prints the version for the App
+
+var HelpPrinter helpPrinter = printHelp
+    HelpPrinter is a function that writes the help output. If not set
+    explicitly, this calls HelpPrinterCustom using only the default template
+    functions.
+
+    If custom logic for printing help is required, this function can be
+    overridden. If the ExtraInfo field is defined on an App, this function
+    should not be modified, as HelpPrinterCustom will be used directly in order
+    to capture the extra information.
+
+var HelpPrinterCustom helpPrinterCustom = printHelpCustom
+    HelpPrinterCustom is a function that writes the help output. It is used as
+    the default implementation of HelpPrinter, and may be called directly if the
+    ExtraInfo field is set on an App.
+
+    In the default implementation, if the customFuncs argument contains a
+    "wrapAt" key, which is a function which takes no arguments and returns an
+    int, this int value will be used to produce a "wrap" function used by the
+    default template to wrap long lines.
+
+
+FUNCTIONS
+
+func DefaultAppComplete(cCtx *Context)
+    DefaultAppComplete prints the list of subcommands as the default app
+    completion method
+
+func DefaultCompleteWithFlags(cmd *Command) func(cCtx *Context)
+func FlagNames(name string, aliases []string) []string
+func HandleAction(action interface{}, cCtx *Context) (err error)
+    HandleAction attempts to figure out which Action signature was used.
+    If it's an ActionFunc or a func with the legacy signature for Action,
+    the func is run!
+
+func HandleExitCoder(err error)
+    HandleExitCoder handles errors implementing ExitCoder by printing their
+    message and calling OsExiter with the given exit code.
+
+    If the given error instead implements MultiError, each error will be checked
+    for the ExitCoder interface, and OsExiter will be called with the last exit
+    code found, or exit code 1 if no ExitCoder is found.
+
+    This function is the default error-handling behavior for an App.
+
+func ShowAppHelp(cCtx *Context) error
+    ShowAppHelp is an action that displays the help.
+
+func ShowAppHelpAndExit(c *Context, exitCode int)
+    ShowAppHelpAndExit - Prints the list of subcommands for the app and exits
+    with exit code.
+
+func ShowCommandCompletions(ctx *Context, command string)
+    ShowCommandCompletions prints the custom completions for a given command
+
+func ShowCommandHelp(ctx *Context, command string) error
+    ShowCommandHelp prints help for the given command
+
+func ShowCommandHelpAndExit(c *Context, command string, code int)
+    ShowCommandHelpAndExit - exits with code after showing help
+
+func ShowCompletions(cCtx *Context)
+    ShowCompletions prints the lists of commands within a given context
+
+func ShowSubcommandHelp(cCtx *Context) error
+    ShowSubcommandHelp prints help for the given subcommand
+
+func ShowSubcommandHelpAndExit(c *Context, exitCode int)
+    ShowSubcommandHelpAndExit - Prints help for the given subcommand and exits
+    with exit code.
+
+func ShowVersion(cCtx *Context)
+    ShowVersion prints the version number of the App
+
+
+TYPES
+
+type ActionFunc func(*Context) error
+    ActionFunc is the action to execute when no subcommands are specified
+
+type ActionableFlag interface {
+	Flag
+	RunAction(*Context) error
+}
+    ActionableFlag is an interface that wraps Flag interface and RunAction
+    operation.
+
+type AfterFunc func(*Context) error
+    AfterFunc is an action to execute after any subcommands are run, but after
+    the subcommand has finished it is run even if Action() panics
+
+type App struct {
+	// The name of the program. Defaults to path.Base(os.Args[0])
+	Name string
+	// Full name of command for help, defaults to Name
+	HelpName string
+	// Description of the program.
+	Usage string
+	// Text to override the USAGE section of help
+	UsageText string
+	// Whether this command supports arguments
+	Args bool
+	// Description of the program argument format.
+	ArgsUsage string
+	// Version of the program
+	Version string
+	// Description of the program
+	Description string
+	// DefaultCommand is the (optional) name of a command
+	// to run if no command names are passed as CLI arguments.
+	DefaultCommand string
+	// List of commands to execute
+	Commands []*Command
+	// List of flags to parse
+	Flags []Flag
+	// Boolean to enable bash completion commands
+	EnableBashCompletion bool
+	// Boolean to hide built-in help command and help flag
+	HideHelp bool
+	// Boolean to hide built-in help command but keep help flag.
+	// Ignored if HideHelp is true.
+	HideHelpCommand bool
+	// Boolean to hide built-in version flag and the VERSION section of help
+	HideVersion bool
+
+	// An action to execute when the shell completion flag is set
+	BashComplete BashCompleteFunc
+	// An action to execute before any subcommands are run, but after the context is ready
+	// If a non-nil error is returned, no subcommands are run
+	Before BeforeFunc
+	// An action to execute after any subcommands are run, but after the subcommand has finished
+	// It is run even if Action() panics
+	After AfterFunc
+	// The action to execute when no subcommands are specified
+	Action ActionFunc
+	// Execute this function if the proper command cannot be found
+	CommandNotFound CommandNotFoundFunc
+	// Execute this function if a usage error occurs
+	OnUsageError OnUsageErrorFunc
+	// Execute this function when an invalid flag is accessed from the context
+	InvalidFlagAccessHandler InvalidFlagAccessFunc
+	// Compilation date
+	Compiled time.Time
+	// List of all authors who contributed
+	Authors []*Author
+	// Copyright of the binary if any
+	Copyright string
+	// Reader reader to write input to (useful for tests)
+	Reader io.Reader
+	// Writer writer to write output to
+	Writer io.Writer
+	// ErrWriter writes error output
+	ErrWriter io.Writer
+	// ExitErrHandler processes any error encountered while running an App before
+	// it is returned to the caller. If no function is provided, HandleExitCoder
+	// is used as the default behavior.
+	ExitErrHandler ExitErrHandlerFunc
+	// Other custom info
+	Metadata map[string]interface{}
+	// Carries a function which returns app specific info.
+	ExtraInfo func() map[string]string
+	// CustomAppHelpTemplate the text template for app help topic.
+	// cli.go uses text/template to render templates. You can
+	// render custom help text by setting this variable.
+	CustomAppHelpTemplate string
+	// SliceFlagSeparator is used to customize the separator for SliceFlag, the default is ","
+	SliceFlagSeparator string
+	// DisableSliceFlagSeparator is used to disable SliceFlagSeparator, the default is false
+	DisableSliceFlagSeparator bool
+	// Boolean to enable short-option handling so user can combine several
+	// single-character bool arguments into one
+	// i.e. foobar -o -v -> foobar -ov
+	UseShortOptionHandling bool
+	// Enable suggestions for commands and flags
+	Suggest bool
+	// Allows global flags set by libraries which use flag.XXXVar(...) directly
+	// to be parsed through this library
+	AllowExtFlags bool
+	// Treat all flags as normal arguments if true
+	SkipFlagParsing bool
+
+	// Has unexported fields.
+}
+    App is the main structure of a cli application. It is recommended that an
+    app be created with the cli.NewApp() function
+
+func NewApp() *App
+    NewApp creates a new cli Application with some reasonable defaults for Name,
+    Usage, Version and Action.
+
+func (a *App) Command(name string) *Command
+    Command returns the named command on App. Returns nil if the command does
+    not exist
+
+func (a *App) Run(arguments []string) (err error)
+    Run is the entry point to the cli app. Parses the arguments slice and routes
+    to the proper flag/args combination
+
+func (a *App) RunAndExitOnError()
+    RunAndExitOnError calls .Run() and exits non-zero if an error was returned
+
+    Deprecated: instead you should return an error that fulfills cli.ExitCoder
+    to cli.App.Run. This will cause the application to exit with the given error
+    code in the cli.ExitCoder
+
+func (a *App) RunAsSubcommand(ctx *Context) (err error)
+    RunAsSubcommand is for legacy/compatibility purposes only. New code should
+    only use App.RunContext. This function is slated to be removed in v3.
+
+func (a *App) RunContext(ctx context.Context, arguments []string) (err error)
+    RunContext is like Run except it takes a Context that will be passed to
+    its commands and sub-commands. Through this, you can propagate timeouts and
+    cancellation requests
+
+func (a *App) Setup()
+    Setup runs initialization code to ensure all data structures are ready
+    for `Run` or inspection prior to `Run`. It is internally called by `Run`,
+    but will return early if setup has already happened.
+
+func (a *App) ToFishCompletion() (string, error)
+    ToFishCompletion creates a fish completion string for the `*App` The
+    function errors if either parsing or writing of the string fails.
+
+func (a *App) ToMan() (string, error)
+    ToMan creates a man page string for the `*App` The function errors if either
+    parsing or writing of the string fails.
+
+func (a *App) ToManWithSection(sectionNumber int) (string, error)
+    ToMan creates a man page string with section number for the `*App` The
+    function errors if either parsing or writing of the string fails.
+
+func (a *App) ToMarkdown() (string, error)
+    ToMarkdown creates a markdown string for the `*App` The function errors if
+    either parsing or writing of the string fails.
+
+func (a *App) VisibleCategories() []CommandCategory
+    VisibleCategories returns a slice of categories and commands that are
+    Hidden=false
+
+func (a *App) VisibleCommands() []*Command
+    VisibleCommands returns a slice of the Commands with Hidden=false
+
+func (a *App) VisibleFlagCategories() []VisibleFlagCategory
+    VisibleFlagCategories returns a slice containing all the categories with the
+    flags they contain
+
+func (a *App) VisibleFlags() []Flag
+    VisibleFlags returns a slice of the Flags with Hidden=false
+
+type Args interface {
+	// Get returns the nth argument, or else a blank string
+	Get(n int) string
+	// First returns the first argument, or else a blank string
+	First() string
+	// Tail returns the rest of the arguments (not the first one)
+	// or else an empty string slice
+	Tail() []string
+	// Len returns the length of the wrapped slice
+	Len() int
+	// Present checks if there are any arguments present
+	Present() bool
+	// Slice returns a copy of the internal slice
+	Slice() []string
+}
+
+type Author struct {
+	Name  string // The Authors name
+	Email string // The Authors email
+}
+    Author represents someone who has contributed to a cli project.
+
+func (a *Author) String() string
+    String makes Author comply to the Stringer interface, to allow an easy print
+    in the templating process
+
+type BashCompleteFunc func(*Context)
+    BashCompleteFunc is an action to execute when the shell completion flag is
+    set
+
+type BeforeFunc func(*Context) error
+    BeforeFunc is an action to execute before any subcommands are run, but after
+    the context is ready if a non-nil error is returned, no subcommands are run
+
+type BoolFlag struct {
+	Name string
+
+	Category    string
+	DefaultText string
+	FilePath    string
+	Usage       string
+
+	Required   bool
+	Hidden     bool
+	HasBeenSet bool
+
+	Value       bool
+	Destination *bool
+
+	Aliases []string
+	EnvVars []string
+
+	Count *int
+
+	DisableDefaultText bool
+
+	Action func(*Context, bool) error
+	// Has unexported fields.
+}
+    BoolFlag is a flag with type bool
+
+func (f *BoolFlag) Apply(set *flag.FlagSet) error
+    Apply populates the flag given the flag set and environment
+
+func (f *BoolFlag) Get(ctx *Context) bool
+    Get returns the flag’s value in the given Context.
+
+func (f *BoolFlag) GetCategory() string
+    GetCategory returns the category for the flag
+
+func (f *BoolFlag) GetDefaultText() string
+    GetDefaultText returns the default text for this flag
+
+func (f *BoolFlag) GetEnvVars() []string
+    GetEnvVars returns the env vars for this flag
+
+func (f *BoolFlag) GetUsage() string
+    GetUsage returns the usage string for the flag
+
+func (f *BoolFlag) GetValue() string
+    GetValue returns the flags value as string representation and an empty
+    string if the flag takes no value at all.
+
+func (f *BoolFlag) IsRequired() bool
+    IsRequired returns whether or not the flag is required
+
+func (f *BoolFlag) IsSet() bool
+    IsSet returns whether or not the flag has been set through env or file
+
+func (f *BoolFlag) IsVisible() bool
+    IsVisible returns true if the flag is not hidden, otherwise false
+
+func (f *BoolFlag) Names() []string
+    Names returns the names of the flag
+
+func (f *BoolFlag) RunAction(c *Context) error
+    RunAction executes flag action if set
+
+func (f *BoolFlag) String() string
+    String returns a readable representation of this value (for usage defaults)
+
+func (f *BoolFlag) TakesValue() bool
+    TakesValue returns true of the flag takes a value, otherwise false
+
+type CategorizableFlag interface {
+	VisibleFlag
+
+	GetCategory() string
+}
+    CategorizableFlag is an interface that allows us to potentially use a flag
+    in a categorized representation.
+
+type Command struct {
+	// The name of the command
+	Name string
+	// A list of aliases for the command
+	Aliases []string
+	// A short description of the usage of this command
+	Usage string
+	// Custom text to show on USAGE section of help
+	UsageText string
+	// A longer explanation of how the command works
+	Description string
+	// Whether this command supports arguments
+	Args bool
+	// A short description of the arguments of this command
+	ArgsUsage string
+	// The category the command is part of
+	Category string
+	// The function to call when checking for bash command completions
+	BashComplete BashCompleteFunc
+	// An action to execute before any sub-subcommands are run, but after the context is ready
+	// If a non-nil error is returned, no sub-subcommands are run
+	Before BeforeFunc
+	// An action to execute after any subcommands are run, but after the subcommand has finished
+	// It is run even if Action() panics
+	After AfterFunc
+	// The function to call when this command is invoked
+	Action ActionFunc
+	// Execute this function if a usage error occurs.
+	OnUsageError OnUsageErrorFunc
+	// List of child commands
+	Subcommands []*Command
+	// List of flags to parse
+	Flags []Flag
+
+	// Treat all flags as normal arguments if true
+	SkipFlagParsing bool
+	// Boolean to hide built-in help command and help flag
+	HideHelp bool
+	// Boolean to hide built-in help command but keep help flag
+	// Ignored if HideHelp is true.
+	HideHelpCommand bool
+	// Boolean to hide this command from help or completion
+	Hidden bool
+	// Boolean to enable short-option handling so user can combine several
+	// single-character bool arguments into one
+	// i.e. foobar -o -v -> foobar -ov
+	UseShortOptionHandling bool
+
+	// Full name of command for help, defaults to full command name, including parent commands.
+	HelpName string
+
+	// CustomHelpTemplate the text template for the command help topic.
+	// cli.go uses text/template to render templates. You can
+	// render custom help text by setting this variable.
+	CustomHelpTemplate string
+
+	// Has unexported fields.
+}
+    Command is a subcommand for a cli.App.
+
+func (cmd *Command) Command(name string) *Command
+
+func (c *Command) FullName() string
+    FullName returns the full name of the command. For subcommands this ensures
+    that parent commands are part of the command path
+
+func (c *Command) HasName(name string) bool
+    HasName returns true if Command.Name matches given name
+
+func (c *Command) Names() []string
+    Names returns the names including short names and aliases.
+
+func (c *Command) Run(cCtx *Context, arguments ...string) (err error)
+
+func (c *Command) VisibleCategories() []CommandCategory
+    VisibleCategories returns a slice of categories and commands that are
+    Hidden=false
+
+func (c *Command) VisibleCommands() []*Command
+    VisibleCommands returns a slice of the Commands with Hidden=false
+
+func (c *Command) VisibleFlagCategories() []VisibleFlagCategory
+    VisibleFlagCategories returns a slice containing all the visible flag
+    categories with the flags they contain
+
+func (c *Command) VisibleFlags() []Flag
+    VisibleFlags returns a slice of the Flags with Hidden=false
+
+type CommandCategories interface {
+	// AddCommand adds a command to a category, creating a new category if necessary.
+	AddCommand(category string, command *Command)
+	// Categories returns a slice of categories sorted by name
+	Categories() []CommandCategory
+}
+    CommandCategories interface allows for category manipulation
+
+type CommandCategory interface {
+	// Name returns the category name string
+	Name() string
+	// VisibleCommands returns a slice of the Commands with Hidden=false
+	VisibleCommands() []*Command
+}
+    CommandCategory is a category containing commands.
+
+type CommandNotFoundFunc func(*Context, string)
+    CommandNotFoundFunc is executed if the proper command cannot be found
+
+type Commands []*Command
+
+type CommandsByName []*Command
+
+func (c CommandsByName) Len() int
+
+func (c CommandsByName) Less(i, j int) bool
+
+func (c CommandsByName) Swap(i, j int)
+
+type Context struct {
+	context.Context
+	App     *App
+	Command *Command
+
+	// Has unexported fields.
+}
+    Context is a type that is passed through to each Handler action in a cli
+    application. Context can be used to retrieve context-specific args and
+    parsed command-line options.
+
+func NewContext(app *App, set *flag.FlagSet, parentCtx *Context) *Context
+    NewContext creates a new context. For use in when invoking an App or Command
+    action.
+
+func (cCtx *Context) Args() Args
+    Args returns the command line arguments associated with the context.
+
+func (cCtx *Context) Bool(name string) bool
+    Bool looks up the value of a local BoolFlag, returns false if not found
+
+func (cCtx *Context) Count(name string) int
+    Count returns the num of occurrences of this flag
+
+func (cCtx *Context) Duration(name string) time.Duration
+    Duration looks up the value of a local DurationFlag, returns 0 if not found
+
+func (cCtx *Context) FlagNames() []string
+    FlagNames returns a slice of flag names used by the this context and all of
+    its parent contexts.
+
+func (cCtx *Context) Float64(name string) float64
+    Float64 looks up the value of a local Float64Flag, returns 0 if not found
+
+func (cCtx *Context) Float64Slice(name string) []float64
+    Float64Slice looks up the value of a local Float64SliceFlag, returns nil if
+    not found
+
+func (cCtx *Context) Generic(name string) interface{}
+    Generic looks up the value of a local GenericFlag, returns nil if not found
+
+func (cCtx *Context) Int(name string) int
+    Int looks up the value of a local IntFlag, returns 0 if not found
+
+func (cCtx *Context) Int64(name string) int64
+    Int64 looks up the value of a local Int64Flag, returns 0 if not found
+
+func (cCtx *Context) Int64Slice(name string) []int64
+    Int64Slice looks up the value of a local Int64SliceFlag, returns nil if not
+    found
+
+func (cCtx *Context) IntSlice(name string) []int
+    IntSlice looks up the value of a local IntSliceFlag, returns nil if not
+    found
+
+func (cCtx *Context) IsSet(name string) bool
+    IsSet determines if the flag was actually set
+
+func (cCtx *Context) Lineage() []*Context
+    Lineage returns *this* context and all of its ancestor contexts in order
+    from child to parent
+
+func (cCtx *Context) LocalFlagNames() []string
+    LocalFlagNames returns a slice of flag names used in this context.
+
+func (cCtx *Context) NArg() int
+    NArg returns the number of the command line arguments.
+
+func (cCtx *Context) NumFlags() int
+    NumFlags returns the number of flags set
+
+func (cCtx *Context) Path(name string) string
+    Path looks up the value of a local PathFlag, returns "" if not found
+
+func (cCtx *Context) Set(name, value string) error
+    Set sets a context flag to a value.
+
+func (cCtx *Context) String(name string) string
+    String looks up the value of a local StringFlag, returns "" if not found
+
+func (cCtx *Context) StringSlice(name string) []string
+    StringSlice looks up the value of a local StringSliceFlag, returns nil if
+    not found
+
+func (cCtx *Context) Timestamp(name string) *time.Time
+    Timestamp gets the timestamp from a flag name
+
+func (cCtx *Context) Uint(name string) uint
+    Uint looks up the value of a local UintFlag, returns 0 if not found
+
+func (cCtx *Context) Uint64(name string) uint64
+    Uint64 looks up the value of a local Uint64Flag, returns 0 if not found
+
+func (cCtx *Context) Uint64Slice(name string) []uint64
+    Uint64Slice looks up the value of a local Uint64SliceFlag, returns nil if
+    not found
+
+func (cCtx *Context) UintSlice(name string) []uint
+    UintSlice looks up the value of a local UintSliceFlag, returns nil if not
+    found
+
+func (cCtx *Context) Value(name string) interface{}
+    Value returns the value of the flag corresponding to `name`
+
+type Countable interface {
+	Count() int
+}
+    Countable is an interface to enable detection of flag values which support
+    repetitive flags
+
+type DocGenerationFlag interface {
+	Flag
+
+	// TakesValue returns true if the flag takes a value, otherwise false
+	TakesValue() bool
+
+	// GetUsage returns the usage string for the flag
+	GetUsage() string
+
+	// GetValue returns the flags value as string representation and an empty
+	// string if the flag takes no value at all.
+	GetValue() string
+
+	// GetDefaultText returns the default text for this flag
+	GetDefaultText() string
+
+	// GetEnvVars returns the env vars for this flag
+	GetEnvVars() []string
+}
+    DocGenerationFlag is an interface that allows documentation generation for
+    the flag
+
+type DocGenerationSliceFlag interface {
+	DocGenerationFlag
+
+	// IsSliceFlag returns true for flags that can be given multiple times.
+	IsSliceFlag() bool
+}
+    DocGenerationSliceFlag extends DocGenerationFlag for slice-based flags.
+
+type DurationFlag struct {
+	Name string
+
+	Category    string
+	DefaultText string
+	FilePath    string
+	Usage       string
+
+	Required   bool
+	Hidden     bool
+	HasBeenSet bool
+
+	Value       time.Duration
+	Destination *time.Duration
+
+	Aliases []string
+	EnvVars []string
+
+	Action func(*Context, time.Duration) error
+	// Has unexported fields.
+}
+    DurationFlag is a flag with type time.Duration
+
+func (f *DurationFlag) Apply(set *flag.FlagSet) error
+    Apply populates the flag given the flag set and environment
+
+func (f *DurationFlag) Get(ctx *Context) time.Duration
+    Get returns the flag’s value in the given Context.
+
+func (f *DurationFlag) GetCategory() string
+    GetCategory returns the category for the flag
+
+func (f *DurationFlag) GetDefaultText() string
+    GetDefaultText returns the default text for this flag
+
+func (f *DurationFlag) GetEnvVars() []string
+    GetEnvVars returns the env vars for this flag
+
+func (f *DurationFlag) GetUsage() string
+    GetUsage returns the usage string for the flag
+
+func (f *DurationFlag) GetValue() string
+    GetValue returns the flags value as string representation and an empty
+    string if the flag takes no value at all.
+
+func (f *DurationFlag) IsRequired() bool
+    IsRequired returns whether or not the flag is required
+
+func (f *DurationFlag) IsSet() bool
+    IsSet returns whether or not the flag has been set through env or file
+
+func (f *DurationFlag) IsVisible() bool
+    IsVisible returns true if the flag is not hidden, otherwise false
+
+func (f *DurationFlag) Names() []string
+    Names returns the names of the flag
+
+func (f *DurationFlag) RunAction(c *Context) error
+    RunAction executes flag action if set
+
+func (f *DurationFlag) String() string
+    String returns a readable representation of this value (for usage defaults)
+
+func (f *DurationFlag) TakesValue() bool
+    TakesValue returns true of the flag takes a value, otherwise false
+
+type ErrorFormatter interface {
+	Format(s fmt.State, verb rune)
+}
+    ErrorFormatter is the interface that will suitably format the error output
+
+type ExitCoder interface {
+	error
+	ExitCode() int
+}
+    ExitCoder is the interface checked by `App` and `Command` for a custom exit
+    code
+
+func Exit(message interface{}, exitCode int) ExitCoder
+    Exit wraps a message and exit code into an error, which by default is
+    handled with a call to os.Exit during default error handling.
+
+    This is the simplest way to trigger a non-zero exit code for an App
+    without having to call os.Exit manually. During testing, this behavior
+    can be avoided by overriding the ExitErrHandler function on an App or the
+    package-global OsExiter function.
+
+func NewExitError(message interface{}, exitCode int) ExitCoder
+    NewExitError calls Exit to create a new ExitCoder.
+
+    Deprecated: This function is a duplicate of Exit and will eventually be
+    removed.
+
+type ExitErrHandlerFunc func(cCtx *Context, err error)
+    ExitErrHandlerFunc is executed if provided in order to handle exitError
+    values returned by Actions and Before/After functions.
+
+type Flag interface {
+	fmt.Stringer
+	// Apply Flag settings to the given flag set
+	Apply(*flag.FlagSet) error
+	Names() []string
+	IsSet() bool
+}
+    Flag is a common interface related to parsing flags in cli. For more
+    advanced flag parsing techniques, it is recommended that this interface be
+    implemented.
+
+var BashCompletionFlag Flag = &BoolFlag{
+	Name:   "generate-bash-completion",
+	Hidden: true,
+}
+    BashCompletionFlag enables bash-completion for all commands and subcommands
+
+var HelpFlag Flag = &BoolFlag{
+	Name:               "help",
+	Aliases:            []string{"h"},
+	Usage:              "show help",
+	DisableDefaultText: true,
+}
+    HelpFlag prints the help for all commands and subcommands. Set to nil to
+    disable the flag. The subcommand will still be added unless HideHelp or
+    HideHelpCommand is set to true.
+
+var VersionFlag Flag = &BoolFlag{
+	Name:               "version",
+	Aliases:            []string{"v"},
+	Usage:              "print the version",
+	DisableDefaultText: true,
+}
+    VersionFlag prints the version for the application
+
+type FlagCategories interface {
+	// AddFlags adds a flag to a category, creating a new category if necessary.
+	AddFlag(category string, fl Flag)
+	// VisibleCategories returns a slice of visible flag categories sorted by name
+	VisibleCategories() []VisibleFlagCategory
+}
+    FlagCategories interface allows for category manipulation
+
+type FlagEnvHintFunc func(envVars []string, str string) string
+    FlagEnvHintFunc is used by the default FlagStringFunc to annotate flag help
+    with the environment variable details.
+
+var FlagEnvHinter FlagEnvHintFunc = withEnvHint
+    FlagEnvHinter annotates flag help message with the environment variable
+    details. This is used by the default FlagStringer.
+
+type FlagFileHintFunc func(filePath, str string) string
+    FlagFileHintFunc is used by the default FlagStringFunc to annotate flag help
+    with the file path details.
+
+var FlagFileHinter FlagFileHintFunc = withFileHint
+    FlagFileHinter annotates flag help message with the environment variable
+    details. This is used by the default FlagStringer.
+
+type FlagNamePrefixFunc func(fullName []string, placeholder string) string
+    FlagNamePrefixFunc is used by the default FlagStringFunc to create prefix
+    text for a flag's full name.
+
+var FlagNamePrefixer FlagNamePrefixFunc = prefixedNames
+    FlagNamePrefixer converts a full flag name and its placeholder into the help
+    message flag prefix. This is used by the default FlagStringer.
+
+type FlagStringFunc func(Flag) string
+    FlagStringFunc is used by the help generation to display a flag, which is
+    expected to be a single line.
+
+var FlagStringer FlagStringFunc = stringifyFlag
+    FlagStringer converts a flag definition to a string. This is used by help to
+    display a flag.
+
+type FlagsByName []Flag
+    FlagsByName is a slice of Flag.
+
+func (f FlagsByName) Len() int
+
+func (f FlagsByName) Less(i, j int) bool
+
+func (f FlagsByName) Swap(i, j int)
+
+type Float64Flag struct {
+	Name string
+
+	Category    string
+	DefaultText string
+	FilePath    string
+	Usage       string
+
+	Required   bool
+	Hidden     bool
+	HasBeenSet bool
+
+	Value       float64
+	Destination *float64
+
+	Aliases []string
+	EnvVars []string
+
+	Action func(*Context, float64) error
+	// Has unexported fields.
+}
+    Float64Flag is a flag with type float64
+
+func (f *Float64Flag) Apply(set *flag.FlagSet) error
+    Apply populates the flag given the flag set and environment
+
+func (f *Float64Flag) Get(ctx *Context) float64
+    Get returns the flag’s value in the given Context.
+
+func (f *Float64Flag) GetCategory() string
+    GetCategory returns the category for the flag
+
+func (f *Float64Flag) GetDefaultText() string
+    GetDefaultText returns the default text for this flag
+
+func (f *Float64Flag) GetEnvVars() []string
+    GetEnvVars returns the env vars for this flag
+
+func (f *Float64Flag) GetUsage() string
+    GetUsage returns the usage string for the flag
+
+func (f *Float64Flag) GetValue() string
+    GetValue returns the flags value as string representation and an empty
+    string if the flag takes no value at all.
+
+func (f *Float64Flag) IsRequired() bool
+    IsRequired returns whether or not the flag is required
+
+func (f *Float64Flag) IsSet() bool
+    IsSet returns whether or not the flag has been set through env or file
+
+func (f *Float64Flag) IsVisible() bool
+    IsVisible returns true if the flag is not hidden, otherwise false
+
+func (f *Float64Flag) Names() []string
+    Names returns the names of the flag
+
+func (f *Float64Flag) RunAction(c *Context) error
+    RunAction executes flag action if set
+
+func (f *Float64Flag) String() string
+    String returns a readable representation of this value (for usage defaults)
+
+func (f *Float64Flag) TakesValue() bool
+    TakesValue returns true of the flag takes a value, otherwise false
+
+type Float64Slice struct {
+	// Has unexported fields.
+}
+    Float64Slice wraps []float64 to satisfy flag.Value
+
+func NewFloat64Slice(defaults ...float64) *Float64Slice
+    NewFloat64Slice makes a *Float64Slice with default values
+
+func (f *Float64Slice) Get() interface{}
+    Get returns the slice of float64s set by this flag
+
+func (f *Float64Slice) Serialize() string
+    Serialize allows Float64Slice to fulfill Serializer
+
+func (f *Float64Slice) Set(value string) error
+    Set parses the value into a float64 and appends it to the list of values
+
+func (f *Float64Slice) String() string
+    String returns a readable representation of this value (for usage defaults)
+
+func (f *Float64Slice) Value() []float64
+    Value returns the slice of float64s set by this flag
+
+func (f *Float64Slice) WithSeparatorSpec(spec separatorSpec)
+
+type Float64SliceFlag struct {
+	Name string
+
+	Category    string
+	DefaultText string
+	FilePath    string
+	Usage       string
+
+	Required   bool
+	Hidden     bool
+	HasBeenSet bool
+
+	Value       *Float64Slice
+	Destination *Float64Slice
+
+	Aliases []string
+	EnvVars []string
+
+	Action func(*Context, []float64) error
+	// Has unexported fields.
+}
+    Float64SliceFlag is a flag with type *Float64Slice
+
+func (f *Float64SliceFlag) Apply(set *flag.FlagSet) error
+    Apply populates the flag given the flag set and environment
+
+func (f *Float64SliceFlag) Get(ctx *Context) []float64
+    Get returns the flag’s value in the given Context.
+
+func (f *Float64SliceFlag) GetCategory() string
+    GetCategory returns the category for the flag
+
+func (f *Float64SliceFlag) GetDefaultText() string
+    GetDefaultText returns the default text for this flag
+
+func (f *Float64SliceFlag) GetDestination() []float64
+
+func (f *Float64SliceFlag) GetEnvVars() []string
+    GetEnvVars returns the env vars for this flag
+
+func (f *Float64SliceFlag) GetUsage() string
+    GetUsage returns the usage string for the flag
+
+func (f *Float64SliceFlag) GetValue() string
+    GetValue returns the flags value as string representation and an empty
+    string if the flag takes no value at all.
+
+func (f *Float64SliceFlag) IsRequired() bool
+    IsRequired returns whether or not the flag is required
+
+func (f *Float64SliceFlag) IsSet() bool
+    IsSet returns whether or not the flag has been set through env or file
+
+func (f *Float64SliceFlag) IsSliceFlag() bool
+    IsSliceFlag implements DocGenerationSliceFlag.
+
+func (f *Float64SliceFlag) IsVisible() bool
+    IsVisible returns true if the flag is not hidden, otherwise false
+
+func (f *Float64SliceFlag) Names() []string
+    Names returns the names of the flag
+
+func (f *Float64SliceFlag) RunAction(c *Context) error
+    RunAction executes flag action if set
+
+func (f *Float64SliceFlag) SetDestination(slice []float64)
+
+func (f *Float64SliceFlag) SetValue(slice []float64)
+
+func (f *Float64SliceFlag) String() string
+    String returns a readable representation of this value (for usage defaults)
+
+func (f *Float64SliceFlag) TakesValue() bool
+    TakesValue returns true if the flag takes a value, otherwise false
+
+func (f *Float64SliceFlag) WithSeparatorSpec(spec separatorSpec)
+
+type Generic interface {
+	Set(value string) error
+	String() string
+}
+    Generic is a generic parseable type identified by a specific flag
+
+type GenericFlag struct {
+	Name string
+
+	Category    string
+	DefaultText string
+	FilePath    string
+	Usage       string
+
+	Required   bool
+	Hidden     bool
+	HasBeenSet bool
+
+	Value       Generic
+	Destination Generic
+
+	Aliases []string
+	EnvVars []string
+
+	TakesFile bool
+
+	Action func(*Context, interface{}) error
+	// Has unexported fields.
+}
+    GenericFlag is a flag with type Generic
+
+func (f *GenericFlag) Apply(set *flag.FlagSet) error
+    Apply takes the flagset and calls Set on the generic flag with the value
+    provided by the user for parsing by the flag
+
+func (f *GenericFlag) Get(ctx *Context) interface{}
+    Get returns the flag’s value in the given Context.
+
+func (f *GenericFlag) GetCategory() string
+    GetCategory returns the category for the flag
+
+func (f *GenericFlag) GetDefaultText() string
+    GetDefaultText returns the default text for this flag
+
+func (f *GenericFlag) GetEnvVars() []string
+    GetEnvVars returns the env vars for this flag
+
+func (f *GenericFlag) GetUsage() string
+    GetUsage returns the usage string for the flag
+
+func (f *GenericFlag) GetValue() string
+    GetValue returns the flags value as string representation and an empty
+    string if the flag takes no value at all.
+
+func (f *GenericFlag) IsRequired() bool
+    IsRequired returns whether or not the flag is required
+
+func (f *GenericFlag) IsSet() bool
+    IsSet returns whether or not the flag has been set through env or file
+
+func (f *GenericFlag) IsVisible() bool
+    IsVisible returns true if the flag is not hidden, otherwise false
+
+func (f *GenericFlag) Names() []string
+    Names returns the names of the flag
+
+func (f *GenericFlag) RunAction(c *Context) error
+    RunAction executes flag action if set
+
+func (f *GenericFlag) String() string
+    String returns a readable representation of this value (for usage defaults)
+
+func (f *GenericFlag) TakesValue() bool
+    TakesValue returns true of the flag takes a value, otherwise false
+
+type Int64Flag struct {
+	Name string
+
+	Category    string
+	DefaultText string
+	FilePath    string
+	Usage       string
+
+	Required   bool
+	Hidden     bool
+	HasBeenSet bool
+
+	Value       int64
+	Destination *int64
+
+	Aliases []string
+	EnvVars []string
+
+	Base int
+
+	Action func(*Context, int64) error
+	// Has unexported fields.
+}
+    Int64Flag is a flag with type int64
+
+func (f *Int64Flag) Apply(set *flag.FlagSet) error
+    Apply populates the flag given the flag set and environment
+
+func (f *Int64Flag) Get(ctx *Context) int64
+    Get returns the flag’s value in the given Context.
+
+func (f *Int64Flag) GetCategory() string
+    GetCategory returns the category for the flag
+
+func (f *Int64Flag) GetDefaultText() string
+    GetDefaultText returns the default text for this flag
+
+func (f *Int64Flag) GetEnvVars() []string
+    GetEnvVars returns the env vars for this flag
+
+func (f *Int64Flag) GetUsage() string
+    GetUsage returns the usage string for the flag
+
+func (f *Int64Flag) GetValue() string
+    GetValue returns the flags value as string representation and an empty
+    string if the flag takes no value at all.
+
+func (f *Int64Flag) IsRequired() bool
+    IsRequired returns whether or not the flag is required
+
+func (f *Int64Flag) IsSet() bool
+    IsSet returns whether or not the flag has been set through env or file
+
+func (f *Int64Flag) IsVisible() bool
+    IsVisible returns true if the flag is not hidden, otherwise false
+
+func (f *Int64Flag) Names() []string
+    Names returns the names of the flag
+
+func (f *Int64Flag) RunAction(c *Context) error
+    RunAction executes flag action if set
+
+func (f *Int64Flag) String() string
+    String returns a readable representation of this value (for usage defaults)
+
+func (f *Int64Flag) TakesValue() bool
+    TakesValue returns true of the flag takes a value, otherwise false
+
+type Int64Slice struct {
+	// Has unexported fields.
+}
+    Int64Slice wraps []int64 to satisfy flag.Value
+
+func NewInt64Slice(defaults ...int64) *Int64Slice
+    NewInt64Slice makes an *Int64Slice with default values
+
+func (i *Int64Slice) Get() interface{}
+    Get returns the slice of ints set by this flag
+
+func (i *Int64Slice) Serialize() string
+    Serialize allows Int64Slice to fulfill Serializer
+
+func (i *Int64Slice) Set(value string) error
+    Set parses the value into an integer and appends it to the list of values
+
+func (i *Int64Slice) String() string
+    String returns a readable representation of this value (for usage defaults)
+
+func (i *Int64Slice) Value() []int64
+    Value returns the slice of ints set by this flag
+
+func (i *Int64Slice) WithSeparatorSpec(spec separatorSpec)
+
+type Int64SliceFlag struct {
+	Name string
+
+	Category    string
+	DefaultText string
+	FilePath    string
+	Usage       string
+
+	Required   bool
+	Hidden     bool
+	HasBeenSet bool
+
+	Value       *Int64Slice
+	Destination *Int64Slice
+
+	Aliases []string
+	EnvVars []string
+
+	Action func(*Context, []int64) error
+	// Has unexported fields.
+}
+    Int64SliceFlag is a flag with type *Int64Slice
+
+func (f *Int64SliceFlag) Apply(set *flag.FlagSet) error
+    Apply populates the flag given the flag set and environment
+
+func (f *Int64SliceFlag) Get(ctx *Context) []int64
+    Get returns the flag’s value in the given Context.
+
+func (f *Int64SliceFlag) GetCategory() string
+    GetCategory returns the category for the flag
+
+func (f *Int64SliceFlag) GetDefaultText() string
+    GetDefaultText returns the default text for this flag
+
+func (f *Int64SliceFlag) GetDestination() []int64
+
+func (f *Int64SliceFlag) GetEnvVars() []string
+    GetEnvVars returns the env vars for this flag
+
+func (f *Int64SliceFlag) GetUsage() string
+    GetUsage returns the usage string for the flag
+
+func (f *Int64SliceFlag) GetValue() string
+    GetValue returns the flags value as string representation and an empty
+    string if the flag takes no value at all.
+
+func (f *Int64SliceFlag) IsRequired() bool
+    IsRequired returns whether or not the flag is required
+
+func (f *Int64SliceFlag) IsSet() bool
+    IsSet returns whether or not the flag has been set through env or file
+
+func (f *Int64SliceFlag) IsSliceFlag() bool
+    IsSliceFlag implements DocGenerationSliceFlag.
+
+func (f *Int64SliceFlag) IsVisible() bool
+    IsVisible returns true if the flag is not hidden, otherwise false
+
+func (f *Int64SliceFlag) Names() []string
+    Names returns the names of the flag
+
+func (f *Int64SliceFlag) RunAction(c *Context) error
+    RunAction executes flag action if set
+
+func (f *Int64SliceFlag) SetDestination(slice []int64)
+
+func (f *Int64SliceFlag) SetValue(slice []int64)
+
+func (f *Int64SliceFlag) String() string
+    String returns a readable representation of this value (for usage defaults)
+
+func (f *Int64SliceFlag) TakesValue() bool
+    TakesValue returns true of the flag takes a value, otherwise false
+
+func (f *Int64SliceFlag) WithSeparatorSpec(spec separatorSpec)
+
+type IntFlag struct {
+	Name string
+
+	Category    string
+	DefaultText string
+	FilePath    string
+	Usage       string
+
+	Required   bool
+	Hidden     bool
+	HasBeenSet bool
+
+	Value       int
+	Destination *int
+
+	Aliases []string
+	EnvVars []string
+
+	Base int
+
+	Action func(*Context, int) error
+	// Has unexported fields.
+}
+    IntFlag is a flag with type int
+
+func (f *IntFlag) Apply(set *flag.FlagSet) error
+    Apply populates the flag given the flag set and environment
+
+func (f *IntFlag) Get(ctx *Context) int
+    Get returns the flag’s value in the given Context.
+
+func (f *IntFlag) GetCategory() string
+    GetCategory returns the category for the flag
+
+func (f *IntFlag) GetDefaultText() string
+    GetDefaultText returns the default text for this flag
+
+func (f *IntFlag) GetEnvVars() []string
+    GetEnvVars returns the env vars for this flag
+
+func (f *IntFlag) GetUsage() string
+    GetUsage returns the usage string for the flag
+
+func (f *IntFlag) GetValue() string
+    GetValue returns the flags value as string representation and an empty
+    string if the flag takes no value at all.
+
+func (f *IntFlag) IsRequired() bool
+    IsRequired returns whether or not the flag is required
+
+func (f *IntFlag) IsSet() bool
+    IsSet returns whether or not the flag has been set through env or file
+
+func (f *IntFlag) IsVisible() bool
+    IsVisible returns true if the flag is not hidden, otherwise false
+
+func (f *IntFlag) Names() []string
+    Names returns the names of the flag
+
+func (f *IntFlag) RunAction(c *Context) error
+    RunAction executes flag action if set
+
+func (f *IntFlag) String() string
+    String returns a readable representation of this value (for usage defaults)
+
+func (f *IntFlag) TakesValue() bool
+    TakesValue returns true of the flag takes a value, otherwise false
+
+type IntSlice struct {
+	// Has unexported fields.
+}
+    IntSlice wraps []int to satisfy flag.Value
+
+func NewIntSlice(defaults ...int) *IntSlice
+    NewIntSlice makes an *IntSlice with default values
+
+func (i *IntSlice) Get() interface{}
+    Get returns the slice of ints set by this flag
+
+func (i *IntSlice) Serialize() string
+    Serialize allows IntSlice to fulfill Serializer
+
+func (i *IntSlice) Set(value string) error
+    Set parses the value into an integer and appends it to the list of values
+
+func (i *IntSlice) SetInt(value int)
+    TODO: Consistently have specific Set function for Int64 and Float64 ? SetInt
+    directly adds an integer to the list of values
+
+func (i *IntSlice) String() string
+    String returns a readable representation of this value (for usage defaults)
+
+func (i *IntSlice) Value() []int
+    Value returns the slice of ints set by this flag
+
+func (i *IntSlice) WithSeparatorSpec(spec separatorSpec)
+
+type IntSliceFlag struct {
+	Name string
+
+	Category    string
+	DefaultText string
+	FilePath    string
+	Usage       string
+
+	Required   bool
+	Hidden     bool
+	HasBeenSet bool
+
+	Value       *IntSlice
+	Destination *IntSlice
+
+	Aliases []string
+	EnvVars []string
+
+	Action func(*Context, []int) error
+	// Has unexported fields.
+}
+    IntSliceFlag is a flag with type *IntSlice
+
+func (f *IntSliceFlag) Apply(set *flag.FlagSet) error
+    Apply populates the flag given the flag set and environment
+
+func (f *IntSliceFlag) Get(ctx *Context) []int
+    Get returns the flag’s value in the given Context.
+
+func (f *IntSliceFlag) GetCategory() string
+    GetCategory returns the category for the flag
+
+func (f *IntSliceFlag) GetDefaultText() string
+    GetDefaultText returns the default text for this flag
+
+func (f *IntSliceFlag) GetDestination() []int
+
+func (f *IntSliceFlag) GetEnvVars() []string
+    GetEnvVars returns the env vars for this flag
+
+func (f *IntSliceFlag) GetUsage() string
+    GetUsage returns the usage string for the flag
+
+func (f *IntSliceFlag) GetValue() string
+    GetValue returns the flags value as string representation and an empty
+    string if the flag takes no value at all.
+
+func (f *IntSliceFlag) IsRequired() bool
+    IsRequired returns whether or not the flag is required
+
+func (f *IntSliceFlag) IsSet() bool
+    IsSet returns whether or not the flag has been set through env or file
+
+func (f *IntSliceFlag) IsSliceFlag() bool
+    IsSliceFlag implements DocGenerationSliceFlag.
+
+func (f *IntSliceFlag) IsVisible() bool
+    IsVisible returns true if the flag is not hidden, otherwise false
+
+func (f *IntSliceFlag) Names() []string
+    Names returns the names of the flag
+
+func (f *IntSliceFlag) RunAction(c *Context) error
+    RunAction executes flag action if set
+
+func (f *IntSliceFlag) SetDestination(slice []int)
+
+func (f *IntSliceFlag) SetValue(slice []int)
+
+func (f *IntSliceFlag) String() string
+    String returns a readable representation of this value (for usage defaults)
+
+func (f *IntSliceFlag) TakesValue() bool
+    TakesValue returns true of the flag takes a value, otherwise false
+
+func (f *IntSliceFlag) WithSeparatorSpec(spec separatorSpec)
+
+type InvalidFlagAccessFunc func(*Context, string)
+    InvalidFlagAccessFunc is executed when an invalid flag is accessed from the
+    context.
+
+type MultiError interface {
+	error
+	Errors() []error
+}
+    MultiError is an error that wraps multiple errors.
+
+type MultiFloat64Flag = SliceFlag[*Float64SliceFlag, []float64, float64]
+    MultiFloat64Flag extends Float64SliceFlag with support for using slices
+    directly, as Value and/or Destination. See also SliceFlag.
+
+type MultiInt64Flag = SliceFlag[*Int64SliceFlag, []int64, int64]
+    MultiInt64Flag extends Int64SliceFlag with support for using slices
+    directly, as Value and/or Destination. See also SliceFlag.
+
+type MultiIntFlag = SliceFlag[*IntSliceFlag, []int, int]
+    MultiIntFlag extends IntSliceFlag with support for using slices directly,
+    as Value and/or Destination. See also SliceFlag.
+
+type MultiStringFlag = SliceFlag[*StringSliceFlag, []string, string]
+    MultiStringFlag extends StringSliceFlag with support for using slices
+    directly, as Value and/or Destination. See also SliceFlag.
+
+type OnUsageErrorFunc func(cCtx *Context, err error, isSubcommand bool) error
+    OnUsageErrorFunc is executed if a usage error occurs. This is useful for
+    displaying customized usage error messages. This function is able to replace
+    the original error messages. If this function is not set, the "Incorrect
+    usage" is displayed and the execution is interrupted.
+
+type Path = string
+
+type PathFlag struct {
+	Name string
+
+	Category    string
+	DefaultText string
+	FilePath    string
+	Usage       string
+
+	Required   bool
+	Hidden     bool
+	HasBeenSet bool
+
+	Value       Path
+	Destination *Path
+
+	Aliases []string
+	EnvVars []string
+
+	TakesFile bool
+
+	Action func(*Context, Path) error
+	// Has unexported fields.
+}
+    PathFlag is a flag with type Path
+
+func (f *PathFlag) Apply(set *flag.FlagSet) error
+    Apply populates the flag given the flag set and environment
+
+func (f *PathFlag) Get(ctx *Context) string
+    Get returns the flag’s value in the given Context.
+
+func (f *PathFlag) GetCategory() string
+    GetCategory returns the category for the flag
+
+func (f *PathFlag) GetDefaultText() string
+    GetDefaultText returns the default text for this flag
+
+func (f *PathFlag) GetEnvVars() []string
+    GetEnvVars returns the env vars for this flag
+
+func (f *PathFlag) GetUsage() string
+    GetUsage returns the usage string for the flag
+
+func (f *PathFlag) GetValue() string
+    GetValue returns the flags value as string representation and an empty
+    string if the flag takes no value at all.
+
+func (f *PathFlag) IsRequired() bool
+    IsRequired returns whether or not the flag is required
+
+func (f *PathFlag) IsSet() bool
+    IsSet returns whether or not the flag has been set through env or file
+
+func (f *PathFlag) IsVisible() bool
+    IsVisible returns true if the flag is not hidden, otherwise false
+
+func (f *PathFlag) Names() []string
+    Names returns the names of the flag
+
+func (f *PathFlag) RunAction(c *Context) error
+    RunAction executes flag action if set
+
+func (f *PathFlag) String() string
+    String returns a readable representation of this value (for usage defaults)
+
+func (f *PathFlag) TakesValue() bool
+    TakesValue returns true of the flag takes a value, otherwise false
+
+type RequiredFlag interface {
+	Flag
+
+	IsRequired() bool
+}
+    RequiredFlag is an interface that allows us to mark flags as required
+    it allows flags required flags to be backwards compatible with the Flag
+    interface
+
+type Serializer interface {
+	Serialize() string
+}
+    Serializer is used to circumvent the limitations of flag.FlagSet.Set
+
+type SliceFlag[T SliceFlagTarget[E], S ~[]E, E any] struct {
+	Target      T
+	Value       S
+	Destination *S
+}
+    SliceFlag extends implementations like StringSliceFlag and IntSliceFlag
+    with support for using slices directly, as Value and/or Destination.
+    See also SliceFlagTarget, MultiStringFlag, MultiFloat64Flag, MultiInt64Flag,
+    MultiIntFlag.
+
+func (x *SliceFlag[T, S, E]) Apply(set *flag.FlagSet) error
+
+func (x *SliceFlag[T, S, E]) GetCategory() string
+
+func (x *SliceFlag[T, S, E]) GetDefaultText() string
+
+func (x *SliceFlag[T, S, E]) GetDestination() S
+
+func (x *SliceFlag[T, S, E]) GetEnvVars() []string
+
+func (x *SliceFlag[T, S, E]) GetUsage() string
+
+func (x *SliceFlag[T, S, E]) GetValue() string
+
+func (x *SliceFlag[T, S, E]) IsRequired() bool
+
+func (x *SliceFlag[T, S, E]) IsSet() bool
+
+func (x *SliceFlag[T, S, E]) IsVisible() bool
+
+func (x *SliceFlag[T, S, E]) Names() []string
+
+func (x *SliceFlag[T, S, E]) SetDestination(slice S)
+
+func (x *SliceFlag[T, S, E]) SetValue(slice S)
+
+func (x *SliceFlag[T, S, E]) String() string
+
+func (x *SliceFlag[T, S, E]) TakesValue() bool
+
+type SliceFlagTarget[E any] interface {
+	Flag
+	RequiredFlag
+	DocGenerationFlag
+	VisibleFlag
+	CategorizableFlag
+
+	// SetValue should propagate the given slice to the target, ideally as a new value.
+	// Note that a nil slice should nil/clear any existing value (modelled as ~[]E).
+	SetValue(slice []E)
+	// SetDestination should propagate the given slice to the target, ideally as a new value.
+	// Note that a nil slice should nil/clear any existing value (modelled as ~*[]E).
+	SetDestination(slice []E)
+	// GetDestination should return the current value referenced by any destination, or nil if nil/unset.
+	GetDestination() []E
+}
+    SliceFlagTarget models a target implementation for use with SliceFlag. The
+    three methods, SetValue, SetDestination, and GetDestination, are necessary
+    to propagate Value and Destination, where Value is propagated inwards
+    (initially), and Destination is propagated outwards (on every update).
+
+type StringFlag struct {
+	Name string
+
+	Category    string
+	DefaultText string
+	FilePath    string
+	Usage       string
+
+	Required   bool
+	Hidden     bool
+	HasBeenSet bool
+
+	Value       string
+	Destination *string
+
+	Aliases []string
+	EnvVars []string
+
+	TakesFile bool
+
+	Action func(*Context, string) error
+	// Has unexported fields.
+}
+    StringFlag is a flag with type string
+
+func (f *StringFlag) Apply(set *flag.FlagSet) error
+    Apply populates the flag given the flag set and environment
+
+func (f *StringFlag) Get(ctx *Context) string
+    Get returns the flag’s value in the given Context.
+
+func (f *StringFlag) GetCategory() string
+    GetCategory returns the category for the flag
+
+func (f *StringFlag) GetDefaultText() string
+    GetDefaultText returns the default text for this flag
+
+func (f *StringFlag) GetEnvVars() []string
+    GetEnvVars returns the env vars for this flag
+
+func (f *StringFlag) GetUsage() string
+    GetUsage returns the usage string for the flag
+
+func (f *StringFlag) GetValue() string
+    GetValue returns the flags value as string representation and an empty
+    string if the flag takes no value at all.
+
+func (f *StringFlag) IsRequired() bool
+    IsRequired returns whether or not the flag is required
+
+func (f *StringFlag) IsSet() bool
+    IsSet returns whether or not the flag has been set through env or file
+
+func (f *StringFlag) IsVisible() bool
+    IsVisible returns true if the flag is not hidden, otherwise false
+
+func (f *StringFlag) Names() []string
+    Names returns the names of the flag
+
+func (f *StringFlag) RunAction(c *Context) error
+    RunAction executes flag action if set
+
+func (f *StringFlag) String() string
+    String returns a readable representation of this value (for usage defaults)
+
+func (f *StringFlag) TakesValue() bool
+    TakesValue returns true of the flag takes a value, otherwise false
+
+type StringSlice struct {
+	// Has unexported fields.
+}
+    StringSlice wraps a []string to satisfy flag.Value
+
+func NewStringSlice(defaults ...string) *StringSlice
+    NewStringSlice creates a *StringSlice with default values
+
+func (s *StringSlice) Get() interface{}
+    Get returns the slice of strings set by this flag
+
+func (s *StringSlice) Serialize() string
+    Serialize allows StringSlice to fulfill Serializer
+
+func (s *StringSlice) Set(value string) error
+    Set appends the string value to the list of values
+
+func (s *StringSlice) String() string
+    String returns a readable representation of this value (for usage defaults)
+
+func (s *StringSlice) Value() []string
+    Value returns the slice of strings set by this flag
+
+func (s *StringSlice) WithSeparatorSpec(spec separatorSpec)
+
+type StringSliceFlag struct {
+	Name string
+
+	Category    string
+	DefaultText string
+	FilePath    string
+	Usage       string
+
+	Required   bool
+	Hidden     bool
+	HasBeenSet bool
+
+	Value       *StringSlice
+	Destination *StringSlice
+
+	Aliases []string
+	EnvVars []string
+
+	TakesFile bool
+
+	Action func(*Context, []string) error
+
+	KeepSpace bool
+	// Has unexported fields.
+}
+    StringSliceFlag is a flag with type *StringSlice
+
+func (f *StringSliceFlag) Apply(set *flag.FlagSet) error
+    Apply populates the flag given the flag set and environment
+
+func (f *StringSliceFlag) Get(ctx *Context) []string
+    Get returns the flag’s value in the given Context.
+
+func (f *StringSliceFlag) GetCategory() string
+    GetCategory returns the category for the flag
+
+func (f *StringSliceFlag) GetDefaultText() string
+    GetDefaultText returns the default text for this flag
+
+func (f *StringSliceFlag) GetDestination() []string
+
+func (f *StringSliceFlag) GetEnvVars() []string
+    GetEnvVars returns the env vars for this flag
+
+func (f *StringSliceFlag) GetUsage() string
+    GetUsage returns the usage string for the flag
+
+func (f *StringSliceFlag) GetValue() string
+    GetValue returns the flags value as string representation and an empty
+    string if the flag takes no value at all.
+
+func (f *StringSliceFlag) IsRequired() bool
+    IsRequired returns whether or not the flag is required
+
+func (f *StringSliceFlag) IsSet() bool
+    IsSet returns whether or not the flag has been set through env or file
+
+func (f *StringSliceFlag) IsSliceFlag() bool
+    IsSliceFlag implements DocGenerationSliceFlag.
+
+func (f *StringSliceFlag) IsVisible() bool
+    IsVisible returns true if the flag is not hidden, otherwise false
+
+func (f *StringSliceFlag) Names() []string
+    Names returns the names of the flag
+
+func (f *StringSliceFlag) RunAction(c *Context) error
+    RunAction executes flag action if set
+
+func (f *StringSliceFlag) SetDestination(slice []string)
+
+func (f *StringSliceFlag) SetValue(slice []string)
+
+func (f *StringSliceFlag) String() string
+    String returns a readable representation of this value (for usage defaults)
+
+func (f *StringSliceFlag) TakesValue() bool
+    TakesValue returns true of the flag takes a value, otherwise false
+
+func (f *StringSliceFlag) WithSeparatorSpec(spec separatorSpec)
+
+type SuggestCommandFunc func(commands []*Command, provided string) string
+
+type SuggestFlagFunc func(flags []Flag, provided string, hideHelp bool) string
+
+type Timestamp struct {
+	// Has unexported fields.
+}
+    Timestamp wrap to satisfy golang's flag interface.
+
+func NewTimestamp(timestamp time.Time) *Timestamp
+    Timestamp constructor
+
+func (t *Timestamp) Get() interface{}
+    Get returns the flag structure
+
+func (t *Timestamp) Set(value string) error
+    Parses the string value to timestamp
+
+func (t *Timestamp) SetLayout(layout string)
+    Set the timestamp string layout for future parsing
+
+func (t *Timestamp) SetLocation(loc *time.Location)
+    Set perceived timezone of the to-be parsed time string
+
+func (t *Timestamp) SetTimestamp(value time.Time)
+    Set the timestamp value directly
+
+func (t *Timestamp) String() string
+    String returns a readable representation of this value (for usage defaults)
+
+func (t *Timestamp) Value() *time.Time
+    Value returns the timestamp value stored in the flag
+
+type TimestampFlag struct {
+	Name string
+
+	Category    string
+	DefaultText string
+	FilePath    string
+	Usage       string
+
+	Required   bool
+	Hidden     bool
+	HasBeenSet bool
+
+	Value       *Timestamp
+	Destination *Timestamp
+
+	Aliases []string
+	EnvVars []string
+
+	Layout string
+
+	Timezone *time.Location
+
+	Action func(*Context, *time.Time) error
+	// Has unexported fields.
+}
+    TimestampFlag is a flag with type *Timestamp
+
+func (f *TimestampFlag) Apply(set *flag.FlagSet) error
+    Apply populates the flag given the flag set and environment
+
+func (f *TimestampFlag) Get(ctx *Context) *time.Time
+    Get returns the flag’s value in the given Context.
+
+func (f *TimestampFlag) GetCategory() string
+    GetCategory returns the category for the flag
+
+func (f *TimestampFlag) GetDefaultText() string
+    GetDefaultText returns the default text for this flag
+
+func (f *TimestampFlag) GetEnvVars() []string
+    GetEnvVars returns the env vars for this flag
+
+func (f *TimestampFlag) GetUsage() string
+    GetUsage returns the usage string for the flag
+
+func (f *TimestampFlag) GetValue() string
+    GetValue returns the flags value as string representation and an empty
+    string if the flag takes no value at all.
+
+func (f *TimestampFlag) IsRequired() bool
+    IsRequired returns whether or not the flag is required
+
+func (f *TimestampFlag) IsSet() bool
+    IsSet returns whether or not the flag has been set through env or file
+
+func (f *TimestampFlag) IsVisible() bool
+    IsVisible returns true if the flag is not hidden, otherwise false
+
+func (f *TimestampFlag) Names() []string
+    Names returns the names of the flag
+
+func (f *TimestampFlag) RunAction(c *Context) error
+    RunAction executes flag action if set
+
+func (f *TimestampFlag) String() string
+    String returns a readable representation of this value (for usage defaults)
+
+func (f *TimestampFlag) TakesValue() bool
+    TakesValue returns true of the flag takes a value, otherwise false
+
+type Uint64Flag struct {
+	Name string
+
+	Category    string
+	DefaultText string
+	FilePath    string
+	Usage       string
+
+	Required   bool
+	Hidden     bool
+	HasBeenSet bool
+
+	Value       uint64
+	Destination *uint64
+
+	Aliases []string
+	EnvVars []string
+
+	Base int
+
+	Action func(*Context, uint64) error
+	// Has unexported fields.
+}
+    Uint64Flag is a flag with type uint64
+
+func (f *Uint64Flag) Apply(set *flag.FlagSet) error
+    Apply populates the flag given the flag set and environment
+
+func (f *Uint64Flag) Get(ctx *Context) uint64
+    Get returns the flag’s value in the given Context.
+
+func (f *Uint64Flag) GetCategory() string
+    GetCategory returns the category for the flag
+
+func (f *Uint64Flag) GetDefaultText() string
+    GetDefaultText returns the default text for this flag
+
+func (f *Uint64Flag) GetEnvVars() []string
+    GetEnvVars returns the env vars for this flag
+
+func (f *Uint64Flag) GetUsage() string
+    GetUsage returns the usage string for the flag
+
+func (f *Uint64Flag) GetValue() string
+    GetValue returns the flags value as string representation and an empty
+    string if the flag takes no value at all.
+
+func (f *Uint64Flag) IsRequired() bool
+    IsRequired returns whether or not the flag is required
+
+func (f *Uint64Flag) IsSet() bool
+    IsSet returns whether or not the flag has been set through env or file
+
+func (f *Uint64Flag) IsVisible() bool
+    IsVisible returns true if the flag is not hidden, otherwise false
+
+func (f *Uint64Flag) Names() []string
+    Names returns the names of the flag
+
+func (f *Uint64Flag) RunAction(c *Context) error
+    RunAction executes flag action if set
+
+func (f *Uint64Flag) String() string
+    String returns a readable representation of this value (for usage defaults)
+
+func (f *Uint64Flag) TakesValue() bool
+    TakesValue returns true of the flag takes a value, otherwise false
+
+type Uint64Slice struct {
+	// Has unexported fields.
+}
+    Uint64Slice wraps []int64 to satisfy flag.Value
+
+func NewUint64Slice(defaults ...uint64) *Uint64Slice
+    NewUint64Slice makes an *Uint64Slice with default values
+
+func (i *Uint64Slice) Get() interface{}
+    Get returns the slice of ints set by this flag
+
+func (i *Uint64Slice) Serialize() string
+    Serialize allows Uint64Slice to fulfill Serializer
+
+func (i *Uint64Slice) Set(value string) error
+    Set parses the value into an integer and appends it to the list of values
+
+func (i *Uint64Slice) String() string
+    String returns a readable representation of this value (for usage defaults)
+
+func (i *Uint64Slice) Value() []uint64
+    Value returns the slice of ints set by this flag
+
+func (i *Uint64Slice) WithSeparatorSpec(spec separatorSpec)
+
+type Uint64SliceFlag struct {
+	Name string
+
+	Category    string
+	DefaultText string
+	FilePath    string
+	Usage       string
+
+	Required   bool
+	Hidden     bool
+	HasBeenSet bool
+
+	Value       *Uint64Slice
+	Destination *Uint64Slice
+
+	Aliases []string
+	EnvVars []string
+
+	Action func(*Context, []uint64) error
+	// Has unexported fields.
+}
+    Uint64SliceFlag is a flag with type *Uint64Slice
+
+func (f *Uint64SliceFlag) Apply(set *flag.FlagSet) error
+    Apply populates the flag given the flag set and environment
+
+func (f *Uint64SliceFlag) Get(ctx *Context) []uint64
+    Get returns the flag’s value in the given Context.
+
+func (f *Uint64SliceFlag) GetCategory() string
+    GetCategory returns the category for the flag
+
+func (f *Uint64SliceFlag) GetDefaultText() string
+    GetDefaultText returns the default text for this flag
+
+func (f *Uint64SliceFlag) GetEnvVars() []string
+    GetEnvVars returns the env vars for this flag
+
+func (f *Uint64SliceFlag) GetUsage() string
+    GetUsage returns the usage string for the flag
+
+func (f *Uint64SliceFlag) GetValue() string
+    GetValue returns the flags value as string representation and an empty
+    string if the flag takes no value at all.
+
+func (f *Uint64SliceFlag) IsRequired() bool
+    IsRequired returns whether or not the flag is required
+
+func (f *Uint64SliceFlag) IsSet() bool
+    IsSet returns whether or not the flag has been set through env or file
+
+func (f *Uint64SliceFlag) IsSliceFlag() bool
+    IsSliceFlag implements DocGenerationSliceFlag.
+
+func (f *Uint64SliceFlag) IsVisible() bool
+    IsVisible returns true if the flag is not hidden, otherwise false
+
+func (f *Uint64SliceFlag) Names() []string
+    Names returns the names of the flag
+
+func (f *Uint64SliceFlag) RunAction(c *Context) error
+    RunAction executes flag action if set
+
+func (f *Uint64SliceFlag) String() string
+    String returns a readable representation of this value (for usage defaults)
+
+func (f *Uint64SliceFlag) TakesValue() bool
+    TakesValue returns true of the flag takes a value, otherwise false
+
+func (f *Uint64SliceFlag) WithSeparatorSpec(spec separatorSpec)
+
+type UintFlag struct {
+	Name string
+
+	Category    string
+	DefaultText string
+	FilePath    string
+	Usage       string
+
+	Required   bool
+	Hidden     bool
+	HasBeenSet bool
+
+	Value       uint
+	Destination *uint
+
+	Aliases []string
+	EnvVars []string
+
+	Base int
+
+	Action func(*Context, uint) error
+	// Has unexported fields.
+}
+    UintFlag is a flag with type uint
+
+func (f *UintFlag) Apply(set *flag.FlagSet) error
+    Apply populates the flag given the flag set and environment
+
+func (f *UintFlag) Get(ctx *Context) uint
+    Get returns the flag’s value in the given Context.
+
+func (f *UintFlag) GetCategory() string
+    GetCategory returns the category for the flag
+
+func (f *UintFlag) GetDefaultText() string
+    GetDefaultText returns the default text for this flag
+
+func (f *UintFlag) GetEnvVars() []string
+    GetEnvVars returns the env vars for this flag
+
+func (f *UintFlag) GetUsage() string
+    GetUsage returns the usage string for the flag
+
+func (f *UintFlag) GetValue() string
+    GetValue returns the flags value as string representation and an empty
+    string if the flag takes no value at all.
+
+func (f *UintFlag) IsRequired() bool
+    IsRequired returns whether or not the flag is required
+
+func (f *UintFlag) IsSet() bool
+    IsSet returns whether or not the flag has been set through env or file
+
+func (f *UintFlag) IsVisible() bool
+    IsVisible returns true if the flag is not hidden, otherwise false
+
+func (f *UintFlag) Names() []string
+    Names returns the names of the flag
+
+func (f *UintFlag) RunAction(c *Context) error
+    RunAction executes flag action if set
+
+func (f *UintFlag) String() string
+    String returns a readable representation of this value (for usage defaults)
+
+func (f *UintFlag) TakesValue() bool
+    TakesValue returns true of the flag takes a value, otherwise false
+
+type UintSlice struct {
+	// Has unexported fields.
+}
+    UintSlice wraps []int to satisfy flag.Value
+
+func NewUintSlice(defaults ...uint) *UintSlice
+    NewUintSlice makes an *UintSlice with default values
+
+func (i *UintSlice) Get() interface{}
+    Get returns the slice of ints set by this flag
+
+func (i *UintSlice) Serialize() string
+    Serialize allows UintSlice to fulfill Serializer
+
+func (i *UintSlice) Set(value string) error
+    Set parses the value into an integer and appends it to the list of values
+
+func (i *UintSlice) SetUint(value uint)
+    TODO: Consistently have specific Set function for Int64 and Float64 ? SetInt
+    directly adds an integer to the list of values
+
+func (i *UintSlice) String() string
+    String returns a readable representation of this value (for usage defaults)
+
+func (i *UintSlice) Value() []uint
+    Value returns the slice of ints set by this flag
+
+func (i *UintSlice) WithSeparatorSpec(spec separatorSpec)
+
+type UintSliceFlag struct {
+	Name string
+
+	Category    string
+	DefaultText string
+	FilePath    string
+	Usage       string
+
+	Required   bool
+	Hidden     bool
+	HasBeenSet bool
+
+	Value       *UintSlice
+	Destination *UintSlice
+
+	Aliases []string
+	EnvVars []string
+
+	Action func(*Context, []uint) error
+	// Has unexported fields.
+}
+    UintSliceFlag is a flag with type *UintSlice
+
+func (f *UintSliceFlag) Apply(set *flag.FlagSet) error
+    Apply populates the flag given the flag set and environment
+
+func (f *UintSliceFlag) Get(ctx *Context) []uint
+    Get returns the flag’s value in the given Context.
+
+func (f *UintSliceFlag) GetCategory() string
+    GetCategory returns the category for the flag
+
+func (f *UintSliceFlag) GetDefaultText() string
+    GetDefaultText returns the default text for this flag
+
+func (f *UintSliceFlag) GetEnvVars() []string
+    GetEnvVars returns the env vars for this flag
+
+func (f *UintSliceFlag) GetUsage() string
+    GetUsage returns the usage string for the flag
+
+func (f *UintSliceFlag) GetValue() string
+    GetValue returns the flags value as string representation and an empty
+    string if the flag takes no value at all.
+
+func (f *UintSliceFlag) IsRequired() bool
+    IsRequired returns whether or not the flag is required
+
+func (f *UintSliceFlag) IsSet() bool
+    IsSet returns whether or not the flag has been set through env or file
+
+func (f *UintSliceFlag) IsSliceFlag() bool
+    IsSliceFlag implements DocGenerationSliceFlag.
+
+func (f *UintSliceFlag) IsVisible() bool
+    IsVisible returns true if the flag is not hidden, otherwise false
+
+func (f *UintSliceFlag) Names() []string
+    Names returns the names of the flag
+
+func (f *UintSliceFlag) RunAction(c *Context) error
+    RunAction executes flag action if set
+
+func (f *UintSliceFlag) String() string
+    String returns a readable representation of this value (for usage defaults)
+
+func (f *UintSliceFlag) TakesValue() bool
+    TakesValue returns true of the flag takes a value, otherwise false
+
+func (f *UintSliceFlag) WithSeparatorSpec(spec separatorSpec)
+
+type VisibleFlag interface {
+	Flag
+
+	// IsVisible returns true if the flag is not hidden, otherwise false
+	IsVisible() bool
+}
+    VisibleFlag is an interface that allows to check if a flag is visible
+
+type VisibleFlagCategory interface {
+	// Name returns the category name string
+	Name() string
+	// Flags returns a slice of VisibleFlag sorted by name
+	Flags() []VisibleFlag
+}
+    VisibleFlagCategory is a category containing flags.
+
+package altsrc // import "github.com/urfave/cli/v2/altsrc"
+
+
+FUNCTIONS
+
+func ApplyInputSourceValues(cCtx *cli.Context, inputSourceContext InputSourceContext, flags []cli.Flag) error
+    ApplyInputSourceValues iterates over all provided flags and executes
+    ApplyInputSourceValue on flags implementing the FlagInputSourceExtension
+    interface to initialize these flags to an alternate input source.
+
+func InitInputSource(flags []cli.Flag, createInputSource func() (InputSourceContext, error)) cli.BeforeFunc
+    InitInputSource is used to to setup an InputSourceContext on a cli.Command
+    Before method. It will create a new input source based on the func provided.
+    If there is no error it will then apply the new input source to any flags
+    that are supported by the input source
+
+func InitInputSourceWithContext(flags []cli.Flag, createInputSource func(cCtx *cli.Context) (InputSourceContext, error)) cli.BeforeFunc
+    InitInputSourceWithContext is used to to setup an InputSourceContext on
+    a cli.Command Before method. It will create a new input source based on
+    the func provided with potentially using existing cli.Context values to
+    initialize itself. If there is no error it will then apply the new input
+    source to any flags that are supported by the input source
+
+func NewJSONSourceFromFlagFunc(flag string) func(c *cli.Context) (InputSourceContext, error)
+    NewJSONSourceFromFlagFunc returns a func that takes a cli.Context and
+    returns an InputSourceContext suitable for retrieving config variables from
+    a file containing JSON data with the file name defined by the given flag.
+
+func NewTomlSourceFromFlagFunc(flagFileName string) func(cCtx *cli.Context) (InputSourceContext, error)
+    NewTomlSourceFromFlagFunc creates a new TOML InputSourceContext from a
+    provided flag name and source context.
+
+func NewYamlSourceFromFlagFunc(flagFileName string) func(cCtx *cli.Context) (InputSourceContext, error)
+    NewYamlSourceFromFlagFunc creates a new Yaml InputSourceContext from a
+    provided flag name and source context.
+
+
+TYPES
+
+type BoolFlag struct {
+	*cli.BoolFlag
+	// Has unexported fields.
+}
+    BoolFlag is the flag type that wraps cli.BoolFlag to allow for other values
+    to be specified
+
+func NewBoolFlag(fl *cli.BoolFlag) *BoolFlag
+    NewBoolFlag creates a new BoolFlag
+
+func (f *BoolFlag) Apply(set *flag.FlagSet) error
+    Apply saves the flagSet for later usage calls, then calls the wrapped
+    BoolFlag.Apply
+
+func (f *BoolFlag) ApplyInputSourceValue(cCtx *cli.Context, isc InputSourceContext) error
+    ApplyInputSourceValue applies a Bool value to the flagSet if required
+
+type DurationFlag struct {
+	*cli.DurationFlag
+	// Has unexported fields.
+}
+    DurationFlag is the flag type that wraps cli.DurationFlag to allow for other
+    values to be specified
+
+func NewDurationFlag(fl *cli.DurationFlag) *DurationFlag
+    NewDurationFlag creates a new DurationFlag
+
+func (f *DurationFlag) Apply(set *flag.FlagSet) error
+    Apply saves the flagSet for later usage calls, then calls the wrapped
+    DurationFlag.Apply
+
+func (f *DurationFlag) ApplyInputSourceValue(cCtx *cli.Context, isc InputSourceContext) error
+    ApplyInputSourceValue applies a Duration value to the flagSet if required
+
+type FlagInputSourceExtension interface {
+	cli.Flag
+	ApplyInputSourceValue(cCtx *cli.Context, isc InputSourceContext) error
+}
+    FlagInputSourceExtension is an extension interface of cli.Flag that allows a
+    value to be set on the existing parsed flags.
+
+type Float64Flag struct {
+	*cli.Float64Flag
+	// Has unexported fields.
+}
+    Float64Flag is the flag type that wraps cli.Float64Flag to allow for other
+    values to be specified
+
+func NewFloat64Flag(fl *cli.Float64Flag) *Float64Flag
+    NewFloat64Flag creates a new Float64Flag
+
+func (f *Float64Flag) Apply(set *flag.FlagSet) error
+    Apply saves the flagSet for later usage calls, then calls the wrapped
+    Float64Flag.Apply
+
+func (f *Float64Flag) ApplyInputSourceValue(cCtx *cli.Context, isc InputSourceContext) error
+    ApplyInputSourceValue applies a Float64 value to the flagSet if required
+
+type Float64SliceFlag struct {
+	*cli.Float64SliceFlag
+	// Has unexported fields.
+}
+    Float64SliceFlag is the flag type that wraps cli.Float64SliceFlag to allow
+    for other values to be specified
+
+func NewFloat64SliceFlag(fl *cli.Float64SliceFlag) *Float64SliceFlag
+    NewFloat64SliceFlag creates a new Float64SliceFlag
+
+func (f *Float64SliceFlag) Apply(set *flag.FlagSet) error
+    Apply saves the flagSet for later usage calls, then calls the wrapped
+    Float64SliceFlag.Apply
+
+func (f *Float64SliceFlag) ApplyInputSourceValue(cCtx *cli.Context, isc InputSourceContext) error
+    ApplyInputSourceValue applies a Float64Slice value if required
+
+type GenericFlag struct {
+	*cli.GenericFlag
+	// Has unexported fields.
+}
+    GenericFlag is the flag type that wraps cli.GenericFlag to allow for other
+    values to be specified
+
+func NewGenericFlag(fl *cli.GenericFlag) *GenericFlag
+    NewGenericFlag creates a new GenericFlag
+
+func (f *GenericFlag) Apply(set *flag.FlagSet) error
+    Apply saves the flagSet for later usage calls, then calls the wrapped
+    GenericFlag.Apply
+
+func (f *GenericFlag) ApplyInputSourceValue(cCtx *cli.Context, isc InputSourceContext) error
+    ApplyInputSourceValue applies a generic value to the flagSet if required
+
+type InputSourceContext interface {
+	Source() string
+
+	Int(name string) (int, error)
+	Int64(name string) (int64, error)
+	Uint(name string) (uint, error)
+	Uint64(name string) (uint64, error)
+	Duration(name string) (time.Duration, error)
+	Float64(name string) (float64, error)
+	String(name string) (string, error)
+	StringSlice(name string) ([]string, error)
+	IntSlice(name string) ([]int, error)
+	Int64Slice(name string) ([]int64, error)
+	Float64Slice(name string) ([]float64, error)
+	Generic(name string) (cli.Generic, error)
+	Bool(name string) (bool, error)
+
+	// Has unexported methods.
+}
+    InputSourceContext is an interface used to allow other input sources to be
+    implemented as needed.
+
+    Source returns an identifier for the input source. In case of file source it
+    should return path to the file.
+
+func NewJSONSource(data []byte) (InputSourceContext, error)
+    NewJSONSource returns an InputSourceContext suitable for retrieving config
+    variables from raw JSON data.
+
+func NewJSONSourceFromFile(f string) (InputSourceContext, error)
+    NewJSONSourceFromFile returns an InputSourceContext suitable for retrieving
+    config variables from a file (or url) containing JSON data.
+
+func NewJSONSourceFromReader(r io.Reader) (InputSourceContext, error)
+    NewJSONSourceFromReader returns an InputSourceContext suitable for
+    retrieving config variables from an io.Reader that returns JSON data.
+
+func NewTomlSourceFromFile(file string) (InputSourceContext, error)
+    NewTomlSourceFromFile creates a new TOML InputSourceContext from a filepath.
+
+func NewYamlSourceFromFile(file string) (InputSourceContext, error)
+    NewYamlSourceFromFile creates a new Yaml InputSourceContext from a filepath.
+
+type Int64Flag struct {
+	*cli.Int64Flag
+	// Has unexported fields.
+}
+    Int64Flag is the flag type that wraps cli.Int64Flag to allow for other
+    values to be specified
+
+func NewInt64Flag(fl *cli.Int64Flag) *Int64Flag
+    NewInt64Flag creates a new Int64Flag
+
+func (f *Int64Flag) Apply(set *flag.FlagSet) error
+    Apply saves the flagSet for later usage calls, then calls the wrapped
+    Int64Flag.Apply
+
+func (f *Int64Flag) ApplyInputSourceValue(cCtx *cli.Context, isc InputSourceContext) error
+
+type Int64SliceFlag struct {
+	*cli.Int64SliceFlag
+	// Has unexported fields.
+}
+    Int64SliceFlag is the flag type that wraps cli.Int64SliceFlag to allow for
+    other values to be specified
+
+func NewInt64SliceFlag(fl *cli.Int64SliceFlag) *Int64SliceFlag
+    NewInt64SliceFlag creates a new Int64SliceFlag
+
+func (f *Int64SliceFlag) Apply(set *flag.FlagSet) error
+    Apply saves the flagSet for later usage calls, then calls the wrapped
+    Int64SliceFlag.Apply
+
+func (f *Int64SliceFlag) ApplyInputSourceValue(cCtx *cli.Context, isc InputSourceContext) error
+    ApplyInputSourceValue applies a Int64Slice value if required
+
+type IntFlag struct {
+	*cli.IntFlag
+	// Has unexported fields.
+}
+    IntFlag is the flag type that wraps cli.IntFlag to allow for other values to
+    be specified
+
+func NewIntFlag(fl *cli.IntFlag) *IntFlag
+    NewIntFlag creates a new IntFlag
+
+func (f *IntFlag) Apply(set *flag.FlagSet) error
+    Apply saves the flagSet for later usage calls, then calls the wrapped
+    IntFlag.Apply
+
+func (f *IntFlag) ApplyInputSourceValue(cCtx *cli.Context, isc InputSourceContext) error
+    ApplyInputSourceValue applies a int value to the flagSet if required
+
+type IntSliceFlag struct {
+	*cli.IntSliceFlag
+	// Has unexported fields.
+}
+    IntSliceFlag is the flag type that wraps cli.IntSliceFlag to allow for other
+    values to be specified
+
+func NewIntSliceFlag(fl *cli.IntSliceFlag) *IntSliceFlag
+    NewIntSliceFlag creates a new IntSliceFlag
+
+func (f *IntSliceFlag) Apply(set *flag.FlagSet) error
+    Apply saves the flagSet for later usage calls, then calls the wrapped
+    IntSliceFlag.Apply
+
+func (f *IntSliceFlag) ApplyInputSourceValue(cCtx *cli.Context, isc InputSourceContext) error
+    ApplyInputSourceValue applies a IntSlice value if required
+
+type MapInputSource struct {
+	// Has unexported fields.
+}
+    MapInputSource implements InputSourceContext to return data from the map
+    that is loaded.
+
+func NewMapInputSource(file string, valueMap map[interface{}]interface{}) *MapInputSource
+    NewMapInputSource creates a new MapInputSource for implementing custom input
+    sources.
+
+func (fsm *MapInputSource) Bool(name string) (bool, error)
+    Bool returns an bool from the map otherwise returns false
+
+func (fsm *MapInputSource) Duration(name string) (time.Duration, error)
+    Duration returns a duration from the map if it exists otherwise returns 0
+
+func (fsm *MapInputSource) Float64(name string) (float64, error)
+    Float64 returns an float64 from the map if it exists otherwise returns 0
+
+func (fsm *MapInputSource) Float64Slice(name string) ([]float64, error)
+    Float64Slice returns an []float64 from the map if it exists otherwise
+    returns nil
+
+func (fsm *MapInputSource) Generic(name string) (cli.Generic, error)
+    Generic returns an cli.Generic from the map if it exists otherwise returns
+    nil
+
+func (fsm *MapInputSource) Int(name string) (int, error)
+    Int returns an int from the map if it exists otherwise returns 0
+
+func (fsm *MapInputSource) Int64(name string) (int64, error)
+    Int64 returns an int64 from the map if it exists otherwise returns 0
+
+func (fsm *MapInputSource) Int64Slice(name string) ([]int64, error)
+    Int64Slice returns an []int64 from the map if it exists otherwise returns
+    nil
+
+func (fsm *MapInputSource) IntSlice(name string) ([]int, error)
+    IntSlice returns an []int from the map if it exists otherwise returns nil
+
+func (fsm *MapInputSource) Source() string
+    Source returns the path of the source file
+
+func (fsm *MapInputSource) String(name string) (string, error)
+    String returns a string from the map if it exists otherwise returns an empty
+    string
+
+func (fsm *MapInputSource) StringSlice(name string) ([]string, error)
+    StringSlice returns an []string from the map if it exists otherwise returns
+    nil
+
+func (fsm *MapInputSource) Uint(name string) (uint, error)
+    Int64 returns an int64 from the map if it exists otherwise returns 0
+
+func (fsm *MapInputSource) Uint64(name string) (uint64, error)
+    UInt64 returns an uint64 from the map if it exists otherwise returns 0
+
+type PathFlag struct {
+	*cli.PathFlag
+	// Has unexported fields.
+}
+    PathFlag is the flag type that wraps cli.PathFlag to allow for other values
+    to be specified
+
+func NewPathFlag(fl *cli.PathFlag) *PathFlag
+    NewPathFlag creates a new PathFlag
+
+func (f *PathFlag) Apply(set *flag.FlagSet) error
+    Apply saves the flagSet for later usage calls, then calls the wrapped
+    PathFlag.Apply
+
+func (f *PathFlag) ApplyInputSourceValue(cCtx *cli.Context, isc InputSourceContext) error
+    ApplyInputSourceValue applies a Path value to the flagSet if required
+
+type StringFlag struct {
+	*cli.StringFlag
+	// Has unexported fields.
+}
+    StringFlag is the flag type that wraps cli.StringFlag to allow for other
+    values to be specified
+
+func NewStringFlag(fl *cli.StringFlag) *StringFlag
+    NewStringFlag creates a new StringFlag
+
+func (f *StringFlag) Apply(set *flag.FlagSet) error
+    Apply saves the flagSet for later usage calls, then calls the wrapped
+    StringFlag.Apply
+
+func (f *StringFlag) ApplyInputSourceValue(cCtx *cli.Context, isc InputSourceContext) error
+    ApplyInputSourceValue applies a String value to the flagSet if required
+
+type StringSliceFlag struct {
+	*cli.StringSliceFlag
+	// Has unexported fields.
+}
+    StringSliceFlag is the flag type that wraps cli.StringSliceFlag to allow for
+    other values to be specified
+
+func NewStringSliceFlag(fl *cli.StringSliceFlag) *StringSliceFlag
+    NewStringSliceFlag creates a new StringSliceFlag
+
+func (f *StringSliceFlag) Apply(set *flag.FlagSet) error
+    Apply saves the flagSet for later usage calls, then calls the wrapped
+    StringSliceFlag.Apply
+
+func (f *StringSliceFlag) ApplyInputSourceValue(cCtx *cli.Context, isc InputSourceContext) error
+    ApplyInputSourceValue applies a StringSlice value to the flagSet if required
+
+type Uint64Flag struct {
+	*cli.Uint64Flag
+	// Has unexported fields.
+}
+    Uint64Flag is the flag type that wraps cli.Uint64Flag to allow for other
+    values to be specified
+
+func NewUint64Flag(fl *cli.Uint64Flag) *Uint64Flag
+    NewUint64Flag creates a new Uint64Flag
+
+func (f *Uint64Flag) Apply(set *flag.FlagSet) error
+    Apply saves the flagSet for later usage calls, then calls the wrapped
+    Uint64Flag.Apply
+
+func (f *Uint64Flag) ApplyInputSourceValue(cCtx *cli.Context, isc InputSourceContext) error
+
+type UintFlag struct {
+	*cli.UintFlag
+	// Has unexported fields.
+}
+    UintFlag is the flag type that wraps cli.UintFlag to allow for other values
+    to be specified
+
+func NewUintFlag(fl *cli.UintFlag) *UintFlag
+    NewUintFlag creates a new UintFlag
+
+func (f *UintFlag) Apply(set *flag.FlagSet) error
+    Apply saves the flagSet for later usage calls, then calls the wrapped
+    UintFlag.Apply
+
+func (f *UintFlag) ApplyInputSourceValue(cCtx *cli.Context, isc InputSourceContext) error
+

--- a/vendor/github.com/urfave/cli/v2/help.go
+++ b/vendor/github.com/urfave/cli/v2/help.go
@@ -1,0 +1,569 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"text/tabwriter"
+	"text/template"
+	"unicode/utf8"
+)
+
+const (
+	helpName  = "help"
+	helpAlias = "h"
+)
+
+// this instance is to avoid recursion in the ShowCommandHelp which can
+// add a help command again
+var helpCommandDontUse = &Command{
+	Name:      helpName,
+	Aliases:   []string{helpAlias},
+	Usage:     "Shows a list of commands or help for one command",
+	ArgsUsage: "[command]",
+}
+
+var helpCommand = &Command{
+	Name:      helpName,
+	Aliases:   []string{helpAlias},
+	Usage:     "Shows a list of commands or help for one command",
+	ArgsUsage: "[command]",
+	Action: func(cCtx *Context) error {
+		args := cCtx.Args()
+		argsPresent := args.First() != ""
+		firstArg := args.First()
+
+		// This action can be triggered by a "default" action of a command
+		// or via cmd.Run when cmd == helpCmd. So we have following possibilities
+		//
+		// 1 $ app
+		// 2 $ app help
+		// 3 $ app foo
+		// 4 $ app help foo
+		// 5 $ app foo help
+		// 6 $ app foo -h (with no other sub-commands nor flags defined)
+
+		// Case 4. when executing a help command set the context to parent
+		// to allow resolution of subsequent args. This will transform
+		// $ app help foo
+		//     to
+		// $ app foo
+		// which will then be handled as case 3
+		if cCtx.Command.Name == helpName || cCtx.Command.Name == helpAlias {
+			cCtx = cCtx.parentContext
+		}
+
+		// Case 4. $ app hello foo
+		// foo is the command for which help needs to be shown
+		if argsPresent {
+			return ShowCommandHelp(cCtx, firstArg)
+		}
+
+		// Case 1 & 2
+		// Special case when running help on main app itself as opposed to individual
+		// commands/subcommands
+		if cCtx.parentContext.App == nil {
+			_ = ShowAppHelp(cCtx)
+			return nil
+		}
+
+		// Case 3, 5
+		if (len(cCtx.Command.Subcommands) == 1 && !cCtx.Command.HideHelp && !cCtx.Command.HideHelpCommand) ||
+			(len(cCtx.Command.Subcommands) == 0 && cCtx.Command.HideHelp) {
+			templ := cCtx.Command.CustomHelpTemplate
+			if templ == "" {
+				templ = CommandHelpTemplate
+			}
+			HelpPrinter(cCtx.App.Writer, templ, cCtx.Command)
+			return nil
+		}
+
+		// Case 6, handling incorporated in the callee itself
+		return ShowSubcommandHelp(cCtx)
+	},
+}
+
+// Prints help for the App or Command
+type helpPrinter func(w io.Writer, templ string, data interface{})
+
+// Prints help for the App or Command with custom template function.
+type helpPrinterCustom func(w io.Writer, templ string, data interface{}, customFunc map[string]interface{})
+
+// HelpPrinter is a function that writes the help output. If not set explicitly,
+// this calls HelpPrinterCustom using only the default template functions.
+//
+// If custom logic for printing help is required, this function can be
+// overridden. If the ExtraInfo field is defined on an App, this function
+// should not be modified, as HelpPrinterCustom will be used directly in order
+// to capture the extra information.
+var HelpPrinter helpPrinter = printHelp
+
+// HelpPrinterCustom is a function that writes the help output. It is used as
+// the default implementation of HelpPrinter, and may be called directly if
+// the ExtraInfo field is set on an App.
+//
+// In the default implementation, if the customFuncs argument contains a
+// "wrapAt" key, which is a function which takes no arguments and returns
+// an int, this int value will be used to produce a "wrap" function used
+// by the default template to wrap long lines.
+var HelpPrinterCustom helpPrinterCustom = printHelpCustom
+
+// VersionPrinter prints the version for the App
+var VersionPrinter = printVersion
+
+// ShowAppHelpAndExit - Prints the list of subcommands for the app and exits with exit code.
+func ShowAppHelpAndExit(c *Context, exitCode int) {
+	_ = ShowAppHelp(c)
+	os.Exit(exitCode)
+}
+
+// ShowAppHelp is an action that displays the help.
+func ShowAppHelp(cCtx *Context) error {
+	tpl := cCtx.App.CustomAppHelpTemplate
+	if tpl == "" {
+		tpl = AppHelpTemplate
+	}
+
+	if cCtx.App.ExtraInfo == nil {
+		HelpPrinter(cCtx.App.Writer, tpl, cCtx.App)
+		return nil
+	}
+
+	customAppData := func() map[string]interface{} {
+		return map[string]interface{}{
+			"ExtraInfo": cCtx.App.ExtraInfo,
+		}
+	}
+	HelpPrinterCustom(cCtx.App.Writer, tpl, cCtx.App, customAppData())
+
+	return nil
+}
+
+// DefaultAppComplete prints the list of subcommands as the default app completion method
+func DefaultAppComplete(cCtx *Context) {
+	DefaultCompleteWithFlags(nil)(cCtx)
+}
+
+func printCommandSuggestions(commands []*Command, writer io.Writer) {
+	for _, command := range commands {
+		if command.Hidden {
+			continue
+		}
+		if strings.HasSuffix(os.Getenv("0"), "zsh") {
+			for _, name := range command.Names() {
+				_, _ = fmt.Fprintf(writer, "%s:%s\n", name, command.Usage)
+			}
+		} else {
+			for _, name := range command.Names() {
+				_, _ = fmt.Fprintf(writer, "%s\n", name)
+			}
+		}
+	}
+}
+
+func cliArgContains(flagName string) bool {
+	for _, name := range strings.Split(flagName, ",") {
+		name = strings.TrimSpace(name)
+		count := utf8.RuneCountInString(name)
+		if count > 2 {
+			count = 2
+		}
+		flag := fmt.Sprintf("%s%s", strings.Repeat("-", count), name)
+		for _, a := range os.Args {
+			if a == flag {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func printFlagSuggestions(lastArg string, flags []Flag, writer io.Writer) {
+	cur := strings.TrimPrefix(lastArg, "-")
+	cur = strings.TrimPrefix(cur, "-")
+	for _, flag := range flags {
+		if bflag, ok := flag.(*BoolFlag); ok && bflag.Hidden {
+			continue
+		}
+		for _, name := range flag.Names() {
+			name = strings.TrimSpace(name)
+			// this will get total count utf8 letters in flag name
+			count := utf8.RuneCountInString(name)
+			if count > 2 {
+				count = 2 // reuse this count to generate single - or -- in flag completion
+			}
+			// if flag name has more than one utf8 letter and last argument in cli has -- prefix then
+			// skip flag completion for short flags example -v or -x
+			if strings.HasPrefix(lastArg, "--") && count == 1 {
+				continue
+			}
+			// match if last argument matches this flag and it is not repeated
+			if strings.HasPrefix(name, cur) && cur != name && !cliArgContains(name) {
+				flagCompletion := fmt.Sprintf("%s%s", strings.Repeat("-", count), name)
+				_, _ = fmt.Fprintln(writer, flagCompletion)
+			}
+		}
+	}
+}
+
+func DefaultCompleteWithFlags(cmd *Command) func(cCtx *Context) {
+	return func(cCtx *Context) {
+		var lastArg string
+
+		// TODO: This shouldnt depend on os.Args rather it should
+		// depend on root arguments passed to App
+		if len(os.Args) > 2 {
+			lastArg = os.Args[len(os.Args)-2]
+		}
+
+		if lastArg != "" {
+			if strings.HasPrefix(lastArg, "-") {
+				if cmd != nil {
+					printFlagSuggestions(lastArg, cmd.Flags, cCtx.App.Writer)
+
+					return
+				}
+
+				printFlagSuggestions(lastArg, cCtx.App.Flags, cCtx.App.Writer)
+
+				return
+			}
+		}
+
+		if cmd != nil {
+			printCommandSuggestions(cmd.Subcommands, cCtx.App.Writer)
+			return
+		}
+
+		printCommandSuggestions(cCtx.Command.Subcommands, cCtx.App.Writer)
+	}
+}
+
+// ShowCommandHelpAndExit - exits with code after showing help
+func ShowCommandHelpAndExit(c *Context, command string, code int) {
+	_ = ShowCommandHelp(c, command)
+	os.Exit(code)
+}
+
+// ShowCommandHelp prints help for the given command
+func ShowCommandHelp(ctx *Context, command string) error {
+	commands := ctx.App.Commands
+	if ctx.Command.Subcommands != nil {
+		commands = ctx.Command.Subcommands
+	}
+	for _, c := range commands {
+		if c.HasName(command) {
+			if !ctx.App.HideHelpCommand && !c.HasName(helpName) && len(c.Subcommands) != 0 && c.Command(helpName) == nil {
+				c.Subcommands = append(c.Subcommands, helpCommandDontUse)
+			}
+			if !ctx.App.HideHelp && HelpFlag != nil {
+				c.appendFlag(HelpFlag)
+			}
+			templ := c.CustomHelpTemplate
+			if templ == "" {
+				if len(c.Subcommands) == 0 {
+					templ = CommandHelpTemplate
+				} else {
+					templ = SubcommandHelpTemplate
+				}
+			}
+
+			HelpPrinter(ctx.App.Writer, templ, c)
+
+			return nil
+		}
+	}
+
+	if ctx.App.CommandNotFound == nil {
+		errMsg := fmt.Sprintf("No help topic for '%v'", command)
+		if ctx.App.Suggest && SuggestCommand != nil {
+			if suggestion := SuggestCommand(ctx.Command.Subcommands, command); suggestion != "" {
+				errMsg += ". " + suggestion
+			}
+		}
+		return Exit(errMsg, 3)
+	}
+
+	ctx.App.CommandNotFound(ctx, command)
+	return nil
+}
+
+// ShowSubcommandHelpAndExit - Prints help for the given subcommand and exits with exit code.
+func ShowSubcommandHelpAndExit(c *Context, exitCode int) {
+	_ = ShowSubcommandHelp(c)
+	os.Exit(exitCode)
+}
+
+// ShowSubcommandHelp prints help for the given subcommand
+func ShowSubcommandHelp(cCtx *Context) error {
+	if cCtx == nil {
+		return nil
+	}
+	// use custom template when provided (fixes #1703)
+	templ := SubcommandHelpTemplate
+	if cCtx.Command != nil && cCtx.Command.CustomHelpTemplate != "" {
+		templ = cCtx.Command.CustomHelpTemplate
+	}
+	HelpPrinter(cCtx.App.Writer, templ, cCtx.Command)
+	return nil
+}
+
+// ShowVersion prints the version number of the App
+func ShowVersion(cCtx *Context) {
+	VersionPrinter(cCtx)
+}
+
+func printVersion(cCtx *Context) {
+	_, _ = fmt.Fprintf(cCtx.App.Writer, "%v version %v\n", cCtx.App.Name, cCtx.App.Version)
+}
+
+// ShowCompletions prints the lists of commands within a given context
+func ShowCompletions(cCtx *Context) {
+	c := cCtx.Command
+	if c != nil && c.BashComplete != nil {
+		c.BashComplete(cCtx)
+	}
+}
+
+// ShowCommandCompletions prints the custom completions for a given command
+func ShowCommandCompletions(ctx *Context, command string) {
+	c := ctx.Command.Command(command)
+	if c != nil {
+		if c.BashComplete != nil {
+			c.BashComplete(ctx)
+		} else {
+			DefaultCompleteWithFlags(c)(ctx)
+		}
+	}
+}
+
+// printHelpCustom is the default implementation of HelpPrinterCustom.
+//
+// The customFuncs map will be combined with a default template.FuncMap to
+// allow using arbitrary functions in template rendering.
+func printHelpCustom(out io.Writer, templ string, data interface{}, customFuncs map[string]interface{}) {
+	const maxLineLength = 10000
+
+	funcMap := template.FuncMap{
+		"join":           strings.Join,
+		"subtract":       subtract,
+		"indent":         indent,
+		"nindent":        nindent,
+		"trim":           strings.TrimSpace,
+		"wrap":           func(input string, offset int) string { return wrap(input, offset, maxLineLength) },
+		"offset":         offset,
+		"offsetCommands": offsetCommands,
+	}
+
+	if customFuncs["wrapAt"] != nil {
+		if wa, ok := customFuncs["wrapAt"]; ok {
+			if waf, ok := wa.(func() int); ok {
+				wrapAt := waf()
+				customFuncs["wrap"] = func(input string, offset int) string {
+					return wrap(input, offset, wrapAt)
+				}
+			}
+		}
+	}
+
+	for key, value := range customFuncs {
+		funcMap[key] = value
+	}
+
+	w := tabwriter.NewWriter(out, 1, 8, 2, ' ', 0)
+	t := template.Must(template.New("help").Funcs(funcMap).Parse(templ))
+	templates := map[string]string{
+		"helpNameTemplate":                  helpNameTemplate,
+		"usageTemplate":                     usageTemplate,
+		"descriptionTemplate":               descriptionTemplate,
+		"visibleCommandTemplate":            visibleCommandTemplate,
+		"copyrightTemplate":                 copyrightTemplate,
+		"versionTemplate":                   versionTemplate,
+		"visibleFlagCategoryTemplate":       visibleFlagCategoryTemplate,
+		"visibleFlagTemplate":               visibleFlagTemplate,
+		"visibleGlobalFlagCategoryTemplate": strings.Replace(visibleFlagCategoryTemplate, "OPTIONS", "GLOBAL OPTIONS", -1),
+		"authorsTemplate":                   authorsTemplate,
+		"visibleCommandCategoryTemplate":    visibleCommandCategoryTemplate,
+	}
+	for name, value := range templates {
+		if _, err := t.New(name).Parse(value); err != nil {
+			if os.Getenv("CLI_TEMPLATE_ERROR_DEBUG") != "" {
+				_, _ = fmt.Fprintf(ErrWriter, "CLI TEMPLATE ERROR: %#v\n", err)
+			}
+		}
+	}
+
+	err := t.Execute(w, data)
+	if err != nil {
+		// If the writer is closed, t.Execute will fail, and there's nothing
+		// we can do to recover.
+		if os.Getenv("CLI_TEMPLATE_ERROR_DEBUG") != "" {
+			_, _ = fmt.Fprintf(ErrWriter, "CLI TEMPLATE ERROR: %#v\n", err)
+		}
+		return
+	}
+	_ = w.Flush()
+}
+
+func printHelp(out io.Writer, templ string, data interface{}) {
+	HelpPrinterCustom(out, templ, data, nil)
+}
+
+func checkVersion(cCtx *Context) bool {
+	found := false
+	for _, name := range VersionFlag.Names() {
+		if cCtx.Bool(name) {
+			found = true
+		}
+	}
+	return found
+}
+
+func checkHelp(cCtx *Context) bool {
+	if HelpFlag == nil {
+		return false
+	}
+	found := false
+	for _, name := range HelpFlag.Names() {
+		if cCtx.Bool(name) {
+			found = true
+			break
+		}
+	}
+
+	return found
+}
+
+func checkShellCompleteFlag(a *App, arguments []string) (bool, []string) {
+	if !a.EnableBashCompletion {
+		return false, arguments
+	}
+
+	pos := len(arguments) - 1
+	lastArg := arguments[pos]
+
+	if lastArg != "--generate-bash-completion" {
+		return false, arguments
+	}
+
+	for _, arg := range arguments {
+		// If arguments include "--", shell completion is disabled
+		// because after "--" only positional arguments are accepted.
+		// https://unix.stackexchange.com/a/11382
+		if arg == "--" {
+			return false, arguments
+		}
+	}
+
+	return true, arguments[:pos]
+}
+
+func checkCompletions(cCtx *Context) bool {
+	if !cCtx.shellComplete {
+		return false
+	}
+
+	if args := cCtx.Args(); args.Present() {
+		name := args.First()
+		if cmd := cCtx.Command.Command(name); cmd != nil {
+			// let the command handle the completion
+			return false
+		}
+	}
+
+	ShowCompletions(cCtx)
+	return true
+}
+
+func subtract(a, b int) int {
+	return a - b
+}
+
+func indent(spaces int, v string) string {
+	pad := strings.Repeat(" ", spaces)
+	return pad + strings.Replace(v, "\n", "\n"+pad, -1)
+}
+
+func nindent(spaces int, v string) string {
+	return "\n" + indent(spaces, v)
+}
+
+func wrap(input string, offset int, wrapAt int) string {
+	var ss []string
+
+	lines := strings.Split(input, "\n")
+
+	padding := strings.Repeat(" ", offset)
+
+	for i, line := range lines {
+		if line == "" {
+			ss = append(ss, line)
+		} else {
+			wrapped := wrapLine(line, offset, wrapAt, padding)
+			if i == 0 {
+				ss = append(ss, wrapped)
+			} else {
+				ss = append(ss, padding+wrapped)
+			}
+
+		}
+	}
+
+	return strings.Join(ss, "\n")
+}
+
+func wrapLine(input string, offset int, wrapAt int, padding string) string {
+	if wrapAt <= offset || len(input) <= wrapAt-offset {
+		return input
+	}
+
+	lineWidth := wrapAt - offset
+	words := strings.Fields(input)
+	if len(words) == 0 {
+		return input
+	}
+
+	wrapped := words[0]
+	spaceLeft := lineWidth - len(wrapped)
+	for _, word := range words[1:] {
+		if len(word)+1 > spaceLeft {
+			wrapped += "\n" + padding + word
+			spaceLeft = lineWidth - len(word)
+		} else {
+			wrapped += " " + word
+			spaceLeft -= 1 + len(word)
+		}
+	}
+
+	return wrapped
+}
+
+func offset(input string, fixed int) int {
+	return len(input) + fixed
+}
+
+// this function tries to find the max width of the names column
+// so say we have the following rows for help
+//
+//	foo1, foo2, foo3  some string here
+//	bar1, b2 some other string here
+//
+// We want to offset the 2nd row usage by some amount so that everything
+// is aligned
+//
+//	foo1, foo2, foo3  some string here
+//	bar1, b2          some other string here
+//
+// to find that offset we find the length of all the rows and use the max
+// to calculate the offset
+func offsetCommands(cmds []*Command, fixed int) int {
+	var max int = 0
+	for _, cmd := range cmds {
+		s := strings.Join(cmd.Names(), ", ")
+		if len(s) > max {
+			max = len(s)
+		}
+	}
+	return max + fixed
+}

--- a/vendor/github.com/urfave/cli/v2/mkdocs-reqs.txt
+++ b/vendor/github.com/urfave/cli/v2/mkdocs-reqs.txt
@@ -1,0 +1,5 @@
+mkdocs-git-revision-date-localized-plugin~=1.0
+mkdocs-material-extensions~=1.0
+mkdocs-material~=8.2
+mkdocs~=1.3
+pygments~=2.12

--- a/vendor/github.com/urfave/cli/v2/mkdocs.yml
+++ b/vendor/github.com/urfave/cli/v2/mkdocs.yml
@@ -1,0 +1,107 @@
+# NOTE: the mkdocs dependencies will need to be installed out of
+# band until this whole thing gets more automated:
+#
+#     pip install -r mkdocs-reqs.txt
+#
+
+site_name: urfave/cli
+site_url: https://cli.urfave.org/
+repo_url: https://github.com/urfave/cli
+edit_uri: edit/main/docs/
+nav:
+  - Home:
+      - Welcome: index.md
+      - Contributing: CONTRIBUTING.md
+      - Code of Conduct: CODE_OF_CONDUCT.md
+      - Releasing: RELEASING.md
+      - Security: SECURITY.md
+      - Migrate v1 to v2: migrate-v1-to-v2.md
+  - v2 Manual:
+      - Getting Started: v2/getting-started.md
+      - Migrating From Older Releases: v2/migrating-from-older-releases.md
+      - Examples:
+          - Greet: v2/examples/greet.md
+          - Arguments: v2/examples/arguments.md
+          - Flags: v2/examples/flags.md
+          - Subcommands: v2/examples/subcommands.md
+          - Subcommands Categories: v2/examples/subcommands-categories.md
+          - Exit Codes: v2/examples/exit-codes.md
+          - Combining Short Options: v2/examples/combining-short-options.md
+          - Bash Completions: v2/examples/bash-completions.md
+          - Generated Help Text: v2/examples/generated-help-text.md
+          - Version Flag: v2/examples/version-flag.md
+          - Timestamp Flag: v2/examples/timestamp-flag.md
+          - Suggestions: v2/examples/suggestions.md
+          - Full API Example: v2/examples/full-api-example.md
+  - v1 Manual:
+      - Getting Started: v1/getting-started.md
+      - Migrating to v2: v1/migrating-to-v2.md
+      - Examples:
+          - Greet: v1/examples/greet.md
+          - Arguments: v1/examples/arguments.md
+          - Flags: v1/examples/flags.md
+          - Subcommands: v1/examples/subcommands.md
+          - Subcommands (Categories): v1/examples/subcommands-categories.md
+          - Exit Codes: v1/examples/exit-codes.md
+          - Combining Short Options: v1/examples/combining-short-options.md
+          - Bash Completions: v1/examples/bash-completions.md
+          - Generated Help Text: v1/examples/generated-help-text.md
+          - Version Flag: v1/examples/version-flag.md
+
+theme:
+  name: material
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      toggle:
+        icon: material/brightness-4
+        name: dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      toggle:
+        icon: material/brightness-7
+        name: light mode
+  features:
+    - content.code.annotate
+    - navigation.top
+    - navigation.instant
+    - navigation.expand
+    - navigation.sections
+    - navigation.tabs
+    - navigation.tabs.sticky
+plugins:
+  - git-revision-date-localized
+  - search
+  - tags
+# NOTE: this is the recommended configuration from
+# https://squidfunk.github.io/mkdocs-material/setup/extensions/#recommended-configuration
+markdown_extensions:
+  - abbr
+  - admonition
+  - attr_list
+  - def_list
+  - footnotes
+  - meta
+  - md_in_html
+  - toc:
+      permalink: true
+  - pymdownx.arithmatex:
+      generic: true
+  - pymdownx.betterem:
+      smart_enable: all
+  - pymdownx.caret
+  - pymdownx.details
+  - pymdownx.emoji:
+      emoji_index: !!python/name:materialx.emoji.twemoji
+      emoji_generator: !!python/name:materialx.emoji.to_svg
+  - pymdownx.highlight
+  - pymdownx.inlinehilite
+  - pymdownx.keys
+  - pymdownx.mark
+  - pymdownx.smartsymbols
+  - pymdownx.superfences
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.tasklist:
+      custom_checkbox: true
+  - pymdownx.tilde

--- a/vendor/github.com/urfave/cli/v2/parse.go
+++ b/vendor/github.com/urfave/cli/v2/parse.go
@@ -1,0 +1,102 @@
+package cli
+
+import (
+	"flag"
+	"strings"
+)
+
+type iterativeParser interface {
+	newFlagSet() (*flag.FlagSet, error)
+	useShortOptionHandling() bool
+}
+
+// To enable short-option handling (e.g., "-it" vs "-i -t") we have to
+// iteratively catch parsing errors. This way we achieve LR parsing without
+// transforming any arguments. Otherwise, there is no way we can discriminate
+// combined short options from common arguments that should be left untouched.
+// Pass `shellComplete` to continue parsing options on failure during shell
+// completion when, the user-supplied options may be incomplete.
+func parseIter(set *flag.FlagSet, ip iterativeParser, args []string, shellComplete bool) error {
+	for {
+		err := set.Parse(args)
+		if !ip.useShortOptionHandling() || err == nil {
+			if shellComplete {
+				return nil
+			}
+			return err
+		}
+
+		trimmed, trimErr := flagFromError(err)
+		if trimErr != nil {
+			return err
+		}
+
+		// regenerate the initial args with the split short opts
+		argsWereSplit := false
+		for i, arg := range args {
+			// skip args that are not part of the error message
+			if name := strings.TrimLeft(arg, "-"); name != trimmed {
+				continue
+			}
+
+			// if we can't split, the error was accurate
+			shortOpts := splitShortOptions(set, arg)
+			if len(shortOpts) == 1 {
+				return err
+			}
+
+			// swap current argument with the split version
+			// do not include args that parsed correctly so far as it would
+			// trigger Value.Set() on those args and would result in
+			// duplicates for slice type flags
+			args = append(shortOpts, args[i+1:]...)
+			argsWereSplit = true
+			break
+		}
+
+		// This should be an impossible to reach code path, but in case the arg
+		// splitting failed to happen, this will prevent infinite loops
+		if !argsWereSplit {
+			return err
+		}
+	}
+}
+
+const providedButNotDefinedErrMsg = "flag provided but not defined: -"
+
+// flagFromError tries to parse a provided flag from an error message. If the
+// parsing fials, it returns the input error and an empty string
+func flagFromError(err error) (string, error) {
+	errStr := err.Error()
+	trimmed := strings.TrimPrefix(errStr, providedButNotDefinedErrMsg)
+	if errStr == trimmed {
+		return "", err
+	}
+	return trimmed, nil
+}
+
+func splitShortOptions(set *flag.FlagSet, arg string) []string {
+	shortFlagsExist := func(s string) bool {
+		for _, c := range s[1:] {
+			if f := set.Lookup(string(c)); f == nil {
+				return false
+			}
+		}
+		return true
+	}
+
+	if !isSplittable(arg) || !shortFlagsExist(arg) {
+		return []string{arg}
+	}
+
+	separated := make([]string, 0, len(arg)-1)
+	for _, flagChar := range arg[1:] {
+		separated = append(separated, "-"+string(flagChar))
+	}
+
+	return separated
+}
+
+func isSplittable(flagArg string) bool {
+	return strings.HasPrefix(flagArg, "-") && !strings.HasPrefix(flagArg, "--") && len(flagArg) > 2
+}

--- a/vendor/github.com/urfave/cli/v2/sliceflag.go
+++ b/vendor/github.com/urfave/cli/v2/sliceflag.go
@@ -1,0 +1,290 @@
+package cli
+
+import (
+	"flag"
+	"reflect"
+)
+
+type (
+	// SliceFlag extends implementations like StringSliceFlag and IntSliceFlag with support for using slices directly,
+	// as Value and/or Destination.
+	// See also SliceFlagTarget, MultiStringFlag, MultiFloat64Flag, MultiInt64Flag, MultiIntFlag.
+	SliceFlag[T SliceFlagTarget[E], S ~[]E, E any] struct {
+		Target      T
+		Value       S
+		Destination *S
+	}
+
+	// SliceFlagTarget models a target implementation for use with SliceFlag.
+	// The three methods, SetValue, SetDestination, and GetDestination, are necessary to propagate Value and
+	// Destination, where Value is propagated inwards (initially), and Destination is propagated outwards (on every
+	// update).
+	SliceFlagTarget[E any] interface {
+		Flag
+		RequiredFlag
+		DocGenerationFlag
+		VisibleFlag
+		CategorizableFlag
+
+		// SetValue should propagate the given slice to the target, ideally as a new value.
+		// Note that a nil slice should nil/clear any existing value (modelled as ~[]E).
+		SetValue(slice []E)
+		// SetDestination should propagate the given slice to the target, ideally as a new value.
+		// Note that a nil slice should nil/clear any existing value (modelled as ~*[]E).
+		SetDestination(slice []E)
+		// GetDestination should return the current value referenced by any destination, or nil if nil/unset.
+		GetDestination() []E
+	}
+
+	// MultiStringFlag extends StringSliceFlag with support for using slices directly, as Value and/or Destination.
+	// See also SliceFlag.
+	MultiStringFlag = SliceFlag[*StringSliceFlag, []string, string]
+
+	// MultiFloat64Flag extends Float64SliceFlag with support for using slices directly, as Value and/or Destination.
+	// See also SliceFlag.
+	MultiFloat64Flag = SliceFlag[*Float64SliceFlag, []float64, float64]
+
+	// MultiInt64Flag extends Int64SliceFlag with support for using slices directly, as Value and/or Destination.
+	// See also SliceFlag.
+	MultiInt64Flag = SliceFlag[*Int64SliceFlag, []int64, int64]
+
+	// MultiIntFlag extends IntSliceFlag with support for using slices directly, as Value and/or Destination.
+	// See also SliceFlag.
+	MultiIntFlag = SliceFlag[*IntSliceFlag, []int, int]
+
+	flagValueHook struct {
+		value Generic
+		hook  func()
+	}
+)
+
+var (
+	// compile time assertions
+
+	_ SliceFlagTarget[string]  = (*StringSliceFlag)(nil)
+	_ SliceFlagTarget[string]  = (*SliceFlag[*StringSliceFlag, []string, string])(nil)
+	_ SliceFlagTarget[string]  = (*MultiStringFlag)(nil)
+	_ SliceFlagTarget[float64] = (*MultiFloat64Flag)(nil)
+	_ SliceFlagTarget[int64]   = (*MultiInt64Flag)(nil)
+	_ SliceFlagTarget[int]     = (*MultiIntFlag)(nil)
+
+	_ Generic    = (*flagValueHook)(nil)
+	_ Serializer = (*flagValueHook)(nil)
+)
+
+func (x *SliceFlag[T, S, E]) Apply(set *flag.FlagSet) error {
+	x.Target.SetValue(x.convertSlice(x.Value))
+
+	destination := x.Destination
+	if destination == nil {
+		x.Target.SetDestination(nil)
+
+		return x.Target.Apply(set)
+	}
+
+	x.Target.SetDestination(x.convertSlice(*destination))
+
+	return applyFlagValueHook(set, x.Target.Apply, func() {
+		*destination = x.Target.GetDestination()
+	})
+}
+
+func (x *SliceFlag[T, S, E]) convertSlice(slice S) []E {
+	result := make([]E, len(slice))
+	copy(result, slice)
+	return result
+}
+
+func (x *SliceFlag[T, S, E]) SetValue(slice S) {
+	x.Value = slice
+}
+
+func (x *SliceFlag[T, S, E]) SetDestination(slice S) {
+	if slice != nil {
+		x.Destination = &slice
+	} else {
+		x.Destination = nil
+	}
+}
+
+func (x *SliceFlag[T, S, E]) GetDestination() S {
+	if destination := x.Destination; destination != nil {
+		return *destination
+	}
+	return nil
+}
+
+func (x *SliceFlag[T, S, E]) String() string         { return x.Target.String() }
+func (x *SliceFlag[T, S, E]) Names() []string        { return x.Target.Names() }
+func (x *SliceFlag[T, S, E]) IsSet() bool            { return x.Target.IsSet() }
+func (x *SliceFlag[T, S, E]) IsRequired() bool       { return x.Target.IsRequired() }
+func (x *SliceFlag[T, S, E]) TakesValue() bool       { return x.Target.TakesValue() }
+func (x *SliceFlag[T, S, E]) GetUsage() string       { return x.Target.GetUsage() }
+func (x *SliceFlag[T, S, E]) GetValue() string       { return x.Target.GetValue() }
+func (x *SliceFlag[T, S, E]) GetDefaultText() string { return x.Target.GetDefaultText() }
+func (x *SliceFlag[T, S, E]) GetEnvVars() []string   { return x.Target.GetEnvVars() }
+func (x *SliceFlag[T, S, E]) IsVisible() bool        { return x.Target.IsVisible() }
+func (x *SliceFlag[T, S, E]) GetCategory() string    { return x.Target.GetCategory() }
+
+func (x *flagValueHook) Set(value string) error {
+	if err := x.value.Set(value); err != nil {
+		return err
+	}
+	x.hook()
+	return nil
+}
+
+func (x *flagValueHook) String() string {
+	// note: this is necessary due to the way Go's flag package handles defaults
+	isZeroValue := func(f flag.Value, v string) bool {
+		/*
+			https://cs.opensource.google/go/go/+/refs/tags/go1.18.3:src/flag/flag.go;drc=2580d0e08d5e9f979b943758d3c49877fb2324cb;l=453
+
+			Copyright (c) 2009 The Go Authors. All rights reserved.
+			Redistribution and use in source and binary forms, with or without
+			modification, are permitted provided that the following conditions are
+			met:
+			   * Redistributions of source code must retain the above copyright
+			notice, this list of conditions and the following disclaimer.
+			   * Redistributions in binary form must reproduce the above
+			copyright notice, this list of conditions and the following disclaimer
+			in the documentation and/or other materials provided with the
+			distribution.
+			   * Neither the name of Google Inc. nor the names of its
+			contributors may be used to endorse or promote products derived from
+			this software without specific prior written permission.
+			THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+			"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+			LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+			A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+			OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+			SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+			LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+			DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+			THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+			(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+			OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+		*/
+		// Build a zero value of the flag's Value type, and see if the
+		// result of calling its String method equals the value passed in.
+		// This works unless the Value type is itself an interface type.
+		typ := reflect.TypeOf(f)
+		var z reflect.Value
+		if typ.Kind() == reflect.Pointer {
+			z = reflect.New(typ.Elem())
+		} else {
+			z = reflect.Zero(typ)
+		}
+		return v == z.Interface().(flag.Value).String()
+	}
+	if x.value != nil {
+		// only return non-empty if not the same string as returned by the zero value
+		if s := x.value.String(); !isZeroValue(x.value, s) {
+			return s
+		}
+	}
+	return ``
+}
+
+func (x *flagValueHook) Serialize() string {
+	if value, ok := x.value.(Serializer); ok {
+		return value.Serialize()
+	}
+	return x.String()
+}
+
+// applyFlagValueHook wraps calls apply then wraps flags to call a hook function on update and after initial apply.
+func applyFlagValueHook(set *flag.FlagSet, apply func(set *flag.FlagSet) error, hook func()) error {
+	if apply == nil || set == nil || hook == nil {
+		panic(`invalid input`)
+	}
+	var tmp flag.FlagSet
+	if err := apply(&tmp); err != nil {
+		return err
+	}
+	tmp.VisitAll(func(f *flag.Flag) { set.Var(&flagValueHook{value: f.Value, hook: hook}, f.Name, f.Usage) })
+	hook()
+	return nil
+}
+
+// newSliceFlagValue is for implementing SliceFlagTarget.SetValue and SliceFlagTarget.SetDestination.
+// It's e.g. as part of StringSliceFlag.SetValue, using the factory NewStringSlice.
+func newSliceFlagValue[R any, S ~[]E, E any](factory func(defaults ...E) *R, defaults S) *R {
+	if defaults == nil {
+		return nil
+	}
+	return factory(defaults...)
+}
+
+// unwrapFlagValue strips any/all *flagValueHook wrappers.
+func unwrapFlagValue(v flag.Value) flag.Value {
+	for {
+		h, ok := v.(*flagValueHook)
+		if !ok {
+			return v
+		}
+		v = h.value
+	}
+}
+
+// NOTE: the methods below are in this file to make use of the build constraint
+
+func (f *Float64SliceFlag) SetValue(slice []float64) {
+	f.Value = newSliceFlagValue(NewFloat64Slice, slice)
+}
+
+func (f *Float64SliceFlag) SetDestination(slice []float64) {
+	f.Destination = newSliceFlagValue(NewFloat64Slice, slice)
+}
+
+func (f *Float64SliceFlag) GetDestination() []float64 {
+	if destination := f.Destination; destination != nil {
+		return destination.Value()
+	}
+	return nil
+}
+
+func (f *Int64SliceFlag) SetValue(slice []int64) {
+	f.Value = newSliceFlagValue(NewInt64Slice, slice)
+}
+
+func (f *Int64SliceFlag) SetDestination(slice []int64) {
+	f.Destination = newSliceFlagValue(NewInt64Slice, slice)
+}
+
+func (f *Int64SliceFlag) GetDestination() []int64 {
+	if destination := f.Destination; destination != nil {
+		return destination.Value()
+	}
+	return nil
+}
+
+func (f *IntSliceFlag) SetValue(slice []int) {
+	f.Value = newSliceFlagValue(NewIntSlice, slice)
+}
+
+func (f *IntSliceFlag) SetDestination(slice []int) {
+	f.Destination = newSliceFlagValue(NewIntSlice, slice)
+}
+
+func (f *IntSliceFlag) GetDestination() []int {
+	if destination := f.Destination; destination != nil {
+		return destination.Value()
+	}
+	return nil
+}
+
+func (f *StringSliceFlag) SetValue(slice []string) {
+	f.Value = newSliceFlagValue(NewStringSlice, slice)
+}
+
+func (f *StringSliceFlag) SetDestination(slice []string) {
+	f.Destination = newSliceFlagValue(NewStringSlice, slice)
+}
+
+func (f *StringSliceFlag) GetDestination() []string {
+	if destination := f.Destination; destination != nil {
+		return destination.Value()
+	}
+	return nil
+}

--- a/vendor/github.com/urfave/cli/v2/sort.go
+++ b/vendor/github.com/urfave/cli/v2/sort.go
@@ -1,0 +1,29 @@
+package cli
+
+import "unicode"
+
+// lexicographicLess compares strings alphabetically considering case.
+func lexicographicLess(i, j string) bool {
+	iRunes := []rune(i)
+	jRunes := []rune(j)
+
+	lenShared := len(iRunes)
+	if lenShared > len(jRunes) {
+		lenShared = len(jRunes)
+	}
+
+	for index := 0; index < lenShared; index++ {
+		ir := iRunes[index]
+		jr := jRunes[index]
+
+		if lir, ljr := unicode.ToLower(ir), unicode.ToLower(jr); lir != ljr {
+			return lir < ljr
+		}
+
+		if ir != jr {
+			return ir < jr
+		}
+	}
+
+	return i < j
+}

--- a/vendor/github.com/urfave/cli/v2/suggestions.go
+++ b/vendor/github.com/urfave/cli/v2/suggestions.go
@@ -1,0 +1,68 @@
+//go:build !urfave_cli_no_suggest
+// +build !urfave_cli_no_suggest
+
+package cli
+
+import (
+	"fmt"
+
+	"github.com/xrash/smetrics"
+)
+
+func init() {
+	SuggestFlag = suggestFlag
+	SuggestCommand = suggestCommand
+}
+
+func jaroWinkler(a, b string) float64 {
+	// magic values are from https://github.com/xrash/smetrics/blob/039620a656736e6ad994090895784a7af15e0b80/jaro-winkler.go#L8
+	const (
+		boostThreshold = 0.7
+		prefixSize     = 4
+	)
+	return smetrics.JaroWinkler(a, b, boostThreshold, prefixSize)
+}
+
+func suggestFlag(flags []Flag, provided string, hideHelp bool) string {
+	distance := 0.0
+	suggestion := ""
+
+	for _, flag := range flags {
+		flagNames := flag.Names()
+		if !hideHelp && HelpFlag != nil {
+			flagNames = append(flagNames, HelpFlag.Names()...)
+		}
+		for _, name := range flagNames {
+			newDistance := jaroWinkler(name, provided)
+			if newDistance > distance {
+				distance = newDistance
+				suggestion = name
+			}
+		}
+	}
+
+	if len(suggestion) == 1 {
+		suggestion = "-" + suggestion
+	} else if len(suggestion) > 1 {
+		suggestion = "--" + suggestion
+	}
+
+	return suggestion
+}
+
+// suggestCommand takes a list of commands and a provided string to suggest a
+// command name
+func suggestCommand(commands []*Command, provided string) (suggestion string) {
+	distance := 0.0
+	for _, command := range commands {
+		for _, name := range append(command.Names(), helpName, helpAlias) {
+			newDistance := jaroWinkler(name, provided)
+			if newDistance > distance {
+				distance = newDistance
+				suggestion = name
+			}
+		}
+	}
+
+	return fmt.Sprintf(SuggestDidYouMeanTemplate, suggestion)
+}

--- a/vendor/github.com/urfave/cli/v2/template.go
+++ b/vendor/github.com/urfave/cli/v2/template.go
@@ -1,0 +1,143 @@
+package cli
+
+var helpNameTemplate = `{{$v := offset .HelpName 6}}{{wrap .HelpName 3}}{{if .Usage}} - {{wrap .Usage $v}}{{end}}`
+var usageTemplate = `{{if .UsageText}}{{wrap .UsageText 3}}{{else}}{{.HelpName}}{{if .VisibleFlags}} [command options]{{end}}{{if .ArgsUsage}} {{.ArgsUsage}}{{else}}{{if .Args}} [arguments...]{{end}}{{end}}{{end}}`
+var descriptionTemplate = `{{wrap .Description 3}}`
+var authorsTemplate = `{{with $length := len .Authors}}{{if ne 1 $length}}S{{end}}{{end}}:
+   {{range $index, $author := .Authors}}{{if $index}}
+   {{end}}{{$author}}{{end}}`
+var visibleCommandTemplate = `{{ $cv := offsetCommands .VisibleCommands 5}}{{range .VisibleCommands}}
+   {{$s := join .Names ", "}}{{$s}}{{ $sp := subtract $cv (offset $s 3) }}{{ indent $sp ""}}{{wrap .Usage $cv}}{{end}}`
+var visibleCommandCategoryTemplate = `{{range .VisibleCategories}}{{if .Name}}
+   {{.Name}}:{{range .VisibleCommands}}
+     {{join .Names ", "}}{{"\t"}}{{.Usage}}{{end}}{{else}}{{template "visibleCommandTemplate" .}}{{end}}{{end}}`
+var visibleFlagCategoryTemplate = `{{range .VisibleFlagCategories}}
+   {{if .Name}}{{.Name}}
+
+   {{end}}{{$flglen := len .Flags}}{{range $i, $e := .Flags}}{{if eq (subtract $flglen $i) 1}}{{$e}}
+{{else}}{{$e}}
+   {{end}}{{end}}{{end}}`
+
+var visibleFlagTemplate = `{{range $i, $e := .VisibleFlags}}
+   {{wrap $e.String 6}}{{end}}`
+
+var versionTemplate = `{{if .Version}}{{if not .HideVersion}}
+
+VERSION:
+   {{.Version}}{{end}}{{end}}`
+
+var copyrightTemplate = `{{wrap .Copyright 3}}`
+
+// AppHelpTemplate is the text template for the Default help topic.
+// cli.go uses text/template to render templates. You can
+// render custom help text by setting this variable.
+var AppHelpTemplate = `NAME:
+   {{template "helpNameTemplate" .}}
+
+USAGE:
+   {{if .UsageText}}{{wrap .UsageText 3}}{{else}}{{.HelpName}} {{if .VisibleFlags}}[global options]{{end}}{{if .Commands}} command [command options]{{end}}{{if .ArgsUsage}} {{.ArgsUsage}}{{else}}{{if .Args}} [arguments...]{{end}}{{end}}{{end}}{{if .Version}}{{if not .HideVersion}}
+
+VERSION:
+   {{.Version}}{{end}}{{end}}{{if .Description}}
+
+DESCRIPTION:
+   {{template "descriptionTemplate" .}}{{end}}
+{{- if len .Authors}}
+
+AUTHOR{{template "authorsTemplate" .}}{{end}}{{if .VisibleCommands}}
+
+COMMANDS:{{template "visibleCommandCategoryTemplate" .}}{{end}}{{if .VisibleFlagCategories}}
+
+GLOBAL OPTIONS:{{template "visibleFlagCategoryTemplate" .}}{{else if .VisibleFlags}}
+
+GLOBAL OPTIONS:{{template "visibleFlagTemplate" .}}{{end}}{{if .Copyright}}
+
+COPYRIGHT:
+   {{template "copyrightTemplate" .}}{{end}}
+`
+
+// CommandHelpTemplate is the text template for the command help topic.
+// cli.go uses text/template to render templates. You can
+// render custom help text by setting this variable.
+var CommandHelpTemplate = `NAME:
+   {{template "helpNameTemplate" .}}
+
+USAGE:
+   {{template "usageTemplate" .}}{{if .Category}}
+
+CATEGORY:
+   {{.Category}}{{end}}{{if .Description}}
+
+DESCRIPTION:
+   {{template "descriptionTemplate" .}}{{end}}{{if .VisibleFlagCategories}}
+
+OPTIONS:{{template "visibleFlagCategoryTemplate" .}}{{else if .VisibleFlags}}
+
+OPTIONS:{{template "visibleFlagTemplate" .}}{{end}}
+`
+
+// SubcommandHelpTemplate is the text template for the subcommand help topic.
+// cli.go uses text/template to render templates. You can
+// render custom help text by setting this variable.
+var SubcommandHelpTemplate = `NAME:
+   {{template "helpNameTemplate" .}}
+
+USAGE:
+   {{if .UsageText}}{{wrap .UsageText 3}}{{else}}{{.HelpName}} {{if .VisibleFlags}}command [command options]{{end}}{{if .ArgsUsage}} {{.ArgsUsage}}{{else}}{{if .Args}} [arguments...]{{end}}{{end}}{{end}}{{if .Description}}
+
+DESCRIPTION:
+   {{template "descriptionTemplate" .}}{{end}}{{if .VisibleCommands}}
+
+COMMANDS:{{template "visibleCommandCategoryTemplate" .}}{{end}}{{if .VisibleFlagCategories}}
+
+OPTIONS:{{template "visibleFlagCategoryTemplate" .}}{{else if .VisibleFlags}}
+
+OPTIONS:{{template "visibleFlagTemplate" .}}{{end}}
+`
+
+var MarkdownDocTemplate = `{{if gt .SectionNum 0}}% {{ .App.Name }} {{ .SectionNum }}
+
+{{end}}# NAME
+
+{{ .App.Name }}{{ if .App.Usage }} - {{ .App.Usage }}{{ end }}
+
+# SYNOPSIS
+
+{{ .App.Name }}
+{{ if .SynopsisArgs }}
+` + "```" + `
+{{ range $v := .SynopsisArgs }}{{ $v }}{{ end }}` + "```" + `
+{{ end }}{{ if .App.Description }}
+# DESCRIPTION
+
+{{ .App.Description }}
+{{ end }}
+**Usage**:
+
+` + "```" + `{{ if .App.UsageText }}
+{{ .App.UsageText }}
+{{ else }}
+{{ .App.Name }} [GLOBAL OPTIONS] command [COMMAND OPTIONS] [ARGUMENTS...]
+{{ end }}` + "```" + `
+{{ if .GlobalArgs }}
+# GLOBAL OPTIONS
+{{ range $v := .GlobalArgs }}
+{{ $v }}{{ end }}
+{{ end }}{{ if .Commands }}
+# COMMANDS
+{{ range $v := .Commands }}
+{{ $v }}{{ end }}{{ end }}`
+
+var FishCompletionTemplate = `# {{ .App.Name }} fish shell completion
+
+function __fish_{{ .App.Name }}_no_subcommand --description 'Test if there has been any subcommand yet'
+    for i in (commandline -opc)
+        if contains -- $i{{ range $v := .AllCommands }} {{ $v }}{{ end }}
+            return 1
+        end
+    end
+    return 0
+end
+
+{{ range $v := .Completions }}{{ $v }}
+{{ end }}`

--- a/vendor/github.com/urfave/cli/v2/zz_generated.flags.go
+++ b/vendor/github.com/urfave/cli/v2/zz_generated.flags.go
@@ -1,0 +1,865 @@
+// WARNING: this file is generated. DO NOT EDIT
+
+package cli
+
+import "time"
+
+// Float64SliceFlag is a flag with type *Float64Slice
+type Float64SliceFlag struct {
+	Name string
+
+	Category    string
+	DefaultText string
+	FilePath    string
+	Usage       string
+
+	Required   bool
+	Hidden     bool
+	HasBeenSet bool
+
+	Value       *Float64Slice
+	Destination *Float64Slice
+
+	Aliases []string
+	EnvVars []string
+
+	defaultValue    *Float64Slice
+	defaultValueSet bool
+
+	separator separatorSpec
+
+	Action func(*Context, []float64) error
+}
+
+// IsSet returns whether or not the flag has been set through env or file
+func (f *Float64SliceFlag) IsSet() bool {
+	return f.HasBeenSet
+}
+
+// Names returns the names of the flag
+func (f *Float64SliceFlag) Names() []string {
+	return FlagNames(f.Name, f.Aliases)
+}
+
+// IsRequired returns whether or not the flag is required
+func (f *Float64SliceFlag) IsRequired() bool {
+	return f.Required
+}
+
+// IsVisible returns true if the flag is not hidden, otherwise false
+func (f *Float64SliceFlag) IsVisible() bool {
+	return !f.Hidden
+}
+
+// GenericFlag is a flag with type Generic
+type GenericFlag struct {
+	Name string
+
+	Category    string
+	DefaultText string
+	FilePath    string
+	Usage       string
+
+	Required   bool
+	Hidden     bool
+	HasBeenSet bool
+
+	Value       Generic
+	Destination Generic
+
+	Aliases []string
+	EnvVars []string
+
+	defaultValue    Generic
+	defaultValueSet bool
+
+	TakesFile bool
+
+	Action func(*Context, interface{}) error
+}
+
+// String returns a readable representation of this value (for usage defaults)
+func (f *GenericFlag) String() string {
+	return FlagStringer(f)
+}
+
+// IsSet returns whether or not the flag has been set through env or file
+func (f *GenericFlag) IsSet() bool {
+	return f.HasBeenSet
+}
+
+// Names returns the names of the flag
+func (f *GenericFlag) Names() []string {
+	return FlagNames(f.Name, f.Aliases)
+}
+
+// IsRequired returns whether or not the flag is required
+func (f *GenericFlag) IsRequired() bool {
+	return f.Required
+}
+
+// IsVisible returns true if the flag is not hidden, otherwise false
+func (f *GenericFlag) IsVisible() bool {
+	return !f.Hidden
+}
+
+// Int64SliceFlag is a flag with type *Int64Slice
+type Int64SliceFlag struct {
+	Name string
+
+	Category    string
+	DefaultText string
+	FilePath    string
+	Usage       string
+
+	Required   bool
+	Hidden     bool
+	HasBeenSet bool
+
+	Value       *Int64Slice
+	Destination *Int64Slice
+
+	Aliases []string
+	EnvVars []string
+
+	defaultValue    *Int64Slice
+	defaultValueSet bool
+
+	separator separatorSpec
+
+	Action func(*Context, []int64) error
+}
+
+// IsSet returns whether or not the flag has been set through env or file
+func (f *Int64SliceFlag) IsSet() bool {
+	return f.HasBeenSet
+}
+
+// Names returns the names of the flag
+func (f *Int64SliceFlag) Names() []string {
+	return FlagNames(f.Name, f.Aliases)
+}
+
+// IsRequired returns whether or not the flag is required
+func (f *Int64SliceFlag) IsRequired() bool {
+	return f.Required
+}
+
+// IsVisible returns true if the flag is not hidden, otherwise false
+func (f *Int64SliceFlag) IsVisible() bool {
+	return !f.Hidden
+}
+
+// IntSliceFlag is a flag with type *IntSlice
+type IntSliceFlag struct {
+	Name string
+
+	Category    string
+	DefaultText string
+	FilePath    string
+	Usage       string
+
+	Required   bool
+	Hidden     bool
+	HasBeenSet bool
+
+	Value       *IntSlice
+	Destination *IntSlice
+
+	Aliases []string
+	EnvVars []string
+
+	defaultValue    *IntSlice
+	defaultValueSet bool
+
+	separator separatorSpec
+
+	Action func(*Context, []int) error
+}
+
+// IsSet returns whether or not the flag has been set through env or file
+func (f *IntSliceFlag) IsSet() bool {
+	return f.HasBeenSet
+}
+
+// Names returns the names of the flag
+func (f *IntSliceFlag) Names() []string {
+	return FlagNames(f.Name, f.Aliases)
+}
+
+// IsRequired returns whether or not the flag is required
+func (f *IntSliceFlag) IsRequired() bool {
+	return f.Required
+}
+
+// IsVisible returns true if the flag is not hidden, otherwise false
+func (f *IntSliceFlag) IsVisible() bool {
+	return !f.Hidden
+}
+
+// PathFlag is a flag with type Path
+type PathFlag struct {
+	Name string
+
+	Category    string
+	DefaultText string
+	FilePath    string
+	Usage       string
+
+	Required   bool
+	Hidden     bool
+	HasBeenSet bool
+
+	Value       Path
+	Destination *Path
+
+	Aliases []string
+	EnvVars []string
+
+	defaultValue    Path
+	defaultValueSet bool
+
+	TakesFile bool
+
+	Action func(*Context, Path) error
+}
+
+// String returns a readable representation of this value (for usage defaults)
+func (f *PathFlag) String() string {
+	return FlagStringer(f)
+}
+
+// IsSet returns whether or not the flag has been set through env or file
+func (f *PathFlag) IsSet() bool {
+	return f.HasBeenSet
+}
+
+// Names returns the names of the flag
+func (f *PathFlag) Names() []string {
+	return FlagNames(f.Name, f.Aliases)
+}
+
+// IsRequired returns whether or not the flag is required
+func (f *PathFlag) IsRequired() bool {
+	return f.Required
+}
+
+// IsVisible returns true if the flag is not hidden, otherwise false
+func (f *PathFlag) IsVisible() bool {
+	return !f.Hidden
+}
+
+// StringSliceFlag is a flag with type *StringSlice
+type StringSliceFlag struct {
+	Name string
+
+	Category    string
+	DefaultText string
+	FilePath    string
+	Usage       string
+
+	Required   bool
+	Hidden     bool
+	HasBeenSet bool
+
+	Value       *StringSlice
+	Destination *StringSlice
+
+	Aliases []string
+	EnvVars []string
+
+	defaultValue    *StringSlice
+	defaultValueSet bool
+
+	separator separatorSpec
+
+	TakesFile bool
+
+	Action func(*Context, []string) error
+
+	KeepSpace bool
+}
+
+// IsSet returns whether or not the flag has been set through env or file
+func (f *StringSliceFlag) IsSet() bool {
+	return f.HasBeenSet
+}
+
+// Names returns the names of the flag
+func (f *StringSliceFlag) Names() []string {
+	return FlagNames(f.Name, f.Aliases)
+}
+
+// IsRequired returns whether or not the flag is required
+func (f *StringSliceFlag) IsRequired() bool {
+	return f.Required
+}
+
+// IsVisible returns true if the flag is not hidden, otherwise false
+func (f *StringSliceFlag) IsVisible() bool {
+	return !f.Hidden
+}
+
+// TimestampFlag is a flag with type *Timestamp
+type TimestampFlag struct {
+	Name string
+
+	Category    string
+	DefaultText string
+	FilePath    string
+	Usage       string
+
+	Required   bool
+	Hidden     bool
+	HasBeenSet bool
+
+	Value       *Timestamp
+	Destination *Timestamp
+
+	Aliases []string
+	EnvVars []string
+
+	defaultValue    *Timestamp
+	defaultValueSet bool
+
+	Layout string
+
+	Timezone *time.Location
+
+	Action func(*Context, *time.Time) error
+}
+
+// String returns a readable representation of this value (for usage defaults)
+func (f *TimestampFlag) String() string {
+	return FlagStringer(f)
+}
+
+// IsSet returns whether or not the flag has been set through env or file
+func (f *TimestampFlag) IsSet() bool {
+	return f.HasBeenSet
+}
+
+// Names returns the names of the flag
+func (f *TimestampFlag) Names() []string {
+	return FlagNames(f.Name, f.Aliases)
+}
+
+// IsRequired returns whether or not the flag is required
+func (f *TimestampFlag) IsRequired() bool {
+	return f.Required
+}
+
+// IsVisible returns true if the flag is not hidden, otherwise false
+func (f *TimestampFlag) IsVisible() bool {
+	return !f.Hidden
+}
+
+// Uint64SliceFlag is a flag with type *Uint64Slice
+type Uint64SliceFlag struct {
+	Name string
+
+	Category    string
+	DefaultText string
+	FilePath    string
+	Usage       string
+
+	Required   bool
+	Hidden     bool
+	HasBeenSet bool
+
+	Value       *Uint64Slice
+	Destination *Uint64Slice
+
+	Aliases []string
+	EnvVars []string
+
+	defaultValue    *Uint64Slice
+	defaultValueSet bool
+
+	separator separatorSpec
+
+	Action func(*Context, []uint64) error
+}
+
+// IsSet returns whether or not the flag has been set through env or file
+func (f *Uint64SliceFlag) IsSet() bool {
+	return f.HasBeenSet
+}
+
+// Names returns the names of the flag
+func (f *Uint64SliceFlag) Names() []string {
+	return FlagNames(f.Name, f.Aliases)
+}
+
+// IsRequired returns whether or not the flag is required
+func (f *Uint64SliceFlag) IsRequired() bool {
+	return f.Required
+}
+
+// IsVisible returns true if the flag is not hidden, otherwise false
+func (f *Uint64SliceFlag) IsVisible() bool {
+	return !f.Hidden
+}
+
+// UintSliceFlag is a flag with type *UintSlice
+type UintSliceFlag struct {
+	Name string
+
+	Category    string
+	DefaultText string
+	FilePath    string
+	Usage       string
+
+	Required   bool
+	Hidden     bool
+	HasBeenSet bool
+
+	Value       *UintSlice
+	Destination *UintSlice
+
+	Aliases []string
+	EnvVars []string
+
+	defaultValue    *UintSlice
+	defaultValueSet bool
+
+	separator separatorSpec
+
+	Action func(*Context, []uint) error
+}
+
+// IsSet returns whether or not the flag has been set through env or file
+func (f *UintSliceFlag) IsSet() bool {
+	return f.HasBeenSet
+}
+
+// Names returns the names of the flag
+func (f *UintSliceFlag) Names() []string {
+	return FlagNames(f.Name, f.Aliases)
+}
+
+// IsRequired returns whether or not the flag is required
+func (f *UintSliceFlag) IsRequired() bool {
+	return f.Required
+}
+
+// IsVisible returns true if the flag is not hidden, otherwise false
+func (f *UintSliceFlag) IsVisible() bool {
+	return !f.Hidden
+}
+
+// BoolFlag is a flag with type bool
+type BoolFlag struct {
+	Name string
+
+	Category    string
+	DefaultText string
+	FilePath    string
+	Usage       string
+
+	Required   bool
+	Hidden     bool
+	HasBeenSet bool
+
+	Value       bool
+	Destination *bool
+
+	Aliases []string
+	EnvVars []string
+
+	defaultValue    bool
+	defaultValueSet bool
+
+	Count *int
+
+	DisableDefaultText bool
+
+	Action func(*Context, bool) error
+}
+
+// String returns a readable representation of this value (for usage defaults)
+func (f *BoolFlag) String() string {
+	return FlagStringer(f)
+}
+
+// IsSet returns whether or not the flag has been set through env or file
+func (f *BoolFlag) IsSet() bool {
+	return f.HasBeenSet
+}
+
+// Names returns the names of the flag
+func (f *BoolFlag) Names() []string {
+	return FlagNames(f.Name, f.Aliases)
+}
+
+// IsRequired returns whether or not the flag is required
+func (f *BoolFlag) IsRequired() bool {
+	return f.Required
+}
+
+// IsVisible returns true if the flag is not hidden, otherwise false
+func (f *BoolFlag) IsVisible() bool {
+	return !f.Hidden
+}
+
+// Float64Flag is a flag with type float64
+type Float64Flag struct {
+	Name string
+
+	Category    string
+	DefaultText string
+	FilePath    string
+	Usage       string
+
+	Required   bool
+	Hidden     bool
+	HasBeenSet bool
+
+	Value       float64
+	Destination *float64
+
+	Aliases []string
+	EnvVars []string
+
+	defaultValue    float64
+	defaultValueSet bool
+
+	Action func(*Context, float64) error
+}
+
+// String returns a readable representation of this value (for usage defaults)
+func (f *Float64Flag) String() string {
+	return FlagStringer(f)
+}
+
+// IsSet returns whether or not the flag has been set through env or file
+func (f *Float64Flag) IsSet() bool {
+	return f.HasBeenSet
+}
+
+// Names returns the names of the flag
+func (f *Float64Flag) Names() []string {
+	return FlagNames(f.Name, f.Aliases)
+}
+
+// IsRequired returns whether or not the flag is required
+func (f *Float64Flag) IsRequired() bool {
+	return f.Required
+}
+
+// IsVisible returns true if the flag is not hidden, otherwise false
+func (f *Float64Flag) IsVisible() bool {
+	return !f.Hidden
+}
+
+// IntFlag is a flag with type int
+type IntFlag struct {
+	Name string
+
+	Category    string
+	DefaultText string
+	FilePath    string
+	Usage       string
+
+	Required   bool
+	Hidden     bool
+	HasBeenSet bool
+
+	Value       int
+	Destination *int
+
+	Aliases []string
+	EnvVars []string
+
+	defaultValue    int
+	defaultValueSet bool
+
+	Base int
+
+	Action func(*Context, int) error
+}
+
+// String returns a readable representation of this value (for usage defaults)
+func (f *IntFlag) String() string {
+	return FlagStringer(f)
+}
+
+// IsSet returns whether or not the flag has been set through env or file
+func (f *IntFlag) IsSet() bool {
+	return f.HasBeenSet
+}
+
+// Names returns the names of the flag
+func (f *IntFlag) Names() []string {
+	return FlagNames(f.Name, f.Aliases)
+}
+
+// IsRequired returns whether or not the flag is required
+func (f *IntFlag) IsRequired() bool {
+	return f.Required
+}
+
+// IsVisible returns true if the flag is not hidden, otherwise false
+func (f *IntFlag) IsVisible() bool {
+	return !f.Hidden
+}
+
+// Int64Flag is a flag with type int64
+type Int64Flag struct {
+	Name string
+
+	Category    string
+	DefaultText string
+	FilePath    string
+	Usage       string
+
+	Required   bool
+	Hidden     bool
+	HasBeenSet bool
+
+	Value       int64
+	Destination *int64
+
+	Aliases []string
+	EnvVars []string
+
+	defaultValue    int64
+	defaultValueSet bool
+
+	Base int
+
+	Action func(*Context, int64) error
+}
+
+// String returns a readable representation of this value (for usage defaults)
+func (f *Int64Flag) String() string {
+	return FlagStringer(f)
+}
+
+// IsSet returns whether or not the flag has been set through env or file
+func (f *Int64Flag) IsSet() bool {
+	return f.HasBeenSet
+}
+
+// Names returns the names of the flag
+func (f *Int64Flag) Names() []string {
+	return FlagNames(f.Name, f.Aliases)
+}
+
+// IsRequired returns whether or not the flag is required
+func (f *Int64Flag) IsRequired() bool {
+	return f.Required
+}
+
+// IsVisible returns true if the flag is not hidden, otherwise false
+func (f *Int64Flag) IsVisible() bool {
+	return !f.Hidden
+}
+
+// StringFlag is a flag with type string
+type StringFlag struct {
+	Name string
+
+	Category    string
+	DefaultText string
+	FilePath    string
+	Usage       string
+
+	Required   bool
+	Hidden     bool
+	HasBeenSet bool
+
+	Value       string
+	Destination *string
+
+	Aliases []string
+	EnvVars []string
+
+	defaultValue    string
+	defaultValueSet bool
+
+	TakesFile bool
+
+	Action func(*Context, string) error
+}
+
+// String returns a readable representation of this value (for usage defaults)
+func (f *StringFlag) String() string {
+	return FlagStringer(f)
+}
+
+// IsSet returns whether or not the flag has been set through env or file
+func (f *StringFlag) IsSet() bool {
+	return f.HasBeenSet
+}
+
+// Names returns the names of the flag
+func (f *StringFlag) Names() []string {
+	return FlagNames(f.Name, f.Aliases)
+}
+
+// IsRequired returns whether or not the flag is required
+func (f *StringFlag) IsRequired() bool {
+	return f.Required
+}
+
+// IsVisible returns true if the flag is not hidden, otherwise false
+func (f *StringFlag) IsVisible() bool {
+	return !f.Hidden
+}
+
+// DurationFlag is a flag with type time.Duration
+type DurationFlag struct {
+	Name string
+
+	Category    string
+	DefaultText string
+	FilePath    string
+	Usage       string
+
+	Required   bool
+	Hidden     bool
+	HasBeenSet bool
+
+	Value       time.Duration
+	Destination *time.Duration
+
+	Aliases []string
+	EnvVars []string
+
+	defaultValue    time.Duration
+	defaultValueSet bool
+
+	Action func(*Context, time.Duration) error
+}
+
+// String returns a readable representation of this value (for usage defaults)
+func (f *DurationFlag) String() string {
+	return FlagStringer(f)
+}
+
+// IsSet returns whether or not the flag has been set through env or file
+func (f *DurationFlag) IsSet() bool {
+	return f.HasBeenSet
+}
+
+// Names returns the names of the flag
+func (f *DurationFlag) Names() []string {
+	return FlagNames(f.Name, f.Aliases)
+}
+
+// IsRequired returns whether or not the flag is required
+func (f *DurationFlag) IsRequired() bool {
+	return f.Required
+}
+
+// IsVisible returns true if the flag is not hidden, otherwise false
+func (f *DurationFlag) IsVisible() bool {
+	return !f.Hidden
+}
+
+// UintFlag is a flag with type uint
+type UintFlag struct {
+	Name string
+
+	Category    string
+	DefaultText string
+	FilePath    string
+	Usage       string
+
+	Required   bool
+	Hidden     bool
+	HasBeenSet bool
+
+	Value       uint
+	Destination *uint
+
+	Aliases []string
+	EnvVars []string
+
+	defaultValue    uint
+	defaultValueSet bool
+
+	Base int
+
+	Action func(*Context, uint) error
+}
+
+// String returns a readable representation of this value (for usage defaults)
+func (f *UintFlag) String() string {
+	return FlagStringer(f)
+}
+
+// IsSet returns whether or not the flag has been set through env or file
+func (f *UintFlag) IsSet() bool {
+	return f.HasBeenSet
+}
+
+// Names returns the names of the flag
+func (f *UintFlag) Names() []string {
+	return FlagNames(f.Name, f.Aliases)
+}
+
+// IsRequired returns whether or not the flag is required
+func (f *UintFlag) IsRequired() bool {
+	return f.Required
+}
+
+// IsVisible returns true if the flag is not hidden, otherwise false
+func (f *UintFlag) IsVisible() bool {
+	return !f.Hidden
+}
+
+// Uint64Flag is a flag with type uint64
+type Uint64Flag struct {
+	Name string
+
+	Category    string
+	DefaultText string
+	FilePath    string
+	Usage       string
+
+	Required   bool
+	Hidden     bool
+	HasBeenSet bool
+
+	Value       uint64
+	Destination *uint64
+
+	Aliases []string
+	EnvVars []string
+
+	defaultValue    uint64
+	defaultValueSet bool
+
+	Base int
+
+	Action func(*Context, uint64) error
+}
+
+// String returns a readable representation of this value (for usage defaults)
+func (f *Uint64Flag) String() string {
+	return FlagStringer(f)
+}
+
+// IsSet returns whether or not the flag has been set through env or file
+func (f *Uint64Flag) IsSet() bool {
+	return f.HasBeenSet
+}
+
+// Names returns the names of the flag
+func (f *Uint64Flag) Names() []string {
+	return FlagNames(f.Name, f.Aliases)
+}
+
+// IsRequired returns whether or not the flag is required
+func (f *Uint64Flag) IsRequired() bool {
+	return f.Required
+}
+
+// IsVisible returns true if the flag is not hidden, otherwise false
+func (f *Uint64Flag) IsVisible() bool {
+	return !f.Hidden
+}
+
+// vim:ro

--- a/vendor/github.com/xrash/smetrics/.travis.yml
+++ b/vendor/github.com/xrash/smetrics/.travis.yml
@@ -1,0 +1,9 @@
+language: go
+go:
+    - 1.11
+    - 1.12
+    - 1.13
+    - 1.14.x
+    - master
+script:
+    - cd tests && make

--- a/vendor/github.com/xrash/smetrics/LICENSE
+++ b/vendor/github.com/xrash/smetrics/LICENSE
@@ -1,0 +1,21 @@
+Copyright (C) 2016 Felipe da Cunha Gonçalves
+All Rights Reserved.
+
+MIT LICENSE
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/vendor/github.com/xrash/smetrics/README.md
+++ b/vendor/github.com/xrash/smetrics/README.md
@@ -1,0 +1,49 @@
+[![Build Status](https://travis-ci.org/xrash/smetrics.svg?branch=master)](http://travis-ci.org/xrash/smetrics)
+
+# smetrics
+
+`smetrics` is "string metrics".
+
+Package smetrics provides a bunch of algorithms for calculating the distance between strings.
+
+There are implementations for calculating the popular Levenshtein distance (aka Edit Distance or Wagner-Fischer), as well as the Jaro distance, the Jaro-Winkler distance, and more.
+
+# How to import
+
+```go
+import "github.com/xrash/smetrics"
+```
+
+# Documentation
+
+Go to [https://pkg.go.dev/github.com/xrash/smetrics](https://pkg.go.dev/github.com/xrash/smetrics) for complete documentation.
+
+# Example
+
+```go
+package main
+
+import (
+	"github.com/xrash/smetrics"
+)
+
+func main() {
+	smetrics.WagnerFischer("POTATO", "POTATTO", 1, 1, 2)
+	smetrics.WagnerFischer("MOUSE", "HOUSE", 2, 2, 4)
+
+	smetrics.Ukkonen("POTATO", "POTATTO", 1, 1, 2)
+	smetrics.Ukkonen("MOUSE", "HOUSE", 2, 2, 4)
+
+	smetrics.Jaro("AL", "AL")
+	smetrics.Jaro("MARTHA", "MARHTA")
+
+	smetrics.JaroWinkler("AL", "AL", 0.7, 4)
+	smetrics.JaroWinkler("MARTHA", "MARHTA", 0.7, 4)
+
+	smetrics.Soundex("Euler")
+	smetrics.Soundex("Ellery")
+
+	smetrics.Hamming("aaa", "aaa")
+	smetrics.Hamming("aaa", "aab")
+}
+```

--- a/vendor/github.com/xrash/smetrics/doc.go
+++ b/vendor/github.com/xrash/smetrics/doc.go
@@ -1,0 +1,19 @@
+/*
+Package smetrics provides a bunch of algorithms for calculating
+the distance between strings.
+
+There are implementations for calculating the popular Levenshtein
+distance (aka Edit Distance or Wagner-Fischer), as well as the Jaro
+distance, the Jaro-Winkler distance, and more.
+
+For the Levenshtein distance, you can use the functions WagnerFischer()
+and Ukkonen(). Read the documentation on these functions.
+
+For the Jaro and Jaro-Winkler algorithms, check the functions
+Jaro() and JaroWinkler(). Read the documentation on these functions.
+
+For the Soundex algorithm, check the function Soundex().
+
+For the Hamming distance algorithm, check the function Hamming().
+*/
+package smetrics

--- a/vendor/github.com/xrash/smetrics/hamming.go
+++ b/vendor/github.com/xrash/smetrics/hamming.go
@@ -1,0 +1,25 @@
+package smetrics
+
+import (
+	"fmt"
+)
+
+// The Hamming distance is the minimum number of substitutions required to change string A into string B. Both strings must have the same size. If the strings have different sizes, the function returns an error.
+func Hamming(a, b string) (int, error) {
+	al := len(a)
+	bl := len(b)
+
+	if al != bl {
+		return -1, fmt.Errorf("strings are not equal (len(a)=%d, len(b)=%d)", al, bl)
+	}
+
+	var difference = 0
+
+	for i := range a {
+		if a[i] != b[i] {
+			difference = difference + 1
+		}
+	}
+
+	return difference, nil
+}

--- a/vendor/github.com/xrash/smetrics/jaro-winkler.go
+++ b/vendor/github.com/xrash/smetrics/jaro-winkler.go
@@ -1,0 +1,28 @@
+package smetrics
+
+import (
+	"math"
+)
+
+// The Jaro-Winkler distance. The result is 1 for equal strings, and 0 for completely different strings. It is commonly used on Record Linkage stuff, thus it tries to be accurate for common typos when writing real names such as  person names and street names.
+// Jaro-Winkler is a modification of the Jaro algorithm. It works by first running Jaro, then boosting the score of exact matches at the beginning of the strings. Because of that, it introduces two more parameters: the boostThreshold and the prefixSize. These are commonly set to 0.7 and 4, respectively.
+func JaroWinkler(a, b string, boostThreshold float64, prefixSize int) float64 {
+	j := Jaro(a, b)
+
+	if j <= boostThreshold {
+		return j
+	}
+
+	prefixSize = int(math.Min(float64(len(a)), math.Min(float64(prefixSize), float64(len(b)))))
+
+	var prefixMatch float64
+	for i := 0; i < prefixSize; i++ {
+		if a[i] == b[i] {
+			prefixMatch++
+		} else {
+			break
+		}
+	}
+
+	return j + 0.1*prefixMatch*(1.0-j)
+}

--- a/vendor/github.com/xrash/smetrics/jaro.go
+++ b/vendor/github.com/xrash/smetrics/jaro.go
@@ -1,0 +1,86 @@
+package smetrics
+
+import (
+	"math"
+)
+
+// The Jaro distance. The result is 1 for equal strings, and 0 for completely different strings.
+func Jaro(a, b string) float64 {
+	// If both strings are zero-length, they are completely equal,
+	// therefore return 1.
+	if len(a) == 0 && len(b) == 0 {
+		return 1
+	}
+
+	// If one string is zero-length, strings are completely different,
+	// therefore return 0.
+	if len(a) == 0 || len(b) == 0 {
+		return 0
+	}
+
+	// Define the necessary variables for the algorithm.
+	la := float64(len(a))
+	lb := float64(len(b))
+	matchRange := int(math.Max(0, math.Floor(math.Max(la, lb)/2.0)-1))
+	matchesA := make([]bool, len(a))
+	matchesB := make([]bool, len(b))
+	var matches float64 = 0
+
+	// Step 1: Matches
+	// Loop through each character of the first string,
+	// looking for a matching character in the second string.
+	for i := 0; i < len(a); i++ {
+		start := int(math.Max(0, float64(i-matchRange)))
+		end := int(math.Min(lb-1, float64(i+matchRange)))
+
+		for j := start; j <= end; j++ {
+			if matchesB[j] {
+				continue
+			}
+
+			if a[i] == b[j] {
+				matchesA[i] = true
+				matchesB[j] = true
+				matches++
+				break
+			}
+		}
+	}
+
+	// If there are no matches, strings are completely different,
+	// therefore return 0.
+	if matches == 0 {
+		return 0
+	}
+
+	// Step 2: Transpositions
+	// Loop through the matches' arrays, looking for
+	// unaligned matches. Count the number of unaligned matches.
+	unaligned := 0
+	j := 0
+	for i := 0; i < len(a); i++ {
+		if !matchesA[i] {
+			continue
+		}
+
+		for !matchesB[j] {
+			j++
+		}
+
+		if a[i] != b[j] {
+			unaligned++
+		}
+
+		j++
+	}
+
+	// The number of unaligned matches divided by two, is the number of _transpositions_.
+	transpositions := math.Floor(float64(unaligned / 2))
+
+	// Jaro distance is the average between these three numbers:
+	// 1. matches / length of string A
+	// 2. matches / length of string B
+	// 3. (matches - transpositions/matches)
+	// So, all that divided by three is the final result.
+	return ((matches / la) + (matches / lb) + ((matches - transpositions) / matches)) / 3.0
+}

--- a/vendor/github.com/xrash/smetrics/soundex.go
+++ b/vendor/github.com/xrash/smetrics/soundex.go
@@ -1,0 +1,63 @@
+package smetrics
+
+import (
+	"strings"
+)
+
+// The Soundex encoding. It is a phonetic algorithm that considers how the words sound in English. Soundex maps a string to a 4-byte code consisting of the first letter of the original string and three numbers. Strings that sound similar should map to the same code.
+func Soundex(s string) string {
+	b := strings.Builder{}
+	b.Grow(4)
+
+	p := s[0]
+	if p <= 'z' && p >= 'a' {
+		p -= 32 // convert to uppercase
+	}
+	b.WriteByte(p)
+
+	n := 0
+	for i := 1; i < len(s); i++ {
+		c := s[i]
+
+		if c <= 'z' && c >= 'a' {
+			c -= 32 // convert to uppercase
+		} else if c < 'A' || c > 'Z' {
+			continue
+		}
+
+		if c == p {
+			continue
+		}
+
+		p = c
+
+		switch c {
+		case 'B', 'P', 'F', 'V':
+			c = '1'
+		case 'C', 'S', 'K', 'G', 'J', 'Q', 'X', 'Z':
+			c = '2'
+		case 'D', 'T':
+			c = '3'
+		case 'L':
+			c = '4'
+		case 'M', 'N':
+			c = '5'
+		case 'R':
+			c = '6'
+		default:
+			continue
+		}
+
+		b.WriteByte(c)
+		n++
+		if n == 3 {
+			break
+		}
+	}
+
+	for i := n; i < 3; i++ {
+		b.WriteByte('0')
+	}
+
+	return b.String()
+}

--- a/vendor/github.com/xrash/smetrics/ukkonen.go
+++ b/vendor/github.com/xrash/smetrics/ukkonen.go
@@ -1,0 +1,94 @@
+package smetrics
+
+import (
+	"math"
+)
+
+// The Ukkonen algorithm for calculating the Levenshtein distance. The algorithm is described in http://www.cs.helsinki.fi/u/ukkonen/InfCont85.PDF, or in docs/InfCont85.PDF. It runs on O(t . min(m, n)) where t is the actual distance between strings a and b. It needs O(min(t, m, n)) space. This function might be preferred over WagnerFischer() for *very* similar strings. But test it out yourself.
+// The first two parameters are the two strings to be compared. The last three parameters are the insertion cost, the deletion cost and the substitution cost. These are normally defined as 1, 1 and 2 respectively.
+func Ukkonen(a, b string, icost, dcost, scost int) int {
+	var lowerCost int
+
+	if icost < dcost && icost < scost {
+		lowerCost = icost
+	} else if dcost < scost {
+		lowerCost = dcost
+	} else {
+		lowerCost = scost
+	}
+
+	infinite := math.MaxInt32 / 2
+
+	var r []int
+	var k, kprime, p, t int
+	var ins, del, sub int
+
+	if len(a) > len(b) {
+		t = (len(a) - len(b) + 1) * lowerCost
+	} else {
+		t = (len(b) - len(a) + 1) * lowerCost
+	}
+
+	for {
+		if (t / lowerCost) < (len(b) - len(a)) {
+			continue
+		}
+
+		// This is the right damn thing since the original Ukkonen
+		// paper minimizes the expression result only, but the uncommented version
+		// doesn't need to deal with floats so it's faster.
+		// p = int(math.Floor(0.5*((float64(t)/float64(lowerCost)) - float64(len(b) - len(a)))))
+		p = ((t / lowerCost) - (len(b) - len(a))) / 2
+
+		k = -p
+		kprime = k
+
+		rowlength := (len(b) - len(a)) + (2 * p)
+
+		r = make([]int, rowlength+2)
+
+		for i := 0; i < rowlength+2; i++ {
+			r[i] = infinite
+		}
+
+		for i := 0; i <= len(a); i++ {
+			for j := 0; j <= rowlength; j++ {
+				if i == j+k && i == 0 {
+					r[j] = 0
+				} else {
+					if j-1 < 0 {
+						ins = infinite
+					} else {
+						ins = r[j-1] + icost
+					}
+
+					del = r[j+1] + dcost
+					sub = r[j] + scost
+
+					if i-1 < 0 || i-1 >= len(a) || j+k-1 >= len(b) || j+k-1 < 0 {
+						sub = infinite
+					} else if a[i-1] == b[j+k-1] {
+						sub = r[j]
+					}
+
+					if ins < del && ins < sub {
+						r[j] = ins
+					} else if del < sub {
+						r[j] = del
+					} else {
+						r[j] = sub
+					}
+				}
+			}
+			k++
+		}
+
+		if r[(len(b)-len(a))+(2*p)+kprime] <= t {
+			break
+		} else {
+			t *= 2
+		}
+	}
+
+	return r[(len(b)-len(a))+(2*p)+kprime]
+}

--- a/vendor/github.com/xrash/smetrics/wagner-fischer.go
+++ b/vendor/github.com/xrash/smetrics/wagner-fischer.go
@@ -1,0 +1,48 @@
+package smetrics
+
+// The Wagner-Fischer algorithm for calculating the Levenshtein distance.
+// The first two parameters are the two strings to be compared. The last three parameters are the insertion cost, the deletion cost and the substitution cost. These are normally defined as 1, 1 and 2 respectively.
+func WagnerFischer(a, b string, icost, dcost, scost int) int {
+
+	// Allocate both rows.
+	row1 := make([]int, len(b)+1)
+	row2 := make([]int, len(b)+1)
+	var tmp []int
+
+	// Initialize the first row.
+	for i := 1; i <= len(b); i++ {
+		row1[i] = i * icost
+	}
+
+	// For each row...
+	for i := 1; i <= len(a); i++ {
+		row2[0] = i * dcost
+
+		// For each column...
+		for j := 1; j <= len(b); j++ {
+			if a[i-1] == b[j-1] {
+				row2[j] = row1[j-1]
+			} else {
+				ins := row2[j-1] + icost
+				del := row1[j] + dcost
+				sub := row1[j-1] + scost
+
+				if ins < del && ins < sub {
+					row2[j] = ins
+				} else if del < sub {
+					row2[j] = del
+				} else {
+					row2[j] = sub
+				}
+			}
+		}
+
+		// Swap the rows at the end of each row.
+		tmp = row1
+		row1 = row2
+		row2 = tmp
+	}
+
+	// Because we swapped the rows, the final result is in row1 instead of row2.
+	return row1[len(row1)-1]
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -121,7 +121,7 @@ github.com/containerd/typeurl/v2
 # github.com/coreos/go-systemd/v22 v22.5.0
 ## explicit; go 1.12
 github.com/coreos/go-systemd/v22/dbus
-# github.com/cpuguy83/go-md2man/v2 v2.0.4
+# github.com/cpuguy83/go-md2man/v2 v2.0.5
 ## explicit; go 1.11
 github.com/cpuguy83/go-md2man/v2/md2man
 # github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0
@@ -440,6 +440,9 @@ github.com/tchap/go-patricia/v2/patricia
 # github.com/urfave/cli v1.22.15
 ## explicit; go 1.11
 github.com/urfave/cli
+# github.com/urfave/cli/v2 v2.27.5
+## explicit; go 1.18
+github.com/urfave/cli/v2
 # github.com/vbatts/tar-split v0.11.3
 ## explicit; go 1.15
 github.com/vbatts/tar-split/archive/tar
@@ -462,6 +465,9 @@ github.com/xeipuuv/gojsonpointer
 # github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415
 ## explicit
 github.com/xeipuuv/gojsonreference
+# github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1
+## explicit; go 1.15
+github.com/xrash/smetrics
 # github.com/yashtewari/glob-intersection v0.2.0
 ## explicit; go 1.17
 github.com/yashtewari/glob-intersection


### PR DESCRIPTION
Add tool to merge layer tarball files, which is used for creating WCOW uVM images with additional features added, without first needing to create a dedicated container image.

This basically amounts to the append and flatten container image operations from the
[crane](github.com/google/go-containerregistry/cmd/crane) tool, with some specific changes:
 - use `"path"` and not `"path/filepath"` for path manipulation, which avoids paths with `\` separators;
 - append a trailing `/` to directory paths (since different `tar` implementations may append them); and
 - overwrite the owner UID and GID to zero, to avoid any user issues.

The tool avoids needing to unpack tar files within the same directory (as is done for LCOW) to combine the deltas with tar images.