### PR TITLE
Add `uvm://` mount support for LCOW

### DIFF
--- a/internal/guest/runtime/hcsv2/workload_container.go
+++ b/internal/guest/runtime/hcsv2/workload_container.go
@@ -132,11 +132,11 @@ func updateUVMMounts(spec *oci.Spec) error {
 		if !strings.HasPrefix(m.Source, guestpath.UVMMountPrefix) {
 			continue
 		}
-		hostPath := strings.TrimPrefix(m.Source, guestpath.UVMMountPrefix)
+		uvmPath := strings.TrimPrefix(m.Source, guestpath.UVMMountPrefix)
 
-		spec.Mounts[i].Source = hostPath
+		spec.Mounts[i].Source = uvmPath
 
-		if _, err := os.Stat(hostPath); err != nil {
+		if _, err := os.Stat(uvmPath); err != nil {
 			return errors.Wrap(err, "could not open uVM mount target")
 		}
 	}

--- a/internal/hcsoci/resources_lcow.go
+++ b/internal/hcsoci/resources_lcow.go
@@ -129,9 +129,11 @@ func allocateLinuxResources(ctx context.Context, coi *createOptionsInternal, r *
 					mt = "bind"
 				}
 				coi.Spec.Mounts[i].Type = mt
-			} else if strings.HasPrefix(mount.Source, guestpath.SandboxMountPrefix) {
-				// Mounts that map to a path in UVM are specified with 'sandbox://' prefix.
-				// example: sandbox:///a/dirInUvm destination:/b/dirInContainer
+			} else if strings.HasPrefix(mount.Source, guestpath.SandboxMountPrefix) || strings.HasPrefix(mount.Source, guestpath.UVMMountPrefix) {
+				// Mounts that map to a path in UVM are specified with a 'sandbox://' or 'uvm://' prefix.
+				// examples:
+				//  - sandbox:///a/dirInUvm destination:/b/dirInContainer
+				//  - uvm:///a/dirInUvm destination:/b/dirInContainer
 				uvmPathForFile = mount.Source
 			} else if strings.HasPrefix(mount.Source, guestpath.HugePagesMountPrefix) {
 				// currently we only support 2M hugepage size


### PR DESCRIPTION
Allow privileged LCOW containers to mount the uVM's filesystem. This supports cadvisor and related tools to monitor the pod and associated containers without needing to run directly within the uVM.

See: https://github.com/google/cadvisor