### PR TITLE
Switch to `golangci-lint` v2 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,9 +34,9 @@ jobs:
           cache: false
 
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v8
         with:
-          version: v1.64
+          version: v2.1
           args: >-
             --verbose
             --max-issues-per-linter=0

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,173 +1,165 @@
+version: "2"
+
 run:
-  timeout: 8m
-  tests: true
   build-tags:
     - admin
     - functional
     - integration
+  tests: true
 
 linters:
   enable:
-    # defaults:
-    # - errcheck
-    # - gosimple
-    # - govet
-    # - ineffassign
-    # - staticcheck
-    # - typecheck
-    # - unused
-
     - errorlint # error wrapping (eg, not using `errors.Is`, using `%s` instead of `%w` in `fmt.Errorf`)
-    - gofmt # whether code was gofmt-ed
-    - govet # enabled by default, but just to be sure
     - nolintlint # ill-formed or insufficient nolint directives
-    - stylecheck # golint replacement
     - thelper #  test helpers without t.Helper()
 
-linters-settings:
-  govet:
-    enable-all: true
-    disable:
-      # struct order is often for Win32 compat
-      # also, ignore pointer bytes/GC issues for now until performance becomes an issue
-      - fieldalignment
+  settings:
+    govet:
+      disable:
+        # struct order is often for Win32 compat
+        # also, ignore pointer bytes/GC issues for now until performance becomes an issue
+        - fieldalignment
+      enable-all: true
 
-  stylecheck:
-    # https://staticcheck.io/docs/checks
-    checks: ["all"]
+    staticcheck:
+      # https://staticcheck.io/docs/checks
+      checks:
+        - all
 
-issues:
-  exclude-dirs:
-    # paths are relative to module root
-    - cri-containerd/test-images
-  exclude-rules:
-    # err is very often shadowed in nested scopes
-    - linters:
-        - govet
-      text: '^shadow: declaration of "err" shadows declaration'
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      # err is very often shadowed in nested scopes
+      - linters:
+          - govet
+        text: '^shadow: declaration of "err" shadows declaration'
 
-    # path is relative to module root, which is ./test/
-    - path: cri-containerd
-      linters:
-        - stylecheck
-      text: "^ST1003: should not use underscores in package names$"
-      source: "^package cri_containerd$"
+      # path is relative to module root, which is ./test/
+      - linters:
+          - staticcheck
+        path: cri-containerd
+        text: "^ST1003: should not use underscores in package names$"
+        source: ^package cri_containerd$
 
-    # don't bother with propper error wrapping in test code
-    - path: cri-containerd
-      linters:
-        - errorlint
-      text: "non-wrapping format verb for fmt.Errorf"
+      # don't bother with propper error wrapping in test code
+      - linters:
+          - errorlint
+        path: cri-containerd
+        text: non-wrapping format verb for fmt.Errorf
 
-    # This repo has a LOT of generated schema files, operating system bindings, and other
-    # things that ST1003 from stylecheck won't like (screaming case Windows api constants for example).
-    # There's also some structs that we *could* change the initialisms to be Go friendly
-    # (Id -> ID) but they're exported and it would be a breaking change.
-    # This makes it so that most new code, code that isn't supposed to be a pretty faithful
-    # mapping to an OS call/constants, or non-generated code still checks if we're following idioms,
-    # while ignoring the things that are just noise or would be more of a hassle than it'd be worth to change.
-    - path: layer.go
-      linters:
-        - stylecheck
-      text: "ST1003:"
+      # static check doesn't recognize `t.Fatal[f]?` when checking for potential `nil` pointer dereference
+      - linters:
+          - staticcheck
+        path: ".*_test.go$"
+        text: "^SA5011"
 
-    - path: hcsshim.go
-      linters:
-        - stylecheck
-      text: "ST1003:"
+      # This repo has a LOT of generated schema files, operating system bindings, and other
+      # things that ST1003 from stylecheck won't like (screaming case Windows api constants for example).
+      # There's also some structs that we *could* change the initialisms to be Go friendly
+      # (Id -> ID) but they're exported and it would be a breaking change.
+      # This makes it so that most new code, code that isn't supposed to be a pretty faithful
+      # mapping to an OS call/constants, or non-generated code still checks if we're following idioms,
+      # while ignoring the things that are just noise or would be more of a hassle than it'd be worth to change.
+      - linters:
+          - staticcheck
+        path: layer.go
+        text: "ST1003:"
+      - linters:
+          - staticcheck
+        path: hcsshim.go
+        text: "ST1003:"
+      - linters:
+          - staticcheck
+        path: cmd/ncproxy/nodenetsvc/
+        text: "ST1003:"
+      - linters:
+          - staticcheck
+        path: cmd/ncproxy_mock/
+        text: "ST1003:"
+      - linters:
+          - staticcheck
+        path: internal/hcs/schema2/
+      - linters:
+          - staticcheck
+        path: internal/wclayer/
+        text: "ST1003:"
+      - linters:
+          - staticcheck
+        path: hcn/
+        text: "ST1003:"
+      - linters:
+          - staticcheck
+        path: internal/hcs/schema1/
+        text: "ST1003:"
+      - linters:
+          - staticcheck
+        path: internal/hns/
+        text: "ST1003:"
+      - linters:
+          - staticcheck
+        path: ext4/internal/compactext4/
+        text: "ST1003:"
+      - linters:
+          - staticcheck
+        path: ext4/internal/format/
+        text: "ST1003:"
+      - linters:
+          - staticcheck
+        path: internal/guestrequest/
+        text: "ST1003:"
+      - linters:
+          - staticcheck
+        path: internal/guest/prot/
+        text: "ST1003:"
+      - linters:
+          - staticcheck
+        path: internal/windevice/
+        text: "ST1003:"
+      - linters:
+          - staticcheck
+        path: internal/winapi/
+        text: "ST1003:"
+      - linters:
+          - staticcheck
+        path: internal/vmcompute/
+        text: "ST1003:"
+      - linters:
+          - staticcheck
+        path: internal/regstate/
+        text: "ST1003:"
+      - linters:
+          - staticcheck
+        path: internal/hcserror/
+        text: "ST1003:"
 
-    - path: cmd\\ncproxy\\nodenetsvc\\
-      linters:
-        - stylecheck
-      text: "ST1003:"
+      # v0 APIs are deprecated, but still retained for backwards compatability
+      - linters:
+          - staticcheck
+        path: cmd/ncproxy/
+        text: "^SA1019: .*(ncproxygrpc|nodenetsvc)[/]?v0"
+      - linters:
+          - staticcheck
+        path: internal/tools/networkagent
+        text: "^SA1019: .*nodenetsvc[/]?v0"
+      - linters:
+          - staticcheck
+        path: internal/vhdx/info
+        text: "ST1003:"
 
-    - path: cmd\\ncproxy_mock\\
-      linters:
-        - stylecheck
-      text: "ST1003:"
+    paths:
+      # paths are relative to module root
+      - cri-containerd/test-images
 
-    - path: internal\\hcs\\schema2\\
-      linters:
-        - stylecheck
-        - gofmt
-
-    - path: internal\\wclayer\\
-      linters:
-        - stylecheck
-      text: "ST1003:"
-
-    - path: hcn\\
-      linters:
-        - stylecheck
-      text: "ST1003:"
-
-    - path: internal\\hcs\\schema1\\
-      linters:
-        - stylecheck
-      text: "ST1003:"
-
-    - path: internal\\hns\\
-      linters:
-        - stylecheck
-      text: "ST1003:"
-
-    - path: ext4\\internal\\compactext4\\
-      linters:
-        - stylecheck
-      text: "ST1003:"
-
-    - path: ext4\\internal\\format\\
-      linters:
-        - stylecheck
-      text: "ST1003:"
-
-    - path: internal\\guestrequest\\
-      linters:
-        - stylecheck
-      text: "ST1003:"
-
-    - path: internal\\guest\\prot\\
-      linters:
-        - stylecheck
-      text: "ST1003:"
-
-    - path: internal\\windevice\\
-      linters:
-        - stylecheck
-      text: "ST1003:"
-
-    - path: internal\\winapi\\
-      linters:
-        - stylecheck
-      text: "ST1003:"
-
-    - path: internal\\vmcompute\\
-      linters:
-        - stylecheck
-      text: "ST1003:"
-
-    - path: internal\\regstate\\
-      linters:
-        - stylecheck
-      text: "ST1003:"
-
-    - path: internal\\hcserror\\
-      linters:
-        - stylecheck
-      text: "ST1003:"
-
-    # v0 APIs are deprecated, but still retained for backwards compatability
-    - path: cmd\\ncproxy\\
-      linters:
-        - staticcheck
-      text: "^SA1019: .*(ncproxygrpc|nodenetsvc)[/]?v0"
-
-    - path: internal\\tools\\networkagent
-      linters:
-        - staticcheck
-      text: "^SA1019: .*nodenetsvc[/]?v0"
-
-    - path: internal\\vhdx\\info
-      linters:
-        - stylecheck
-      text: "ST1003:"
+formatters:
+  enable:
+    - gofmt
+  exclusions:
+    generated: lax
+    paths:
+      - cri-containerd/test-images
+      - internal/hcs/schema2/

--- a/hcn/hcnerrors.go
+++ b/hcn/hcnerrors.go
@@ -23,11 +23,7 @@ var (
 )
 
 func checkForErrors(methodName string, hr error, resultBuffer *uint16) error {
-	errorFound := false
-
-	if hr != nil {
-		errorFound = true
-	}
+	errorFound := hr != nil
 
 	result := ""
 	if resultBuffer != nil {

--- a/internal/cmd/io_npipe.go
+++ b/internal/cmd/io_npipe.go
@@ -114,7 +114,7 @@ func (nprw *nPipeRetryWriter) Write(p []byte) (n int, err error) {
 				}).Error("Named pipe disconnected, retrying dial")
 
 				// Close the old conn first.
-				nprw.Conn.Close()
+				nprw.Close()
 				newConn, retryErr := nprw.retryDialPipe()
 				if retryErr == nil {
 					log.G(nprw.ctx).WithField("address", nprw.pipePath).Info("Succeeded in reconnecting to named pipe")

--- a/internal/exec/exec.go
+++ b/internal/exec/exec.go
@@ -113,7 +113,7 @@ func (e *Exec) Start() error {
 	pi := new(windows.ProcessInformation)
 
 	// Need EXTENDED_STARTUPINFO_PRESENT as we're making use of the attribute list field.
-	flags := uint32(windows.CREATE_UNICODE_ENVIRONMENT) | windows.EXTENDED_STARTUPINFO_PRESENT | e.execConfig.processFlags
+	flags := uint32(windows.CREATE_UNICODE_ENVIRONMENT) | windows.EXTENDED_STARTUPINFO_PRESENT | e.processFlags
 
 	// Allocate an attribute list that's large enough to do the operations we care about
 	// 1. Assigning to a job object at creation time
@@ -177,9 +177,9 @@ func (e *Exec) Start() error {
 
 	siEx.ProcThreadAttributeList = attrList.List()
 	siEx.Cb = uint32(unsafe.Sizeof(*siEx))
-	if e.execConfig.token != 0 {
+	if e.token != 0 {
 		err = windows.CreateProcessAsUser(
-			e.execConfig.token,
+			e.token,
 			argv0p,
 			argvp,
 			pSec,

--- a/internal/guest/network/netns.go
+++ b/internal/guest/network/netns.go
@@ -247,7 +247,7 @@ func configureLink(ctx context.Context,
 
 		// dst will be nil when setting default gateways
 		var dst *net.IPNet
-		if !(r.DestinationPrefix == ipv4GwDestination || r.DestinationPrefix == ipv6GwDestination) {
+		if r.DestinationPrefix != ipv4GwDestination && r.DestinationPrefix != ipv6GwDestination {
 			dstIP, dstAddr, err := net.ParseCIDR(r.DestinationPrefix)
 			if err != nil {
 				return fmt.Errorf("parsing route dst address %s failed: %w", r.DestinationPrefix, err)

--- a/internal/guest/runtime/hcsv2/container.go
+++ b/internal/guest/runtime/hcsv2/container.go
@@ -251,9 +251,10 @@ func (c *Container) setExitType(signal syscall.Signal) {
 	c.etL.Lock()
 	defer c.etL.Unlock()
 
-	if signal == syscall.SIGTERM {
+	switch signal {
+	case syscall.SIGTERM:
 		c.exitType = prot.NtGracefulExit
-	} else if signal == syscall.SIGKILL {
+	case syscall.SIGKILL:
 		c.exitType = prot.NtForcedExit
 	}
 }

--- a/internal/guest/runtime/hcsv2/uvm.go
+++ b/internal/guest/runtime/hcsv2/uvm.go
@@ -565,7 +565,8 @@ func (h *Host) modifyHostSettings(ctx context.Context, containerID string, req *
 			if err != nil {
 				return err
 			}
-			if req.RequestType == guestrequest.RequestTypeAdd {
+			switch req.RequestType {
+			case guestrequest.RequestTypeAdd:
 				if err := h.hostMounts.AddRWDevice(mvd.MountPath, source, mvd.Encrypted); err != nil {
 					return err
 				}
@@ -574,7 +575,7 @@ func (h *Host) modifyHostSettings(ctx context.Context, containerID string, req *
 						_ = h.hostMounts.RemoveRWDevice(mvd.MountPath, source)
 					}
 				}()
-			} else if req.RequestType == guestrequest.RequestTypeRemove {
+			case guestrequest.RequestTypeRemove:
 				if err := h.hostMounts.RemoveRWDevice(mvd.MountPath, source); err != nil {
 					return err
 				}
@@ -818,7 +819,8 @@ func (h *Host) GetProperties(ctx context.Context, containerID string, query prot
 
 	properties := &prot.PropertiesV2{}
 	for _, requestedProperty := range query.PropertyTypes {
-		if requestedProperty == prot.PtProcessList {
+		switch requestedProperty {
+		case prot.PtProcessList:
 			pids, err := c.GetAllProcessPids(ctx)
 			if err != nil {
 				return nil, err
@@ -830,7 +832,7 @@ func (h *Host) GetProperties(ctx context.Context, containerID string, query prot
 				}
 				properties.ProcessList[i].ProcessID = uint32(pid)
 			}
-		} else if requestedProperty == prot.PtStatistics {
+		case prot.PtStatistics:
 			cgroupMetrics, err := c.GetStats(ctx)
 			if err != nil {
 				return nil, err

--- a/internal/guest/spec/spec_devices.go
+++ b/internal/guest/spec/spec_devices.go
@@ -85,13 +85,13 @@ func devicePathsFromPCIPath(ctx context.Context, pciPath string) ([]*devices.Dev
 
 		// find corresponding entries in sysfs
 		for _, d := range hostDevices {
-			major := d.Rule.Major
-			minor := d.Rule.Minor
+			major := d.Major
+			minor := d.Minor
 
 			log.G(ctx).WithField("device", d).Infof("looking at device: %+v", d)
 
 			deviceTypeString := ""
-			switch d.Rule.Type {
+			switch d.Type {
 			case devices.BlockDevice:
 				deviceTypeString = blockType
 			case devices.CharDevice:

--- a/internal/guest/storage/devicemapper/devicemapper.go
+++ b/internal/guest/storage/devicemapper/devicemapper.go
@@ -33,7 +33,7 @@ var (
 	_createDevice       = CreateDevice
 )
 
-//nolint:stylecheck // ST1003: ALL_CAPS
+//nolint:staticcheck // ST1003: ALL_CAPS
 const (
 	_DM_IOCTL      = 0xfd
 	_DM_IOCTL_SIZE = 312
@@ -46,7 +46,7 @@ const (
 
 const blockSize = 512
 
-//nolint:stylecheck // ST1003: ALL_CAPS
+//nolint:staticcheck // ST1003: ALL_CAPS
 const (
 	_DM_VERSION = iota
 	_DM_REMOVE_ALL

--- a/internal/hcs/errors_test.go
+++ b/internal/hcs/errors_test.go
@@ -41,7 +41,7 @@ func TestHcsErrorUnwrap(t *testing.T) {
 			}
 
 			var e *MyError
-			if !(errors.As(nerr, &e) && e.S == err.S) {
+			if !errors.As(nerr, &e) || e.S != err.S {
 				t.Errorf("error '%v' did not unwrap '%v' properly", errors.Unwrap(nerr), e)
 			}
 

--- a/internal/layers/wcow_parse.go
+++ b/internal/layers/wcow_parse.go
@@ -125,11 +125,12 @@ func parseBlockCIMMount(m *types.Mount) (*wcowBlockCIMLayers, error) {
 				return nil, err
 			}
 		} else if val, ok = strings.CutPrefix(option, blockCIMTypeFlag); ok {
-			if val == "device" {
+			switch val {
+			case "device":
 				layerType = cimfs.BlockCIMTypeDevice
-			} else if val == "file" {
+			case "file":
 				layerType = cimfs.BlockCIMTypeSingleFile
-			} else {
+			default:
 				return nil, fmt.Errorf("invalid block CIM type `%s`", val)
 			}
 		} else if val, ok = strings.CutPrefix(option, mergedCIMPathFlag); ok {

--- a/internal/log/hook.go
+++ b/internal/log/hook.go
@@ -82,7 +82,7 @@ func (h *Hook) encode(e *logrus.Entry) {
 
 	formatTime := h.TimeFormat != ""
 	formatDuration := h.DurationFormat != nil
-	if !(h.EncodeAsJSON || formatTime || formatDuration) {
+	if !h.EncodeAsJSON && !formatTime && !formatDuration {
 		return
 	}
 

--- a/internal/oc/exporter.go
+++ b/internal/oc/exporter.go
@@ -68,15 +68,15 @@ func (le *LogrusExporter) ExportSpan(s *trace.SpanData) {
 	}
 
 	level := logrus.InfoLevel
-	if s.Status.Code != 0 {
+	if s.Code != 0 {
 		level = logrus.ErrorLevel
 
 		// don't overwrite an existing "error" or "errorCode" attributes
 		if _, ok := data[logrus.ErrorKey]; !ok {
-			data[logrus.ErrorKey] = s.Status.Message
+			data[logrus.ErrorKey] = s.Message
 		}
 		if _, ok := data[_errorCodeKey]; !ok {
-			data[_errorCodeKey] = codes.Code(s.Status.Code).String()
+			data[_errorCodeKey] = codes.Code(s.Code).String()
 		}
 	}
 

--- a/internal/protocol/guestrequest/types.go
+++ b/internal/protocol/guestrequest/types.go
@@ -31,13 +31,13 @@ type ModificationRequest struct {
 }
 
 type NetworkModifyRequest struct {
-	AdapterId   string      `json:"AdapterId,omitempty"` //nolint:stylecheck
+	AdapterId   string      `json:"AdapterId,omitempty"` //nolint:staticcheck // ST1003: ALL_CAPS
 	RequestType RequestType `json:"RequestType,omitempty"`
 	Settings    interface{} `json:"Settings,omitempty"`
 }
 
 type RS4NetworkModifyRequest struct {
-	AdapterInstanceId string      `json:"AdapterInstanceId,omitempty"` //nolint:stylecheck
+	AdapterInstanceId string      `json:"AdapterInstanceId,omitempty"` //nolint:staticcheck // ST1003: ALL_CAPS
 	RequestType       RequestType `json:"RequestType,omitempty"`
 	Settings          interface{} `json:"Settings,omitempty"`
 }

--- a/internal/security/grantvmgroupaccess.go
+++ b/internal/security/grantvmgroupaccess.go
@@ -63,8 +63,7 @@ const (
 	shareModeRead  shareMode = 0x1
 	shareModeWrite shareMode = 0x2
 
-	//nolint:stylecheck // ST1003
-	sidVmGroup = "S-1-5-83-0"
+	sidVMGroup = "S-1-5-83-0"
 
 	trusteeFormIsSid trusteeForm = 0
 
@@ -75,13 +74,13 @@ const (
 // include Grant ACE entries for the VM Group SID. This is a golang re-
 // implementation of the same function in vmcompute, just not exported in
 // RS5. Which kind of sucks. Sucks a lot :/
-func GrantVmGroupAccess(name string) error { //nolint:stylecheck // ST1003
+func GrantVmGroupAccess(name string) error { //nolint:staticcheck // ST1003: ALL_CAPS
 	return GrantVmGroupAccessWithMask(name, accessMaskDesiredPermission)
 }
 
 // GrantVmGroupAccessWithMask sets the desired DACL for a specified file or
 // directory.
-func GrantVmGroupAccessWithMask(name string, access accessMask) error { //nolint:stylecheck // ST1003
+func GrantVmGroupAccessWithMask(name string, access accessMask) error { //nolint:staticcheck // ST1003: ALL_CAPS
 	if access == 0 || access<<4 != 0 {
 		return fmt.Errorf("invalid access mask: 0x%08x", access)
 	}
@@ -154,9 +153,9 @@ func createFile(name string, isDir bool) (syscall.Handle, error) {
 // The caller is responsible for LocalFree of the returned DACL on success.
 func generateDACLWithAcesAdded(name string, isDir bool, desiredAccess accessMask, origDACL uintptr) (uintptr, error) {
 	// Generate pointers to the SIDs based on the string SIDs
-	sid, err := syscall.StringToSid(sidVmGroup)
+	sid, err := syscall.StringToSid(sidVMGroup)
 	if err != nil {
-		return 0, fmt.Errorf("%s syscall.StringToSid %s %s: %w", gvmga, name, sidVmGroup, err)
+		return 0, fmt.Errorf("%s syscall.StringToSid %s %s: %w", gvmga, name, sidVMGroup, err)
 	}
 
 	inheritance := inheritModeNoInheritance

--- a/internal/tools/networkagent/main.go
+++ b/internal/tools/networkagent/main.go
@@ -50,7 +50,7 @@ func generateMAC() (string, error) {
 	buf[0] = 0
 	mac := net.HardwareAddr(buf)
 	macString := strings.ToUpper(mac.String())
-	macString = strings.Replace(macString, ":", "-", -1)
+	macString = strings.ReplaceAll(macString, ":", "-")
 
 	return macString, nil
 }
@@ -307,7 +307,8 @@ func (s *service) ConfigureContainerNetworking(ctx context.Context, req *nodenet
 	// for testing purposes, make endpoints here
 	log.G(ctx).WithField("req", req).Info("ConfigureContainerNetworking request")
 
-	if req.RequestType == nodenetsvc.RequestType_Setup {
+	switch req.RequestType {
+	case nodenetsvc.RequestType_Setup:
 		interfaces := []*nodenetsvc.ContainerNetworkInterface{}
 		if s.conf.NetworkingSettings != nil && s.conf.NetworkingSettings.HNSSettings != nil {
 			result, err := s.configureHCNNetworkingHelper(ctx, req)
@@ -326,7 +327,7 @@ func (s *service) ConfigureContainerNetworking(ctx context.Context, req *nodenet
 		return &nodenetsvc.ConfigureContainerNetworkingResponse{
 			Interfaces: interfaces,
 		}, nil
-	} else if req.RequestType == nodenetsvc.RequestType_Teardown {
+	case nodenetsvc.RequestType_Teardown:
 		return s.teardownConfigureContainerNetworking(ctx, req)
 	}
 	return nil, fmt.Errorf("invalid request type %v", req.RequestType)
@@ -448,7 +449,7 @@ func (s *service) ConfigureNetworking(ctx context.Context, req *nodenetsvc.Confi
 	return s.teardownHelper(ctx, req, containerNamespaceID)
 }
 
-//nolint:stylecheck
+//nolint:staticcheck // ST1003: ALL_CAPS
 func (s *service) GetHostLocalIpAddress(ctx context.Context, req *nodenetsvc.GetHostLocalIpAddressRequest) (*nodenetsvc.GetHostLocalIpAddressResponse, error) {
 	return &nodenetsvc.GetHostLocalIpAddressResponse{IpAddr: ""}, nil
 }

--- a/internal/tools/networkagent/v0_service_wrapper.go
+++ b/internal/tools/networkagent/v0_service_wrapper.go
@@ -62,7 +62,7 @@ func (s *v0ServiceWrapper) ConfigureNetworking(ctx context.Context, req *nodenet
 	return &nodenetsvcV0.ConfigureNetworkingResponse{}, nil
 }
 
-//nolint:stylecheck
+//nolint:staticcheck // ST1003: ALL_CAPS
 func (s *v0ServiceWrapper) GetHostLocalIpAddress(ctx context.Context, req *nodenetsvcV0.GetHostLocalIpAddressRequest) (*nodenetsvcV0.GetHostLocalIpAddressResponse, error) {
 	return &nodenetsvcV0.GetHostLocalIpAddressResponse{IpAddr: ""}, nil
 }

--- a/internal/tools/uvmboot/wcow.go
+++ b/internal/tools/uvmboot/wcow.go
@@ -132,7 +132,7 @@ func getLayers(imageName string) ([]string, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to find layers for %s", imageName)
 	}
-	imagePath := strings.Replace(strings.TrimSpace(string(out)), `"`, ``, -1)
+	imagePath := strings.ReplaceAll(strings.TrimSpace(string(out)), `"`, ``)
 	layers, err := getLayerChain(imagePath)
 	if err != nil {
 		return nil, err

--- a/internal/uvm/scsi/attach.go
+++ b/internal/uvm/scsi/attach.go
@@ -120,8 +120,8 @@ func (am *attachManager) trackAttachment(c *attachConfig) (*attachment, bool, er
 	defer am.m.Unlock()
 
 	var (
-		freeController int = -1
-		freeLUN        int = -1
+		freeController = -1
+		freeLUN        = -1
 	)
 	for controller := range am.slots {
 		for lun := range am.slots[controller] {

--- a/internal/uvm/scsi/mount.go
+++ b/internal/uvm/scsi/mount.go
@@ -115,7 +115,7 @@ func (mm *mountManager) trackMount(controller, lun uint, path string, c *mountCo
 	mm.m.Lock()
 	defer mm.m.Unlock()
 
-	var freeIndex int = -1
+	var freeIndex = -1
 	for i, mount := range mm.mounts {
 		if mount == nil {
 			if freeIndex == -1 {

--- a/internal/uvm/share.go
+++ b/internal/uvm/share.go
@@ -60,7 +60,7 @@ func (uvm *UtilityVM) Share(ctx context.Context, reqHostPath, reqUVMPath string,
 			return fmt.Errorf("could not open '%s' path on host: %w", reqHostPath, err)
 		}
 		var (
-			hostPath       string = reqHostPath
+			hostPath       = reqHostPath
 			restrictAccess bool
 			fileName       string
 			allowedNames   []string

--- a/internal/wclayer/importlayer.go
+++ b/internal/wclayer/importlayer.go
@@ -70,7 +70,7 @@ func (r *legacyLayerWriterWrapper) Close() (err error) {
 	defer r.s.End()
 	defer func() { oc.SetSpanStatus(r.s, err) }()
 	defer os.RemoveAll(r.root.Name())
-	defer r.legacyLayerWriter.CloseRoots()
+	defer r.CloseRoots()
 
 	err = r.legacyLayerWriter.Close()
 	if err != nil {

--- a/internal/winobjdir/object_dir.go
+++ b/internal/winobjdir/object_dir.go
@@ -71,10 +71,8 @@ func EnumerateNTObjectDirectory(ntObjDirPath string) ([]string, error) {
 		}
 		dirInfo := (*winapi.ObjectDirectoryInformation)(unsafe.Pointer(&buffer[0]))
 		index := 1
-		for {
-			if dirInfo == nil || dirInfo.Name.Length == 0 {
-				break
-			}
+		for dirInfo != nil && dirInfo.Name.Length != 0 {
+
 			result = append(result, dirInfo.Name.String())
 			size := unsafe.Sizeof(winapi.ObjectDirectoryInformation{}) * uintptr(index)
 			dirInfo = (*winapi.ObjectDirectoryInformation)(unsafe.Pointer(&buffer[size]))

--- a/pkg/cimfs/cim_writer_windows.go
+++ b/pkg/cimfs/cim_writer_windows.go
@@ -75,7 +75,7 @@ func CreateBlockCIM(blockPath, name string, blockType BlockCIMType) (_ *CimFsWri
 
 	// When creating block CIMs we always want them to be consistent CIMs i.e a CIMs
 	// created from the same layer tar will always be identical.
-	var createFlags uint32 = CimCreateFlagConsistentCim
+	var createFlags = CimCreateFlagConsistentCim
 	switch blockType {
 	case BlockCIMTypeDevice:
 		createFlags |= CimCreateFlagBlockDeviceCim

--- a/pkg/cimfs/mount_cim.go
+++ b/pkg/cimfs/mount_cim.go
@@ -47,7 +47,7 @@ func Unmount(volumePath string) error {
 		volumePath += "\\"
 	}
 
-	if !(strings.HasPrefix(volumePath, "\\\\?\\Volume{") && strings.HasSuffix(volumePath, "}\\")) {
+	if !strings.HasPrefix(volumePath, "\\\\?\\Volume{") || !strings.HasSuffix(volumePath, "}\\") {
 		return errors.Errorf("volume path %s is not in the expected format", volumePath)
 	}
 

--- a/pkg/octtrpc/interceptor.go
+++ b/pkg/octtrpc/interceptor.go
@@ -34,7 +34,7 @@ const metadataTraceContextKey = "octtrpc.tracecontext"
 
 func convertMethodName(name string) string {
 	name = strings.TrimPrefix(name, "/")
-	name = strings.Replace(name, "/", ".", -1)
+	name = strings.ReplaceAll(name, "/", ".")
 	return name
 }
 

--- a/pkg/securitypolicy/securitypolicy_test.go
+++ b/pkg/securitypolicy/securitypolicy_test.go
@@ -1290,10 +1290,11 @@ func generateMounts(r *rand.Rand) []mountInternal {
 		// select a "source type". our default is "no special prefix" ie a
 		// "standard source".
 		prefixType := randMinMax(r, 1, 3)
-		if prefixType == 2 {
+		switch prefixType {
+		case 2:
 			// sandbox mount, gets special handling
 			sourcePrefix = guestpath.SandboxMountPrefix
-		} else if prefixType == 3 {
+		case 3:
 			// huge page mount, gets special handling
 			sourcePrefix = guestpath.HugePagesMountPrefix
 		}
@@ -1399,11 +1400,12 @@ func (gen *dataGenerator) createValidOverlayForContainer(enforcer SecurityPolicy
 
 func (gen *dataGenerator) createInvalidOverlayForContainer(enforcer SecurityPolicyEnforcer, container *securityPolicyContainer) ([]string, error) {
 	method := gen.rng.Intn(3)
-	if method == 0 {
+	switch method {
+	case 0:
 		return gen.invalidOverlaySameSizeWrongMounts(enforcer, container)
-	} else if method == 1 {
+	case 1:
 		return gen.invalidOverlayCorrectDevicesWrongOrderSomeMissing(enforcer, container)
-	} else {
+	default:
 		return gen.invalidOverlayRandomJunk(enforcer, container)
 	}
 }

--- a/test/functional/lcow_policy_test.go
+++ b/test/functional/lcow_policy_test.go
@@ -89,8 +89,7 @@ func TestGetProperties_WithPolicy(t *testing.T) {
 				if allowProperties {
 					t.Fatalf("get properties should have been allowed: %s", err)
 				}
-				if !(policytest.AssertErrorContains(t, err, "deny") &&
-					policytest.AssertErrorContains(t, err, "get_properties")) {
+				if !policytest.AssertErrorContains(t, err, "deny") || !policytest.AssertErrorContains(t, err, "get_properties") {
 					t.Fatalf("get properties denial error, got: %s", err)
 				}
 			} else {

--- a/test/internal/layers/lazy.go
+++ b/test/internal/layers/lazy.go
@@ -159,14 +159,15 @@ func (x *LazyImageLayers) extractLayers(ctx context.Context) (err error) {
 
 func extractImageHandler(platform string, appendVerity bool) (extractHandler, error) {
 	var extract extractHandler
-	if platform == images.PlatformLinux {
+	switch platform {
+	case images.PlatformLinux:
 		extract = linuxExt4LayerExtractHandler()
 		if appendVerity {
 			extract = withAppendVerity(extract)
 		}
 		extract = withVHDFooter(extract)
 		return extract, nil
-	} else if platform == images.PlatformWindows {
+	case images.PlatformWindows:
 		return windowsImage, nil
 	}
 	return nil, fmt.Errorf("unsupported platform %q", platform)


### PR DESCRIPTION
v1 is deprecated, and `golangci/golangci-lint-action@v8` requires v2.1+.

Use `golangci-lint migrate` to switch to v2 settings and remove outdated/deprecated settings.

Ignore `nil` pointer lints for tests, since the linter doesn't handle `t.Fatal` appropriately.

Fix various new lint issues, mostly `staticcheck` quick fixes (via `golangci-ling --fix`):
 - embedded field selector
 - simplify conditionals via De Morgan
 - replace `strings.Replace(_, _, _, -1)` with `strings.ReplaceAll()`
 - switch `if/else-if` to `switch`
 - move conditional into infinite `for` loops
 - omit unnecessary type declaration

See #2427