### PR TITLE
Organize annotations; change annotation expansions

### DIFF
--- a/internal/annotations/annotations.go
+++ b/internal/annotations/annotations.go
@@ -5,8 +5,7 @@
 // Do not rely on these annotations to customize production workload behavior.
 package annotations
 
-// uVM specific annotations
-
+// uVM annotations.
 const (
 	// UVMHyperVSocketConfigPrefix is the prefix of an annotation to map a [hyper-v socket] service GUID
 	// to a JSON-encoded string of its [configuration].
@@ -30,6 +29,27 @@ const (
 	// [configuration]: https://learn.microsoft.com/en-us/virtualization/api/hcs/schemareference#HvSocketServiceConfig
 	UVMHyperVSocketConfigPrefix = "io.microsoft.virtualmachine.hv-socket.service-table."
 
+	// UVMConsolePipe is the name of the named pipe that the UVM console is connected to. This works only for non-SNP
+	// scenario, for SNP use a debugger.
+	UVMConsolePipe = "io.microsoft.virtualmachine.console.pipe"
+)
+
+// LCOW uVM annotations.
+const (
+	// ExtraVSockPorts adds additional ports to the list of ports that the UVM is allowed to use.
+	ExtraVSockPorts = "io.microsoft.virtualmachine.lcow.extra-vsock-ports"
+
+	// NetworkingPolicyBasedRouting toggles on the ability to set policy based routing in the
+	// guest for LCOW.
+	//
+	// TODO(katiewasnothere): The goal of this annotation was to be used as a fallback if the
+	// work to support multiple custom network routes per adapter in LCOW breaks existing
+	// LCOW scenarios. Ideally, this annotation should be removed if no issues are found.
+	NetworkingPolicyBasedRouting = "io.microsoft.virtualmachine.lcow.network.policybasedrouting"
+)
+
+// WCOW uVM annotations.
+const (
 	// AdditionalRegistryValues specifies additional registry keys and their values to set in the WCOW UVM.
 	// The format is a JSON-encoded string of an array containing [HCS RegistryValue] objects.
 	//
@@ -41,19 +61,4 @@ const (
 	//
 	// [HCS RegistryValue]: https://learn.microsoft.com/en-us/virtualization/api/hcs/schemareference#registryvalue
 	AdditionalRegistryValues = "io.microsoft.virtualmachine.wcow.additional-reg-keys"
-
-	// ExtraVSockPorts adds additional ports to the list of ports that the UVM is allowed to use.
-	ExtraVSockPorts = "io.microsoft.virtualmachine.lcow.extra-vsock-ports"
-
-	// UVMConsolePipe is the name of the named pipe that the UVM console is connected to. This works only for non-SNP
-	// scenario, for SNP use a debugger.
-	UVMConsolePipe = "io.microsoft.virtualmachine.console.pipe"
-
-	// NetworkingPolicyBasedRouting toggles on the ability to set policy based routing in the
-	// guest for LCOW.
-	//
-	// TODO(katiewasnothere): The goal of this annotation was to be used as a fallback if the
-	// work to support multiple custom network routes per adapter in LCOW breaks existing
-	// LCOW scenarios. Ideally, this annotation should be removed if no issues are found.
-	NetworkingPolicyBasedRouting = "io.microsoft.virtualmachine.lcow.network.policybasedrouting"
 )

--- a/internal/oci/annotations.go
+++ b/internal/oci/annotations.go
@@ -34,7 +34,7 @@ func ProcessAnnotations(ctx context.Context, s *specs.Spec) error {
 
 	// expand annotations
 	var errs []error
-	for key, exps := range annotations.AnnotationExpansions {
+	for key, exps := range annotations.AnnotationExpansionMap() {
 		// check if annotation is present
 		if val, ok := s.Annotations[key]; ok {
 			// ideally, some normalization would occur here (ie, "True" -> "true")

--- a/internal/oci/annotations_test.go
+++ b/internal/oci/annotations_test.go
@@ -186,7 +186,8 @@ func TestProccessAnnotations_Expansion(t *testing.T) {
 					subtest.Fatalf("could not update spec from options: %v", err)
 				}
 
-				for _, k := range annotations.AnnotationExpansions[annotations.DisableUnsafeOperations] {
+				ae := annotations.AnnotationExpansionMap()
+				for _, k := range ae[annotations.DisableUnsafeOperations] {
 					if vv := tt.spec.Annotations[k]; vv != v {
 						subtest.Fatalf("annotation %q was incorrectly expanded to %q, expected %q", k, vv, v)
 					}

--- a/pkg/annotations/annotations.go
+++ b/pkg/annotations/annotations.go
@@ -1,5 +1,24 @@
 package annotations
 
+// General annotations.
+const (
+	// KubernetesContainerType is the annotation used by CRI to define the `ContainerType`.
+	KubernetesContainerType = "io.kubernetes.cri.container-type"
+
+	// KubernetesSandboxID is the annotation used by CRI to define the
+	// KubernetesContainerType == "sandbox"` ID.
+	KubernetesSandboxID = "io.kubernetes.cri.sandbox-id"
+)
+
+// Container annotations.
+const (
+	// ContainerProcessDumpLocation specifies a path inside of containers to save process dumps to. As
+	// the scratch space for a container is generally cleaned up after exit, this is best set to a volume mount of
+	// some kind (vhd, bind mount, fileshare mount etc.)
+	ContainerProcessDumpLocation = "io.microsoft.container.processdumplocation"
+)
+
+// Container resource annotations.
 const (
 	// ContainerMemorySizeInMB overrides the container memory size set
 	// via the OCI spec.
@@ -51,7 +70,10 @@ const (
 	// `WindowsPodSandboxConfig` for setting this correctly. It should not be
 	// used via OCI runtimes and rather use `spec.Windows.Resources.CPU.Shares`.
 	ContainerProcessorWeight = "io.microsoft.container.processor.weight"
+)
 
+// Container storage (Quality of Service) annotations.
+const (
 	// ContainerStorageQoSBandwidthMaximum overrides the container
 	// storage bandwidth per second set via the OCI spec.
 	//
@@ -69,26 +91,101 @@ const (
 	// used via OCI runtimes and rather use
 	// `spec.Windows.Resources.Storage.Iops`.
 	ContainerStorageQoSIopsMaximum = "io.microsoft.container.storage.qos.iopsmaximum"
+)
 
-	// GPUVHDPath overrides the default path to search for the gpu vhd.
+// LCOW container annotations.
+const (
+
+	// RLimitCore specifies the core rlimit value for a container. This will need to be set
+	// in order to have core dumps generated for a given container.
+	RLimitCore = "io.microsoft.lcow.rlimitcore"
+
+	// LCOWDevShmSizeInKb specifies the size of LCOW /dev/shm.
+	LCOWDevShmSizeInKb = "io.microsoft.lcow.shm.size-kb"
+
+	// LCOWPrivileged is used to specify that the container should be run in privileged mode.
+	LCOWPrivileged = "io.microsoft.virtualmachine.lcow.privileged"
+)
+
+// LCOW integrity protection and confidential container annotations.
+const (
+	// DmVerityCreateArgs specifies the `dm-mod.create` parameters to kernel and enables integrity protection of
+	// the rootfs.
+	DmVerityCreateArgs = "io.microsoft.virtualmachine.lcow.dmverity-create-args"
+
+	// DmVerityMode specifies whether the rootfs is expected to be presented as a standalone SCSI attachment,
+	// in which case the UVM boots with dm-verity.
+	DmVerityMode = "io.microsoft.virtualmachine.lcow.dmverity-mode"
+
+	// DmVerityRootFsVhd specifies the path of the VHD (with embedded dmverity data) file to use if required.
+	// Only applies in SNP mode.
+	DmVerityRootFsVhd = "io.microsoft.virtualmachine.lcow.dmverity-rootfs-vhd"
+
+	// EncryptedScratchDisk indicates whether or not the container scratch disks
+	// should be encrypted or not.
 	//
-	// Deprecated: GPU VHDs are no longer supported.
-	GPUVHDPath = "io.microsoft.lcow.gpuvhdpath"
+	// LCOW only.
+	EncryptedScratchDisk = "io.microsoft.virtualmachine.storage.scratch.encrypted"
 
-	// ContainerGPUCapabilities is used to find the gpu capabilities on the container spec.
-	ContainerGPUCapabilities = "io.microsoft.container.gpu.capabilities"
+	// GuestStateFile specifies the path of the vmgs file to use if required. Only applies in SNP mode.
+	GuestStateFile = "io.microsoft.virtualmachine.lcow.gueststatefile"
 
-	// VirtualMachineKernelDrivers indicates what drivers to install in the pod.
-	// This value should contain a list of comma separated directories containing all
-	// files and information needed to install given driver(s). For windows, this may
-	// include .sys, .inf, .cer, and/or other files used during standard installation with pnputil.
-	// For LCOW, this may include a vhd file that contains kernel modules as *.ko files.
-	VirtualMachineKernelDrivers = "io.microsoft.virtualmachine.kerneldrivers"
+	// HclEnabled specifies whether to enable the host compatibility layer.
+	HclEnabled = "io.microsoft.virtualmachine.lcow.hcl-enabled"
 
+	// HostAMDCertificate specifies the filename of the AMD certificates to be passed to UVM.
+	// The certificate is expected to be located in the same directory as the shim executable.
+	HostAMDCertificate = "io.microsoft.virtualmachine.lcow.amd-certificate"
+
+	// NoSecurityHardware allows us, when it is set to true, to do testing and development without requiring SNP hardware.
+	NoSecurityHardware = "io.microsoft.virtualmachine.lcow.no_security_hardware"
+
+	// SecurityPolicy is used to specify a security policy for opengcs to enforce.
+	SecurityPolicy = "io.microsoft.virtualmachine.lcow.securitypolicy"
+
+	// SecurityPolicyEnforcer is used to specify which enforcer to initialize (open-door, standard or rego).
+	// This allows for better fallback mechanics.
+	SecurityPolicyEnforcer = "io.microsoft.virtualmachine.lcow.enforcer"
+
+	// UVMSecurityPolicyEnv specifies if confidential containers' related information
+	// should be written to containers' rootfs. The filenames and location are defined
+	// by securitypolicy.PolicyFilename, securitypolicy.HostAMDCertFilename and
+	// securitypolicy.ReferenceInfoFilename.
+	UVMSecurityPolicyEnv = "io.microsoft.virtualmachine.lcow.securitypolicy.env"
+
+	// UVMReferenceInfoFile specifies the filename of a signed UVM reference file to be passed to UVM.
+	UVMReferenceInfoFile = "io.microsoft.virtualmachine.lcow.uvm-reference-info-file"
+)
+
+// WCOW container annotations.
+const (
 	// DeviceExtensions contains a comma separated list of full paths to device extension files.
 	// The content of these are added to a container's hcs create document.
 	DeviceExtensions = "io.microsoft.container.wcow.deviceextensions"
 
+	// HostProcessRootfsLocation indicates where the rootfs for a host process container should be located. If file binding support is
+	// available (Windows versions 20H1 and up) this will be the absolute path where the rootfs for a container will be located on the host
+	// and will be unique per container. On < 20H1 hosts, the location will be C:\<path-supplied>\<containerID>. So for example, if the value
+	// supplied was C:\rootfs and the container's ID is 12345678 the rootfs will be located at C:\rootfs\12345678.
+	HostProcessRootfsLocation = "microsoft.com/hostprocess-rootfs-location"
+
+	// WCOWDisableGMSA disables providing gMSA (Group Managed Service Accounts) to
+	// a WCOW container.
+	WCOWDisableGMSA = "io.microsoft.container.wcow.gmsa.disable"
+
+	// WCOWProcessDumpType specifies the type of dump to create when generating a local user mode
+	// process dump for Windows containers. The supported options are "mini", and "full".
+	// See DumpType: https://docs.microsoft.com/en-us/windows/win32/wer/collecting-user-mode-dumps
+	WCOWProcessDumpType = "io.microsoft.wcow.processdumptype"
+
+	// WCOWProcessDumpCount specifies the maximum number of dumps to be collected in the specified
+	// ContainerProcessDumpLocation path. When the maximum value is exceeded, the oldest dump file in the
+	// folder will be replaced by the new dump file. The default value is 10.
+	WCOWProcessDumpCount = "io.microsoft.wcow.processdumpcount"
+)
+
+// WCOW host process container annotations.
+const (
 	// HostProcessInheritUser indicates whether to ignore the username passed in to run a host process
 	// container as and instead inherit the user token from the executable that is launching the container process.
 	HostProcessInheritUser = "microsoft.com/hostprocess-inherit-user"
@@ -98,40 +195,29 @@ const (
 
 	// DisableHostProcessContainer disables the ability to start a host process container (job container in this repository).
 	DisableHostProcessContainer = "microsoft.com/disable-hostprocess-container"
+)
 
-	// HostProcessRootfsLocation indicates where the rootfs for a host process container should be located. If file binding support is
-	// available (Windows versions 20H1 and up) this will be the absolute path where the rootfs for a container will be located on the host
-	// and will be unique per container. On < 20H1 hosts, the location will be C:\<path-supplied>\<containerID>. So for example, if the value
-	// supplied was C:\rootfs and the container's ID is 12345678 the rootfs will be located at C:\rootfs\12345678.
-	HostProcessRootfsLocation = "microsoft.com/hostprocess-rootfs-location"
+// uVM annotations.
+const (
+	// DumpDirectoryPath provides a path to the directory in which dumps for a UVM will be collected in
+	// case the UVM crashes.
+	DumpDirectoryPath = "io.microsoft.virtualmachine.dump-directory-path"
 
-	// AllowOvercommit indicates if we should allow over commit memory for UVM.
-	// Defaults to true. For physical backed memory, set to false.
-	AllowOvercommit = "io.microsoft.virtualmachine.computetopology.memory.allowovercommit"
+	// DisableWritableFileShares disables adding any writable fileshares to the UVM.
+	DisableWritableFileShares = "io.microsoft.virtualmachine.fileshares.disablewritable"
 
-	// EnableDeferredCommit indicates if we should allow deferred memory commit for UVM.
-	// Defaults to false. For virtual memory with deferred commit, set to true.
-	EnableDeferredCommit = "io.microsoft.virtualmachine.computetopology.memory.enabledeferredcommit"
+	// VirtualMachineKernelDrivers indicates what drivers to install in the pod.
+	// This value should contain a list of comma separated directories containing all
+	// files and information needed to install given driver(s). For windows, this may
+	// include .sys, .inf, .cer, and/or other files used during standard installation with pnputil.
+	// For LCOW, this may include a vhd file that contains kernel modules as *.ko files.
+	VirtualMachineKernelDrivers = "io.microsoft.virtualmachine.kerneldrivers"
+)
 
-	// EnableColdDiscardHint indicates whether to enable cold discard hint, which allows the UVM
-	// to trim non-zeroed pages from the working set (if supported by the guest operating system).
-	EnableColdDiscardHint = "io.microsoft.virtualmachine.computetopology.memory.enablecolddiscardhint"
-
-	// MemorySizeInMB overrides the container memory size set via the
-	// OCI spec.
-	//
-	// Note: This annotation is in MB. OCI is in Bytes. When using this override
-	// the caller MUST use MB or sizing will be wrong.
-	MemorySizeInMB = "io.microsoft.virtualmachine.computetopology.memory.sizeinmb"
-
-	// MemoryLowMMIOGapInMB indicates the low MMIO gap in MB.
-	MemoryLowMMIOGapInMB = "io.microsoft.virtualmachine.computetopology.memory.lowmmiogapinmb"
-
-	// MemoryHighMMIOBaseInMB indicates the high MMIO base in MB.
-	MemoryHighMMIOBaseInMB = "io.microsoft.virtualmachine.computetopology.memory.highmmiobaseinmb"
-
-	// MemoryHighMMIOGapInMB indicates the high MMIO gap in MB.
-	MemoryHighMMIOGapInMB = "io.microsoft.virtualmachine.computetopology.memory.highmmiogapinmb"
+// uVM CPU annotations.
+const (
+	// CPUGroupID specifies the cpugroup ID that a UVM should be assigned to, if any.
+	CPUGroupID = "io.microsoft.virtualmachine.cpugroup.id"
 
 	// ProcessorCount overrides the hypervisor isolated vCPU count set
 	// via the OCI spec.
@@ -158,164 +244,45 @@ const (
 	// Note: Unlike Windows process isolated container QoS Count/Limt/Weight on
 	// the UVM are not mutually exclusive and can be set together.
 	ProcessorWeight = "io.microsoft.virtualmachine.computetopology.processor.weight"
+)
 
-	// VPMemCount indicates the max number of vpmem devices that can be used on the UVM.
-	VPMemCount = "io.microsoft.virtualmachine.devices.virtualpmem.maximumcount"
+// uVM memory annotations.
+const (
+	// AllowOvercommit indicates if we should allow over commit memory for UVM.
+	// Defaults to true. For physical backed memory, set to false.
+	AllowOvercommit = "io.microsoft.virtualmachine.computetopology.memory.allowovercommit"
 
-	// VPMemSize indicates the size of the VPMem devices.
-	VPMemSize = "io.microsoft.virtualmachine.devices.virtualpmem.maximumsizebytes"
+	// EnableDeferredCommit indicates if we should allow deferred memory commit for UVM.
+	// Defaults to false. For virtual memory with deferred commit, set to true.
+	EnableDeferredCommit = "io.microsoft.virtualmachine.computetopology.memory.enabledeferredcommit"
 
-	// PreferredRootFSType indicates what the preferred rootfs type should be for an LCOW UVM.
-	// valid values are "initrd" or "vhd".
-	PreferredRootFSType = "io.microsoft.virtualmachine.lcow.preferredrootfstype"
-
-	// BootFilesRootPath indicates the path to find the LCOW boot files to use when creating the UVM.
-	BootFilesRootPath = "io.microsoft.virtualmachine.lcow.bootfilesrootpath"
-
-	// KernelDirectBoot indicates that we should skip UEFI and boot directly to `kernel`.
-	KernelDirectBoot = "io.microsoft.virtualmachine.lcow.kerneldirectboot"
-
-	// VPCIEnabled indicates that pci support should be enabled for the LCOW UVM.
-	VPCIEnabled = "io.microsoft.virtualmachine.lcow.vpcienabled"
-
-	// VPMemNoMultiMapping indicates that we should disable LCOW vpmem layer multi mapping.
-	VPMemNoMultiMapping = "io.microsoft.virtualmachine.lcow.vpmem.nomultimapping"
-
-	// KernelBootOptions is used to specify kernel options used while booting a linux kernel.
-	KernelBootOptions = "io.microsoft.virtualmachine.lcow.kernelbootoptions"
-
-	// StorageQoSBandwidthMaximum indicates the maximum number of bytes per second. If `0`
-	// will default to the platform default.
-	StorageQoSBandwidthMaximum = "io.microsoft.virtualmachine.storageqos.bandwidthmaximum"
-
-	// StorageQoSIopsMaximum indicates the maximum number of Iops. If `0` will
-	// default to the platform default.
-	StorageQoSIopsMaximum = "io.microsoft.virtualmachine.storageqos.iopsmaximum"
+	// EnableColdDiscardHint indicates whether to enable cold discard hint, which allows the UVM
+	// to trim non-zeroed pages from the working set (if supported by the guest operating system).
+	EnableColdDiscardHint = "io.microsoft.virtualmachine.computetopology.memory.enablecolddiscardhint"
 
 	// FullyPhysicallyBacked indicates that the UVM should use physically backed memory only,
 	// including for additional devices added later.
 	FullyPhysicallyBacked = "io.microsoft.virtualmachine.fullyphysicallybacked"
 
-	// DisableCompartmentNamespace sets whether to disable namespacing the network compartment in the UVM
-	// for WCOW.
-	DisableCompartmentNamespace = "io.microsoft.virtualmachine.disablecompartmentnamespace"
+	// MemorySizeInMB overrides the container memory size set via the
+	// OCI spec.
+	//
+	// Note: This annotation is in MB. OCI is in Bytes. When using this override
+	// the caller MUST use MB or sizing will be wrong.
+	MemorySizeInMB = "io.microsoft.virtualmachine.computetopology.memory.sizeinmb"
 
-	// VSMBNoDirectMap specifies that no direct mapping should be used for any VSMBs added to the UVM.
-	VSMBNoDirectMap = "io.microsoft.virtualmachine.wcow.virtualSMB.nodirectmap"
+	// MemoryLowMMIOGapInMB indicates the low MMIO gap in MB.
+	MemoryLowMMIOGapInMB = "io.microsoft.virtualmachine.computetopology.memory.lowmmiogapinmb"
 
-	// DisableWritableFileShares disables adding any writable fileshares to the UVM.
-	DisableWritableFileShares = "io.microsoft.virtualmachine.fileshares.disablewritable"
+	// MemoryHighMMIOBaseInMB indicates the high MMIO base in MB.
+	MemoryHighMMIOBaseInMB = "io.microsoft.virtualmachine.computetopology.memory.highmmiobaseinmb"
 
-	// CPUGroupID specifies the cpugroup ID that a UVM should be assigned to, if any.
-	CPUGroupID = "io.microsoft.virtualmachine.cpugroup.id"
+	// MemoryHighMMIOGapInMB indicates the high MMIO gap in MB.
+	MemoryHighMMIOGapInMB = "io.microsoft.virtualmachine.computetopology.memory.highmmiogapinmb"
+)
 
-	// NetworkConfigProxy holds the address of the network config proxy service.
-	// If set, network setup will be attempted via ncproxy.
-	NetworkConfigProxy = "io.microsoft.network.ncproxy"
-
-	// NcproxyContainerID indicates whether or not to use the hcsshim container ID
-	// when setting up ncproxy and computeagent.
-	NcproxyContainerID = "io.microsoft.network.ncproxy.containerid"
-
-	// EncryptedScratchDisk indicates whether or not the container scratch disks
-	// should be encrypted or not.
-	EncryptedScratchDisk = "io.microsoft.virtualmachine.storage.scratch.encrypted"
-
-	// SecurityPolicy is used to specify a security policy for opengcs to enforce.
-	SecurityPolicy = "io.microsoft.virtualmachine.lcow.securitypolicy"
-
-	// SecurityPolicyEnforcer is used to specify which enforcer to initialize (open-door, standard or rego).
-	// This allows for better fallback mechanics.
-	SecurityPolicyEnforcer = "io.microsoft.virtualmachine.lcow.enforcer"
-
-	// HclEnabled specifies whether to enable the host compatibility layer.
-	HclEnabled = "io.microsoft.virtualmachine.lcow.hcl-enabled"
-
-	// ContainerProcessDumpLocation specifies a path inside of containers to save process dumps to. As
-	// the scratch space for a container is generally cleaned up after exit, this is best set to a volume mount of
-	// some kind (vhd, bind mount, fileshare mount etc.)
-	ContainerProcessDumpLocation = "io.microsoft.container.processdumplocation"
-
-	// WCOWProcessDumpType specifies the type of dump to create when generating a local user mode
-	// process dump for Windows containers. The supported options are "mini", and "full".
-	// See DumpType: https://docs.microsoft.com/en-us/windows/win32/wer/collecting-user-mode-dumps
-	WCOWProcessDumpType = "io.microsoft.wcow.processdumptype"
-
-	// WCOWProcessDumpCount specifies the maximum number of dumps to be collected in the specified
-	// ContainerProcessDumpLocation path. When the maximum value is exceeded, the oldest dump file in the
-	// folder will be replaced by the new dump file. The default value is 10.
-	WCOWProcessDumpCount = "io.microsoft.wcow.processdumpcount"
-
-	// RLimitCore specifies the core rlimit value for a container. This will need to be set
-	// in order to have core dumps generated for a given container.
-	RLimitCore = "io.microsoft.lcow.rlimitcore"
-
-	// LCOWDevShmSizeInKb specifies the size of LCOW /dev/shm.
-	LCOWDevShmSizeInKb = "io.microsoft.lcow.shm.size-kb"
-
-	// LCOWPrivileged is used to specify that the container should be run in privileged mode.
-	LCOWPrivileged = "io.microsoft.virtualmachine.lcow.privileged"
-
-	// KubernetesContainerType is the annotation used by CRI to define the `ContainerType`.
-	KubernetesContainerType = "io.kubernetes.cri.container-type"
-
-	// KubernetesSandboxID is the annotation used by CRI to define the
-	// KubernetesContainerType == "sandbox"` ID.
-	KubernetesSandboxID = "io.kubernetes.cri.sandbox-id"
-
-	// NoSecurityHardware allows us, when it is set to true, to do testing and development without requiring SNP hardware.
-	NoSecurityHardware = "io.microsoft.virtualmachine.lcow.no_security_hardware"
-
-	// GuestStateFile specifies the path of the vmgs file to use if required. Only applies in SNP mode.
-	GuestStateFile = "io.microsoft.virtualmachine.lcow.gueststatefile"
-
-	// DmVerityRootFsVhd specifies the path of the VHD (with embedded dmverity data) file to use if required.
-	// Only applies in SNP mode.
-	DmVerityRootFsVhd = "io.microsoft.virtualmachine.lcow.dmverity-rootfs-vhd"
-
-	// DmVerityMode specifies whether the rootfs is expected to be presented as a standalone SCSI attachment,
-	// in which case the UVM boots with dm-verity.
-	DmVerityMode = "io.microsoft.virtualmachine.lcow.dmverity-mode"
-
-	// DmVerityCreateArgs specifies the `dm-mod.create` parameters to kernel and enables integrity protection of
-	// the rootfs.
-	DmVerityCreateArgs = "io.microsoft.virtualmachine.lcow.dmverity-create-args"
-
-	// UVMSecurityPolicyEnv specifies if confidential containers' related information
-	// should be written to containers' rootfs. The filenames and location are defined
-	// by securitypolicy.PolicyFilename, securitypolicy.HostAMDCertFilename and
-	// securitypolicy.ReferenceInfoFilename.
-	UVMSecurityPolicyEnv = "io.microsoft.virtualmachine.lcow.securitypolicy.env"
-
-	// UVMReferenceInfoFile specifies the filename of a signed UVM reference file to be passed to UVM.
-	UVMReferenceInfoFile = "io.microsoft.virtualmachine.lcow.uvm-reference-info-file"
-
-	// HostAMDCertificate specifies the filename of the AMD certificates to be passed to UVM.
-	// The certificate is expected to be located in the same directory as the shim executable.
-	HostAMDCertificate = "io.microsoft.virtualmachine.lcow.amd-certificate"
-
-	// DisableLCOWTimeSyncService is used to disable the chronyd time
-	// synchronization service inside the LCOW UVM.
-	DisableLCOWTimeSyncService = "io.microsoft.virtualmachine.lcow.timesync.disable"
-
-	// NoInheritHostTimezone specifies for the hosts timezone to not be inherited by the WCOW UVM. The UVM will be set to UTC time
-	// as a default.
-	NoInheritHostTimezone = "io.microsoft.virtualmachine.wcow.timezone.noinherit"
-
-	// WCOWDisableGMSA disables providing gMSA (Group Managed Service Accounts) to
-	// a WCOW container.
-	WCOWDisableGMSA = "io.microsoft.container.wcow.gmsa.disable"
-
-	// DisableUnsafeOperations disables several unsafe operations, such as writable
-	// file share mounts, for hostile multi-tenant environments. See `AnnotationExpansions`
-	// for more information.
-	DisableUnsafeOperations = "io.microsoft.disable-unsafe-operations"
-
-	// DumpDirectoryPath provides a path to the directory in which dumps for a UVM will be collected in
-	// case the UVM crashes.
-	DumpDirectoryPath = "io.microsoft.virtualmachine.dump-directory-path"
-
-	// NumaMaximumProcessorsPerNode is the maximum number of processors per vNUMA node.
+// uVM NUMA annotations.
+const (
 	// This should be used for implicit vNUMA topology.
 	NumaMaximumProcessorsPerNode = "io.microsoft.virtualmachine.computetopology.processor.numa.max-processors-per-node"
 
@@ -345,15 +312,109 @@ const (
 	NumaCountOfMemoryBlocks = "io.microsoft.virtualmachine.computetopology.numa.count-of-memory-blocks"
 )
 
-// AnnotationExpansions maps annotations that will be expanded into an array of
-// other annotations. The expanded annotations will have the same value as the
-// original. It is an error for the expansions to already exist and have a value
-// that differs from the original.
-var AnnotationExpansions = map[string][]string{
-	DisableUnsafeOperations: {
-		WCOWDisableGMSA,
-		DisableWritableFileShares,
-		VSMBNoDirectMap,
-		DisableHostProcessContainer,
-	},
+// uVM storage (Quality of Service) annotations.
+const (
+	// StorageQoSBandwidthMaximum indicates the maximum number of bytes per second. If `0`
+	// will default to the platform default.
+	StorageQoSBandwidthMaximum = "io.microsoft.virtualmachine.storageqos.bandwidthmaximum"
+
+	// StorageQoSIopsMaximum indicates the maximum number of Iops. If `0` will
+	// default to the platform default.
+	StorageQoSIopsMaximum = "io.microsoft.virtualmachine.storageqos.iopsmaximum"
+)
+
+// WCOW uVM annotations.
+const (
+	// DisableCompartmentNamespace sets whether to disable namespacing the network compartment in the UVM
+	// for WCOW.
+	DisableCompartmentNamespace = "io.microsoft.virtualmachine.disablecompartmentnamespace"
+
+	// NoInheritHostTimezone specifies for the hosts timezone to not be inherited by the WCOW UVM. The UVM will be set to UTC time
+	// as a default.
+	NoInheritHostTimezone = "io.microsoft.virtualmachine.wcow.timezone.noinherit"
+
+	// VSMBNoDirectMap specifies that no direct mapping should be used for any VSMBs added to the UVM.
+	VSMBNoDirectMap = "io.microsoft.virtualmachine.wcow.virtualSMB.nodirectmap"
+)
+
+// LCOW uVM annotations.
+const (
+	// BootFilesRootPath indicates the path to find the LCOW boot files to use when creating the UVM.
+	BootFilesRootPath = "io.microsoft.virtualmachine.lcow.bootfilesrootpath"
+
+	// DisableLCOWTimeSyncService is used to disable the chronyd time
+	// synchronization service inside the LCOW UVM.
+	DisableLCOWTimeSyncService = "io.microsoft.virtualmachine.lcow.timesync.disable"
+
+	// KernelBootOptions is used to specify kernel options used while booting a linux kernel.
+	KernelBootOptions = "io.microsoft.virtualmachine.lcow.kernelbootoptions"
+
+	// KernelDirectBoot indicates that we should skip UEFI and boot directly to `kernel`.
+	KernelDirectBoot = "io.microsoft.virtualmachine.lcow.kerneldirectboot"
+
+	// PreferredRootFSType indicates what the preferred rootfs type should be for an LCOW UVM.
+	// valid values are "initrd" or "vhd".
+	PreferredRootFSType = "io.microsoft.virtualmachine.lcow.preferredrootfstype"
+
+	// VPCIEnabled indicates that pci support should be enabled for the LCOW UVM.
+	VPCIEnabled = "io.microsoft.virtualmachine.lcow.vpcienabled"
+
+	// VPMemCount indicates the max number of vpmem devices that can be used on the UVM.
+	VPMemCount = "io.microsoft.virtualmachine.devices.virtualpmem.maximumcount"
+
+	// VPMemNoMultiMapping indicates that we should disable LCOW vpmem layer multi mapping.
+	VPMemNoMultiMapping = "io.microsoft.virtualmachine.lcow.vpmem.nomultimapping"
+
+	// VPMemSize indicates the size of the VPMem devices.
+	VPMemSize = "io.microsoft.virtualmachine.devices.virtualpmem.maximumsizebytes"
+)
+
+// Networking annotations.
+const (
+	// NetworkConfigProxy holds the address of the network config proxy service.
+	// If set, network setup will be attempted via ncproxy.
+	NetworkConfigProxy = "io.microsoft.network.ncproxy"
+
+	// NcproxyContainerID indicates whether or not to use the hcsshim container ID
+	// when setting up ncproxy and computeagent.
+	NcproxyContainerID = "io.microsoft.network.ncproxy.containerid"
+)
+
+// GPU annotations.
+const (
+	// GPUVHDPath overrides the default path to search for the gpu vhd.
+	//
+	// Deprecated: GPU VHDs are no longer supported.
+	GPUVHDPath = "io.microsoft.lcow.gpuvhdpath"
+
+	// ContainerGPUCapabilities is used to find the gpu capabilities on the container spec.
+	ContainerGPUCapabilities = "io.microsoft.container.gpu.capabilities"
+)
+
+// Expansion annotations.
+const (
+	// DisableUnsafeOperations disables several unsafe operations, such as writable
+	// file share mounts, for hostile multi-tenant environments. See `AnnotationExpansions`
+	// for more information.
+	DisableUnsafeOperations = "io.microsoft.disable-unsafe-operations"
+)
+
+// See: [AnnotationExpansionMap].
+//
+// Deprecated: use [AnnotationExpansionMap] instead.
+var AnnotationExpansions = AnnotationExpansionMap()
+
+// AnnotationExpansionMap maps annotations into the array of annotations they will be expanded into.
+// The expanded annotations will have the same value as the original.
+// It is an error for the expansions to already exist and have a value that differs from the original.
+func AnnotationExpansionMap() map[string][]string {
+	// use a func instead of var to avoid accidentally modifying the map
+	return map[string][]string{
+		DisableUnsafeOperations: {
+			WCOWDisableGMSA,
+			DisableWritableFileShares,
+			VSMBNoDirectMap,
+			DisableHostProcessContainer,
+		},
+	}
 }


### PR DESCRIPTION
Break out `pkg\annotations\annotations.go` constants into sections (by container or uVM; LCOW, WCOW, or both) for easier searching and readability.

Deprecate `AnnotationExpansions` and instead provide `AnnotationExpansionMap()`, which returns the same value, but provides a
new copy every call, so the `map` cannot be modified.
Cannot delete it or change its type, since it is technically public.

Requires #2440.

A quick and dirty way to validate that no annotations have been deleted:
```pwsh
git checkout helsaawy/annotations-org
$r = '(?-i)^\s([A-Z]\w+)\s=\s"[\w\.\-/]+"'
$new = ((Select-String -Path .\pkg\annotations\annotations.go -Pattern $r).Matches.Groups | Where-Object Name -eq 1).Value
git checkout main
((Select-String -Path .\pkg\annotations\annotations.go -Pattern $r).Matches.Groups | Where-Object Name -eq 1).Value |
	foreach { if ( $_ -notin $new ) { throw "missing variable: $_" } }
```