### PR TITLE
lcow: disable virtio-vsock init

### DIFF
--- a/internal/uvm/create_lcow.go
+++ b/internal/uvm/create_lcow.go
@@ -795,6 +795,10 @@ func makeLCOWDoc(ctx context.Context, opts *OptionsLCOW, uvm *UtilityVM) (_ *hcs
 		}
 	}
 
+	// Explicitly disable virtio_vsock_init, to make sure that we use hv_sock transport. For kernels built without
+	// virtio-vsock this is a no-op.
+	kernelArgs += " initcall_blacklist=virtio_vsock_init"
+
 	vmDebugging := false
 	if opts.ConsolePipe != "" {
 		vmDebugging = true


### PR DESCRIPTION
When a kernel is built with virtio-vsock we encounter a kernel panic in our init script, while trying to read entropy from the host. Parsing through the boot logs, it seems like the hv_sock transport is not being initialized:
```
[    0.712310] NET: Registered PF_VSOCK protocol family
[    0.716225] hv_vmbus: registering driver hv_sock
[    0.719551] hv_vmbus: unregistering driver hv_sock
[    0.723281] IPI shorthand broadcast: enabled
```

Disabling `virtio_vsock_init` seems to fix the problem:
```
[    0.829397] NET: Registered PF_VSOCK protocol family
[    0.831728] initcall virtio_vsock_init blacklisted
[    0.835999] hv_vmbus: registering driver hv_sock
[    0.837906] IPI shorthand broadcast: enabled
```

For kernels built without virtio-vsock, skipping `virtio_vsock_init` is a no-op:
```
[    0.539320] NET: Registered PF_VSOCK protocol family
[    0.541417] hv_vmbus: registering driver hv_sock
[    0.549999] IPI shorthand broadcast: enabled
```