### PR TITLE
fix: close handle when DeviceIoControl fails

### DIFF
--- a/internal/hvsocket/hvsocket.go
+++ b/internal/hvsocket/hvsocket.go
@@ -6,6 +6,7 @@ package hvsocket
 import (
 	"context"
 	"fmt"
+	"github.com/Microsoft/hcsshim/internal/log"
 	"unsafe"
 
 	"github.com/Microsoft/go-winio/pkg/guid"
@@ -92,6 +93,9 @@ func CreateAddressInfo(systemID, vmID, siloID guid.GUID, passthru bool) (resourc
 		&ret,
 		nil,
 	); err != nil {
+		if closeErr := windows.CloseHandle(h); closeErr != nil {
+			log.G(context.Background()).WithError(closeErr).Debug("failed to close address info handle")
+		}
 		return nil, err
 	}
 

--- a/internal/tools/hvsocketaddr/main.go
+++ b/internal/tools/hvsocketaddr/main.go
@@ -32,6 +32,7 @@ func main() {
 	g, err := HCSIDToGUID(os.Args[1])
 	if err != nil {
 		fmt.Printf("error: %s\n", err)
+		os.Exit(1)
 	}
 	fmt.Printf("%s\n", g)
 }


### PR DESCRIPTION
Update hvsocketaddr utility to exit on error.