### PR TITLE
oc/exporter: Include the name of a span in the message

### DIFF
--- a/internal/oc/exporter.go
+++ b/internal/oc/exporter.go
@@ -9,7 +9,7 @@ import (
 	"github.com/Microsoft/hcsshim/internal/logfields"
 )
 
-const spanMessage = "Span"
+const spanMessage = "Span %s"
 
 var _errorCodeKey = logrus.ErrorKey + "Code"
 
@@ -82,5 +82,5 @@ func (le *LogrusExporter) ExportSpan(s *trace.SpanData) {
 
 	entry.Data = data
 	entry.Time = s.StartTime
-	entry.Log(level, spanMessage)
+	entry.Logf(level, spanMessage, s.Name)
 }


### PR DESCRIPTION
This makes it easier to read the logs and see which spans are there, especially since WPA sorts the field by its name, independently for each row.

see:

![image](https://github.com/user-attachments/assets/5c4eb718-b91c-4c0f-ad25-409e66c63fce)

versus

![image](https://github.com/user-attachments/assets/9b53ffaa-8cac-40de-a692-30e7dbe1f808)

I've discussed with Maksim. His worry is that DRIs might already be filtering out rows based on this string, but I think this is still worth considering.