### PR TITLE
log `mkfs.ext4` stderr output

### DIFF
--- a/internal/lcow/scratch.go
+++ b/internal/lcow/scratch.go
@@ -105,6 +105,7 @@ func CreateScratch(ctx context.Context, lcowUVM *uvm.UtilityVM, destFile string,
 	err = cmd.Run()
 	cancel()
 	if err != nil {
+		log.G(ctx).WithError(err).WithField("stderr", mkfsStderr.String()).Error("mkfs.ext4 failed")
 		return fmt.Errorf("failed to `%+v` following hot-add %s to utility VM: %w", cmd.Spec.Args, destFile, err)
 	}
 


### PR DESCRIPTION
Log the stderr output when `mkfs.ext4` fails during scratch formatting. This should help troubleshooting easier, e.g. when the binary is missing or not properly symlinked etc.