### PR TITLE
add support for resource partitions

### DIFF
--- a/internal/oci/annotations.go
+++ b/internal/oci/annotations.go
@@ -383,7 +383,7 @@ func ParseAnnotationsGUID(a map[string]string, key string, def *guid.GUID) (*gui
 	if v, ok := a[key]; ok {
 		g, err := guid.FromString(v)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to parse annotation %q with value %q as GUID: %w", key, v, err)
 		}
 		return &g, nil
 	}

--- a/internal/oci/annotations.go
+++ b/internal/oci/annotations.go
@@ -377,6 +377,19 @@ func ParseAnnotationCommaSeparated(key string, a map[string]string) []string {
 	return results
 }
 
+// ParseAnnotationsGUID searches `a` for `key`. If `key` is found, tries to parse it as guid.GUID, otherwise
+// returns `def`.
+func ParseAnnotationsGUID(a map[string]string, key string, def *guid.GUID) (*guid.GUID, error) {
+	if v, ok := a[key]; ok {
+		g, err := guid.FromString(v)
+		if err != nil {
+			return nil, err
+		}
+		return &g, nil
+	}
+	return def, nil
+}
+
 func logAnnotationValueParseError(ctx context.Context, k, v, et string, err error) {
 	entry := log.G(ctx).WithFields(logrus.Fields{
 		logfields.OCIAnnotation: k,

--- a/internal/oci/uvm.go
+++ b/internal/oci/uvm.go
@@ -251,7 +251,7 @@ func parseDevices(ctx context.Context, specWindows *specs.Windows) []uvm.VPCIDev
 }
 
 // sets options common to both WCOW and LCOW from annotations.
-func specToUVMCreateOptionsCommon(ctx context.Context, opts *uvm.Options, s *specs.Spec) (err error) {
+func specToUVMCreateOptionsCommon(ctx context.Context, opts *uvm.Options, s *specs.Spec) error {
 	opts.MemorySizeInMB = ParseAnnotationsMemory(ctx, s, annotations.MemorySizeInMB, opts.MemorySizeInMB)
 	opts.LowMMIOGapInMB = ParseAnnotationsUint64(ctx, s.Annotations, annotations.MemoryLowMMIOGapInMB, opts.LowMMIOGapInMB)
 	opts.HighMMIOBaseInMB = ParseAnnotationsUint64(ctx, s.Annotations, annotations.MemoryHighMMIOBaseInMB, opts.HighMMIOBaseInMB)
@@ -284,7 +284,8 @@ func specToUVMCreateOptionsCommon(ctx context.Context, opts *uvm.Options, s *spe
 	maps.Copy(opts.AdditionalHyperVConfig, parseHVSocketServiceTable(ctx, s.Annotations))
 
 	// parse error yielding annotations
-	opts.ResourcePoolID, err = ParseAnnotationsGUID(s.Annotations, annotations.ResourcePoolID, opts.ResourcePoolID)
+	var err error
+	opts.ResourcePartitionID, err = ParseAnnotationsGUID(s.Annotations, annotations.ResourcePartitionID, opts.ResourcePartitionID)
 	if err != nil {
 		return err
 	}

--- a/internal/oci/uvm.go
+++ b/internal/oci/uvm.go
@@ -264,6 +264,7 @@ func specToUVMCreateOptionsCommon(ctx context.Context, opts *uvm.Options, s *spe
 	opts.StorageQoSBandwidthMaximum = ParseAnnotationsStorageBps(ctx, s, annotations.StorageQoSBandwidthMaximum, opts.StorageQoSBandwidthMaximum)
 	opts.StorageQoSIopsMaximum = ParseAnnotationsStorageIops(ctx, s, annotations.StorageQoSIopsMaximum, opts.StorageQoSIopsMaximum)
 	opts.CPUGroupID = ParseAnnotationsString(s.Annotations, annotations.CPUGroupID, opts.CPUGroupID)
+	opts.ResourcePoolID = ParseAnnotationsString(s.Annotations, annotations.ResourcePoolID, opts.ResourcePoolID)
 	opts.NetworkConfigProxy = ParseAnnotationsString(s.Annotations, annotations.NetworkConfigProxy, opts.NetworkConfigProxy)
 	opts.ProcessDumpLocation = ParseAnnotationsString(s.Annotations, annotations.ContainerProcessDumpLocation, opts.ProcessDumpLocation)
 	opts.NoWritableFileShares = ParseAnnotationsBool(ctx, s.Annotations, annotations.DisableWritableFileShares, opts.NoWritableFileShares)

--- a/internal/tools/uvmboot/main.go
+++ b/internal/tools/uvmboot/main.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/Microsoft/go-winio/pkg/guid"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 
@@ -131,7 +132,11 @@ func setGlobalOptions(c *cli.Context, options *uvm.Options) {
 		options.EnableDeferredCommit = c.GlobalBool(enableDeferredCommitArgName)
 	}
 	if c.GlobalIsSet(resourcePoolArgName) {
-		options.ResourcePoolID = c.GlobalString(resourcePoolArgName)
+		rpID, err := guid.FromString(c.GlobalString(resourcePoolArgName))
+		if err != nil {
+			logrus.Fatalf("Failed to parse resource pool GUID: %v", err)
+		}
+		options.ResourcePoolID = &rpID
 	}
 	// Always set the console pipe in uvmboot, it helps with testing/debugging
 	options.ConsolePipe = uvmConsolePipe

--- a/internal/tools/uvmboot/main.go
+++ b/internal/tools/uvmboot/main.go
@@ -25,7 +25,7 @@ const (
 	measureArgName              = "measure"
 	parallelArgName             = "parallel"
 	countArgName                = "count"
-	resourcePoolArgName         = "resource-pool"
+	resourcePartitionArgName    = "resource-partition"
 
 	execCommandLineArgName = "exec"
 	uvmConsolePipe         = "\\\\.\\pipe\\uvmpipe"
@@ -85,8 +85,8 @@ func main() {
 			Destination: &useGCS,
 		},
 		cli.StringFlag{
-			Name:  resourcePoolArgName,
-			Usage: "Resource pool GUID to assign UVM to",
+			Name:  resourcePartitionArgName,
+			Usage: "Resource partition GUID to assign UVM to",
 		},
 	}
 
@@ -131,12 +131,12 @@ func setGlobalOptions(c *cli.Context, options *uvm.Options) {
 	if c.GlobalIsSet(enableDeferredCommitArgName) {
 		options.EnableDeferredCommit = c.GlobalBool(enableDeferredCommitArgName)
 	}
-	if c.GlobalIsSet(resourcePoolArgName) {
-		rpID, err := guid.FromString(c.GlobalString(resourcePoolArgName))
+	if c.GlobalIsSet(resourcePartitionArgName) {
+		rpID, err := guid.FromString(c.GlobalString(resourcePartitionArgName))
 		if err != nil {
-			logrus.Fatalf("Failed to parse resource pool GUID: %v", err)
+			logrus.Fatalf("Failed to parse resource partition GUID: %v", err)
 		}
-		options.ResourcePoolID = &rpID
+		options.ResourcePartitionID = &rpID
 	}
 	// Always set the console pipe in uvmboot, it helps with testing/debugging
 	options.ConsolePipe = uvmConsolePipe

--- a/internal/tools/uvmboot/main.go
+++ b/internal/tools/uvmboot/main.go
@@ -24,6 +24,7 @@ const (
 	measureArgName              = "measure"
 	parallelArgName             = "parallel"
 	countArgName                = "count"
+	resourcePoolArgName         = "resource-pool"
 
 	execCommandLineArgName = "exec"
 	uvmConsolePipe         = "\\\\.\\pipe\\uvmpipe"
@@ -82,6 +83,10 @@ func main() {
 			Usage:       "Launch the GCS and perform requested operations via its RPC interface",
 			Destination: &useGCS,
 		},
+		cli.StringFlag{
+			Name:  resourcePoolArgName,
+			Usage: "Resource pool GUID to assign UVM to",
+		},
 	}
 
 	app.Commands = []cli.Command{
@@ -124,6 +129,9 @@ func setGlobalOptions(c *cli.Context, options *uvm.Options) {
 	}
 	if c.GlobalIsSet(enableDeferredCommitArgName) {
 		options.EnableDeferredCommit = c.GlobalBool(enableDeferredCommitArgName)
+	}
+	if c.GlobalIsSet(resourcePoolArgName) {
+		options.ResourcePoolID = c.GlobalString(resourcePoolArgName)
 	}
 	// Always set the console pipe in uvmboot, it helps with testing/debugging
 	options.ConsolePipe = uvmConsolePipe

--- a/internal/uvm/create.go
+++ b/internal/uvm/create.go
@@ -85,8 +85,8 @@ type Options struct {
 	// Defaults to an empty string which indicates the UVM should not be added to any CPUGroup.
 	CPUGroupID string
 
-	// ResourcePoolID holds the resource pool guid.GUID the UVM should be assigned to.
-	ResourcePoolID *guid.GUID
+	// ResourcePartitionID holds the resource partition guid.GUID the UVM should be assigned to.
+	ResourcePartitionID *guid.GUID
 
 	// NetworkConfigProxy holds the address of the network config proxy service.
 	// This != "" determines whether to start the ComputeAgent TTRPC service
@@ -175,6 +175,11 @@ func verifyOptions(_ context.Context, options interface{}) error {
 		if opts.EnableColdDiscardHint && osversion.Build() < 18967 {
 			return errors.New("EnableColdDiscardHint is not supported on builds older than 18967")
 		}
+		if opts.ResourcePartitionID != nil {
+			if opts.CPUGroupID != "" {
+				return errors.New("resource partition ID and CPU group ID cannot be set at the same time")
+			}
+		}
 	case *OptionsWCOW:
 		if opts.EnableDeferredCommit && !opts.AllowOvercommit {
 			return errors.New("EnableDeferredCommit is not supported on physically backed VMs")
@@ -187,6 +192,11 @@ func verifyOptions(_ context.Context, options interface{}) error {
 		}
 		if opts.SecurityPolicyEnabled && opts.GuestStateFilePath == "" {
 			return fmt.Errorf("GuestStateFilePath must be provided when enabling security policy")
+		}
+		if opts.ResourcePartitionID != nil {
+			if opts.CPUGroupID != "" {
+				return errors.New("resource partition ID and CPU group ID cannot be set at the same time")
+			}
 		}
 	}
 	return nil

--- a/internal/uvm/create.go
+++ b/internal/uvm/create.go
@@ -85,8 +85,8 @@ type Options struct {
 	// Defaults to an empty string which indicates the UVM should not be added to any CPUGroup.
 	CPUGroupID string
 
-	// ResourcePoolID holds the resource pool ID the UVM should be assigned to.
-	ResourcePoolID string
+	// ResourcePoolID holds the resource pool guid.GUID the UVM should be assigned to.
+	ResourcePoolID *guid.GUID
 
 	// NetworkConfigProxy holds the address of the network config proxy service.
 	// This != "" determines whether to start the ComputeAgent TTRPC service

--- a/internal/uvm/create.go
+++ b/internal/uvm/create.go
@@ -84,6 +84,10 @@ type Options struct {
 	// CPUGroupID set the ID of a CPUGroup on the host that the UVM should be added to on start.
 	// Defaults to an empty string which indicates the UVM should not be added to any CPUGroup.
 	CPUGroupID string
+
+	// ResourcePoolID holds the resource pool ID the UVM should be assigned to.
+	ResourcePoolID string
+
 	// NetworkConfigProxy holds the address of the network config proxy service.
 	// This != "" determines whether to start the ComputeAgent TTRPC service
 	// that receives the UVMs set of NICs from this proxy instead of enumerating

--- a/internal/uvm/create_lcow.go
+++ b/internal/uvm/create_lcow.go
@@ -657,6 +657,11 @@ func makeLCOWDoc(ctx context.Context, opts *OptionsLCOW, uvm *UtilityVM) (_ *hcs
 		doc.VirtualMachine.ComputeTopology.Memory.SlitType = &firmwareFallbackMeasured
 	}
 
+	if opts.ResourcePoolID != "" {
+		// TODO (maksiman): assign pod to resource pool and potentially do an OS version check before that
+		log.G(ctx).WithField("resource-pool-id", opts.ResourcePoolID).Debug("setting resource pool ID")
+	}
+
 	// Add optional devices that were specified on the UVM spec
 	if len(opts.AssignedDevices) > 0 {
 		if doc.VirtualMachine.Devices.VirtualPci == nil {

--- a/internal/uvm/create_lcow.go
+++ b/internal/uvm/create_lcow.go
@@ -657,9 +657,9 @@ func makeLCOWDoc(ctx context.Context, opts *OptionsLCOW, uvm *UtilityVM) (_ *hcs
 		doc.VirtualMachine.ComputeTopology.Memory.SlitType = &firmwareFallbackMeasured
 	}
 
-	if opts.ResourcePoolID != "" {
+	if opts.ResourcePoolID != nil {
 		// TODO (maksiman): assign pod to resource pool and potentially do an OS version check before that
-		log.G(ctx).WithField("resource-pool-id", opts.ResourcePoolID).Debug("setting resource pool ID")
+		log.G(ctx).WithField("resource-pool-id", opts.ResourcePoolID.String()).Debug("setting resource pool ID")
 	}
 
 	// Add optional devices that were specified on the UVM spec

--- a/internal/uvm/create_lcow.go
+++ b/internal/uvm/create_lcow.go
@@ -657,9 +657,9 @@ func makeLCOWDoc(ctx context.Context, opts *OptionsLCOW, uvm *UtilityVM) (_ *hcs
 		doc.VirtualMachine.ComputeTopology.Memory.SlitType = &firmwareFallbackMeasured
 	}
 
-	if opts.ResourcePoolID != nil {
-		// TODO (maksiman): assign pod to resource pool and potentially do an OS version check before that
-		log.G(ctx).WithField("resource-pool-id", opts.ResourcePoolID.String()).Debug("setting resource pool ID")
+	if opts.ResourcePartitionID != nil {
+		// TODO (maksiman): assign pod to resource partition and potentially do an OS version check before that
+		log.G(ctx).WithField("resource-partition-id", opts.ResourcePartitionID.String()).Debug("setting resource partition ID")
 	}
 
 	// Add optional devices that were specified on the UVM spec

--- a/internal/uvm/create_wcow.go
+++ b/internal/uvm/create_wcow.go
@@ -231,9 +231,9 @@ func prepareCommonConfigDoc(ctx context.Context, uvm *UtilityVM, opts *OptionsWC
 		doc.VirtualMachine.ComputeTopology.Memory.SlitType = &firmwareFallbackMeasured
 	}
 
-	if opts.ResourcePoolID != "" {
+	if opts.ResourcePoolID != nil {
 		// TODO (maksiman): assign pod to resource pool and potentially do an OS version check before that
-		log.G(ctx).WithField("resource-pool-id", opts.ResourcePoolID).Debug("setting resource pool ID")
+		log.G(ctx).WithField("resource-pool-id", opts.ResourcePoolID.String()).Debug("setting resource pool ID")
 	}
 
 	maps.Copy(doc.VirtualMachine.Devices.HvSocket.HvSocketConfig.ServiceTable, opts.AdditionalHyperVConfig)

--- a/internal/uvm/create_wcow.go
+++ b/internal/uvm/create_wcow.go
@@ -231,6 +231,11 @@ func prepareCommonConfigDoc(ctx context.Context, uvm *UtilityVM, opts *OptionsWC
 		doc.VirtualMachine.ComputeTopology.Memory.SlitType = &firmwareFallbackMeasured
 	}
 
+	if opts.ResourcePoolID != "" {
+		// TODO (maksiman): assign pod to resource pool and potentially do an OS version check before that
+		log.G(ctx).WithField("resource-pool-id", opts.ResourcePoolID).Debug("setting resource pool ID")
+	}
+
 	maps.Copy(doc.VirtualMachine.Devices.HvSocket.HvSocketConfig.ServiceTable, opts.AdditionalHyperVConfig)
 
 	// Handle StorageQoS if set

--- a/internal/uvm/create_wcow.go
+++ b/internal/uvm/create_wcow.go
@@ -231,9 +231,9 @@ func prepareCommonConfigDoc(ctx context.Context, uvm *UtilityVM, opts *OptionsWC
 		doc.VirtualMachine.ComputeTopology.Memory.SlitType = &firmwareFallbackMeasured
 	}
 
-	if opts.ResourcePoolID != nil {
-		// TODO (maksiman): assign pod to resource pool and potentially do an OS version check before that
-		log.G(ctx).WithField("resource-pool-id", opts.ResourcePoolID.String()).Debug("setting resource pool ID")
+	if opts.ResourcePartitionID != nil {
+		// TODO (maksiman): assign pod to resource partition and potentially do an OS version check before that
+		log.G(ctx).WithField("resource-partition-id", opts.ResourcePartitionID.String()).Debug("setting resource partition ID")
 	}
 
 	maps.Copy(doc.VirtualMachine.Devices.HvSocket.HvSocketConfig.ServiceTable, opts.AdditionalHyperVConfig)

--- a/pkg/annotations/annotations.go
+++ b/pkg/annotations/annotations.go
@@ -217,6 +217,7 @@ const (
 // uVM CPU annotations.
 const (
 	// CPUGroupID specifies the cpugroup ID that a UVM should be assigned to, if any.
+	// Passing this annotation together with ResourcePartitionID will result in an error.
 	CPUGroupID = "io.microsoft.virtualmachine.cpugroup.id"
 
 	// ProcessorCount overrides the hypervisor isolated vCPU count set
@@ -313,8 +314,10 @@ const (
 	// This should be used for explicit vNUMA topology.
 	NumaCountOfMemoryBlocks = "io.microsoft.virtualmachine.computetopology.numa.count-of-memory-blocks"
 
-	// ResourcePoolID is a GUID string representing a resource pool ID the UVM should be associated with.
-	ResourcePoolID = "io.microsoft.virtualmachine.resource-pool-id"
+	// ResourcePartitionID is a GUID string representing a resource partition ID the UVM should be associated with.
+	// Resource partition will have its own CPU group, as a result this annotation cannot be used together with
+	// CPUGroupID and will yield an error.
+	ResourcePartitionID = "io.microsoft.virtualmachine.resource-partition-id"
 )
 
 // uVM storage (Quality of Service) annotations.

--- a/pkg/annotations/annotations.go
+++ b/pkg/annotations/annotations.go
@@ -312,6 +312,9 @@ const (
 	// number of memory blocks at slice index 1, etc.
 	// This should be used for explicit vNUMA topology.
 	NumaCountOfMemoryBlocks = "io.microsoft.virtualmachine.computetopology.numa.count-of-memory-blocks"
+
+	// ResourcePoolID is a GUID string representing a resource pool ID the UVM should be associated with.
+	ResourcePoolID = "io.microsoft.virtualmachine.resource-pool-id"
 )
 
 // uVM storage (Quality of Service) annotations.


### PR DESCRIPTION
Adds annotation for resource partition id, when present, set the
corresponding field on HCS doc (no-op for now), the rest
will be handled by HCS.