### PR TITLE
Support usr-merged root filesystems

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,14 @@ out/delta-snp.tar.gz: out/delta.tar.gz bin/internal/tools/snp-report boot/startu
 out/delta.tar.gz: bin/init bin/vsockexec bin/cmd/gcs bin/cmd/gcstools bin/cmd/hooks/wait-paths Makefile
 	@mkdir -p out
 	rm -rf rootfs
-	mkdir -p rootfs/bin/
+	rm -rf /tmp/base-rootfs && mkdir -p /tmp/base-rootfs
+	tar -xf $(BASE) -C /tmp/base-rootfs
+	if [ "$$(readlink -f /tmp/base-rootfs/bin)" = "/tmp/base-rootfs/usr/bin" ]; then \
+		mkdir -p rootfs/usr/bin; \
+		ln -s usr/bin rootfs/bin; \
+	else \
+		mkdir -p rootfs/bin; \
+	fi
 	mkdir -p rootfs/info/
 	cp bin/init rootfs/
 	cp bin/vsockexec rootfs/bin/


### PR DESCRIPTION
### Why

Some linux distros, such as AzureLinux, are usr-merged meaning that binaries are not where containerplat will expect them to be. This means we need to create symlinks from the usr directory to /bin.

### How

When constructing delta.tar.gz, detect if the input rootfs is usr merged, if it isn't, keep the existing behaviour, otherwise create /usr/bin instead of /bin and then symlink.