### PR TITLE
Fix CUDA for non-privileged containers

### DIFF
--- a/internal/guest/runtime/hcsv2/nvidia_utils.go
+++ b/internal/guest/runtime/hcsv2/nvidia_utils.go
@@ -23,8 +23,9 @@ import (
 const nvidiaDebugFilePath = "nvidia-container.log"
 const nvidiaToolBinary = "nvidia-container-cli"
 
-// described here: https://github.com/opencontainers/runtime-spec/blob/39c287c415bf86fb5b7506528d471db5405f8ca8/config.md#posix-platform-hooks
-// addNvidiaDeviceHook builds the arguments for nvidia-container-cli and creates the prestart hook
+// addNvidiaDeviceHook builds the arguments for nvidia-container-cli and creates the createRuntime [OCI hooks].
+//
+// [OCI hooks]: https://github.com/opencontainers/runtime-spec/blob/39c287c415bf86fb5b7506528d471db5405f8ca8/config.md#posix-platform-hooks
 func addNvidiaDeviceHook(ctx context.Context, spec *oci.Spec, ociBundlePath string) error {
 	genericHookBinary := "generichook"
 	genericHookPath, err := exec.LookPath(genericHookBinary)

--- a/internal/hcsoci/devices.go
+++ b/internal/hcsoci/devices.go
@@ -174,21 +174,21 @@ func handleAssignedDevicesLCOW(
 
 	// assign device into UVM and create corresponding spec windows devices
 	for _, d := range specDevs {
-		if uvm.IsValidDeviceType(d.IDType) {
-			pciID, index := devices.GetDeviceInfoFromPath(d.ID)
-			vpci, err := vm.AssignDevice(ctx, pciID, index, "")
-			if err != nil {
-				return resultDevs, closers, errors.Wrapf(err, "failed to assign device %s, function %d to pod %s", pciID, index, vm.ID())
-			}
-			closers = append(closers, vpci)
-
-			// update device ID on the spec to the assigned device's resulting vmbus guid so gcs knows which devices to
-			// map into the container
-			d.ID = vpci.VMBusGUID
-			resultDevs = append(resultDevs, d)
-		} else {
+		if !uvm.IsValidDeviceType(d.IDType) {
 			return resultDevs, closers, errors.Errorf("specified device %s has unsupported type %s", d.ID, d.IDType)
 		}
+
+		pciID, index := devices.GetDeviceInfoFromPath(d.ID)
+		vpci, err := vm.AssignDevice(ctx, pciID, index, "")
+		if err != nil {
+			return resultDevs, closers, errors.Wrapf(err, "failed to assign device %s, function %d to pod %s", pciID, index, vm.ID())
+		}
+		closers = append(closers, vpci)
+
+		// update device ID on the spec to the assigned device's resulting vmbus guid so gcs knows which devices to
+		// map into the container
+		d.ID = vpci.VMBusGUID
+		resultDevs = append(resultDevs, d)
 	}
 
 	return resultDevs, closers, nil


### PR DESCRIPTION
CUDA initialization for GPUs fails for non-privileged containers. Experimenting shows that adding `rw` for all character devices fixes the error, so expand the [default `c *:* m` permissions](https://github.com/opencontainers/runc/blob/6bae6cad4759a5b3537d550f43ea37d51c6b518a/libcontainer/specconv/spec_linux.go#L205-L222) to `c *:* rwm`.

Add `"gpu"` string constant and streamline device assignment logic.