### PR TITLE
fixes to uvmboot

### DIFF
--- a/internal/tools/uvmboot/conf_wcow.go
+++ b/internal/tools/uvmboot/conf_wcow.go
@@ -4,9 +4,11 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"os"
 
 	"github.com/containerd/console"
+	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/urfave/cli"
 
 	"github.com/Microsoft/hcsshim/internal/cmd"
@@ -140,6 +142,14 @@ var cwcowCommand = cli.Command{
 					cmd.Stdout = os.Stdout
 					con, err := console.ConsoleFromFile(os.Stdin)
 					if err == nil {
+						csz, err := con.Size()
+						if err != nil {
+							return fmt.Errorf("failed to get console size: %w", err)
+						}
+						cmd.Spec.ConsoleSize = &specs.Box{
+							Height: uint(csz.Height),
+							Width:  uint(csz.Width),
+						}
 						err = con.SetRaw()
 						if err != nil {
 							return err

--- a/internal/tools/uvmboot/lcow.go
+++ b/internal/tools/uvmboot/lcow.go
@@ -4,11 +4,13 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"os"
 	"strings"
 
 	"github.com/containerd/console"
+	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/urfave/cli"
 
 	"github.com/Microsoft/hcsshim/internal/cmd"
@@ -306,6 +308,14 @@ func execViaGCS(ctx context.Context, vm *uvm.UtilityVM, cCtx *cli.Context) error
 		if err != nil {
 			log.G(ctx).WithError(err).Warn("could not create console from stdin")
 		} else {
+			csz, err := con.Size()
+			if err != nil {
+				return fmt.Errorf("failed to get console size: %w", err)
+			}
+			c.Spec.ConsoleSize = &specs.Box{
+				Height: uint(csz.Height),
+				Width:  uint(csz.Width),
+			}
 			if err := con.SetRaw(); err != nil {
 				return err
 			}

--- a/internal/tools/uvmboot/wcow.go
+++ b/internal/tools/uvmboot/wcow.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/containerd/console"
+	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/urfave/cli"
 
 	"github.com/Microsoft/hcsshim/internal/cmd"
@@ -101,6 +102,14 @@ var wcowCommand = cli.Command{
 					cmd.Stdout = os.Stdout
 					con, err := console.ConsoleFromFile(os.Stdin)
 					if err == nil {
+						csz, err := con.Size()
+						if err != nil {
+							return fmt.Errorf("failed to get console size: %w", err)
+						}
+						cmd.Spec.ConsoleSize = &specs.Box{
+							Height: uint(csz.Height),
+							Width:  uint(csz.Width),
+						}
 						err = con.SetRaw()
 						if err != nil {
 							return err


### PR DESCRIPTION
This PR adds 2 changes to the uvmboot tool.

1. sidecar GCS requires a valid policy to be passed. When that is enforced, we won't be able to boot the UVM anymore without a proper policy. This commit adds a default policy and a flag to override it if required while creating UVMs with the tool.

2. Currently the uvmboot code doesn't set a size for the console, that causes it to use the default size and causes weird formatting errors. This fixes that by explicitly passing the current window/console's size. 