### PR TITLE
Support for starting confidential containers

### DIFF
--- a/cmd/containerd-shim-runhcs-v1/pod.go
+++ b/cmd/containerd-shim-runhcs-v1/pod.go
@@ -18,12 +18,48 @@ import (
 	"github.com/Microsoft/hcsshim/pkg/annotations"
 	eventstypes "github.com/containerd/containerd/api/events"
 	task "github.com/containerd/containerd/api/runtime/task/v2"
+	"github.com/containerd/containerd/api/types"
 	"github.com/containerd/containerd/v2/core/runtime"
 	"github.com/containerd/errdefs"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
 	"golang.org/x/sync/errgroup"
 )
+
+// initializeWCOWBootFiles handles the initialization of boot files for WCOW VMs
+func initializeWCOWBootFiles(ctx context.Context, wopts *uvm.OptionsWCOW, rootfs []*types.Mount, s *specs.Spec) error {
+	var (
+		layerFolders []string
+		err          error
+	)
+
+	if s.Windows != nil {
+		layerFolders = s.Windows.LayerFolders
+	}
+
+	wopts.BootFiles, err = layers.GetWCOWUVMBootFilesFromLayers(ctx, rootfs, layerFolders)
+	if err != nil {
+		return err
+	}
+
+	if wopts.SecurityPolicyEnabled {
+		if wopts.BootFiles.BootType != uvm.BlockCIMBoot {
+			return fmt.Errorf("security policy (confidential mode) only works with block CIM based layers")
+		}
+		// we use measured EFI & rootfs for confidential UVMs, use those instead of the ones passed in layers/rootfs
+		wopts.BootFiles.BlockCIMFiles.EFIVHDPath = uvm.GetDefaultConfidentialEFIPath()
+		wopts.BootFiles.BlockCIMFiles.BootCIMVHDPath = uvm.GetDefaultConfidentialBootCIMPath()
+	} else if wopts.BootFiles.BootType == uvm.BlockCIMBoot {
+		// Supporting hyperv isolation with block CIM layers requires changes in
+		// the image pull path to prepare the EFI VHD. But more importantly, since both the
+		// container and UtilityVM files will be in the same CIM, the early boot
+		// code (bootmgr, winload etc.) will need to support reading the UVM OS
+		// files from `UtilityVM/Files` inside the CIM. Once that support is added
+		// we can enable this.
+		return fmt.Errorf("hyperv isolation is not supported with block CIM layers yet")
+	}
+	return nil
+}
 
 // shimPod represents the logical grouping of all tasks in a single set of
 // shared namespaces. The pod sandbox (container) is represented by the task
@@ -123,16 +159,11 @@ func createPod(ctx context.Context, events publisher, req *task.CreateTaskReques
 				return nil, err
 			}
 		case *uvm.OptionsWCOW:
-			var layerFolders []string
-			if s.Windows != nil {
-				layerFolders = s.Windows.LayerFolders
-			}
 			wopts := (opts).(*uvm.OptionsWCOW)
-			wopts.BootFiles, err = layers.GetWCOWUVMBootFilesFromLayers(ctx, req.Rootfs, layerFolders)
+			err = initializeWCOWBootFiles(ctx, wopts, req.Rootfs, s)
 			if err != nil {
 				return nil, err
 			}
-
 			parent, err = uvm.CreateWCOW(ctx, wopts)
 			if err != nil {
 				return nil, err

--- a/internal/fsformatter/formatter_driver.go
+++ b/internal/fsformatter/formatter_driver.go
@@ -60,12 +60,17 @@ func (filesystemType kernelFormatVolumeFilesystemTypes) String() string {
 
 type kernelFormatVolumeFormatInputBufferFlags uint32
 
-const kernelFormatVolumeFormatInputBufferFlagNone = kernelFormatVolumeFormatInputBufferFlags(0x00000000)
+const (
+	kernelFormatVolumeFormatInputBufferFlagNone        = kernelFormatVolumeFormatInputBufferFlags(0x00000000)
+	kernelFormatVolumeFormatInputBufferFlagSuperFloppy = kernelFormatVolumeFormatInputBufferFlags(0x00000001)
+)
 
 func (flag kernelFormatVolumeFormatInputBufferFlags) String() string {
 	switch flag {
 	case kernelFormatVolumeFormatInputBufferFlagNone:
 		return "kernelFormatVolumeFormatInputBufferFlagNone"
+	case kernelFormatVolumeFormatInputBufferFlagSuperFloppy:
+		return "kernelFormatVolumeFormatInputBufferFlagSuperFloppy"
 	default:
 		return "Unknown"
 	}
@@ -211,7 +216,7 @@ func KmFmtCreateFormatInputBuffer(diskPath string) *KernelFormatVolumeFormatInpu
 	inputBuffer := (*KernelFormatVolumeFormatInputBuffer)(unsafe.Pointer(&buf[0]))
 
 	inputBuffer.Size = uint64(bufferSize)
-	inputBuffer.Flags = kernelFormatVolumeFormatInputBufferFlagNone
+	inputBuffer.Flags = kernelFormatVolumeFormatInputBufferFlagSuperFloppy
 
 	inputBuffer.FsParameters.FileSystemType = kernelFormatVolumeFilesystemTypeRefs
 	inputBuffer.FsParameters.VolumeLabelLength = 0

--- a/internal/gcs-sidecar/handlers.go
+++ b/internal/gcs-sidecar/handlers.go
@@ -338,7 +338,11 @@ func (b *Bridge) modifySettings(req *request) (err error) {
 
 		case guestresource.ResourceTypeWCOWBlockCims:
 			// This is request to mount the merged cim at given volumeGUID
-			wcowBlockCimMounts := modifyGuestSettingsRequest.Settings.(*guestresource.WCOWBlockCIMMounts)
+			if modifyGuestSettingsRequest.RequestType == guestrequest.RequestTypeRemove {
+				return fmt.Errorf("not implemented")
+			}
+
+			wcowBlockCimMounts := modifyGuestSettingsRequest.Settings.(*guestresource.CWCOWBlockCIMMounts)
 			log.G(ctx).Tracef("WCOWBlockCIMMounts { %v}", wcowBlockCimMounts)
 
 			// The block device takes some time to show up. Wait for a few seconds.
@@ -386,6 +390,11 @@ func (b *Bridge) modifySettings(req *request) (err error) {
 			return nil
 
 		case guestresource.ResourceTypeCWCOWCombinedLayers:
+
+			if modifyGuestSettingsRequest.RequestType == guestrequest.RequestTypeRemove {
+				return fmt.Errorf("not implemented")
+			}
+
 			settings := modifyGuestSettingsRequest.Settings.(*guestresource.CWCOWCombinedLayers)
 			containerID := settings.ContainerID
 			log.G(ctx).Tracef("CWCOWCombinedLayers:: ContainerID: %v, ContainerRootPath: %v, Layers: %v, ScratchPath: %v",

--- a/internal/gcs-sidecar/uvm.go
+++ b/internal/gcs-sidecar/uvm.go
@@ -106,7 +106,7 @@ func unmarshalContainerModifySettings(req *request) (_ *prot.ContainerModifySett
 			modifyGuestSettingsRequest.Settings = wcowMappedVirtualDisk
 
 		case guestresource.ResourceTypeWCOWBlockCims:
-			wcowBlockCimMounts := &guestresource.WCOWBlockCIMMounts{}
+			wcowBlockCimMounts := &guestresource.CWCOWBlockCIMMounts{}
 			if err := commonutils.UnmarshalJSONWithHresult(rawGuestRequest, wcowBlockCimMounts); err != nil {
 				return nil, fmt.Errorf("invalid ResourceTypeWCOWBlockCims request: %w", err)
 			}

--- a/internal/guest/runtime/hcsv2/uvm.go
+++ b/internal/guest/runtime/hcsv2/uvm.go
@@ -456,9 +456,9 @@ func (h *Host) CreateContainer(ctx context.Context, id string, settings *prot.VM
 	// containing the files is exposed via UVM_SECURITY_CONTEXT_DIR env var.
 	// It may be an error to have a security policy but not expose it to the
 	// container as in that case it can never be checked as correct by a verifier.
-	if oci.ParseAnnotationsBool(ctx, settings.OCISpecification.Annotations, annotations.UVMSecurityPolicyEnv, true) {
+	if oci.ParseAnnotationsBool(ctx, settings.OCISpecification.Annotations, annotations.LCOWSecurityPolicyEnv, true) {
 		encodedPolicy := h.securityPolicyEnforcer.EncodedSecurityPolicy()
-		hostAMDCert := settings.OCISpecification.Annotations[annotations.HostAMDCertificate]
+		hostAMDCert := settings.OCISpecification.Annotations[annotations.LCOWHostAMDCertificate]
 		if len(encodedPolicy) > 0 || len(hostAMDCert) > 0 || len(h.uvmReferenceInfo) > 0 {
 			// Use os.MkdirTemp to make sure that the directory is unique.
 			securityContextDir, err := os.MkdirTemp(settings.OCISpecification.Root.Path, securitypolicy.SecurityContextDirTemplate)

--- a/internal/layers/wcow_mount.go
+++ b/internal/layers/wcow_mount.go
@@ -440,7 +440,8 @@ func mountHypervIsolatedWCIFSLayers(ctx context.Context, l *wcowWCIFSLayers, vm 
 		})
 	}
 
-	err = vm.CombineLayersWCOW(ctx, hcsLayers, ml.RootFS, hcsschema.WCIFS)
+	// containerID isn't required when using non-confidential pods (WCIFS based layers can't run confidential pods)
+	err = vm.CombineLayersWCOW(ctx, hcsLayers, ml.RootFS, hcsschema.WCIFS, "")
 	if err != nil {
 		return nil, nil, err
 	}
@@ -476,7 +477,7 @@ func mountHypervIsolatedBlockCIMLayers(ctx context.Context, l *wcowBlockCIMLayer
 		"parent layers": l.parentLayers,
 	}).Debug("mounting hyperv isolated block CIM layers")
 
-	mountedCIMs, err := vm.MountBlockCIMs(ctx, l.mergedLayer, l.parentLayers)
+	mountedCIMs, err := vm.MountBlockCIMs(ctx, l.mergedLayer, l.parentLayers, containerID)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to mount block CIMs in UVM: %w", err)
 	}
@@ -524,8 +525,7 @@ func mountHypervIsolatedBlockCIMLayers(ctx context.Context, l *wcowBlockCIMLayer
 		},
 	}
 
-	// TODO(ambarve): Do we need CWCOW specific request type here?
-	err = vm.CombineLayersWCOW(ctx, hcsLayers, ml.RootFS, hcsschema.UnionFS)
+	err = vm.CombineLayersWCOW(ctx, hcsLayers, ml.RootFS, hcsschema.UnionFS, containerID)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/internal/oci/uvm.go
+++ b/internal/oci/uvm.go
@@ -376,6 +376,9 @@ func SpecToUVMCreateOpts(ctx context.Context, s *specs.Spec, id, owner string) (
 		wopts.AdditionalRegistryKeys = append(wopts.AdditionalRegistryKeys, parseAdditionalRegistryValues(ctx, s.Annotations)...)
 		handleAnnotationFullyPhysicallyBacked(ctx, s.Annotations, wopts)
 
+		// Writable EFI is valid for both confidential and regular Hyper-V isolated WCOW.
+		wopts.WritableEFI = ParseAnnotationsBool(ctx, s.Annotations, annotations.WCOWWritableEFI, wopts.WritableEFI)
+
 		// Handle WCOW security policy settings
 		if err := handleWCOWSecurityPolicy(ctx, s.Annotations, wopts); err != nil {
 			return nil, err

--- a/internal/protocol/guestresource/resources.go
+++ b/internal/protocol/guestresource/resources.go
@@ -73,9 +73,10 @@ type LCOWCombinedLayers struct {
 }
 
 type WCOWCombinedLayers struct {
-	ContainerRootPath string            `json:"ContainerRootPath,omitempty"`
-	Layers            []hcsschema.Layer `json:"Layers,omitempty"`
-	ScratchPath       string            `json:"ScratchPath,omitempty"`
+	ContainerRootPath string                         `json:"ContainerRootPath,omitempty"`
+	Layers            []hcsschema.Layer              `json:"Layers,omitempty"`
+	ScratchPath       string                         `json:"ScratchPath,omitempty"`
+	FilterType        hcsschema.FileSystemFilterType `json:"FilterType,omitempty"`
 }
 
 type CWCOWCombinedLayers struct {

--- a/internal/protocol/guestresource/resources.go
+++ b/internal/protocol/guestresource/resources.go
@@ -114,11 +114,12 @@ type BlockCIMDevice struct {
 	Lun     int32
 }
 
-type WCOWBlockCIMMounts struct {
+type CWCOWBlockCIMMounts struct {
 	// BlockCIMs should be ordered from merged CIM followed by Layer n .. layer 1
-	BlockCIMs  []BlockCIMDevice `json:"BlockCIMs,omitempty"`
-	VolumeGUID guid.GUID        `json:"VolumeGUID,omitempty"`
-	MountFlags uint32           `json:"MountFlags,omitempty"`
+	BlockCIMs   []BlockCIMDevice `json:"BlockCIMs,omitempty"`
+	VolumeGUID  guid.GUID        `json:"VolumeGUID,omitempty"`
+	MountFlags  uint32           `json:"MountFlags,omitempty"`
+	ContainerID string           `json:"ContainerID,omitempty"`
 }
 
 type WCOWMappedVirtualDisk struct {

--- a/internal/uvm/cimfs.go
+++ b/internal/uvm/cimfs.go
@@ -1,0 +1,163 @@
+//go:build windows
+// +build windows
+
+package uvm
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+
+	"github.com/Microsoft/go-winio/pkg/guid"
+	"github.com/Microsoft/hcsshim/internal/log"
+	"github.com/Microsoft/hcsshim/internal/protocol/guestrequest"
+	"github.com/Microsoft/hcsshim/internal/protocol/guestresource"
+	"github.com/Microsoft/hcsshim/internal/uvm/scsi"
+	"github.com/Microsoft/hcsshim/pkg/cimfs"
+	"github.com/sirupsen/logrus"
+)
+
+type UVMMountedBlockCIMs struct {
+	scsiMounts []*scsi.Mount
+	// Volume GUID, inside the UVM this is the volume at which the CIMs are mounted
+	volumeGUID guid.GUID
+	// SCSI mounts are already ref counted, we only need to ref count the mounted merged CIMs
+	refCount uint32
+	// UVM in which these mounts are done
+	host *UtilityVM
+	// reference key used for ref counting
+	refKey string
+}
+
+func (umb *UVMMountedBlockCIMs) MountedVolumePath() string {
+	return fmt.Sprintf(cimfs.VolumePathFormat, umb.volumeGUID)
+}
+
+func (umb *UVMMountedBlockCIMs) Release(ctx context.Context) error {
+	umb.host.blockCIMMountLock.Lock()
+	defer umb.host.blockCIMMountLock.Unlock()
+
+	if umb.refCount > 1 {
+		umb.refCount--
+		return nil
+	}
+
+	guestReq := guestrequest.ModificationRequest{
+		ResourceType: guestresource.ResourceTypeWCOWBlockCims,
+		RequestType:  guestrequest.RequestTypeRemove,
+		Settings: &guestresource.WCOWBlockCIMMounts{
+			VolumeGUID: umb.volumeGUID,
+		},
+	}
+	if err := umb.host.GuestRequest(ctx, guestReq); err != nil {
+		return fmt.Errorf("failed to mount the cim: %w", err)
+	}
+
+	for i := len(umb.scsiMounts) - 1; i >= 0; i-- {
+		if err := umb.scsiMounts[i].Release(ctx); err != nil {
+			return err
+		}
+	}
+
+	// Remove from cache when ref count reaches zero
+	delete(umb.host.blockCIMMounts, umb.refKey)
+	return nil
+}
+
+// mergedCIM can be nil,
+// sourceCIMs MUST be in the top to bottom order
+func (uvm *UtilityVM) MountBlockCIMs(ctx context.Context, mergedCIM *cimfs.BlockCIM, sourceCIMs []*cimfs.BlockCIM) (_ *UVMMountedBlockCIMs, retErr error) {
+	if len(sourceCIMs) < 1 {
+		return nil, fmt.Errorf("at least 1 source CIM is required")
+	}
+
+	uvm.blockCIMMountLock.Lock()
+	defer uvm.blockCIMMountLock.Unlock()
+
+	layersToAttach := sourceCIMs
+	if mergedCIM != nil {
+		layersToAttach = append([]*cimfs.BlockCIM{mergedCIM}, sourceCIMs...)
+	}
+
+	// The block path of the mergedCIM (or the block path of the sourceCIM when there
+	// is just 1 layer) is sufficient to uniquely identify a block CIM mount done in
+	// the UVM. We use that to check if we have already mounted this set of CIMs in
+	// the UVM.
+	if mountedCIMs, ok := uvm.blockCIMMounts[layersToAttach[0].BlockPath]; ok {
+		mountedCIMs.refCount++
+		return mountedCIMs, nil
+	}
+
+	volumeGUID, err := guid.NewV4()
+	if err != nil {
+		return nil, fmt.Errorf("generated cim mount GUID: %w", err)
+	}
+
+	settings := &guestresource.WCOWBlockCIMMounts{
+		BlockCIMs:  []guestresource.BlockCIMDevice{},
+		VolumeGUID: volumeGUID,
+		MountFlags: cimfs.CimMountBlockDeviceCim,
+	}
+
+	umb := &UVMMountedBlockCIMs{
+		volumeGUID: volumeGUID,
+		scsiMounts: []*scsi.Mount{},
+		refCount:   1,
+		host:       uvm,
+		refKey:     layersToAttach[0].BlockPath,
+	}
+
+	// Cleanup function to release all SCSI mounts on error
+	defer func() {
+		if retErr != nil {
+			for _, mount := range umb.scsiMounts {
+				if cErr := mount.Release(ctx); cErr != nil {
+					log.G(ctx).WithFields(logrus.Fields{
+						"mount":          mount,
+						"original error": retErr,
+					}).Debugf("failure during SCSI mount cleanup: %s", cErr)
+				}
+			}
+		}
+	}()
+
+	for _, bcim := range layersToAttach {
+		sm, err := uvm.SCSIManager.AddVirtualDisk(ctx, bcim.BlockPath, true, uvm.ID(), "", nil)
+		if err != nil {
+			return nil, fmt.Errorf("failed to attach block CIM %s: %w", bcim.BlockPath, err)
+		}
+
+		hasher := sha256.New()
+		hasher.Write([]byte(bcim.BlockPath))
+		layerDigest := base64.URLEncoding.EncodeToString(hasher.Sum(nil))
+
+		log.G(ctx).WithFields(logrus.Fields{
+			"block path":      bcim.BlockPath,
+			"cim name":        bcim.CimName,
+			"layer digest":    layerDigest,
+			"scsi controller": sm.Controller(),
+			"scsi LUN":        sm.LUN(),
+		}).Debugf("attached block CIM VHD")
+
+		settings.BlockCIMs = append(settings.BlockCIMs, guestresource.BlockCIMDevice{
+			CimName: bcim.CimName,
+			Lun:     int32(sm.LUN()),
+		})
+		umb.scsiMounts = append(umb.scsiMounts, sm)
+	}
+
+	guestReq := guestrequest.ModificationRequest{
+		ResourceType: guestresource.ResourceTypeWCOWBlockCims,
+		RequestType:  guestrequest.RequestTypeAdd,
+		Settings:     settings,
+	}
+	if err := uvm.GuestRequest(ctx, guestReq); err != nil {
+		return nil, fmt.Errorf("failed to mount the cim: %w", err)
+	}
+
+	// Add to cache for future reference counting
+	uvm.blockCIMMounts[layersToAttach[0].BlockPath] = umb
+
+	return umb, nil
+}

--- a/internal/uvm/combine_layers.go
+++ b/internal/uvm/combine_layers.go
@@ -14,22 +14,41 @@ import (
 // container file system.
 //
 // Note: `layerPaths` and `containerRootPath` are paths from within the UVM.
-func (uvm *UtilityVM) CombineLayersWCOW(ctx context.Context, layerPaths []hcsschema.Layer, containerRootPath string, filterType hcsschema.FileSystemFilterType) error {
+func (uvm *UtilityVM) CombineLayersWCOW(ctx context.Context, layerPaths []hcsschema.Layer, containerRootPath string, filterType hcsschema.FileSystemFilterType, containerID string) error {
 	if uvm.operatingSystem != "windows" {
 		return errNotSupported
 	}
-	msr := &hcsschema.ModifySettingRequest{
-		GuestRequest: guestrequest.ModificationRequest{
-			ResourceType: guestresource.ResourceTypeCombinedLayers,
-			RequestType:  guestrequest.RequestTypeAdd,
-			Settings: guestresource.WCOWCombinedLayers{
-				ContainerRootPath: containerRootPath,
-				Layers:            layerPaths,
-				FilterType:        filterType,
+
+	var modifyRequest *hcsschema.ModifySettingRequest
+	if uvm.HasConfidentialPolicy() {
+		modifyRequest = &hcsschema.ModifySettingRequest{
+			GuestRequest: guestrequest.ModificationRequest{
+				ResourceType: guestresource.ResourceTypeCWCOWCombinedLayers,
+				RequestType:  guestrequest.RequestTypeAdd,
+				Settings: guestresource.CWCOWCombinedLayers{
+					ContainerID: containerID,
+					CombinedLayers: guestresource.WCOWCombinedLayers{
+						ContainerRootPath: containerRootPath,
+						Layers:            layerPaths,
+						FilterType:        filterType,
+					},
+				},
 			},
-		},
+		}
+	} else {
+		modifyRequest = &hcsschema.ModifySettingRequest{
+			GuestRequest: guestrequest.ModificationRequest{
+				ResourceType: guestresource.ResourceTypeCombinedLayers,
+				RequestType:  guestrequest.RequestTypeAdd,
+				Settings: guestresource.WCOWCombinedLayers{
+					ContainerRootPath: containerRootPath,
+					Layers:            layerPaths,
+					FilterType:        filterType,
+				},
+			},
+		}
 	}
-	return uvm.modify(ctx, msr)
+	return uvm.modify(ctx, modifyRequest)
 }
 
 // CombineLayersLCOW combines `layerPaths` and optionally `scratchPath` into an

--- a/internal/uvm/combine_layers.go
+++ b/internal/uvm/combine_layers.go
@@ -14,7 +14,7 @@ import (
 // container file system.
 //
 // Note: `layerPaths` and `containerRootPath` are paths from within the UVM.
-func (uvm *UtilityVM) CombineLayersWCOW(ctx context.Context, layerPaths []hcsschema.Layer, containerRootPath string) error {
+func (uvm *UtilityVM) CombineLayersWCOW(ctx context.Context, layerPaths []hcsschema.Layer, containerRootPath string, filterType hcsschema.FileSystemFilterType) error {
 	if uvm.operatingSystem != "windows" {
 		return errNotSupported
 	}
@@ -25,6 +25,7 @@ func (uvm *UtilityVM) CombineLayersWCOW(ctx context.Context, layerPaths []hcssch
 			Settings: guestresource.WCOWCombinedLayers{
 				ContainerRootPath: containerRootPath,
 				Layers:            layerPaths,
+				FilterType:        filterType,
 			},
 		},
 	}

--- a/internal/uvm/security_policy.go
+++ b/internal/uvm/security_policy.go
@@ -120,3 +120,14 @@ func (uvm *UtilityVM) InjectPolicyFragment(ctx context.Context, fragment *ctrdta
 	}
 	return uvm.modify(ctx, mod)
 }
+
+// returns if this instance of the UtilityVM is created with confidential policy
+func (uvm *UtilityVM) HasConfidentialPolicy() bool {
+	switch opts := uvm.createOpts.(type) {
+	case *OptionsWCOW:
+		return opts.SecurityPolicyEnabled
+	case *OptionsLCOW:
+		return opts.SecurityPolicyEnabled
+	}
+	return false
+}

--- a/internal/uvm/types.go
+++ b/internal/uvm/types.go
@@ -142,6 +142,10 @@ type UtilityVM struct {
 
 	// LCOW only. Indicates whether to use policy based routing when configuring net interfaces in the guest.
 	policyBasedRouting bool
+
+	// ref counting for block CIMs
+	blockCIMMounts    map[string]*UVMMountedBlockCIMs
+	blockCIMMountLock sync.Mutex
 }
 
 func (uvm *UtilityVM) ScratchEncryptionEnabled() bool {

--- a/pkg/annotations/annotations.go
+++ b/pkg/annotations/annotations.go
@@ -223,6 +223,10 @@ const (
 	// Allows disabling secure boot for testing and debugging scenarios, secure boot doesn't apply to confidential LCOW so
 	// this is a WCOW only config
 	WCOWDisableSecureBoot = "io.microsoft.virtualmachine.wcow.no_secure_boot"
+
+	// Attaches the EFI/boot VHD in the writable mode (instead of the default read-only mode). This is usually required
+	// when debugging boot to capture bootstat traces.
+	WCOWWritableEFI = "io.microsoft.virtualmachine.wcow.writable_efi"
 )
 
 // WCOW host process container annotations.

--- a/pkg/annotations/annotations.go
+++ b/pkg/annotations/annotations.go
@@ -121,40 +121,58 @@ const (
 	// Only applies in SNP mode.
 	DmVerityRootFsVhd = "io.microsoft.virtualmachine.lcow.dmverity-rootfs-vhd"
 
-	// EncryptedScratchDisk indicates whether or not the container scratch disks
+	// LCOWEncryptedScratchDisk indicates whether or not the container scratch disks
 	// should be encrypted or not.
 	//
 	// LCOW only.
-	EncryptedScratchDisk = "io.microsoft.virtualmachine.storage.scratch.encrypted"
+	LCOWEncryptedScratchDisk = "io.microsoft.virtualmachine.storage.scratch.encrypted"
+	// Deprecated: use [LCOWEncryptedScratchDisk] instead.
+	EncryptedScratchDisk = LCOWEncryptedScratchDisk
 
-	// GuestStateFile specifies the path of the vmgs file to use if required. Only applies in SNP mode.
-	GuestStateFile = "io.microsoft.virtualmachine.lcow.gueststatefile"
+	// LCOWGuestStateFile specifies the path of the vmgs file to use if required. Only applies in SNP mode.
+	LCOWGuestStateFile = "io.microsoft.virtualmachine.lcow.gueststatefile"
+	// Deprecated: use [LCOWGuestStateFile] instead.
+	GuestStateFile = LCOWGuestStateFile
 
-	// HclEnabled specifies whether to enable the host compatibility layer.
-	HclEnabled = "io.microsoft.virtualmachine.lcow.hcl-enabled"
+	// LCOWHclEnabled specifies whether to enable the host compatibility layer.
+	LCOWHclEnabled = "io.microsoft.virtualmachine.lcow.hcl-enabled"
+	// Deprecated: use [LCOWHclEnabled] instead.
+	HclEnabled = LCOWHclEnabled
 
-	// HostAMDCertificate specifies the filename of the AMD certificates to be passed to UVM.
+	// LCOWHostAMDCertificate specifies the filename of the AMD certificates to be passed to UVM.
 	// The certificate is expected to be located in the same directory as the shim executable.
-	HostAMDCertificate = "io.microsoft.virtualmachine.lcow.amd-certificate"
+	LCOWHostAMDCertificate = "io.microsoft.virtualmachine.lcow.amd-certificate"
+	// Deprecated: use [LCOWHostAMDCertificate] instead.
+	HostAMDCertificate = LCOWHostAMDCertificate
 
-	// NoSecurityHardware allows us, when it is set to true, to do testing and development without requiring SNP hardware.
-	NoSecurityHardware = "io.microsoft.virtualmachine.lcow.no_security_hardware"
+	// LCOWNoSecurityHardware allows us, when it is set to true, to do testing and development without requiring SNP hardware.
+	LCOWNoSecurityHardware = "io.microsoft.virtualmachine.lcow.no_security_hardware"
+	// Deprecated: use [LCOWNoSecurityHardware] instead.
+	NoSecurityHardware = LCOWNoSecurityHardware
 
-	// SecurityPolicy is used to specify a security policy for opengcs to enforce.
-	SecurityPolicy = "io.microsoft.virtualmachine.lcow.securitypolicy"
+	// LCOWSecurityPolicy is used to specify a security policy for opengcs to enforce.
+	LCOWSecurityPolicy = "io.microsoft.virtualmachine.lcow.securitypolicy"
+	// Deprecated: use [LCOWSecurityPolicy] instead.
+	SecurityPolicy = LCOWSecurityPolicy
 
-	// SecurityPolicyEnforcer is used to specify which enforcer to initialize (open-door, standard or rego).
+	// LCOWSecurityPolicyEnforcer is used to specify which enforcer to initialize (open-door, standard or rego).
 	// This allows for better fallback mechanics.
-	SecurityPolicyEnforcer = "io.microsoft.virtualmachine.lcow.enforcer"
+	LCOWSecurityPolicyEnforcer = "io.microsoft.virtualmachine.lcow.enforcer"
+	// Deprecated: use [LCOWSecurityPolicyEnforcer] instead.
+	SecurityPolicyEnforcer = LCOWSecurityPolicyEnforcer
 
-	// UVMSecurityPolicyEnv specifies if confidential containers' related information
+	// LCOWSecurityPolicyEnv specifies if confidential containers' related information
 	// should be written to containers' rootfs. The filenames and location are defined
 	// by securitypolicy.PolicyFilename, securitypolicy.HostAMDCertFilename and
 	// securitypolicy.ReferenceInfoFilename.
-	UVMSecurityPolicyEnv = "io.microsoft.virtualmachine.lcow.securitypolicy.env"
+	LCOWSecurityPolicyEnv = "io.microsoft.virtualmachine.lcow.securitypolicy.env"
+	// Deprecated: use [LCOWSecurityPolicyEnv] instead.
+	UVMSecurityPolicyEnv = LCOWSecurityPolicyEnv
 
-	// UVMReferenceInfoFile specifies the filename of a signed UVM reference file to be passed to UVM.
-	UVMReferenceInfoFile = "io.microsoft.virtualmachine.lcow.uvm-reference-info-file"
+	// LCOWReferenceInfoFile specifies the filename of a signed UVM reference file to be passed to UVM.
+	LCOWReferenceInfoFile = "io.microsoft.virtualmachine.lcow.uvm-reference-info-file"
+	// Deprecated: use [LCOWReferenceInfoFile] instead.
+	UVMReferenceInfoFile = LCOWReferenceInfoFile
 )
 
 // WCOW container annotations.
@@ -182,6 +200,29 @@ const (
 	// ContainerProcessDumpLocation path. When the maximum value is exceeded, the oldest dump file in the
 	// folder will be replaced by the new dump file. The default value is 10.
 	WCOWProcessDumpCount = "io.microsoft.wcow.processdumpcount"
+)
+
+// WCOW confidential container related annotations
+const (
+	// WCOWGuestStateFile allows overriding the default VMGS path.
+	WCOWGuestStateFile = "io.microsoft.virtualmachine.wcow.gueststatefile"
+
+	// WCOWSecurityPolicy is used to specify a security policy for WCOW containers to enforce.
+	WCOWSecurityPolicy = "io.microsoft.virtualmachine.wcow.securitypolicy"
+
+	// WCOWSecurityPolicyEnforcer is used to specify which enforcer to
+	// initialize for WCOW (open-door, standard or rego).  This allows for better
+	// fallback mechanics.
+	WCOWSecurityPolicyEnforcer = "io.microsoft.virtualmachine.wcow.enforcer"
+
+	// WCOWIsolationType allows overriding isolation type of a confidential pod.
+	// Default is "SecureNestedPaging" and valid override values are
+	// "VirtualizationBasedSecurity" and "GuestStateOnly"
+	WCOWIsolationType = "io.microsoft.virtualmachine.wcow.isolation_type"
+
+	// Allows disabling secure boot for testing and debugging scenarios, secure boot doesn't apply to confidential LCOW so
+	// this is a WCOW only config
+	WCOWDisableSecureBoot = "io.microsoft.virtualmachine.wcow.no_secure_boot"
 )
 
 // WCOW host process container annotations.

--- a/pkg/cimfs/mount_cim.go
+++ b/pkg/cimfs/mount_cim.go
@@ -31,13 +31,17 @@ func (e *MountError) Error() string {
 	return s
 }
 
+const (
+	VolumePathFormat = "\\\\?\\Volume{%s}\\"
+)
+
 // Mount mounts the given cim at a volume with given GUID. Returns the full volume
 // path if mount is successful.
 func Mount(cimPath string, volumeGUID guid.GUID, mountFlags uint32) (string, error) {
 	if err := winapi.CimMountImage(filepath.Dir(cimPath), filepath.Base(cimPath), mountFlags, &volumeGUID); err != nil {
 		return "", &MountError{Cim: cimPath, Op: "Mount", VolumeGUID: volumeGUID, Err: err}
 	}
-	return fmt.Sprintf("\\\\?\\Volume{%s}\\", volumeGUID.String()), nil
+	return fmt.Sprintf(VolumePathFormat, volumeGUID.String()), nil
 }
 
 // Unmount unmounts the cim at mounted at path `volumePath`.
@@ -116,7 +120,7 @@ func MountMergedBlockCIMs(mergedCIM *BlockCIM, sourceCIMs []*BlockCIM, mountFlag
 	if err := winapi.CimMergeMountImage(uint32(len(cimsToMerge)), &cimsToMerge[0], mountFlags, &volumeGUID); err != nil {
 		return "", &MountError{Cim: filepath.Join(mergedCIM.BlockPath, mergedCIM.CimName), Op: "MountMerged", Err: err}
 	}
-	return fmt.Sprintf("\\\\?\\Volume{%s}\\", volumeGUID.String()), nil
+	return fmt.Sprintf(VolumePathFormat, volumeGUID.String()), nil
 }
 
 // Mounts a verified block CIM with the provided root hash. The root hash is usually


### PR DESCRIPTION
This PR adds the support for running confidential UVMs/Pods and then running containers inside such pods. It also brings in some additional fixes related to confidential pods.


1. Support for starting confidential pods
This commit allows running confidential pods/UtilityVMs by including a non-empty security
policy in the pod config annotations. The files (VHDs & guest statef file) required for
starting such a confidential UVM MUST be available in a directory named
`WindowsBootFiles/confidential` that is located next to the shim binary.

2. Support for starting confidential containers
Adds support for mounting block CIM based container image layers inside the UVM.
(ResourceTypeWCOWBlockCims is only supported by sidecar GCS at the moment. Inbox GCS will
add this support soon.)

3. Include policy digest in the host data for confidential UVM
When the policy digest is included in the host data field of the UVM config, the SNP
hardware is able to directly access that and include that in the attestation report.


4. Attach EFI VHD in read-only mode by default
EFI VHDs should always be attached as read-only by default to block UVMs from writing to
it and corrupting its contents. A new annotation is added to allow attaching EFI VHDs in
writable mode when debugging boot failures and such. When this annotation is included a
copy of the EFI VHD is made next to the scratch VHD. This is based on the assumption that
generally the scratch of the UVM would be stored in its own snapshot directory so adding
another VHD in there shouldn't be a problem. It should get cleaned up when the snapshot is
removed. This commit also adds the code to always grant VM group access to the VHDs and guest state
files to avoid access denied failures.

5. format container scratch in superfloppy mode
