### PR TITLE
Invoke fsformatter for container scratch

### DIFF
--- a/cmd/containerd-shim-runhcs-v1/pod.go
+++ b/cmd/containerd-shim-runhcs-v1/pod.go
@@ -18,12 +18,48 @@ import (
 	"github.com/Microsoft/hcsshim/pkg/annotations"
 	eventstypes "github.com/containerd/containerd/api/events"
 	task "github.com/containerd/containerd/api/runtime/task/v2"
+	"github.com/containerd/containerd/api/types"
 	"github.com/containerd/containerd/v2/core/runtime"
 	"github.com/containerd/errdefs"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
 	"golang.org/x/sync/errgroup"
 )
+
+// initializeWCOWBootFiles handles the initialization of boot files for WCOW VMs
+func initializeWCOWBootFiles(ctx context.Context, wopts *uvm.OptionsWCOW, rootfs []*types.Mount, s *specs.Spec) error {
+	var (
+		layerFolders []string
+		err          error
+	)
+
+	if s.Windows != nil {
+		layerFolders = s.Windows.LayerFolders
+	}
+
+	wopts.BootFiles, err = layers.GetWCOWUVMBootFilesFromLayers(ctx, rootfs, layerFolders)
+	if err != nil {
+		return err
+	}
+
+	if wopts.SecurityPolicyEnabled {
+		if wopts.BootFiles.BootType != uvm.BlockCIMBoot {
+			return fmt.Errorf("security policy (confidential mode) only works with block CIM based layers")
+		}
+		// we use measured EFI & rootfs for confidential UVMs, use those instead of the ones passed in layers/rootfs
+		wopts.BootFiles.BlockCIMFiles.EFIVHDPath = uvm.GetDefaultConfidentialEFIPath()
+		wopts.BootFiles.BlockCIMFiles.BootCIMVHDPath = uvm.GetDefaultConfidentialBootCIMPath()
+	} else if wopts.BootFiles.BootType == uvm.BlockCIMBoot {
+		// Supporting hyperv isolation with block CIM layers requires changes in
+		// the image pull path to prepare the EFI VHD. But more importantly, since both the
+		// container and UtilityVM files will be in the same CIM, the early boot
+		// code (bootmgr, winload etc.) will need to support reading the UVM OS
+		// files from `UtilityVM/Files` inside the CIM. Once that support is added
+		// we can enable this.
+		return fmt.Errorf("hyperv isolation is not supported with block CIM layers yet")
+	}
+	return nil
+}
 
 // shimPod represents the logical grouping of all tasks in a single set of
 // shared namespaces. The pod sandbox (container) is represented by the task
@@ -123,16 +159,11 @@ func createPod(ctx context.Context, events publisher, req *task.CreateTaskReques
 				return nil, err
 			}
 		case *uvm.OptionsWCOW:
-			var layerFolders []string
-			if s.Windows != nil {
-				layerFolders = s.Windows.LayerFolders
-			}
 			wopts := (opts).(*uvm.OptionsWCOW)
-			wopts.BootFiles, err = layers.GetWCOWUVMBootFilesFromLayers(ctx, req.Rootfs, layerFolders)
+			err = initializeWCOWBootFiles(ctx, wopts, req.Rootfs, s)
 			if err != nil {
 				return nil, err
 			}
-
 			parent, err = uvm.CreateWCOW(ctx, wopts)
 			if err != nil {
 				return nil, err

--- a/internal/fsformatter/formatter_driver.go
+++ b/internal/fsformatter/formatter_driver.go
@@ -60,12 +60,17 @@ func (filesystemType kernelFormatVolumeFilesystemTypes) String() string {
 
 type kernelFormatVolumeFormatInputBufferFlags uint32
 
-const kernelFormatVolumeFormatInputBufferFlagNone = kernelFormatVolumeFormatInputBufferFlags(0x00000000)
+const (
+	kernelFormatVolumeFormatInputBufferFlagNone        = kernelFormatVolumeFormatInputBufferFlags(0x00000000)
+	kernelFormatVolumeFormatInputBufferFlagSuperFloppy = kernelFormatVolumeFormatInputBufferFlags(0x00000001)
+)
 
 func (flag kernelFormatVolumeFormatInputBufferFlags) String() string {
 	switch flag {
 	case kernelFormatVolumeFormatInputBufferFlagNone:
 		return "kernelFormatVolumeFormatInputBufferFlagNone"
+	case kernelFormatVolumeFormatInputBufferFlagSuperFloppy:
+		return "kernelFormatVolumeFormatInputBufferFlagSuperFloppy"
 	default:
 		return "Unknown"
 	}
@@ -211,7 +216,7 @@ func KmFmtCreateFormatInputBuffer(diskPath string) *KernelFormatVolumeFormatInpu
 	inputBuffer := (*KernelFormatVolumeFormatInputBuffer)(unsafe.Pointer(&buf[0]))
 
 	inputBuffer.Size = uint64(bufferSize)
-	inputBuffer.Flags = kernelFormatVolumeFormatInputBufferFlagNone
+	inputBuffer.Flags = kernelFormatVolumeFormatInputBufferFlagSuperFloppy
 
 	inputBuffer.FsParameters.FileSystemType = kernelFormatVolumeFilesystemTypeRefs
 	inputBuffer.FsParameters.VolumeLabelLength = 0

--- a/internal/layers/wcow_mount.go
+++ b/internal/layers/wcow_mount.go
@@ -43,7 +43,7 @@ func MountWCOWLayers(ctx context.Context, containerID string, vm *uvm.UtilityVM,
 		if vm == nil {
 			return mountProcessIsolatedBlockCIMLayers(ctx, containerID, l)
 		}
-		return nil, nil, fmt.Errorf("hyperv isolated containers aren't supported with block cim layers")
+		return mountHypervIsolatedBlockCIMLayers(ctx, l, vm, containerID)
 	default:
 		return nil, nil, fmt.Errorf("invalid layer type %T", wl)
 	}
@@ -440,7 +440,7 @@ func mountHypervIsolatedWCIFSLayers(ctx context.Context, l *wcowWCIFSLayers, vm 
 		})
 	}
 
-	err = vm.CombineLayersWCOW(ctx, hcsLayers, ml.RootFS)
+	err = vm.CombineLayersWCOW(ctx, hcsLayers, ml.RootFS, hcsschema.WCIFS)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -451,6 +451,91 @@ func mountHypervIsolatedWCIFSLayers(ctx context.Context, l *wcowWCIFSLayers, vm 
 		guestCombinedLayersPath: ml.RootFS,
 		scratchMount:            scsiMount,
 		layerClosers:            layerClosers,
+	}, nil
+}
+
+func mountHypervIsolatedBlockCIMLayers(ctx context.Context, l *wcowBlockCIMLayers, vm *uvm.UtilityVM, containerID string) (_ *MountedWCOWLayers, _ resources.ResourceCloser, err error) {
+	ctx, span := oc.StartSpan(ctx, "mountHyperVIsolatedBlockCIMLayers")
+	defer func() {
+		oc.SetSpanStatus(span, err)
+		span.End()
+	}()
+
+	rcl := &resources.ResourceCloserList{}
+	defer func() {
+		if err != nil {
+			if rErr := rcl.Release(ctx); rErr != nil {
+				log.G(ctx).WithError(err).Warnf("mount process isolated forked CIM layers, undo failed with: %s", rErr)
+			}
+		}
+	}()
+
+	log.G(ctx).WithFields(logrus.Fields{
+		"scratch":       l.scratchLayerPath,
+		"merged layer":  l.mergedLayer,
+		"parent layers": l.parentLayers,
+	}).Debug("mounting hyperv isolated block CIM layers")
+
+	mountedCIMs, err := vm.MountBlockCIMs(ctx, l.mergedLayer, l.parentLayers, containerID)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to mount block CIMs in UVM: %w", err)
+	}
+	rcl.Add(mountedCIMs)
+
+	// mount the CIM inside UVM now
+	log.G(ctx).WithField("volume", mountedCIMs.VolumePath).Debug("mounted blockCIM layers for hyperV isolated container")
+
+	hostPath := filepath.Join(l.scratchLayerPath, "sandbox.vhdx")
+
+	scsiMount, err := vm.SCSIManager.AddVirtualDisk(ctx, hostPath, false, vm.ID(), "",
+		&scsi.MountConfig{
+			// TODO(ambarve): Add SCSI config to format the scratch in guest
+		})
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to add SCSI scratch VHD: %w", err)
+	}
+	containerScratchPathInUVM := scsiMount.GuestPath()
+	rcl.Add(scsiMount)
+
+	log.G(ctx).WithFields(logrus.Fields{
+		"hostPath": hostPath,
+		"uvmPath":  containerScratchPathInUVM,
+	}).Debug("mounted scratch VHD")
+
+	mountedCIMLayerID, err := cimlayer.LayerID(mountedCIMs.VolumePath)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get layer ID for mounted block CIM: %w", err)
+	}
+
+	ml := &MountedWCOWLayers{
+		RootFS: containerScratchPathInUVM,
+		MountedLayerPaths: []MountedWCOWLayer{
+			{
+				LayerID:     mountedCIMLayerID,
+				MountedPath: mountedCIMs.VolumePath,
+			},
+		},
+	}
+
+	hcsLayers := []hcsschema.Layer{
+		{
+			Id:   mountedCIMLayerID,
+			Path: filepath.Join(mountedCIMs.VolumePath, "Files"),
+		},
+	}
+
+	// TODO(ambarve): Do we need CWCOW specific request type here?
+	err = vm.CombineLayersWCOW(ctx, hcsLayers, ml.RootFS, hcsschema.UnionFS)
+	if err != nil {
+		return nil, nil, err
+	}
+	log.G(ctx).Debug("hcsshim::mountHyperVIsolatedBlockCIMLayers Succeeded")
+
+	return ml, &wcowIsolatedWCIFSLayerCloser{
+		uvm:                     vm,
+		guestCombinedLayersPath: ml.RootFS,
+		scratchMount:            scsiMount,
+		layerClosers:            []resources.ResourceCloser{rcl},
 	}, nil
 }
 

--- a/internal/layers/wcow_parse.go
+++ b/internal/layers/wcow_parse.go
@@ -217,33 +217,7 @@ func ParseWCOWLayers(rootfs []*types.Mount, layerFolders []string) (WCOWLayers, 
 	}
 }
 
-// GetWCOWUVMBootFilesFromLayers prepares the UVM boot files from the rootfs or layerFolders.
-func GetWCOWUVMBootFilesFromLayers(ctx context.Context, rootfs []*types.Mount, layerFolders []string) (*uvm.WCOWBootFiles, error) {
-	var parentLayers []string
-	var scratchLayer string
-	var err error
-
-	if err = validateRootfsAndLayers(rootfs, layerFolders); err != nil {
-		return nil, err
-	}
-
-	if len(layerFolders) > 0 {
-		parentLayers = layerFolders[:len(layerFolders)-1]
-		scratchLayer = layerFolders[len(layerFolders)-1]
-	} else {
-		m := rootfs[0]
-		switch m.Type {
-		case legacyMountType:
-			parentLayers, err = getOptionAsArray(m, parentLayerPathsFlag)
-			if err != nil {
-				return nil, err
-			}
-			scratchLayer = m.Source
-		default:
-			return nil, fmt.Errorf("mount type '%s' is not supported for UVM boot", m.Type)
-		}
-	}
-
+func getVmbFSBootFiles(ctx context.Context, scratchLayer string, parentLayers []string) (*uvm.WCOWBootFiles, error) {
 	uvmFolder, err := uvmfolder.LocateUVMFolder(ctx, parentLayers)
 	if err != nil {
 		return nil, fmt.Errorf("failed to locate utility VM folder from layer folders: %w", err)
@@ -252,6 +226,10 @@ func GetWCOWUVMBootFilesFromLayers(ctx context.Context, rootfs []*types.Mount, l
 	// In order for the UVM sandbox.vhdx not to collide with the actual
 	// nested Argon sandbox.vhdx we append the \vm folder to the last
 	// entry in the list.
+	// TODO(ambarve): This probably is a bug, we should make a separate `vm` directory
+	// only if we are creating a standalone task. If we are starting a separate pod,
+	// containerd snapshotter already creates a separate directory for the pod. We
+	// won't have to worry about the name collision in that case.
 	scratchLayer = filepath.Join(scratchLayer, "vm")
 	scratchVHDPath := filepath.Join(scratchLayer, "sandbox.vhdx")
 	if err = os.MkdirAll(scratchLayer, 0777); err != nil {
@@ -264,6 +242,7 @@ func GetWCOWUVMBootFilesFromLayers(ctx context.Context, rootfs []*types.Mount, l
 			return nil, err
 		}
 	}
+
 	return &uvm.WCOWBootFiles{
 		BootType: uvm.VmbFSBoot,
 		VmbFSFiles: &uvm.VmbFSBootFiles{
@@ -272,4 +251,39 @@ func GetWCOWUVMBootFilesFromLayers(ctx context.Context, rootfs []*types.Mount, l
 			ScratchVHDPath:        scratchVHDPath,
 		},
 	}, nil
+}
+
+func getBlockCIMBootFiles(ctx context.Context, wl *wcowBlockCIMLayers) (*uvm.WCOWBootFiles, error) {
+	scratchVHDPath := filepath.Join(wl.scratchLayerPath, "sandbox.vhdx")
+
+	// block CIM based layers don't support multiple layers in the UVM, pick the base layer and continue
+	efiVHDPath := filepath.Join(filepath.Dir(wl.parentLayers[0].BlockPath), "boot.vhd")
+
+	return &uvm.WCOWBootFiles{
+		BootType: uvm.BlockCIMBoot,
+		BlockCIMFiles: &uvm.BlockCIMBootFiles{
+			BootCIMVHDPath: wl.parentLayers[0].BlockPath, // This should be a block CIM with VHD footer attached.
+			EFIVHDPath:     efiVHDPath,
+			ScratchVHDPath: scratchVHDPath,
+		},
+	}, nil
+}
+
+// GetWCOWUVMBootFilesFromLayers prepares the UVM boot files from the rootfs or layerFolders.
+func GetWCOWUVMBootFilesFromLayers(ctx context.Context, rootfs []*types.Mount, layerFolders []string) (*uvm.WCOWBootFiles, error) {
+	var err error
+
+	parsedWCOWLayers, err := ParseWCOWLayers(rootfs, layerFolders)
+	if err != nil {
+		return nil, err
+	}
+
+	switch wl := parsedWCOWLayers.(type) {
+	case *wcowWCIFSLayers:
+		return getVmbFSBootFiles(ctx, wl.scratchLayerPath, wl.layerPaths)
+	case *wcowBlockCIMLayers:
+		return getBlockCIMBootFiles(ctx, wl)
+	default:
+		return nil, fmt.Errorf("unsupported layer format for UVM boot")
+	}
 }

--- a/internal/oci/uvm.go
+++ b/internal/oci/uvm.go
@@ -245,6 +245,7 @@ func handleWCOWSecurityPolicy(ctx context.Context, a map[string]string, wopts *u
 	wopts.SecurityPolicyEnforcer = ParseAnnotationsString(a, annotations.WCOWSecurityPolicyEnforcer, wopts.SecurityPolicyEnforcer)
 	wopts.DisableSecureBoot = ParseAnnotationsBool(ctx, a, annotations.WCOWDisableSecureBoot, false)
 	wopts.GuestStateFilePath = ParseAnnotationsString(a, annotations.WCOWGuestStateFile, uvm.GetDefaultConfidentialVMGSPath())
+	wopts.WritableEFI = ParseAnnotationsBool(ctx, a, annotations.WCOWWritableEFI, false)
 	if ParseAnnotationsBool(ctx, a, annotations.WCOWNoSecurityHardware, false) {
 		wopts.NoSecurityHardware = true
 		wopts.IsolationType = "VirtualizationBasedSecurity"

--- a/internal/oci/uvm.go
+++ b/internal/oci/uvm.go
@@ -189,9 +189,9 @@ func handleAnnotationFullyPhysicallyBacked(ctx context.Context, a map[string]str
 	}
 }
 
-// handleSecurityPolicy handles parsing SecurityPolicy and NoSecurityHardware and setting
-// implied options from the results. Both LCOW only, not WCOW.
-func handleSecurityPolicy(ctx context.Context, a map[string]string, lopts *uvm.OptionsLCOW) {
+// handleLCOWSecurityPolicy handles parsing SecurityPolicy and NoSecurityHardware and setting
+// implied options from the results for LCOW.
+func handleLCOWSecurityPolicy(ctx context.Context, a map[string]string, lopts *uvm.OptionsLCOW) {
 	lopts.SecurityPolicy = ParseAnnotationsString(a, annotations.SecurityPolicy, lopts.SecurityPolicy)
 	// allow actual isolated boot etc to be ignored if we have no hardware. Required for dev
 	// this is not a security issue as the attestation will fail without a genuine report
@@ -225,6 +225,29 @@ func handleSecurityPolicy(ctx context.Context, a map[string]string, lopts *uvm.O
 	if len(lopts.SecurityPolicy) > 0 {
 		// will only be false if explicitly set false by the annotation. We will otherwise default to true when there is a security policy
 		lopts.EnableScratchEncryption = ParseAnnotationsBool(ctx, a, annotations.EncryptedScratchDisk, true)
+	}
+}
+
+// handleWCOWSecurityPolicy handles parsing WCOW SecurityPolicy and SecurityPolicyEnforcer and setting
+// implied options from the results for WCOW.
+func handleWCOWSecurityPolicy(ctx context.Context, a map[string]string, wopts *uvm.OptionsWCOW) {
+	wopts.SecurityPolicy = ParseAnnotationsString(a, annotations.WCOWSecurityPolicy, wopts.SecurityPolicy)
+	if len(wopts.SecurityPolicy) == 0 {
+		return
+	}
+	wopts.SecurityPolicyEnabled = true
+	// overcommit isn't allowed when running in confidential mode
+	wopts.AllowOvercommit = false
+
+	// TODO(ambarve): You need a minimum of 2GB memory when running in confidential mode,
+	// we should throw error if the provided value is smaller.
+	wopts.MemorySizeInMB = 2048
+	wopts.SecurityPolicyEnforcer = ParseAnnotationsString(a, annotations.WCOWSecurityPolicyEnforcer, wopts.SecurityPolicyEnforcer)
+	wopts.DisableSecureBoot = ParseAnnotationsBool(ctx, a, annotations.WCOWDisableSecureBoot, false)
+	wopts.GuestStateFilePath = ParseAnnotationsString(a, annotations.WCOWGuestStateFile, uvm.GetDefaultConfidentialVMGSPath())
+	if ParseAnnotationsBool(ctx, a, annotations.WCOWNoSecurityHardware, false) {
+		wopts.NoSecurityHardware = true
+		wopts.IsolationType = "VirtualizationBasedSecurity"
 	}
 }
 
@@ -323,7 +346,7 @@ func SpecToUVMCreateOpts(ctx context.Context, s *specs.Spec, id, owner string) (
 
 		// SecurityPolicy is very sensitive to other settings and will silently change those that are incompatible.
 		// Eg VMPem device count, overridden kernel option cannot be respected.
-		handleSecurityPolicy(ctx, s.Annotations, lopts)
+		handleLCOWSecurityPolicy(ctx, s.Annotations, lopts)
 
 		// override the default GuestState and DmVerityRootFs filenames if specified
 		lopts.GuestStateFile = ParseAnnotationsString(s.Annotations, annotations.GuestStateFile, lopts.GuestStateFile)
@@ -346,6 +369,10 @@ func SpecToUVMCreateOpts(ctx context.Context, s *specs.Spec, id, owner string) (
 		wopts.NoInheritHostTimezone = ParseAnnotationsBool(ctx, s.Annotations, annotations.NoInheritHostTimezone, wopts.NoInheritHostTimezone)
 		wopts.AdditionalRegistryKeys = append(wopts.AdditionalRegistryKeys, parseAdditionalRegistryValues(ctx, s.Annotations)...)
 		handleAnnotationFullyPhysicallyBacked(ctx, s.Annotations, wopts)
+
+		// Handle WCOW security policy settings
+		handleWCOWSecurityPolicy(ctx, s.Annotations, wopts)
+
 		return wopts, nil
 	}
 	return nil, errors.New("cannot create UVM opts spec is not LCOW or WCOW")

--- a/internal/protocol/guestresource/resources.go
+++ b/internal/protocol/guestresource/resources.go
@@ -27,6 +27,10 @@ const (
 	// ResourceTypeMappedVirtualDisk is the modify resource type for mapped
 	// virtual disks
 	ResourceTypeMappedVirtualDisk guestrequest.ResourceType = "MappedVirtualDisk"
+	// ResourceTypeMappedVirtualDiskForContainerScratch is the modify resource type
+	// specifically for refs formatting and mounting scratch vhds for c-wcow cases only.
+	ResourceTypeMappedVirtualDiskForContainerScratch guestrequest.ResourceType = "MappedVirtualDiskForContainerScratch"
+	ResourceTypeWCOWBlockCims                        guestrequest.ResourceType = "WCOWBlockCims"
 	// ResourceTypeNetwork is the modify resource type for the `NetworkAdapterV2`
 	// device.
 	ResourceTypeNetwork          guestrequest.ResourceType = "Network"
@@ -51,12 +55,6 @@ const (
 	ResourceTypeSecurityPolicy guestrequest.ResourceType = "SecurityPolicy"
 	// ResourceTypePolicyFragment is the modify resource type for injecting policy fragments.
 	ResourceTypePolicyFragment guestrequest.ResourceType = "SecurityPolicyFragment"
-	// ResourceTypeWCOWBlockCims is the modify resource type for mounting block cims for hyperv
-	// wcow containers.
-	ResourceTypeWCOWBlockCims guestrequest.ResourceType = "WCOWBlockCims"
-	// ResourceTypeMappedVirtualDiskForContainerScratch is the modify resource type
-	// specifically for refs formatting and mounting scratch vhds for c-wcow cases only.
-	ResourceTypeMappedVirtualDiskForContainerScratch guestrequest.ResourceType = "MappedVirtualDiskForContainerScratch"
 )
 
 // This class is used by a modify request to add or remove a combined layers

--- a/internal/protocol/guestresource/resources.go
+++ b/internal/protocol/guestresource/resources.go
@@ -73,9 +73,10 @@ type LCOWCombinedLayers struct {
 }
 
 type WCOWCombinedLayers struct {
-	ContainerRootPath string            `json:"ContainerRootPath,omitempty"`
-	Layers            []hcsschema.Layer `json:"Layers,omitempty"`
-	ScratchPath       string            `json:"ScratchPath,omitempty"`
+	ContainerRootPath string                         `json:"ContainerRootPath,omitempty"`
+	Layers            []hcsschema.Layer              `json:"Layers,omitempty"`
+	ScratchPath       string                         `json:"ScratchPath,omitempty"`
+	FilterType        hcsschema.FileSystemFilterType `json:"FilterType,omitempty"`
 }
 
 type CWCOWCombinedLayers struct {

--- a/internal/uvm/cimfs.go
+++ b/internal/uvm/cimfs.go
@@ -1,0 +1,139 @@
+//go:build windows
+// +build windows
+
+package uvm
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+
+	"github.com/Microsoft/go-winio/pkg/guid"
+	"github.com/Microsoft/hcsshim/internal/log"
+	"github.com/Microsoft/hcsshim/internal/protocol/guestrequest"
+	"github.com/Microsoft/hcsshim/internal/protocol/guestresource"
+	"github.com/Microsoft/hcsshim/internal/uvm/scsi"
+	"github.com/Microsoft/hcsshim/pkg/cimfs"
+	"github.com/sirupsen/logrus"
+)
+
+type UVMMountedBlockCIMs struct {
+	scsiMounts []*scsi.Mount
+	// Volume Path inside the UVM at which the CIMs are mounted
+	VolumePath string
+	// SCSI mounts are already ref counted, we only need to ref count the mounted merged CIMs
+	refCount uint32
+	// UVM in which these mounts are done
+	host *UtilityVM
+	// reference key used for ref counting
+	refKey string
+}
+
+func (umb *UVMMountedBlockCIMs) Release(ctx context.Context) error {
+	if umb.refCount > 1 {
+		umb.refCount--
+		return nil
+	}
+
+	// TODO(ambarve): add guest request to unmount the CIMs first before removing the block CIM devices
+
+	for i := len(umb.scsiMounts) - 1; i >= 0; i-- {
+		if err := umb.scsiMounts[i].Release(ctx); err != nil {
+			return err
+		}
+	}
+
+	// Remove from cache when ref count reaches zero
+	delete(umb.host.blockCIMMounts, umb.refKey)
+	return nil
+}
+
+// mergedCIM can be nil,
+// sourceCIMs MUST be in the top to bottom order
+func (uvm *UtilityVM) MountBlockCIMs(ctx context.Context, mergedCIM *cimfs.BlockCIM, sourceCIMs []*cimfs.BlockCIM, containerID string) (_ *UVMMountedBlockCIMs, retErr error) {
+	uvm.blockCIMMountLock.Lock()
+	defer uvm.blockCIMMountLock.Unlock()
+
+	layersToAttach := sourceCIMs
+	if mergedCIM != nil {
+		layersToAttach = append([]*cimfs.BlockCIM{mergedCIM}, sourceCIMs...)
+	}
+
+	// The block path of the mergedCIM (or the block path of the sourceCIM when there
+	// is just 1 layer) is sufficient to uniquely identify a block CIM mount done in
+	// the UVM. We use that to check if we have already mounted this set of CIMs in
+	// the UVM.
+	if mountedCIMs, ok := uvm.blockCIMMounts[layersToAttach[0].BlockPath]; ok {
+		mountedCIMs.refCount++
+		return mountedCIMs, nil
+	}
+
+	volumeGUID, err := guid.NewV4()
+	if err != nil {
+		return nil, fmt.Errorf("generated cim mount GUID: %w", err)
+	}
+
+	settings := &guestresource.WCOWBlockCIMMounts{
+		BlockCIMs:  []guestresource.BlockCIMDevice{},
+		VolumeGUID: volumeGUID,
+		MountFlags: cimfs.CimMountBlockDeviceCim,
+	}
+
+	umb := &UVMMountedBlockCIMs{
+		VolumePath: fmt.Sprintf(cimfs.VolumePathFormat, volumeGUID.String()),
+		scsiMounts: []*scsi.Mount{},
+		refCount:   1,
+		host:       uvm,
+		refKey:     layersToAttach[0].BlockPath,
+	}
+
+	// Cleanup function to release all SCSI mounts on error
+	defer func() {
+		if retErr != nil {
+			for _, mount := range umb.scsiMounts {
+				mount.Release(ctx)
+			}
+		}
+	}()
+
+	for _, bcim := range layersToAttach {
+		sm, err := uvm.SCSIManager.AddVirtualDisk(ctx, bcim.BlockPath, true, uvm.ID(), "", nil)
+		if err != nil {
+			return nil, fmt.Errorf("failed to attach block CIM %s: %w", bcim.BlockPath, err)
+		}
+
+		hasher := sha256.New()
+		hasher.Write([]byte(bcim.BlockPath))
+		layerDigest := base64.URLEncoding.EncodeToString(hasher.Sum(nil))
+
+		log.G(ctx).WithFields(logrus.Fields{
+			"block path":      bcim.BlockPath,
+			"cim name":        bcim.CimName,
+			"layer digest":    layerDigest,
+			"scsi controller": sm.Controller(),
+			"scsi LUN":        sm.LUN(),
+		}).Debugf("attached block CIM VHD")
+
+		settings.BlockCIMs = append(settings.BlockCIMs, guestresource.BlockCIMDevice{
+			CimName: bcim.CimName,
+			Lun:     int32(sm.LUN()),
+		})
+		umb.scsiMounts = append(umb.scsiMounts, sm)
+	}
+
+	guestReq := guestrequest.ModificationRequest{
+		ResourceType: guestresource.ResourceTypeWCOWBlockCims,
+		RequestType:  guestrequest.RequestTypeAdd,
+		Settings:     settings,
+	}
+	if err := uvm.GuestRequest(ctx, guestReq); err != nil {
+		return nil, fmt.Errorf("failed to mount the cim: %w", err)
+	}
+	// TODO(ambarve): add guest request to unmount the CIMs in a defer block
+
+	// Add to cache for future reference counting
+	uvm.blockCIMMounts[layersToAttach[0].BlockPath] = umb
+
+	return umb, nil
+}

--- a/internal/uvm/combine_layers.go
+++ b/internal/uvm/combine_layers.go
@@ -14,7 +14,7 @@ import (
 // container file system.
 //
 // Note: `layerPaths` and `containerRootPath` are paths from within the UVM.
-func (uvm *UtilityVM) CombineLayersWCOW(ctx context.Context, layerPaths []hcsschema.Layer, containerRootPath string) error {
+func (uvm *UtilityVM) CombineLayersWCOW(ctx context.Context, layerPaths []hcsschema.Layer, containerRootPath string, filterType hcsschema.FileSystemFilterType) error {
 	if uvm.operatingSystem != "windows" {
 		return errNotSupported
 	}

--- a/internal/uvm/create_wcow.go
+++ b/internal/uvm/create_wcow.go
@@ -42,6 +42,7 @@ type ConfidentialWCOWOptions struct {
 	IsolationType      string
 	DisableSecureBoot  bool
 	FirmwareParameters string
+	WritableEFI        bool
 }
 
 // OptionsWCOW are the set of options passed to CreateWCOW() to create a utility vm.
@@ -402,8 +403,9 @@ func prepareSecurityConfigDoc(ctx context.Context, uvm *UtilityVM, opts *Options
 		Type_: "VirtualDisk",
 	}
 	doc.VirtualMachine.Devices.Scsi[guestrequest.ScsiControllerGuids[0]].Attachments["1"] = hcsschema.Attachment{
-		Path:  opts.BootFiles.BlockCIMFiles.EFIVHDPath,
-		Type_: "VirtualDisk",
+		Path:     opts.BootFiles.BlockCIMFiles.EFIVHDPath,
+		Type_:    "VirtualDisk",
+		ReadOnly: !opts.WritableEFI,
 	}
 	doc.VirtualMachine.Devices.Scsi[guestrequest.ScsiControllerGuids[0]].Attachments["2"] = hcsschema.Attachment{
 		Path:     opts.BootFiles.BlockCIMFiles.BootCIMVHDPath,

--- a/internal/uvm/create_wcow.go
+++ b/internal/uvm/create_wcow.go
@@ -30,11 +30,13 @@ import (
 )
 
 type ConfidentialWCOWOptions struct {
-	GuestStateFilePath    string // The vmgs file path
-	SecurityPolicyEnabled bool   // Set when there is a security policy to apply on actual SNP hardware, use this rathen than checking the string length
-	SecurityPolicy        string // Optional security policy
+	GuestStateFilePath     string // The vmgs file path
+	SecurityPolicyEnabled  bool   // Set when there is a security policy to apply on actual SNP hardware, use this rathen than checking the string length
+	SecurityPolicy         string // Optional security policy
+	SecurityPolicyEnforcer string // Set which security policy enforcer to use (open door or rego). This allows for better fallback mechanic.
 
 	/* Below options are only included for testing/debugging purposes - shouldn't be used in regular scenarios */
+	NoSecurityHardware bool
 	IsolationType      string
 	DisableSecureBoot  bool
 	FirmwareParameters string
@@ -55,6 +57,22 @@ type OptionsWCOW struct {
 
 	// AdditionalRegistryKeys are Registry keys and their values to additionally add to the uVM.
 	AdditionalRegistryKeys []hcsschema.RegistryValue
+}
+
+func defaultConfidentialWCOWOSBootFilesPath() string {
+	return filepath.Join(filepath.Dir(os.Args[0]), "WindowsBootFiles", "confidential")
+}
+
+func GetDefaultConfidentialVMGSPath() string {
+	return filepath.Join(defaultConfidentialWCOWOSBootFilesPath(), "cwcow.vmgs")
+}
+
+func GetDefaultConfidentialBootCIMPath() string {
+	return filepath.Join(defaultConfidentialWCOWOSBootFilesPath(), "rootfs.vhd")
+}
+
+func GetDefaultConfidentialEFIPath() string {
+	return filepath.Join(defaultConfidentialWCOWOSBootFilesPath(), "efi.vhd")
 }
 
 // NewDefaultOptionsWCOW creates the default options for a bootable version of
@@ -220,6 +238,9 @@ func prepareCommonConfigDoc(ctx context.Context, uvm *UtilityVM, opts *OptionsWC
 						DefaultBindSecurityDescriptor: "D:P(A;;FA;;;SY)(A;;FA;;;BA)",
 						ServiceTable:                  make(map[string]hcsschema.HvSocketServiceConfig),
 					},
+				},
+				VirtualSmb: &hcsschema.VirtualSmb{
+					DirectFileMappingInMB: 1024, // Sensible default, but could be a tuning parameter somewhere
 				},
 			},
 		},
@@ -397,16 +418,11 @@ func prepareConfigDoc(ctx context.Context, uvm *UtilityVM, opts *OptionsWCOW) (*
 
 	vsmbOpts := uvm.DefaultVSMBOptions(true)
 	vsmbOpts.TakeBackupPrivilege = true
-	doc.VirtualMachine.Devices.VirtualSmb = &hcsschema.VirtualSmb{
-		DirectFileMappingInMB: 1024, // Sensible default, but could be a tuning parameter somewhere
-		Shares: []hcsschema.VirtualSmbShare{
-			{
-				Name:    "os",
-				Path:    opts.BootFiles.VmbFSFiles.OSFilesPath,
-				Options: vsmbOpts,
-			},
-		},
-	}
+	doc.VirtualMachine.Devices.VirtualSmb.Shares = []hcsschema.VirtualSmbShare{{
+		Name:    "os",
+		Path:    opts.BootFiles.VmbFSFiles.OSFilesPath,
+		Options: vsmbOpts,
+	}}
 
 	doc.VirtualMachine.Chipset = &hcsschema.Chipset{
 		Uefi: &hcsschema.Uefi{

--- a/internal/uvm/create_wcow.go
+++ b/internal/uvm/create_wcow.go
@@ -4,6 +4,7 @@ package uvm
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"maps"
 	"os"
@@ -27,6 +28,7 @@ import (
 	"github.com/Microsoft/hcsshim/internal/uvm/scsi"
 	"github.com/Microsoft/hcsshim/internal/wclayer"
 	"github.com/Microsoft/hcsshim/osversion"
+	"github.com/Microsoft/hcsshim/pkg/securitypolicy"
 )
 
 type ConfidentialWCOWOptions struct {
@@ -336,12 +338,23 @@ func prepareSecurityConfigDoc(ctx context.Context, uvm *UtilityVM, opts *Options
 		}
 	}
 
+	policyDigest, err := securitypolicy.NewSecurityPolicyDigest(opts.SecurityPolicy)
+	if err != nil {
+		return nil, err
+	}
+
+	// HCS API expect a base64 encoded string as LaunchData. Internally it
+	// decodes it to bytes. SEV later returns the decoded byte blob as HostData
+	// field of the report.
+	hostData := base64.StdEncoding.EncodeToString(policyDigest)
+
 	enableHCL := true
 	doc.VirtualMachine.SecuritySettings = &hcsschema.SecuritySettings{
 		EnableTpm: false,
 		Isolation: &hcsschema.IsolationSettings{
 			IsolationType: "SecureNestedPaging",
 			HclEnabled:    &enableHCL,
+			LaunchData:    hostData,
 		},
 	}
 

--- a/internal/uvm/scsi/backend.go
+++ b/internal/uvm/scsi/backend.go
@@ -170,6 +170,13 @@ func mountRequest(controller, lun uint, path string, config *mountConfig, osType
 		ResourceType: guestresource.ResourceTypeMappedVirtualDisk,
 		RequestType:  guestrequest.RequestTypeAdd,
 	}
+	// This option is set only for cwcow scratch disk mount requests
+	// where we need to format the disk with refs.
+	// For refs the scratch disk size should > 30 GB.
+	if config.formatWithRefs {
+		req.ResourceType = guestresource.ResourceTypeMappedVirtualDiskForContainerScratch
+	}
+
 	switch osType {
 	case "windows":
 		// We don't check config.readOnly here, as that will still result in the overall attachment being read-only.
@@ -185,6 +192,7 @@ func mountRequest(controller, lun uint, path string, config *mountConfig, osType
 			ContainerPath: path,
 			Lun:           int32(lun),
 		}
+
 	case "linux":
 		req.Settings = guestresource.LCOWMappedVirtualDisk{
 			MountPath:        path,

--- a/internal/uvm/scsi/manager.go
+++ b/internal/uvm/scsi/manager.go
@@ -86,6 +86,9 @@ type MountConfig struct {
 	// BlockDev indicates if the device should be mounted as a block device.
 	// This is only supported for LCOW.
 	BlockDev bool
+	// FormatWithRefs indicates to refs format the disk.
+	// This is only supported for CWCOW scratch disks.
+	FormatWithRefs bool
 }
 
 // Mount represents a SCSI device that has been attached to a VM, and potentially
@@ -162,6 +165,7 @@ func (m *Manager) AddVirtualDisk(
 			ensureFilesystem: mc.EnsureFilesystem,
 			filesystem:       mc.Filesystem,
 			blockDev:         mc.BlockDev,
+			formatWithRefs:   mc.FormatWithRefs,
 		}
 	}
 	return m.add(ctx,

--- a/internal/uvm/scsi/mount.go
+++ b/internal/uvm/scsi/mount.go
@@ -45,6 +45,7 @@ type mountConfig struct {
 	options          []string
 	ensureFilesystem bool
 	filesystem       string
+	formatWithRefs   bool
 }
 
 func (mm *mountManager) mount(ctx context.Context, controller, lun uint, path string, c *mountConfig) (_ string, err error) {

--- a/internal/uvm/types.go
+++ b/internal/uvm/types.go
@@ -142,6 +142,10 @@ type UtilityVM struct {
 
 	// LCOW only. Indicates whether to use policy based routing when configuring net interfaces in the guest.
 	policyBasedRouting bool
+
+	// ref counting for block CIMs
+	blockCIMMounts    map[string]*UVMMountedBlockCIMs
+	blockCIMMountLock sync.Mutex
 }
 
 func (uvm *UtilityVM) ScratchEncryptionEnabled() bool {

--- a/internal/wclayer/cim/mount.go
+++ b/internal/wclayer/cim/mount.go
@@ -108,6 +108,7 @@ func MergeMountBlockCIMLayer(ctx context.Context, mergedLayer *cimfs.BlockCIM, p
 	if err != nil {
 		return "", fmt.Errorf("generated cim mount GUID: %w", err)
 	}
+
 	return cimfs.MountMergedBlockCIMs(mergedLayer, parentLayers, mountFlags, volumeGUID)
 }
 

--- a/internal/windevice/devicequery_test.go
+++ b/internal/windevice/devicequery_test.go
@@ -4,12 +4,19 @@ package windevice
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"log"
 	"path/filepath"
+	"strings"
+	"syscall"
 	"testing"
 	"time"
 
 	"github.com/Microsoft/go-winio/vhd"
+	"github.com/Microsoft/hcsshim/internal/fsformatter"
 	"golang.org/x/sys/windows"
+	"golang.org/x/sys/windows/svc/mgr"
 )
 
 func TestGetDeviceInterfaceInstances(t *testing.T) {
@@ -76,5 +83,137 @@ func TestGetDeviceInterfaceInstances(t *testing.T) {
 
 	if len(initialInterfacesList) != len(finalInterfaceList) {
 		t.Fatalf("expected interface lists to have same length")
+	}
+}
+
+const (
+	diskSizeInGB           = 35
+	defaultVHDxBlockSizeMB = 1
+)
+
+// startFsformatterDriver checks if fsformatter driver
+// has already been loaded and starts the service.
+// Returns syscall.ERROR_FILE_NOT_FOUND if driver
+// is not loaded.
+func startFsformatterDriver() error {
+	m, err := mgr.Connect()
+	if err != nil {
+		log.Fatalf("Failed to connect to service manager: %v", err)
+	}
+	defer m.Disconnect()
+
+	// Ensure fsformatter driver is loaded by querying for the service.
+	serviceName := "kernelfsformatter"
+	s, err := m.OpenService(serviceName)
+	if err != nil {
+		return syscall.ERROR_FILE_NOT_FOUND
+	}
+	defer s.Close()
+
+	_, err = s.Query()
+	if err != nil {
+		return syscall.ERROR_FILE_NOT_FOUND
+	}
+
+	err = s.Start()
+	if err != nil && !strings.Contains(err.Error(), "An instance of the service is already running") {
+		return fmt.Errorf("Failed to start service: %v", err)
+	}
+
+	return nil
+}
+
+func TestFormatVHDXToReFS(t *testing.T) {
+	// Ensure fsformatter service is loaded and started
+	err := startFsformatterDriver()
+	if err != nil {
+		// if driver is not loaded already, skip.
+		if errors.Is(err, syscall.ERROR_FILE_NOT_FOUND) {
+			t.Skip()
+		}
+		t.Fatalf("Failed to start service: %v", err)
+	}
+
+	ctx := context.Background()
+	initialInterfacesList, err := getDeviceInterfaceInstancesByClass(ctx, &devClassDiskGUID, false)
+	if err != nil {
+		t.Fatalf("failed to get initial disk interfaces: %v", err)
+	}
+	// We expect to see only one device initially
+	if len(initialInterfacesList) != 1 {
+		t.Fatalf("unexpected number of initial disk interfaces: %v", len(initialInterfacesList))
+	}
+	t.Logf("initial interface list: %+v\n", initialInterfacesList)
+
+	// Create a fixed VHDX of 31 GB (refs needs size to be > 30GB)
+	tempDir := t.TempDir()
+	vhdxPath := filepath.Join(tempDir, "test.vhdx")
+	if err := vhd.CreateVhdx(vhdxPath, diskSizeInGB, defaultVHDxBlockSizeMB); err != nil {
+		t.Fatalf("failed to create VHDX: %v", err)
+	}
+
+	diskHandle, err := vhd.OpenVirtualDisk(vhdxPath, vhd.VirtualDiskAccessNone, vhd.OpenVirtualDiskFlagNone)
+	if err != nil {
+		t.Fatalf("failed to open VHD handle: %s", err)
+	}
+	t.Cleanup(func() {
+		if closeErr := windows.CloseHandle(windows.Handle(diskHandle)); closeErr != nil {
+			t.Logf("Failed to close VHD handle: %s", closeErr)
+		}
+	})
+
+	err = vhd.AttachVirtualDisk(diskHandle, vhd.AttachVirtualDiskFlagNone, &vhd.AttachVirtualDiskParameters{Version: 1})
+	if err != nil {
+		t.Fatalf("failed to attach VHD: %s", err)
+	}
+	t.Cleanup(func() {
+		if detachErr := vhd.DetachVirtualDisk(diskHandle); detachErr != nil {
+			t.Logf("failed to detach vhd: %s", detachErr)
+		}
+	})
+	// Disks might take time to show up. Add a small delay
+	time.Sleep(1 * time.Second)
+
+	interfaceListAfterVHDAttach, err := getDeviceInterfaceInstancesByClass(ctx, &devClassDiskGUID, false)
+	if err != nil {
+		t.Fatalf("failed to get initial disk interfaces: %v", err)
+	}
+	t.Logf("interface list after attaching VHD: %+v\n", interfaceListAfterVHDAttach)
+
+	if len(initialInterfacesList) != (len(interfaceListAfterVHDAttach) - 1) {
+		t.Fatalf("expected to find exactly 1 new interface in the returned interfaces list")
+	}
+
+	for _, iPath := range interfaceListAfterVHDAttach {
+		// Take only the newly attached vhdx
+		if iPath == initialInterfacesList[0] {
+			continue
+		}
+		utf16Path, err := windows.UTF16PtrFromString(iPath)
+		if err != nil {
+			t.Fatalf("failed to convert interface path [%s] to utf16: %v", iPath, err)
+		}
+
+		handle, err := windows.CreateFile(utf16Path, windows.GENERIC_READ|windows.GENERIC_WRITE,
+			windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE,
+			nil, windows.OPEN_EXISTING, 0, 0)
+		if err != nil {
+			t.Fatalf("failed to get handle to interface path [%s]: %v", iPath, err)
+		}
+		defer windows.Close(handle)
+
+		deviceNumber, err := getStorageDeviceNumber(ctx, handle)
+		if err != nil {
+			t.Fatalf("failed to get physical device number: %v", err)
+		}
+		diskPath := fmt.Sprintf(fsformatter.VirtualDevObjectPathFormat, deviceNumber.DeviceNumber)
+		t.Logf("diskPath %v", diskPath)
+
+		// Invoke refs formatter and ensure it passes.
+		mountedVolumePath, err := fsformatter.InvokeFsFormatter(ctx, diskPath)
+		if err != nil {
+			t.Fatalf("invoking refsFormatter failed: %v", err)
+		}
+		t.Logf("mountedVolumePath %v", mountedVolumePath)
 	}
 }

--- a/pkg/annotations/annotations.go
+++ b/pkg/annotations/annotations.go
@@ -205,6 +205,10 @@ const (
 	// Allows disabling secure boot for testing and debugging scenarios, secure boot doesn't apply to confidential LCOW so
 	// this is a WCOW only config
 	WCOWDisableSecureBoot = "io.microsoft.virtualmachine.wcow.no_secure_boot"
+
+	// Attaches the EFI/boot VHD in the writable mode (instead of the default read-only mode). This is usually required
+	// when debugging boot to capture bootstat traces.
+	WCOWWritableEFI = "io.microsoft.virtualmachine.wcow.writable_efi"
 )
 
 // WCOW host process container annotations.

--- a/pkg/annotations/annotations.go
+++ b/pkg/annotations/annotations.go
@@ -184,6 +184,29 @@ const (
 	WCOWProcessDumpCount = "io.microsoft.wcow.processdumpcount"
 )
 
+// WCOW confidential container related annotations
+const (
+	// WCOWGuestStateFile allows overriding the default VMGS path.
+	WCOWGuestStateFile = "io.microsoft.virtualmachine.wcow.gueststatefile"
+
+	// WCOWSecurityPolicy is used to specify a security policy for WCOW containers to enforce.
+	WCOWSecurityPolicy = "io.microsoft.virtualmachine.wcow.securitypolicy"
+
+	// WCOWSecurityPolicyEnforcer is used to specify which enforcer to
+	// initialize for WCOW (open-door, standard or rego).  This allows for better
+	// fallback mechanics.
+	WCOWSecurityPolicyEnforcer = "io.microsoft.virtualmachine.wcow.enforcer"
+
+	// WCOWNoSecurityHardware allows us, when it is set to true, to do testing and
+	// development without requiring SNP hardware.  This will automatically change the security isolation mode to
+	// "VirtualizationBasedSecurity" instead of "SecureNestedPaging"
+	WCOWNoSecurityHardware = "io.microsoft.virtualmachine.wcow.no_security_hardware"
+
+	// Allows disabling secure boot for testing and debugging scenarios, secure boot doesn't apply to confidential LCOW so
+	// this is a WCOW only config
+	WCOWDisableSecureBoot = "io.microsoft.virtualmachine.wcow.no_secure_boot"
+)
+
 // WCOW host process container annotations.
 const (
 	// HostProcessInheritUser indicates whether to ignore the username passed in to run a host process

--- a/pkg/cimfs/mount_cim.go
+++ b/pkg/cimfs/mount_cim.go
@@ -31,13 +31,17 @@ func (e *MountError) Error() string {
 	return s
 }
 
+const (
+	VolumePathFormat = "\\\\?\\Volume{%s}\\"
+)
+
 // Mount mounts the given cim at a volume with given GUID. Returns the full volume
 // path if mount is successful.
 func Mount(cimPath string, volumeGUID guid.GUID, mountFlags uint32) (string, error) {
 	if err := winapi.CimMountImage(filepath.Dir(cimPath), filepath.Base(cimPath), mountFlags, &volumeGUID); err != nil {
 		return "", &MountError{Cim: cimPath, Op: "Mount", VolumeGUID: volumeGUID, Err: err}
 	}
-	return fmt.Sprintf("\\\\?\\Volume{%s}\\", volumeGUID.String()), nil
+	return fmt.Sprintf(VolumePathFormat, volumeGUID.String()), nil
 }
 
 // Unmount unmounts the cim at mounted at path `volumePath`.
@@ -116,7 +120,7 @@ func MountMergedBlockCIMs(mergedCIM *BlockCIM, sourceCIMs []*BlockCIM, mountFlag
 	if err := winapi.CimMergeMountImage(uint32(len(cimsToMerge)), &cimsToMerge[0], mountFlags, &volumeGUID); err != nil {
 		return "", &MountError{Cim: filepath.Join(mergedCIM.BlockPath, mergedCIM.CimName), Op: "MountMerged", Err: err}
 	}
-	return fmt.Sprintf("\\\\?\\Volume{%s}\\", volumeGUID.String()), nil
+	return fmt.Sprintf(VolumePathFormat, volumeGUID.String()), nil
 }
 
 // Mounts a verified block CIM with the provided root hash. The root hash is usually

--- a/pkg/cimfs/mount_cim.go
+++ b/pkg/cimfs/mount_cim.go
@@ -15,6 +15,10 @@ import (
 	"golang.org/x/sys/windows"
 )
 
+const (
+	VolumePathFormat = "\\\\?\\Volume{%s}\\"
+)
+
 type MountError struct {
 	Cim        string
 	Op         string
@@ -30,10 +34,6 @@ func (e *MountError) Error() string {
 	s += " " + e.VolumeGUID.String() + ": " + e.Err.Error()
 	return s
 }
-
-const (
-	VolumePathFormat = "\\\\?\\Volume{%s}\\"
-)
 
 // Mount mounts the given cim at a volume with given GUID. Returns the full volume
 // path if mount is successful.


### PR DESCRIPTION
This PR is being opened for the last commit 7fcc84472cbd8f8c565ffd04db6c2d5745960a1d . It depends on commit "Support for starting confidential containers", therefore basing it off of branch https://github.com/ambarve/hcsshim/tree/vcim_boot for now. The previous commits will be checked in first before this PR is checked in. 