### PR TITLE
Add LCOW logpath within uVM

### DIFF
--- a/internal/guest/runtime/hcsv2/container.go
+++ b/internal/guest/runtime/hcsv2/container.go
@@ -45,8 +45,10 @@ const (
 )
 
 type Container struct {
-	id    string
-	vsock transport.Transport
+	id string
+
+	vsock   transport.Transport
+	logFile *os.File
 
 	spec          *oci.Spec
 	ociBundlePath string
@@ -77,10 +79,17 @@ type Container struct {
 
 func (c *Container) Start(ctx context.Context, conSettings stdio.ConnectionSettings) (int, error) {
 	log.G(ctx).WithField(logfields.ContainerID, c.id).Info("opengcs::Container::Start")
-	stdioSet, err := stdio.Connect(c.vsock, conSettings)
+
+	// only use the logfile for the init process, since we don't want to tee stdio of execs
+	t := c.vsock
+	if c.logFile != nil {
+		t = transport.NewMultiWriter(c.vsock, c.logFile)
+	}
+	stdioSet, err := stdio.Connect(t, conSettings)
 	if err != nil {
 		return -1, err
 	}
+
 	if c.initProcess.spec.Terminal {
 		ttyr := c.container.Tty()
 		ttyr.ReplaceConnectionSet(stdioSet)
@@ -180,12 +189,24 @@ func (c *Container) GetAllProcessPids(ctx context.Context) ([]int, error) {
 
 // Kill sends 'signal' to the container process.
 func (c *Container) Kill(ctx context.Context, signal syscall.Signal) error {
-	log.G(ctx).WithField(logfields.ContainerID, c.id).Info("opengcs::Container::Kill")
+	entity := log.G(ctx).WithField(logfields.ContainerID, c.id)
+	entity.Info("opengcs::Container::Kill")
 	err := c.container.Kill(signal)
 	if err != nil {
 		return err
 	}
+
 	c.setExitType(signal)
+	if c.logFile != nil {
+		if err = c.logFile.Close(); err != nil {
+			entity.WithFields(logrus.Fields{
+				logrus.ErrorKey: err,
+				logfields.Path:  c.logFile.Name(),
+			}).Warn("failed to close log file")
+		}
+		c.logFile = nil
+	}
+
 	return nil
 }
 

--- a/internal/guest/runtime/hcsv2/uvm.go
+++ b/internal/guest/runtime/hcsv2/uvm.go
@@ -46,6 +46,7 @@ import (
 	"github.com/Microsoft/hcsshim/internal/guest/storage/scsi"
 	"github.com/Microsoft/hcsshim/internal/guest/transport"
 	"github.com/Microsoft/hcsshim/internal/log"
+	"github.com/Microsoft/hcsshim/internal/logfields"
 	"github.com/Microsoft/hcsshim/internal/oci"
 	"github.com/Microsoft/hcsshim/internal/protocol/guestrequest"
 	"github.com/Microsoft/hcsshim/internal/protocol/guestresource"
@@ -440,6 +441,26 @@ func (h *Host) CreateContainer(ctx context.Context, id string, settings *prot.VM
 		// stdio access isn't allow for this container. Switch to the /dev/null
 		// transport that will eat all input/ouput.
 		c.vsock = h.devNullTransport
+	}
+
+	logPath := settings.OCISpecification.Annotations[annotations.LCOWTeeLogPath]
+	if logPath != "" {
+		if !allowStdio {
+			return nil, errors.Errorf("teeing container stdio to log path %q denied due to policy not allowing stdio access", logPath)
+		}
+
+		if logPath, err = filepath.Abs(logPath); err != nil {
+			return nil, errors.Wrapf(err, "failed to evaluate log path: %s", logPath)
+		}
+
+		log.G(ctx).WithField(logfields.Path, logPath).Debug("creating container log file")
+		dir := filepath.Dir(logPath)
+		if err := mkdirAllModePerm(dir); err != nil {
+			return nil, errors.Wrapf(err, "failed to create log file parent directory: %s", dir)
+		}
+		if c.logFile, err = os.Create(logPath); err != nil {
+			return nil, errors.Wrapf(err, "failed to create log file: %s", logPath)
+		}
 	}
 
 	if envToKeep != nil {

--- a/internal/guest/transport/log.go
+++ b/internal/guest/transport/log.go
@@ -1,0 +1,38 @@
+//go:build linux
+
+package transport
+
+import (
+	"github.com/sirupsen/logrus"
+)
+
+// logConnection wraps the underlying [Connection] and logs the Close*() operations with
+// the connection's port number.
+type logConnection struct {
+	Connection
+	entry *logrus.Entry
+}
+
+var _ Connection = &logConnection{}
+
+func NewLogConnection(c Connection, port uint32) Connection {
+	return &logConnection{c, logrus.WithField("port", port)}
+}
+
+func (c *logConnection) Close() error {
+	c.entry.Debug("opengcs::logConnection::Close - closing connection")
+
+	return c.Connection.Close()
+}
+
+func (c *logConnection) CloseRead() error {
+	c.entry.Debug("opengcs::logConnection::Close - closing read connection")
+
+	return c.Connection.CloseRead()
+}
+
+func (c *logConnection) CloseWrite() error {
+	c.entry.Debug("opengcs::logConnection::Close - closing write connection")
+
+	return c.Connection.CloseWrite()
+}

--- a/internal/guest/transport/multiwriter.go
+++ b/internal/guest/transport/multiwriter.go
@@ -1,0 +1,45 @@
+//go:build linux
+
+package transport
+
+import (
+	"fmt"
+	"io"
+)
+
+// multiWriter writes to both the underlying connection and the [io.Writer], w, via [io.multiWriter].
+type multiWriter struct {
+	t Transport
+	w io.Writer
+}
+
+var _ Transport = &multiWriter{}
+
+func NewMultiWriter(t Transport, w io.Writer) Transport {
+	return &multiWriter{t, w}
+}
+
+// Dial accepts a vsock socket port number as configuration, and
+// returns an unconnected VsockConnection struct.
+func (t *multiWriter) Dial(port uint32) (Connection, error) {
+	if t == nil || t.w == nil || t.t == nil {
+		return nil, fmt.Errorf("invalid transpot")
+	}
+
+	conn, err := t.t.Dial(port)
+	if err != nil {
+		return nil, fmt.Errorf("multiwriter base transport dial: %w", err)
+	}
+	return &multiWriterConnection{conn, io.MultiWriter(conn, t.w)}, nil
+}
+
+type multiWriterConnection struct {
+	Connection
+	multi io.Writer
+}
+
+var _ Connection = &multiWriterConnection{}
+
+func (c *multiWriterConnection) Write(buf []byte) (int, error) {
+	return c.multi.Write(buf)
+}

--- a/internal/guest/transport/transport.go
+++ b/internal/guest/transport/transport.go
@@ -5,6 +5,10 @@ import (
 	"os"
 )
 
+// TODO: specialized [Transport] and [Connection] for [io.Reader]/[io.Writer] instead of both,
+// so either stdin or stdout/stderr can be specialized without affecting the other.
+// i.e., don't use [multiWriter] for stdin.
+
 // Transport is the interface defining a method of transporting data in a
 // connection-like way.
 // Examples of a Transport implementation could be:

--- a/pkg/annotations/annotations.go
+++ b/pkg/annotations/annotations.go
@@ -105,6 +105,12 @@ const (
 
 	// LCOWPrivileged is used to specify that the container should be run in privileged mode.
 	LCOWPrivileged = "io.microsoft.virtualmachine.lcow.privileged"
+
+	// LCOWTeeLogPath specifies a path inside the Linux uVM to write container's stdio to,
+	// in addition to the usual vsock pipe.
+	//
+	// Functionally, it is similar to `LogDirectory` and `LogPath` for CRI, but within the guest.
+	LCOWTeeLogPath = "io.microsoft.container.lcow.tee-log-path"
 )
 
 // LCOW integrity protection and confidential container annotations.

--- a/test/functional/lcow_container_test.go
+++ b/test/functional/lcow_container_test.go
@@ -1,0 +1,140 @@
+//go:build windows && functional
+// +build windows,functional
+
+package functional
+
+import (
+	"context"
+	"fmt"
+	"path"
+	"testing"
+
+	ctrdoci "github.com/containerd/containerd/oci"
+	"github.com/opencontainers/runtime-spec/specs-go"
+
+	"github.com/Microsoft/hcsshim/osversion"
+	"github.com/Microsoft/hcsshim/pkg/annotations"
+
+	testcmd "github.com/Microsoft/hcsshim/test/internal/cmd"
+	testcontainer "github.com/Microsoft/hcsshim/test/internal/container"
+	testlayers "github.com/Microsoft/hcsshim/test/internal/layers"
+	testoci "github.com/Microsoft/hcsshim/test/internal/oci"
+	"github.com/Microsoft/hcsshim/test/internal/util"
+	"github.com/Microsoft/hcsshim/test/pkg/require"
+	testuvm "github.com/Microsoft/hcsshim/test/pkg/uvm"
+)
+
+func TestLCOW_LogPath(t *testing.T) {
+	requireFeatures(t, featureUVM, featureContainer, featureLCOW)
+	require.Build(t, osversion.RS5)
+
+	ctx := util.Context(namespacedContext(context.Background()), t)
+
+	ls := linuxImageLayers(ctx, t)
+	cache := testlayers.CacheFile(ctx, t, "")
+
+	const (
+		helloWorld = "hello world"
+		teeInput   = `please copy me
+this is a line on a new line.
+look at these characters: sdfasd09fc-32r42	3;.er "k🧪3112=3-🧪po4\asdfpas9difasdck s
+another new line, with more letters`
+	)
+
+	t.Run("tee", func(t *testing.T) {
+		const want = helloWorld + "\n" + teeInput
+
+		opts := defaultLCOWOptions(ctx, t)
+		vm := testuvm.CreateAndStart(ctx, t, opts)
+
+		cID := testName(t, "container")
+
+		logFile := path.Join("/run/dira/b/clogs/", util.CleanName(t))
+
+		scratch, _ := testlayers.ScratchSpace(ctx, t, vm, "", "", cache)
+		spec := testoci.CreateLinuxSpec(ctx, t, cID,
+			testoci.DefaultLinuxSpecOpts(cID,
+				ctrdoci.WithProcessArgs("/bin/sh", "-c", fmt.Sprintf("echo %s; tee", helloWorld)),
+				ctrdoci.WithAnnotations(map[string]string{annotations.LCOWTeeLogPath: logFile}),
+				testoci.WithWindowsLayerFolders(append(ls, scratch)))...)
+
+		c, _, cleanup := testcontainer.Create(ctx, t, vm, spec, cID, hcsOwner)
+		t.Cleanup(cleanup)
+
+		io := testcmd.NewBufferedIOFromString(teeInput)
+		init := testcontainer.Start(ctx, t, c, io)
+		t.Cleanup(func() {
+			testcontainer.Kill(ctx, t, c)
+			testcontainer.Wait(ctx, t, c)
+		})
+
+		testcmd.WaitExitCode(ctx, t, init, 0)
+
+		// validate stdout
+		io.TestOutput(t, want, nil)
+
+		logIO := testcmd.NewBufferedIO()
+		cmdArgs := testcmd.Create(ctx, t, vm, &specs.Process{Args: []string{"cat", logFile}}, logIO)
+		testcmd.Start(ctx, t, cmdArgs)
+		testcmd.WaitExitCode(ctx, t, cmdArgs, 0)
+
+		// validate the log file
+		logIO.TestOutput(t, want, nil)
+	})
+
+	t.Run("exec", func(t *testing.T) {
+		const (
+			want     = helloWorld + "\n" + helloWorld
+			execWant = helloWorld + "\n" + teeInput
+		)
+
+		opts := defaultLCOWOptions(ctx, t)
+		vm := testuvm.CreateAndStart(ctx, t, opts)
+
+		cID := testName(t, "container")
+
+		logFile := path.Join("/run/clogs/", util.CleanName(t))
+
+		scratch, _ := testlayers.ScratchSpace(ctx, t, vm, "", "", cache)
+		spec := testoci.CreateLinuxSpec(ctx, t, cID,
+			testoci.DefaultLinuxSpecOpts(cID,
+				ctrdoci.WithProcessArgs("/bin/sh", "-c", fmt.Sprintf("echo %s; sleep 10s; echo %s", helloWorld, helloWorld)),
+				ctrdoci.WithAnnotations(map[string]string{annotations.LCOWTeeLogPath: logFile}),
+				testoci.WithWindowsLayerFolders(append(ls, scratch)))...)
+
+		c, _, cleanup := testcontainer.Create(ctx, t, vm, spec, cID, hcsOwner)
+		t.Cleanup(cleanup)
+
+		io := testcmd.NewBufferedIO()
+		init := testcontainer.Start(ctx, t, c, io)
+		t.Cleanup(func() {
+			testcontainer.Kill(ctx, t, c)
+			testcontainer.Wait(ctx, t, c)
+		})
+
+		ps := testoci.CreateLinuxSpec(ctx, t, cID,
+			testoci.DefaultLinuxSpecOpts(cID,
+				ctrdoci.WithDefaultPathEnv,
+				ctrdoci.WithProcessArgs("/bin/sh", "-c", fmt.Sprintf("echo %s; tee", helloWorld)),
+			)...,
+		).Process
+		execIO := testcmd.NewBufferedIOFromString(teeInput)
+		execCmd := testcmd.Create(ctx, t, c, ps, execIO)
+		testcmd.Start(ctx, t, execCmd)
+
+		testcmd.WaitExitCode(ctx, t, execCmd, 0)
+		testcmd.WaitExitCode(ctx, t, init, 0)
+
+		// validate stdout
+		execIO.TestOutput(t, execWant, nil)
+		io.TestOutput(t, want, nil)
+
+		logIO := testcmd.NewBufferedIO()
+		cmdArgs := testcmd.Create(ctx, t, vm, &specs.Process{Args: []string{"cat", logFile}}, logIO)
+		testcmd.Start(ctx, t, cmdArgs)
+		testcmd.WaitExitCode(ctx, t, cmdArgs, 0)
+
+		// validate the log file
+		logIO.TestOutput(t, want, nil)
+	})
+}

--- a/test/functional/lcow_policy_test.go
+++ b/test/functional/lcow_policy_test.go
@@ -62,7 +62,7 @@ func TestGetProperties_WithPolicy(t *testing.T) {
 			opts.SecurityPolicyEnforcer = "rego"
 			opts.SecurityPolicy = policy
 
-			cleanName := util.CleanName(t.Name())
+			cleanName := util.CleanName(t)
 			vm := testuvm.CreateAndStartLCOWFromOpts(ctx, t, opts)
 			spec := testoci.CreateLinuxSpec(
 				ctx,

--- a/test/functional/main_test.go
+++ b/test/functional/main_test.go
@@ -303,7 +303,7 @@ func defaultWCOWOptions(ctx context.Context, tb testing.TB) *uvm.OptionsWCOW {
 func testName(tb testing.TB, xs ...any) string {
 	tb.Helper()
 
-	return util.CleanName(tb.Name()) + util.RandNameSuffix(xs...)
+	return util.CleanName(tb) + util.RandNameSuffix(xs...)
 }
 
 // linuxImageLayers returns image layer paths appropriate for use as a container rootfs.

--- a/test/internal/layers/lazy.go
+++ b/test/internal/layers/lazy.go
@@ -110,7 +110,7 @@ func (x *LazyImageLayers) extractLayers(ctx context.Context) (err error) {
 		if err != nil {
 			return err
 		}
-		x.dir, err = os.MkdirTemp(dir, util.CleanName(x.Image))
+		x.dir, err = os.MkdirTemp(dir, util.CleanString(x.Image))
 		if err != nil {
 			return fmt.Errorf("failed to create temp directory: %w", err)
 		}

--- a/test/internal/layers/scratch.go
+++ b/test/internal/layers/scratch.go
@@ -69,7 +69,7 @@ func WCOWScratchDir(ctx context.Context, tb testing.TB, dir string) string {
 	return dir
 }
 
-func newTestTempDir(ctx context.Context, tb testing.TB, name string) string {
+func newTestTempDir(_ context.Context, tb testing.TB, name string) string {
 	tb.Helper()
 	dir, err := tempDirOnce()
 	if err != nil {
@@ -77,7 +77,7 @@ func newTestTempDir(ctx context.Context, tb testing.TB, name string) string {
 	}
 
 	if name == "" {
-		name = util.CleanName(tb.Name())
+		name = util.CleanName(tb)
 	}
 	dir, err = os.MkdirTemp(dir, name)
 	if err != nil {

--- a/test/internal/util/util.go
+++ b/test/internal/util/util.go
@@ -17,10 +17,10 @@ import (
 	"github.com/Microsoft/hcsshim/internal/version"
 )
 
-// CleanName returns a string appropriate for uVM, container, or file names.
+// CleanString returns a string appropriate for uVM, container, or file names.
 //
 // Based on [testing.TB.TempDir].
-func CleanName(n string) string {
+func CleanString(n string) string {
 	mapper := func(r rune) rune {
 		const allowed = "!#$%&()+,-.=@^_{}~ "
 		if unicode.IsLetter(r) || unicode.IsNumber(r) || strings.ContainsRune(allowed, r) {
@@ -29,6 +29,13 @@ func CleanName(n string) string {
 		return -1
 	}
 	return strings.TrimSpace(strings.Map(mapper, n))
+}
+
+// CleanName returns [CleanString] applied to the [testing.TB.Name]
+func CleanName(tb testing.TB) string {
+	tb.Helper()
+
+	return CleanString(tb.Name())
 }
 
 // RunningBenchmarks returns whether benchmarks were requested to be run.


### PR DESCRIPTION
Add annotation to tee container `stdin` and `stderr` to a specified path within the uVM.

Add a dedicated `trapsort.MultiWriter` type that writes to both an underlying `transport.Connection` and the provided `io.Writer`.

Also, move `logConnection` from `stdio` to `transport`, to keep the different `Connection` implementations together.

Add functional tests.

Streamline `test/internal/util` by making `CleanName` operation on the test name directly (`testing.TB.Name()`), since that is the majority of the usage.
Add `CleanString` to handle the original functionality.