### PR TITLE
Allow writable `/var` and `/etc` directories

### DIFF
--- a/internal/annotations/annotations.go
+++ b/internal/annotations/annotations.go
@@ -39,6 +39,11 @@ const (
 	// ExtraVSockPorts adds additional ports to the list of ports that the UVM is allowed to use.
 	ExtraVSockPorts = "io.microsoft.virtualmachine.lcow.extra-vsock-ports"
 
+	// WritableOverlayDirs creates writable overlay mounts for the /var and /etc directories.
+	//
+	// This will nop if the LCOW uVM rootfs is already writable (e.g., initramfs-backed initrd).
+	WritableOverlayDirs = "io.microsoft.virtualmachine.lcow.writable-overlay-directories"
+
 	// NetworkingPolicyBasedRouting toggles on the ability to set policy based routing in the
 	// guest for LCOW.
 	//

--- a/internal/oci/uvm.go
+++ b/internal/oci/uvm.go
@@ -317,6 +317,7 @@ func SpecToUVMCreateOpts(ctx context.Context, s *specs.Spec, id, owner string) (
 		lopts.KernelBootOptions = ParseAnnotationsString(s.Annotations, annotations.KernelBootOptions, lopts.KernelBootOptions)
 		lopts.DisableTimeSyncService = ParseAnnotationsBool(ctx, s.Annotations, annotations.DisableLCOWTimeSyncService, lopts.DisableTimeSyncService)
 		lopts.ConsolePipe = ParseAnnotationsString(s.Annotations, iannotations.UVMConsolePipe, lopts.ConsolePipe)
+		lopts.WritableOverlayDirs = ParseAnnotationsBool(ctx, s.Annotations, iannotations.WritableOverlayDirs, lopts.WritableOverlayDirs)
 		handleAnnotationPreferredRootFSType(ctx, s.Annotations, lopts)
 		handleAnnotationKernelDirectBoot(ctx, s.Annotations, lopts)
 		handleAnnotationFullyPhysicallyBacked(ctx, s.Annotations, lopts)

--- a/internal/uvm/create_lcow.go
+++ b/internal/uvm/create_lcow.go
@@ -132,6 +132,7 @@ type OptionsLCOW struct {
 	ExtraVSockPorts         []uint32             // Extra vsock ports to allow
 	AssignedDevices         []VPCIDeviceID       // AssignedDevices are devices to add on pod boot
 	PolicyBasedRouting      bool                 // Whether we should use policy based routing when configuring net interfaces in guest
+	WritableOverlayDirs     bool                 // Whether init should create writable overlay mounts for /var and /etc
 }
 
 // defaultLCOWOSBootFilesPath returns the default path used to locate the LCOW
@@ -579,7 +580,9 @@ Example JSON document produced once the hcsschema.ComputeSytem returned by makeL
 
 // Make the ComputeSystem document object that will be serialized to json to be presented to the HCS api.
 func makeLCOWDoc(ctx context.Context, opts *OptionsLCOW, uvm *UtilityVM) (_ *hcsschema.ComputeSystem, err error) {
-	logrus.Tracef("makeLCOWDoc %v\n", opts)
+	if logrus.IsLevelEnabled(logrus.TraceLevel) {
+		log.G(ctx).WithField("options", log.Format(ctx, opts)).Trace("makeLCOWDoc")
+	}
 
 	kernelFullPath := filepath.Join(opts.BootFilesPath, opts.KernelFile)
 	if _, err := os.Stat(kernelFullPath); os.IsNotExist(err) {
@@ -863,10 +866,20 @@ func makeLCOWDoc(ctx context.Context, opts *OptionsLCOW, uvm *UtilityVM) (_ *hcs
 		execCmdArgs += " -core-dump-location " + opts.ProcessDumpLocation
 	}
 
-	initArgs := fmt.Sprintf("%s %s", entropyArgs, execCmdArgs)
+	initArgs := entropyArgs
+	if opts.WritableOverlayDirs {
+		switch opts.PreferredRootFSType {
+		case PreferredRootFSTypeInitRd:
+			log.G(ctx).Warn("ignoring `WritableOverlayDirs` option since rootfs is already writable")
+		case PreferredRootFSTypeVHD:
+			initArgs += " -w"
+		}
+	}
 	if vmDebugging {
 		// Launch a shell on the console.
-		initArgs = entropyArgs + ` sh -c "` + execCmdArgs + ` & exec sh"`
+		initArgs += ` sh -c "` + execCmdArgs + ` & exec sh"`
+	} else {
+		initArgs += " " + execCmdArgs
 	}
 
 	kernelArgs += fmt.Sprintf(" nr_cpus=%d", opts.ProcessorCount)
@@ -910,7 +923,9 @@ func CreateLCOW(ctx context.Context, opts *OptionsLCOW) (_ *UtilityVM, err error
 	}
 
 	span.AddAttributes(trace.StringAttribute(logfields.UVMID, opts.ID))
-	log.G(ctx).WithField("options", log.Format(ctx, opts)).Debug("uvm::CreateLCOW options")
+	if logrus.IsLevelEnabled(logrus.DebugLevel) {
+		log.G(ctx).WithField("options", log.Format(ctx, opts)).Debug("uvm::CreateLCOW options")
+	}
 
 	// We don't serialize OutputHandlerCreator so if it is missing we need to put it back to the default.
 	if opts.OutputHandlerCreator == nil {
@@ -955,10 +970,20 @@ func CreateLCOW(ctx context.Context, opts *OptionsLCOW) (_ *UtilityVM, err error
 	var doc *hcsschema.ComputeSystem
 	if opts.SecurityPolicyEnabled {
 		doc, err = makeLCOWSecurityDoc(ctx, opts, uvm)
-		log.G(ctx).Tracef("create_lcow::CreateLCOW makeLCOWSecurityDoc result doc: %v err %v", doc, err)
+		if logrus.IsLevelEnabled(logrus.TraceLevel) {
+			log.G(ctx).WithFields(logrus.Fields{
+				"doc":           log.Format(ctx, doc),
+				logrus.ErrorKey: err,
+			}).Trace("create_lcow::CreateLCOW makeLCOWSecurityDoc result")
+		}
 	} else {
 		doc, err = makeLCOWDoc(ctx, opts, uvm)
-		log.G(ctx).Tracef("create_lcow::CreateLCOW makeLCOWDoc result doc: %v err %v", doc, err)
+		if logrus.IsLevelEnabled(logrus.TraceLevel) {
+			log.G(ctx).WithFields(logrus.Fields{
+				"doc":           log.Format(ctx, doc),
+				logrus.ErrorKey: err,
+			}).Trace("create_lcow::CreateLCOW makeLCOWDoc result")
+		}
 	}
 	if err != nil {
 		return nil, err
@@ -967,7 +992,9 @@ func CreateLCOW(ctx context.Context, opts *OptionsLCOW) (_ *UtilityVM, err error
 	if err = uvm.create(ctx, doc); err != nil {
 		return nil, fmt.Errorf("error while creating the compute system: %w", err)
 	}
-	log.G(ctx).WithField("uvm", uvm).Trace("create_lcow::CreateLCOW uvm.create result")
+	if logrus.IsLevelEnabled(logrus.TraceLevel) {
+		log.G(ctx).WithField("uvm", log.Format(ctx, uvm)).Trace("create_lcow::CreateLCOW uvm.create result")
+	}
 
 	// Create a socket to inject entropy during boot.
 	uvm.entropyListener, err = uvm.listenVsock(entropyVsockPort)

--- a/test/internal/cmd/io.go
+++ b/test/internal/cmd/io.go
@@ -42,8 +42,17 @@ func (b *BufferedIO) TestOutput(tb testing.TB, out string, err error) {
 	tb.Helper()
 
 	outGot, errGot := b.Output()
-	if !errors.Is(errGot, err) {
+
+	// dont use [errors.Is] since errGot will always be created via [errors.New] and
+	// therefore never match non-nil errors.
+	if (err == nil && errGot != nil) || (err != nil && errGot == nil) {
 		tb.Fatalf("got stderr: %v; wanted: %v", errGot, err)
+	} else if err != nil && errGot != nil {
+		errStr := strings.ToLower(strings.TrimSpace(err.Error()))
+		errGotStr := strings.ToLower(strings.TrimSpace(errGot.Error()))
+		if diff := cmp.Diff(errStr, errGotStr); diff != "" {
+			tb.Fatalf("stderr mismatch (-want +got):\n%s", diff)
+		}
 	}
 
 	out = strings.ToLower(strings.TrimSpace(out))


### PR DESCRIPTION
Binaries in the uVM can require writing to (or be configured by) files in `/var` (or `/etc`, respectively).

An LCOW uVM VHD-backed rootfs, however, is readonly (as opposed to WCOW, which creates a new snapshot and therefor scratch VHD per uVM). Remedy this by creating `overlay` mounts for the two directories, enabled by the `/init` flag `-w`.

Use `overlay` instead of creating a `tmpfs` mount directly over the directories (which is done for `/run` and `/tmp`) to preserve existing content in the rootfs.

Add a new `WritableOverlayDirs` annotation to enable the feature. Make the annotation internal (unpublished) since:
 - it is implementation dependent (i.e., how LCOW uVMs are run could conceivably change in the future); and
 - the feature is aimed at more advanced use cases where users are modifying the LCOW uVMs rootfs and should be familiar with `hcshims`'s inner workings