### PR TITLE
Disable video console in SNP mode

### DIFF
--- a/internal/tools/uvmboot/conf_wcow.go
+++ b/internal/tools/uvmboot/conf_wcow.go
@@ -114,8 +114,10 @@ var cwcowCommand = cli.Command{
 			options.DisableSecureBoot = cwcowDisableSecureBoot
 			options.GuestStateFilePath = cwcowVMGSPath
 			options.IsolationType = cwcowIsolationMode
-			// always enable graphics console with uvmboot - helps with testing/debugging
-			options.EnableGraphicsConsole = true
+
+			// graphics console helps with testing/debugging however, it
+			// doesn't work in SNP isolation mode.
+			options.EnableGraphicsConsole = cwcowIsolationMode != "SecureNestedPaging"
 			options.WritableEFI = cwcowWritableEFI
 
 			var err error

--- a/internal/uvm/create.go
+++ b/internal/uvm/create.go
@@ -193,6 +193,9 @@ func verifyOptions(_ context.Context, options interface{}) error {
 		if opts.SecurityPolicyEnabled && opts.GuestStateFilePath == "" {
 			return fmt.Errorf("GuestStateFilePath must be provided when enabling security policy")
 		}
+		if opts.IsolationType == "SecureNestedPaging" && opts.EnableGraphicsConsole {
+			return fmt.Errorf("graphics console cannot be enabled with SecureNestedPaging isolation mode")
+		}
 		if opts.ResourcePartitionID != nil {
 			if opts.CPUGroupID != "" {
 				return errors.New("resource partition ID and CPU group ID cannot be set at the same time")

--- a/internal/uvm/create_wcow.go
+++ b/internal/uvm/create_wcow.go
@@ -354,7 +354,7 @@ func prepareSecurityConfigDoc(ctx context.Context, uvm *UtilityVM, opts *Options
 
 	enableHCL := true
 	doc.VirtualMachine.SecuritySettings = &hcsschema.SecuritySettings{
-		EnableTpm: false,
+		EnableTpm: false, // TPM MUST always remain false in confidential mode as per the design
 		Isolation: &hcsschema.IsolationSettings{
 			IsolationType: "SecureNestedPaging",
 			HclEnabled:    &enableHCL,
@@ -522,10 +522,20 @@ func CreateWCOW(ctx context.Context, opts *OptionsWCOW) (_ *UtilityVM, err error
 	var doc *hcsschema.ComputeSystem
 	if opts.SecurityPolicyEnabled {
 		doc, err = prepareSecurityConfigDoc(ctx, uvm, opts)
-		log.G(ctx).Tracef("CreateWCOW prepareSecurityConfigDoc result doc: %v err %v", doc, err)
+		if logrus.IsLevelEnabled(logrus.TraceLevel) {
+			log.G(ctx).WithFields(logrus.Fields{
+				"doc":           log.Format(ctx, doc),
+				logrus.ErrorKey: err,
+			}).Trace("CreateWCOW prepareSecurityConfigDoc")
+		}
 	} else {
 		doc, err = prepareConfigDoc(ctx, uvm, opts)
-		log.G(ctx).Tracef("CreateWCOW prepareConfigDoc result doc: %v err %v", doc, err)
+		if logrus.IsLevelEnabled(logrus.TraceLevel) {
+			log.G(ctx).WithFields(logrus.Fields{
+				"doc":           log.Format(ctx, doc),
+				logrus.ErrorKey: err,
+			}).Trace("CreateWCOW prepareConfigDoc")
+		}
 	}
 	if err != nil {
 		return nil, fmt.Errorf("error in preparing config doc: %w", err)


### PR DESCRIPTION
Video console is not supported when a UVM is being started in SNP isolation mode. It is anyway always disabled when starting a pod, but uvmboot tool always enabled it until now. This change only enables it if the isolation mode isn't SNP.

Also, adds a new log statement to log the generated UVM HCS doc.