### PR TITLE
Support tmpfs backed sandbox mount for LCOW containers

### DIFF
--- a/cmd/containerd-shim-runhcs-v1/task_hcs.go
+++ b/cmd/containerd-shim-runhcs-v1/task_hcs.go
@@ -988,8 +988,9 @@ func isMountTypeSupported(hostPath, mountType string) bool {
 		hcsoci.MountTypeVirtualDisk, hcsoci.MountTypeExtensibleVirtualDisk:
 		return false
 	default:
-		// Ensure that host path is not sandbox://, hugepages://, \\.\pipe, uvm://
+		// Ensure that host path is not sandbox://, sandbox-tmp://, hugepages://, \\.\pipe, uvm://
 		if strings.HasPrefix(hostPath, guestpath.SandboxMountPrefix) ||
+			strings.HasPrefix(hostPath, guestpath.SandboxTmpfsMountPrefix) ||
 			strings.HasPrefix(hostPath, guestpath.HugePagesMountPrefix) ||
 			strings.HasPrefix(hostPath, guestpath.PipePrefix) ||
 			strings.HasPrefix(hostPath, guestpath.UVMMountPrefix) {

--- a/internal/guest/spec/spec.go
+++ b/internal/guest/spec/spec.go
@@ -84,6 +84,11 @@ func SandboxMountsDir(sandboxID string) string {
 	return filepath.Join(SandboxRootDir(sandboxID), "sandboxMounts")
 }
 
+// SandboxTmpfsMountsDir returns sandbox tmpfs mounts directory inside UVM.
+func SandboxTmpfsMountsDir(sandboxID string) string {
+	return filepath.Join(SandboxRootDir(sandboxID), "sandboxTmpfsMounts")
+}
+
 // HugePagesMountsDir returns hugepages mounts directory inside UVM.
 func HugePagesMountsDir(sandboxID string) string {
 	return filepath.Join(SandboxRootDir(sandboxID), "hugepages")
@@ -94,6 +99,13 @@ func SandboxMountSource(sandboxID, path string) string {
 	mountsDir := SandboxMountsDir(sandboxID)
 	subPath := strings.TrimPrefix(path, guestpath.SandboxMountPrefix)
 	return filepath.Join(mountsDir, subPath)
+}
+
+// SandboxTmpfsMountSource returns sandbox tmpfs mount path inside UVM
+func SandboxTmpfsMountSource(sandboxID, path string) string {
+	tmpfsMountDir := SandboxTmpfsMountsDir(sandboxID)
+	subPath := strings.TrimPrefix(path, guestpath.SandboxTmpfsMountPrefix)
+	return filepath.Join(tmpfsMountDir, subPath)
 }
 
 // HugePagesMountSource returns hugepages mount path inside UVM

--- a/internal/guestpath/paths.go
+++ b/internal/guestpath/paths.go
@@ -10,6 +10,9 @@ const (
 	// SandboxMountPrefix is mount prefix used in container spec to mark a
 	// sandbox-mount
 	SandboxMountPrefix = "sandbox://"
+	// SandboxTmpfsMountPrefix is mount prefix used in container spec to mark a
+	// sandbox-tmp mount
+	SandboxTmpfsMountPrefix = "sandbox-tmp://"
 	// HugePagesMountPrefix is mount prefix used in container spec to mark a
 	// huge-pages mount
 	HugePagesMountPrefix = "hugepages://"

--- a/internal/hcsoci/resources_lcow.go
+++ b/internal/hcsoci/resources_lcow.go
@@ -129,10 +129,13 @@ func allocateLinuxResources(ctx context.Context, coi *createOptionsInternal, r *
 					mt = "bind"
 				}
 				coi.Spec.Mounts[i].Type = mt
-			} else if strings.HasPrefix(mount.Source, guestpath.SandboxMountPrefix) || strings.HasPrefix(mount.Source, guestpath.UVMMountPrefix) {
-				// Mounts that map to a path in UVM are specified with a 'sandbox://' or 'uvm://' prefix.
+			} else if strings.HasPrefix(mount.Source, guestpath.SandboxMountPrefix) ||
+				strings.HasPrefix(mount.Source, guestpath.SandboxTmpfsMountPrefix) ||
+				strings.HasPrefix(mount.Source, guestpath.UVMMountPrefix) {
+				// Mounts that map to a path in UVM are specified with a 'sandbox://', 'sandbox-tmp://', or 'uvm://' prefix.
 				// examples:
 				//  - sandbox:///a/dirInUvm destination:/b/dirInContainer
+				//  - sandbox-tmp:///a/dirInUvm destination:/b/dirInContainer
 				//  - uvm:///a/dirInUvm destination:/b/dirInContainer
 				uvmPathForFile = mount.Source
 			} else if strings.HasPrefix(mount.Source, guestpath.HugePagesMountPrefix) {


### PR DESCRIPTION
This PR adds the support for tmpfs backed sandbox mount. The tmpfs mounts are mounted inside UVM under the directory at `/run/gcs/c/<SANDBOX-ID>/sandboxTmpfsMounts`.

Containers can utilize a tmpfs-backed sandbox mount using `sandbox-tmp://` prefix as follows,
```
"mounts": [
      {
          "host_path": "sandbox-tmp://s1",
          "container_path": "/sndbox/m1"
      }
]
```

If checking from the container's perspective,
```
.\crictl.exe exec -i $CONTAINER cat /proc/self/mountinfo
129 122 0:41 /s1 /sndbox/m1 rw,relatime - tmpfs tmpfs rw
```