### PR TITLE
Fix panic in HasConfidentialPolicy for LCOW.

### DIFF
--- a/internal/uvm/create_wcow.go
+++ b/internal/uvm/create_wcow.go
@@ -505,7 +505,7 @@ func CreateWCOW(ctx context.Context, opts *OptionsWCOW) (_ *UtilityVM, err error
 		devicesPhysicallyBacked: opts.FullyPhysicallyBacked,
 		vsmbNoDirectMap:         opts.NoDirectMap,
 		noWritableFileShares:    opts.NoWritableFileShares,
-		createOpts:              *opts,
+		createOpts:              opts,
 		blockCIMMounts:          make(map[string]*UVMMountedBlockCIMs),
 	}
 

--- a/internal/uvm/security_policy.go
+++ b/internal/uvm/security_policy.go
@@ -167,9 +167,9 @@ func (uvm *UtilityVM) InjectPolicyFragment(ctx context.Context, fragment *ctrdta
 // returns if this instance of the UtilityVM is created with confidential policy
 func (uvm *UtilityVM) HasConfidentialPolicy() bool {
 	switch opts := uvm.createOpts.(type) {
-	case OptionsWCOW:
+	case *OptionsWCOW:
 		return opts.SecurityPolicyEnabled
-	case OptionsLCOW:
+	case *OptionsLCOW:
 		return opts.SecurityPolicyEnabled
 	default:
 		panic("unexpected options type")

--- a/internal/uvm/start.go
+++ b/internal/uvm/start.go
@@ -339,8 +339,8 @@ func (uvm *UtilityVM) Start(ctx context.Context) (err error) {
 
 	if uvm.HasConfidentialPolicy() && uvm.OS() == "windows" {
 		copts := []WCOWConfidentialUVMOpt{
-			WithWCOWSecurityPolicy(uvm.createOpts.(OptionsWCOW).SecurityPolicy),
-			WithWCOWSecurityPolicyEnforcer(uvm.createOpts.(OptionsWCOW).SecurityPolicyEnforcer),
+			WithWCOWSecurityPolicy(uvm.createOpts.(*OptionsWCOW).SecurityPolicy),
+			WithWCOWSecurityPolicyEnforcer(uvm.createOpts.(*OptionsWCOW).SecurityPolicyEnforcer),
 		}
 		if err := uvm.SetWCOWConfidentialUVMOptions(ctx, copts...); err != nil {
 			return err


### PR DESCRIPTION
`HasConfidentialPolicy` assumed that
the UVM creation options saved in the UtilityVM struct will always be of type `OptionsWCOW` & `OptionsLCOW`. However, for LCOW we store the options as a pointer (i.e type `*OptionsLCOW`) whereas for WCOW we store the options as a value (i.e type `OptionsWCOW`). This caused the `HasConfidentialPolicy` method to panic when testing the policy for LCOW UtilityVM types.

Easy fix would be to just update the switch case to `*OptionsLCOW` instead of `OptionsLCOW`, but it seems better to use the same type (create options pointer) for both LCOW & WCOW to avoid such issues in future. In the long run we also want to refactor this and have a common set of methods/types for handling confidential options for LCOW & WCOW.