### PR TITLE
add EVD support for LCOW

### DIFF
--- a/internal/uvm/scsi/manager.go
+++ b/internal/uvm/scsi/manager.go
@@ -260,6 +260,7 @@ func (m *Manager) AddExtensibleVirtualDisk(
 			options:          mc.Options,
 			ensureFilesystem: mc.EnsureFilesystem,
 			filesystem:       mc.Filesystem,
+			blockDev:         mc.BlockDev,
 		}
 	}
 	return m.add(ctx,


### PR DESCRIPTION
Add handling of Extensible Virtual Disks mounts for LCOW. Prior to this change, EVDs were supported only for WCOW. The expectation is that the EVD will be presented to container as a block device.