### PR TITLE
[ms/release/0.1] backport signal init process fix

### DIFF
--- a/internal/guest/runtime/hcsv2/uvm.go
+++ b/internal/guest/runtime/hcsv2/uvm.go
@@ -684,17 +684,7 @@ func (h *Host) SignalContainerProcess(ctx context.Context, containerID string, p
 		return err
 	}
 
-	signalingInitProcess := (processID == c.initProcess.pid)
-
-	// Don't allow signalProcessV2 to route around container shutdown policy
-	// Sending SIGTERM or SIGKILL to a containers init process will shut down
-	// the container.
-	if signalingInitProcess {
-		if (signal == unix.SIGTERM) || (signal == unix.SIGKILL) {
-			graceful := (signal == unix.SIGTERM)
-			return h.ShutdownContainer(ctx, containerID, graceful)
-		}
-	}
+	signalingInitProcess := processID == c.initProcess.pid
 
 	startupArgList := p.(*containerProcess).spec.Args
 	err = h.securityPolicyEnforcer.EnforceSignalContainerProcessPolicy(ctx, containerID, signal, signalingInitProcess, startupArgList)

--- a/internal/guest/runtime/runc/container.go
+++ b/internal/guest/runtime/runc/container.go
@@ -78,9 +78,6 @@ func (c *container) ExecProcess(process *oci.Process, stdioSet *stdio.Connection
 func (c *container) Kill(signal syscall.Signal) error {
 	logrus.WithField(logfields.ContainerID, c.id).Debug("runc::container::Kill")
 	args := []string{"kill"}
-	if signal == syscall.SIGTERM || signal == syscall.SIGKILL {
-		args = append(args, "--all")
-	}
 	args = append(args, c.id, strconv.Itoa(int(signal)))
 	cmd := runcCommand(args...)
 	out, err := cmd.CombinedOutput()


### PR DESCRIPTION
When implementing signal container process enforcement policy we introduced a bug, where instead of signalling just the container init process we ended up sending signals (SIGTERM or SIGKILL) to all processes running inside a container (by invoking `runc kill --all`).

`container.Kill` no longer sends signals to all container processes.

This results in an unpleasant behavior, where the init process could be handling (e.g. ignoring) SIGTERM, where as other processes inside container don't.

This PR makes a change to the order in which the signal container policy is enforced:
  - always call `EnforceSignalContainerProcessPolicy` before sending any signals. Otherwise, this looks like a bug, since we would never call `EnforceSignalContainerProcessPolicy` with `signalingInitProcess == true` for `SIGTERM` and `SIGKILL` and potentially bypassing policies, which do not allow `SIGTERM` or `SIGKILL` to be sent to the init process.
  - no longer call `ShutdownContainer` and instead revert back to calling `process.Kill`.


(cherry picked from commit 04735e059bd2f1023d6a33443e18489b3fde423e)