### PR TITLE
cwcow: Use the right VM version

### DIFF
--- a/internal/uvm/create_wcow.go
+++ b/internal/uvm/create_wcow.go
@@ -415,8 +415,9 @@ func prepareSecurityConfigDoc(ctx context.Context, uvm *UtilityVM, opts *Options
 	}
 
 	doc.SchemaVersion = schemaversion.SchemaV25()
+	// VM Version 12 is the min version that supports the various SNP features.
 	doc.VirtualMachine.Version = &hcsschema.Version{
-		Major: 11,
+		Major: 12,
 		Minor: 0,
 	}
 


### PR DESCRIPTION
VM version 12 is the minimum version that supports the various SNP features.