### PR TITLE
Bypass default encryption policy when expanding sandbox vhdx

### DIFF
--- a/internal/wclayer/expandscratchsize.go
+++ b/internal/wclayer/expandscratchsize.go
@@ -9,6 +9,7 @@ import (
 	"syscall"
 	"unsafe"
 
+	"github.com/Microsoft/go-winio/vhd"
 	"github.com/Microsoft/hcsshim/internal/hcserror"
 	"github.com/Microsoft/hcsshim/internal/oc"
 	"go.opencensus.io/trace"
@@ -75,7 +76,7 @@ func attachVhd(path string) (syscall.Handle, error) {
 	if err != nil {
 		return 0, &os.PathError{Op: "OpenVirtualDisk", Path: path, Err: err}
 	}
-	err = attachVirtualDisk(handle, 0, 0, 0, 0, 0)
+	err = vhd.AttachVirtualDisk(handle, vhd.AttachVirtualDiskFlagBypassDefaultEncryptionPolicy, nil)
 	if err != nil {
 		syscall.Close(handle)
 		return 0, &os.PathError{Op: "AttachVirtualDisk", Path: path, Err: err}


### PR DESCRIPTION
This fixes the following error when running on machines with a policy to enforce bitlocker encryption on fixed drives

```
failed to create scratch layer: failed to expand sandbox vhdx size to #### bytes: FSCTL_EXTEND_VOLUME \\?\Volume{xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx}: The media is write protected.
```

Fixed: #2464