### PR TITLE
CWCOW: Unmount CIM volume

### DIFF
--- a/internal/layers/wcow_mount.go
+++ b/internal/layers/wcow_mount.go
@@ -497,7 +497,6 @@ func mountHypervIsolatedBlockCIMLayers(ctx context.Context, l *wcowBlockCIMLayer
 		return nil, nil, fmt.Errorf("failed to add SCSI scratch VHD: %w", err)
 	}
 	containerScratchPathInUVM := scsiMount.GuestPath()
-	rcl.Add(scsiMount)
 
 	log.G(ctx).WithFields(logrus.Fields{
 		"hostPath": hostPath,


### PR DESCRIPTION
- This PR has two changes:
   - Implements CIM volume unmount as part of container shut down process
   - Before this change, Scratch disk gets unmounted twice and it errors out on second attempt and as a result it never reaches to CIM unmount operation. This PR fixes it by removing it from `ResourceCloser` list as it is already unmounted previously i.e. `lc.scratchMount.Release(ctx);`
   