### PR TITLE
CWCOW: roothash and graceful timeout fixes

### DIFF
--- a/internal/gcs-sidecar/handlers.go
+++ b/internal/gcs-sidecar/handlers.go
@@ -4,7 +4,7 @@
 package bridge
 
 import (
-	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -624,7 +624,7 @@ func (b *Bridge) modifySettings(req *request) (err error) {
 						return fmt.Errorf("failed to get CIM verification info: %w", err)
 					}
 					layerDigests[i] = cimRootDigestBytes
-					layerHashes[i] = base64.URLEncoding.EncodeToString(cimRootDigestBytes)
+					layerHashes[i] = hex.EncodeToString(cimRootDigestBytes)
 					layerCIMs = append(layerCIMs, &layerCim)
 
 					log.G(ctx).Debugf("block CIM layer digest %s, path: %s\n", layerHashes[i], physicalDevPath)

--- a/pkg/ociwclayer/cim/import.go
+++ b/pkg/ociwclayer/cim/import.go
@@ -99,7 +99,7 @@ func WithParentLayers(parentLayers []*cimfs.BlockCIM) BlockCIMLayerImportOpt {
 func writeIntegrityChecksumInfoFile(ctx context.Context, blockPath string) error {
 	log.G(ctx).Debugf("writing integrity checksum file for block CIM `%s`", blockPath)
 	// for convenience write a file that has the hex encoded root digest of the generated verified CIM.
-	// this same base64 string can be used in the confidential policy.
+	// this same hex string can be used in the confidential policy.
 	digest, err := cimfs.GetVerificationInfo(blockPath)
 	if err != nil {
 		return fmt.Errorf("failed to query verified info of the CIM layer: %w", err)


### PR DESCRIPTION
This PR has two changes:
- Replace base64 encoding of roothash with hex encoding for better standardization and also parity with how C-LCOW does it.
- Have a graceful timeout when waiting for SCSI devices to show up inside the UVM.