### PR TITLE
adds guest manager interfaces + implementation for guest operations

### DIFF
--- a/internal/vm/guestmanager/block_cims.go
+++ b/internal/vm/guestmanager/block_cims.go
@@ -1,0 +1,58 @@
+//go:build windows
+
+package guestmanager
+
+import (
+	"context"
+	"fmt"
+
+	hcsschema "github.com/Microsoft/hcsshim/internal/hcs/schema2"
+	"github.com/Microsoft/hcsshim/internal/protocol/guestrequest"
+	"github.com/Microsoft/hcsshim/internal/protocol/guestresource"
+)
+
+// CIMsManager exposes guest WCOW block CIM operations.
+type CIMsManager interface {
+	// AddWCOWBlockCIMs adds WCOW block CIM mounts in the guest.
+	AddWCOWBlockCIMs(ctx context.Context, settings *guestresource.CWCOWBlockCIMMounts) error
+	// RemoveWCOWBlockCIMs removes WCOW block CIM mounts from the guest.
+	RemoveWCOWBlockCIMs(ctx context.Context, settings *guestresource.CWCOWBlockCIMMounts) error
+}
+
+var _ CIMsManager = (*Guest)(nil)
+
+// AddWCOWBlockCIMs adds WCOW block CIM mounts in the guest.
+func (gm *Guest) AddWCOWBlockCIMs(ctx context.Context, settings *guestresource.CWCOWBlockCIMMounts) error {
+	request := &hcsschema.ModifySettingRequest{
+		GuestRequest: guestrequest.ModificationRequest{
+			ResourceType: guestresource.ResourceTypeWCOWBlockCims,
+			RequestType:  guestrequest.RequestTypeAdd,
+			Settings:     settings,
+		},
+	}
+
+	err := gm.modify(ctx, request.GuestRequest)
+	if err != nil {
+		return fmt.Errorf("failed to add WCOW block CIMs: %w", err)
+	}
+
+	return nil
+}
+
+// RemoveWCOWBlockCIMs removes WCOW block CIM mounts in the guest.
+func (gm *Guest) RemoveWCOWBlockCIMs(ctx context.Context, settings *guestresource.CWCOWBlockCIMMounts) error {
+	request := &hcsschema.ModifySettingRequest{
+		GuestRequest: guestrequest.ModificationRequest{
+			ResourceType: guestresource.ResourceTypeWCOWBlockCims,
+			RequestType:  guestrequest.RequestTypeRemove,
+			Settings:     settings,
+		},
+	}
+
+	err := gm.modify(ctx, request.GuestRequest)
+	if err != nil {
+		return fmt.Errorf("failed to remove WCOW block CIMs: %w", err)
+	}
+
+	return nil
+}

--- a/internal/vm/guestmanager/combinedlayers_lcow.go
+++ b/internal/vm/guestmanager/combinedlayers_lcow.go
@@ -1,0 +1,56 @@
+//go:build windows
+
+package guestmanager
+
+import (
+	"context"
+	"fmt"
+
+	hcsschema "github.com/Microsoft/hcsshim/internal/hcs/schema2"
+	"github.com/Microsoft/hcsshim/internal/protocol/guestrequest"
+	"github.com/Microsoft/hcsshim/internal/protocol/guestresource"
+)
+
+// LCOWLayersManager exposes combined layer operations in the LCOW guest.
+type LCOWLayersManager interface {
+	// AddLCOWCombinedLayers adds combined layers to the LCOW guest.
+	AddLCOWCombinedLayers(ctx context.Context, settings guestresource.LCOWCombinedLayers) error
+	// RemoveLCOWCombinedLayers removes combined layers from the LCOW guest.
+	RemoveLCOWCombinedLayers(ctx context.Context, settings guestresource.LCOWCombinedLayers) error
+}
+
+var _ LCOWLayersManager = (*Guest)(nil)
+
+// AddLCOWCombinedLayers adds LCOW combined layers in the guest.
+func (gm *Guest) AddLCOWCombinedLayers(ctx context.Context, settings guestresource.LCOWCombinedLayers) error {
+	modifyRequest := &hcsschema.ModifySettingRequest{
+		GuestRequest: guestrequest.ModificationRequest{
+			ResourceType: guestresource.ResourceTypeCombinedLayers,
+			RequestType:  guestrequest.RequestTypeAdd,
+			Settings:     settings,
+		},
+	}
+
+	err := gm.modify(ctx, modifyRequest.GuestRequest)
+	if err != nil {
+		return fmt.Errorf("failed to add LCOW combined layers: %w", err)
+	}
+	return nil
+}
+
+// RemoveLCOWCombinedLayers removes LCOW combined layers in the guest.
+func (gm *Guest) RemoveLCOWCombinedLayers(ctx context.Context, settings guestresource.LCOWCombinedLayers) error {
+	modifyRequest := &hcsschema.ModifySettingRequest{
+		GuestRequest: guestrequest.ModificationRequest{
+			ResourceType: guestresource.ResourceTypeCombinedLayers,
+			RequestType:  guestrequest.RequestTypeRemove,
+			Settings:     settings,
+		},
+	}
+
+	err := gm.modify(ctx, modifyRequest.GuestRequest)
+	if err != nil {
+		return fmt.Errorf("failed to remove LCOW combined layers: %w", err)
+	}
+	return nil
+}

--- a/internal/vm/guestmanager/combinedlayers_wcow.go
+++ b/internal/vm/guestmanager/combinedlayers_wcow.go
@@ -1,0 +1,94 @@
+//go:build windows
+
+package guestmanager
+
+import (
+	"context"
+	"fmt"
+
+	hcsschema "github.com/Microsoft/hcsshim/internal/hcs/schema2"
+	"github.com/Microsoft/hcsshim/internal/protocol/guestrequest"
+	"github.com/Microsoft/hcsshim/internal/protocol/guestresource"
+)
+
+// WCOWLayersManager exposes combined layer operations in the WCOW guest.
+type WCOWLayersManager interface {
+	// AddWCOWCombinedLayers adds combined layers to the WCOW guest.
+	AddWCOWCombinedLayers(ctx context.Context, settings guestresource.WCOWCombinedLayers) error
+	// AddCWCOWCombinedLayers adds combined layers to the CWCOW guest.
+	AddCWCOWCombinedLayers(ctx context.Context, settings guestresource.CWCOWCombinedLayers) error
+	// RemoveWCOWCombinedLayers removes combined layers from the WCOW guest.
+	RemoveWCOWCombinedLayers(ctx context.Context, settings guestresource.WCOWCombinedLayers) error
+	// RemoveCWCOWCombinedLayers removes combined layers from the CWCOW guest.
+	RemoveCWCOWCombinedLayers(ctx context.Context, settings guestresource.CWCOWCombinedLayers) error
+}
+
+var _ WCOWLayersManager = (*Guest)(nil)
+
+// AddWCOWCombinedLayers adds WCOW combined layers in the guest.
+func (gm *Guest) AddWCOWCombinedLayers(ctx context.Context, settings guestresource.WCOWCombinedLayers) error {
+	modifyRequest := &hcsschema.ModifySettingRequest{
+		GuestRequest: guestrequest.ModificationRequest{
+			ResourceType: guestresource.ResourceTypeCombinedLayers,
+			RequestType:  guestrequest.RequestTypeAdd,
+			Settings:     settings,
+		},
+	}
+
+	err := gm.modify(ctx, modifyRequest.GuestRequest)
+	if err != nil {
+		return fmt.Errorf("failed to add WCOW combined layers: %w", err)
+	}
+	return nil
+}
+
+// AddCWCOWCombinedLayers adds combined layers in the CWCOW guest.
+func (gm *Guest) AddCWCOWCombinedLayers(ctx context.Context, settings guestresource.CWCOWCombinedLayers) error {
+	modifyRequest := &hcsschema.ModifySettingRequest{
+		GuestRequest: guestrequest.ModificationRequest{
+			ResourceType: guestresource.ResourceTypeCWCOWCombinedLayers,
+			RequestType:  guestrequest.RequestTypeAdd,
+			Settings:     settings,
+		},
+	}
+
+	err := gm.modify(ctx, modifyRequest.GuestRequest)
+	if err != nil {
+		return fmt.Errorf("failed to add CWCOW combined layers: %w", err)
+	}
+	return nil
+}
+
+// RemoveWCOWCombinedLayers removes WCOW combined layers in the guest.
+func (gm *Guest) RemoveWCOWCombinedLayers(ctx context.Context, settings guestresource.WCOWCombinedLayers) error {
+	modifyRequest := &hcsschema.ModifySettingRequest{
+		GuestRequest: guestrequest.ModificationRequest{
+			ResourceType: guestresource.ResourceTypeCombinedLayers,
+			RequestType:  guestrequest.RequestTypeRemove,
+			Settings:     settings,
+		},
+	}
+
+	err := gm.modify(ctx, modifyRequest.GuestRequest)
+	if err != nil {
+		return fmt.Errorf("failed to remove WCOW combined layers: %w", err)
+	}
+	return nil
+}
+
+// RemoveCWCOWCombinedLayers removes combined layers in CWCOW guest.
+func (gm *Guest) RemoveCWCOWCombinedLayers(ctx context.Context, settings guestresource.CWCOWCombinedLayers) error {
+	modifyRequest := &hcsschema.ModifySettingRequest{
+		GuestRequest: guestrequest.ModificationRequest{
+			ResourceType: guestresource.ResourceTypeCWCOWCombinedLayers,
+			RequestType:  guestrequest.RequestTypeRemove,
+			Settings:     settings,
+		},
+	}
+
+	err := gm.modify(ctx, modifyRequest.GuestRequest)
+	if err != nil {
+		return fmt.Errorf("failed to remove CWCOW combined layers: %w", err)
+	}
+	return nil
+}

--- a/internal/vm/guestmanager/device_lcow.go
+++ b/internal/vm/guestmanager/device_lcow.go
@@ -1,0 +1,75 @@
+//go:build windows
+
+package guestmanager
+
+import (
+	"context"
+	"fmt"
+
+	hcsschema "github.com/Microsoft/hcsshim/internal/hcs/schema2"
+	"github.com/Microsoft/hcsshim/internal/protocol/guestrequest"
+	"github.com/Microsoft/hcsshim/internal/protocol/guestresource"
+)
+
+// LCOWDeviceManager exposes VPCI and VPMem device operations in the LCOW guest.
+type LCOWDeviceManager interface {
+	// AddVPCIDevice adds a VPCI device to the guest.
+	AddVPCIDevice(ctx context.Context, settings guestresource.LCOWMappedVPCIDevice) error
+	// AddVPMemDevice adds a VPMem device to the guest.
+	AddVPMemDevice(ctx context.Context, settings guestresource.LCOWMappedVPMemDevice) error
+	// RemoveVPMemDevice removes a VPMem device from the guest.
+	RemoveVPMemDevice(ctx context.Context, settings guestresource.LCOWMappedVPMemDevice) error
+}
+
+var _ LCOWDeviceManager = (*Guest)(nil)
+
+// AddVPCIDevice adds a VPCI device in the guest.
+func (gm *Guest) AddVPCIDevice(ctx context.Context, settings guestresource.LCOWMappedVPCIDevice) error {
+	request := &hcsschema.ModifySettingRequest{
+		GuestRequest: guestrequest.ModificationRequest{
+			ResourceType: guestresource.ResourceTypeVPCIDevice,
+			RequestType:  guestrequest.RequestTypeAdd,
+			Settings:     settings,
+		},
+	}
+
+	err := gm.modify(ctx, request.GuestRequest)
+	if err != nil {
+		return fmt.Errorf("failed to add VPCI device: %w", err)
+	}
+	return nil
+}
+
+// AddVPMemDevice adds a VPMem device in the guest.
+func (gm *Guest) AddVPMemDevice(ctx context.Context, settings guestresource.LCOWMappedVPMemDevice) error {
+	request := &hcsschema.ModifySettingRequest{
+		GuestRequest: guestrequest.ModificationRequest{
+			ResourceType: guestresource.ResourceTypeVPMemDevice,
+			RequestType:  guestrequest.RequestTypeAdd,
+			Settings:     settings,
+		},
+	}
+
+	err := gm.modify(ctx, request.GuestRequest)
+	if err != nil {
+		return fmt.Errorf("failed to add VPMem device: %w", err)
+	}
+	return nil
+}
+
+// RemoveVPMemDevice removes a VPMem device in the guest.
+func (gm *Guest) RemoveVPMemDevice(ctx context.Context, settings guestresource.LCOWMappedVPMemDevice) error {
+	request := &hcsschema.ModifySettingRequest{
+		GuestRequest: guestrequest.ModificationRequest{
+			ResourceType: guestresource.ResourceTypeVPMemDevice,
+			RequestType:  guestrequest.RequestTypeRemove,
+			Settings:     settings,
+		},
+	}
+
+	err := gm.modify(ctx, request.GuestRequest)
+	if err != nil {
+		return fmt.Errorf("failed to remove VPMem device: %w", err)
+	}
+	return nil
+}

--- a/internal/vm/guestmanager/doc.go
+++ b/internal/vm/guestmanager/doc.go
@@ -1,0 +1,51 @@
+//go:build windows
+
+/*
+Package guestmanager manages guest-side operations for utility VMs (UVMs) via the
+GCS (Guest Compute Service) connection.
+
+It provides a concrete [Guest] struct, a top-level [Manager] interface that
+aggregates connection lifecycle and container/process operations, and a set of
+granular resource-scoped manager interfaces:
+
+  - [Manager] – connection lifecycle, container and process creation, stack dumps,
+    and container state deletion.
+  - [LCOWNetworkManager] – add and remove network interfaces in an LCOW guest.
+  - [WCOWNetworkManager] – add and remove network interfaces and namespaces in a WCOW guest.
+  - [LCOWDirectoryManager] – map and unmap directories in an LCOW guest.
+  - [WCOWDirectoryManager] – map directories in a WCOW guest.
+  - [LCOWScsiManager] – add and remove mapped virtual disks and SCSI devices in an LCOW guest.
+  - [WCOWScsiManager] – add and remove mapped virtual disks and SCSI devices in a WCOW guest.
+  - [LCOWLayersManager] – add and remove combined layers in an LCOW guest.
+  - [WCOWLayersManager] – add and remove combined layers in a WCOW guest.
+  - [CIMsManager] – add and remove WCOW block CIM mounts.
+  - [LCOWDeviceManager] – add and remove VPCI and VPMem devices in an LCOW guest.
+  - [SecurityPolicyManager] – add security policies and inject policy fragments.
+
+All interfaces are implemented by [Guest].
+
+This package is strictly guest-side. It does not own or modify host-side UVM
+state; that is the responsibility of the sibling vmmanager package. It also does
+not store UVM host or guest state — state management belongs to the orchestration
+layer above.
+
+# Creating a Guest
+
+After the UVM has been started via vmmanager, create a [Guest] and establish the
+GCS connection:
+
+	g, err := guestmanager.New(ctx, uvm)
+	if err != nil { // handle error }
+	if err := g.CreateConnection(ctx); err != nil { // handle error }
+
+After the connection is established, use the manager interfaces for guest-side changes:
+
+	_ = g.AddLCOWNetworkInterface(ctx, &guestresource.LCOWNetworkAdapter{...})
+	_ = g.AddLCOWMappedVirtualDisk(ctx, guestresource.LCOWMappedVirtualDisk{...})
+
+# Layer Boundaries
+
+This package covers guest-side changes executed over the GCS connection. Host-side
+VM configuration and lifecycle operations belong in the sibling vmmanager package.
+*/
+package guestmanager

--- a/internal/vm/guestmanager/guest.go
+++ b/internal/vm/guestmanager/guest.go
@@ -1,0 +1,131 @@
+//go:build windows
+
+package guestmanager
+
+import (
+	"context"
+	"fmt"
+	"net"
+
+	"github.com/Microsoft/hcsshim/internal/gcs"
+	"github.com/Microsoft/hcsshim/internal/gcs/prot"
+	hcsschema "github.com/Microsoft/hcsshim/internal/hcs/schema2"
+	"github.com/Microsoft/hcsshim/internal/log"
+	"github.com/Microsoft/hcsshim/internal/logfields"
+	"github.com/Microsoft/hcsshim/internal/vm/vmmanager"
+
+	"github.com/Microsoft/go-winio"
+	"github.com/sirupsen/logrus"
+)
+
+// Guest manages the GCS connection and guest-side operations for a utility VM.
+type Guest struct {
+	log *logrus.Entry
+	// uvm is the utility VM that this GuestManager is managing.
+	// We restrict access to just lifetime manager and VMSocket manager.
+	// Other APIs are outside the purview of this package.
+	uvm interface {
+		vmmanager.LifetimeManager
+		vmmanager.VMSocketManager
+	}
+
+	gcListener net.Listener         // The listener for the GCS connection
+	gc         *gcs.GuestConnection // The GCS connection
+}
+
+// New creates a new Guest Manager.
+func New(ctx context.Context, uvm interface {
+	vmmanager.LifetimeManager
+	vmmanager.VMSocketManager
+}) (*Guest, error) {
+	gm := &Guest{
+		log: log.G(ctx).WithField(logfields.UVMID, uvm.ID()),
+		uvm: uvm,
+	}
+
+	conn, err := winio.ListenHvsock(&winio.HvsockAddr{
+		VMID:      uvm.RuntimeID(),
+		ServiceID: winio.VsockServiceID(prot.LinuxGcsVsockPort),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to listen for guest connection: %w", err)
+	}
+	gm.gcListener = conn
+
+	return gm, nil
+}
+
+// ConfigOption defines a function that modifies the GCS connection config.
+type ConfigOption func(*gcs.GuestConnectionConfig) error
+
+// WithInitializationState applies initial guest state to the GCS connection config.
+func WithInitializationState(state *gcs.InitialGuestState) ConfigOption {
+	return func(cfg *gcs.GuestConnectionConfig) error {
+		cfg.InitGuestState = state
+		return nil
+	}
+}
+
+// CreateConnection accepts the GCS connection and performs initial setup.
+func (gm *Guest) CreateConnection(ctx context.Context, opts ...ConfigOption) error {
+	// 1. Accept the connection
+	conn, err := AcceptConnection(ctx, gm.uvm, gm.gcListener, true)
+	if err != nil {
+		return fmt.Errorf("failed to connect to GCS: %w", err)
+	}
+	gm.gcListener = nil // Listener is closed/consumed by AcceptConnection on success.
+
+	// 2. Create the default base configuration
+	gcc := &gcs.GuestConnectionConfig{
+		Conn:     conn,
+		Log:      gm.log, // Ensure gm has a logger field
+		IoListen: gcs.HvsockIoListen(gm.uvm.RuntimeID()),
+	}
+
+	// 3. Apply all passed options.
+	for _, opt := range opts {
+		if err := opt(gcc); err != nil {
+			return fmt.Errorf("failed to apply GCS config option: %w", err)
+		}
+	}
+
+	// 4. Start the GCS protocol
+	gm.gc, err = gcc.Connect(ctx, true)
+	if err != nil {
+		return fmt.Errorf("failed to connect to GCS: %w", err)
+	}
+
+	// 5. Initial setup required for external GCS connection.
+	hvsocketAddress := &hcsschema.HvSocketAddress{
+		LocalAddress:  gm.uvm.RuntimeID().String(),
+		ParentAddress: prot.WindowsGcsHvHostID.String(),
+	}
+
+	err = gm.updateHvSocketAddress(ctx, hvsocketAddress)
+	if err != nil {
+		return fmt.Errorf("failed to create GCS connection: %w", err)
+	}
+
+	return nil
+}
+
+// CloseConnection closes any active GCS connection and listener.
+func (gm *Guest) CloseConnection() error {
+	var firstErr error
+
+	if gm.gc != nil {
+		if err := gm.gc.Close(); err != nil {
+			firstErr = err
+		}
+		gm.gc = nil
+	}
+
+	if gm.gcListener != nil {
+		if err := gm.gcListener.Close(); err != nil && firstErr == nil {
+			firstErr = err
+		}
+		gm.gcListener = nil
+	}
+
+	return firstErr
+}

--- a/internal/vm/guestmanager/hvsocket.go
+++ b/internal/vm/guestmanager/hvsocket.go
@@ -1,0 +1,29 @@
+//go:build windows
+
+package guestmanager
+
+import (
+	"context"
+	"fmt"
+
+	hcsschema "github.com/Microsoft/hcsshim/internal/hcs/schema2"
+	"github.com/Microsoft/hcsshim/internal/protocol/guestrequest"
+	"github.com/Microsoft/hcsshim/internal/protocol/guestresource"
+)
+
+// updateHvSocketAddress configures the HvSocket address for GCS communication.
+func (gm *Guest) updateHvSocketAddress(ctx context.Context, settings *hcsschema.HvSocketAddress) error {
+	conSetupReq := &hcsschema.ModifySettingRequest{
+		GuestRequest: guestrequest.ModificationRequest{
+			RequestType:  guestrequest.RequestTypeUpdate,
+			ResourceType: guestresource.ResourceTypeHvSocket,
+			Settings:     settings,
+		},
+	}
+
+	err := gm.modify(ctx, conSetupReq.GuestRequest)
+	if err != nil {
+		return fmt.Errorf("failed to update hvSocket address: %w", err)
+	}
+	return nil
+}

--- a/internal/vm/guestmanager/manager.go
+++ b/internal/vm/guestmanager/manager.go
@@ -1,0 +1,81 @@
+//go:build windows
+
+package guestmanager
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Microsoft/hcsshim/internal/cow"
+	"github.com/Microsoft/hcsshim/internal/gcs"
+)
+
+// Manager provides access to guest operations over the GCS connection.
+// Call CreateConnection before invoking other methods.
+type Manager interface {
+	// CreateConnection accepts the GCS connection and performs initial setup.
+	CreateConnection(ctx context.Context, opts ...ConfigOption) error
+	// CloseConnection closes the GCS connection and listener.
+	CloseConnection() error
+	// Capabilities returns the guest's declared capabilities.
+	Capabilities() gcs.GuestDefinedCapabilities
+	// CreateContainer creates a container within guest using ID `cid` and `config`.
+	// Once the container is created, it can be managed using the returned `gcs.Container` interface.
+	// `gcs.Container` uses the underlying guest connection to issue commands to the guest.
+	CreateContainer(ctx context.Context, cid string, config interface{}) (*gcs.Container, error)
+	// CreateProcess creates a process in the guest.
+	// Once the process is created, it can be managed using the returned `cow.Process` interface.
+	// `cow.Process` uses the underlying guest connection to issue commands to the guest.
+	CreateProcess(ctx context.Context, settings interface{}) (cow.Process, error)
+	// DumpStacks requests a stack dump from the guest and returns it as a string.
+	DumpStacks(ctx context.Context) (string, error)
+	// DeleteContainerState removes persisted state for the container identified by `cid` from the guest.
+	DeleteContainerState(ctx context.Context, cid string) error
+}
+
+var _ Manager = (*Guest)(nil)
+
+// Capabilities returns the capabilities of the guest connection.
+func (gm *Guest) Capabilities() gcs.GuestDefinedCapabilities {
+	return gm.gc.Capabilities()
+}
+
+// CreateContainer creates a container in the guest with the given ID and config.
+func (gm *Guest) CreateContainer(ctx context.Context, cid string, config interface{}) (*gcs.Container, error) {
+	c, err := gm.gc.CreateContainer(ctx, cid, config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create container %s: %w", cid, err)
+	}
+
+	return c, nil
+}
+
+// CreateProcess creates a process in the guest using the provided settings.
+func (gm *Guest) CreateProcess(ctx context.Context, settings interface{}) (cow.Process, error) {
+	p, err := gm.gc.CreateProcess(ctx, settings)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create process: %w", err)
+	}
+
+	return p, nil
+}
+
+// DumpStacks requests a stack dump from the guest and returns it as a string.
+func (gm *Guest) DumpStacks(ctx context.Context) (string, error) {
+	dump, err := gm.gc.DumpStacks(ctx)
+	if err != nil {
+		return "", fmt.Errorf("failed to dump stacks: %w", err)
+	}
+
+	return dump, nil
+}
+
+// DeleteContainerState removes persisted state for the container identified by cid from the guest.
+func (gm *Guest) DeleteContainerState(ctx context.Context, cid string) error {
+	err := gm.gc.DeleteContainerState(ctx, cid)
+	if err != nil {
+		return fmt.Errorf("failed to delete container state for container %s: %w", cid, err)
+	}
+
+	return nil
+}

--- a/internal/vm/guestmanager/mapped_directory_lcow.go
+++ b/internal/vm/guestmanager/mapped_directory_lcow.go
@@ -1,0 +1,56 @@
+//go:build windows
+
+package guestmanager
+
+import (
+	"context"
+	"fmt"
+
+	hcsschema "github.com/Microsoft/hcsshim/internal/hcs/schema2"
+	"github.com/Microsoft/hcsshim/internal/protocol/guestrequest"
+	"github.com/Microsoft/hcsshim/internal/protocol/guestresource"
+)
+
+// LCOWDirectoryManager exposes mapped directory operations in the LCOW guest.
+type LCOWDirectoryManager interface {
+	// AddLCOWMappedDirectory maps a directory into the LCOW guest.
+	AddLCOWMappedDirectory(ctx context.Context, settings guestresource.LCOWMappedDirectory) error
+	// RemoveLCOWMappedDirectory unmaps a directory from the LCOW guest.
+	RemoveLCOWMappedDirectory(ctx context.Context, settings guestresource.LCOWMappedDirectory) error
+}
+
+var _ LCOWDirectoryManager = (*Guest)(nil)
+
+// AddLCOWMappedDirectory maps a directory into LCOW guest.
+func (gm *Guest) AddLCOWMappedDirectory(ctx context.Context, settings guestresource.LCOWMappedDirectory) error {
+	request := &hcsschema.ModifySettingRequest{
+		GuestRequest: guestrequest.ModificationRequest{
+			ResourceType: guestresource.ResourceTypeMappedDirectory,
+			RequestType:  guestrequest.RequestTypeAdd,
+			Settings:     settings,
+		},
+	}
+
+	err := gm.modify(ctx, request.GuestRequest)
+	if err != nil {
+		return fmt.Errorf("failed to add mapped directory for lcow: %w", err)
+	}
+	return nil
+}
+
+// RemoveLCOWMappedDirectory unmaps a directory from LCOW guest.
+func (gm *Guest) RemoveLCOWMappedDirectory(ctx context.Context, settings guestresource.LCOWMappedDirectory) error {
+	request := &hcsschema.ModifySettingRequest{
+		GuestRequest: guestrequest.ModificationRequest{
+			ResourceType: guestresource.ResourceTypeMappedDirectory,
+			RequestType:  guestrequest.RequestTypeRemove,
+			Settings:     settings,
+		},
+	}
+
+	err := gm.modify(ctx, request.GuestRequest)
+	if err != nil {
+		return fmt.Errorf("failed to remove mapped directory for lcow: %w", err)
+	}
+	return nil
+}

--- a/internal/vm/guestmanager/mapped_directory_wcow.go
+++ b/internal/vm/guestmanager/mapped_directory_wcow.go
@@ -1,0 +1,37 @@
+//go:build windows
+
+package guestmanager
+
+import (
+	"context"
+	"fmt"
+
+	hcsschema "github.com/Microsoft/hcsshim/internal/hcs/schema2"
+	"github.com/Microsoft/hcsshim/internal/protocol/guestrequest"
+	"github.com/Microsoft/hcsshim/internal/protocol/guestresource"
+)
+
+// WCOWDirectoryManager exposes mapped directory operations in the WCOW guest.
+type WCOWDirectoryManager interface {
+	// AddMappedDirectory maps a directory into the WCOW guest.
+	AddMappedDirectory(ctx context.Context, settings *hcsschema.MappedDirectory) error
+}
+
+var _ WCOWDirectoryManager = (*Guest)(nil)
+
+// AddMappedDirectory maps a directory into the guest.
+func (gm *Guest) AddMappedDirectory(ctx context.Context, settings *hcsschema.MappedDirectory) error {
+	request := &hcsschema.ModifySettingRequest{
+		GuestRequest: guestrequest.ModificationRequest{
+			ResourceType: guestresource.ResourceTypeMappedDirectory,
+			RequestType:  guestrequest.RequestTypeAdd,
+			Settings:     settings,
+		},
+	}
+
+	err := gm.modify(ctx, request.GuestRequest)
+	if err != nil {
+		return fmt.Errorf("failed to add mapped directory: %w", err)
+	}
+	return nil
+}

--- a/internal/vm/guestmanager/network_lcow.go
+++ b/internal/vm/guestmanager/network_lcow.go
@@ -1,0 +1,56 @@
+//go:build windows
+
+package guestmanager
+
+import (
+	"context"
+	"fmt"
+
+	hcsschema "github.com/Microsoft/hcsshim/internal/hcs/schema2"
+	"github.com/Microsoft/hcsshim/internal/protocol/guestrequest"
+	"github.com/Microsoft/hcsshim/internal/protocol/guestresource"
+)
+
+// LCOWNetworkManager exposes guest network operations.
+type LCOWNetworkManager interface {
+	// AddLCOWNetworkInterface adds a network interface to the LCOW guest.
+	AddLCOWNetworkInterface(ctx context.Context, settings *guestresource.LCOWNetworkAdapter) error
+	// RemoveLCOWNetworkInterface removes a network interface from the LCOW guest.
+	RemoveLCOWNetworkInterface(ctx context.Context, settings *guestresource.LCOWNetworkAdapter) error
+}
+
+var _ LCOWNetworkManager = (*Guest)(nil)
+
+// AddLCOWNetworkInterface adds a network interface to the LCOW guest.
+func (gm *Guest) AddLCOWNetworkInterface(ctx context.Context, settings *guestresource.LCOWNetworkAdapter) error {
+	modifyRequest := &hcsschema.ModifySettingRequest{
+		GuestRequest: guestrequest.ModificationRequest{
+			ResourceType: guestresource.ResourceTypeNetwork,
+			RequestType:  guestrequest.RequestTypeAdd,
+			Settings:     settings,
+		},
+	}
+
+	err := gm.modify(ctx, modifyRequest.GuestRequest)
+	if err != nil {
+		return fmt.Errorf("failed to add network interface for lcow: %w", err)
+	}
+	return nil
+}
+
+// RemoveLCOWNetworkInterface removes a network interface from the LCOW guest.
+func (gm *Guest) RemoveLCOWNetworkInterface(ctx context.Context, settings *guestresource.LCOWNetworkAdapter) error {
+	modifyRequest := &hcsschema.ModifySettingRequest{
+		GuestRequest: guestrequest.ModificationRequest{
+			ResourceType: guestresource.ResourceTypeNetwork,
+			RequestType:  guestrequest.RequestTypeRemove,
+			Settings:     settings,
+		},
+	}
+
+	err := gm.modify(ctx, modifyRequest.GuestRequest)
+	if err != nil {
+		return fmt.Errorf("failed to remove network interface for lcow: %w", err)
+	}
+	return nil
+}

--- a/internal/vm/guestmanager/network_wcow.go
+++ b/internal/vm/guestmanager/network_wcow.go
@@ -1,0 +1,103 @@
+//go:build windows
+
+package guestmanager
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Microsoft/hcsshim/hcn"
+	hcsschema "github.com/Microsoft/hcsshim/internal/hcs/schema2"
+	"github.com/Microsoft/hcsshim/internal/protocol/guestrequest"
+	"github.com/Microsoft/hcsshim/internal/protocol/guestresource"
+)
+
+// WCOWNetworkManager exposes guest network operations.
+type WCOWNetworkManager interface {
+	// AddNetworkNamespace adds a network namespace to the WCOW guest.
+	AddNetworkNamespace(ctx context.Context, settings *hcn.HostComputeNamespace) error
+	// RemoveNetworkNamespace removes a network namespace from the WCOW guest.
+	RemoveNetworkNamespace(ctx context.Context, settings *hcn.HostComputeNamespace) error
+	// AddNetworkInterface adds a network interface to the WCOW guest.
+	AddNetworkInterface(ctx context.Context, adapterID string, requestType guestrequest.RequestType, settings *hcn.HostComputeEndpoint) error
+	// RemoveNetworkInterface removes a network interface from the WCOW guest.
+	RemoveNetworkInterface(ctx context.Context, adapterID string, requestType guestrequest.RequestType, settings *hcn.HostComputeEndpoint) error
+}
+
+var _ WCOWNetworkManager = (*Guest)(nil)
+
+// AddNetworkNamespace adds a network namespace in the guest.
+func (gm *Guest) AddNetworkNamespace(ctx context.Context, settings *hcn.HostComputeNamespace) error {
+	modifyRequest := &hcsschema.ModifySettingRequest{
+		GuestRequest: guestrequest.ModificationRequest{
+			ResourceType: guestresource.ResourceTypeNetworkNamespace,
+			RequestType:  guestrequest.RequestTypeAdd,
+			Settings:     settings,
+		},
+	}
+
+	err := gm.modify(ctx, modifyRequest.GuestRequest)
+	if err != nil {
+		return fmt.Errorf("failed to add network namespace: %w", err)
+	}
+	return nil
+}
+
+// RemoveNetworkNamespace removes a network namespace in the guest.
+func (gm *Guest) RemoveNetworkNamespace(ctx context.Context, settings *hcn.HostComputeNamespace) error {
+	modifyRequest := &hcsschema.ModifySettingRequest{
+		GuestRequest: guestrequest.ModificationRequest{
+			ResourceType: guestresource.ResourceTypeNetworkNamespace,
+			RequestType:  guestrequest.RequestTypeRemove,
+			Settings:     settings,
+		},
+	}
+
+	err := gm.modify(ctx, modifyRequest.GuestRequest)
+	if err != nil {
+		return fmt.Errorf("failed to remove network namespace: %w", err)
+	}
+	return nil
+}
+
+// AddNetworkInterface adds a network interface to the WCOW guest.
+func (gm *Guest) AddNetworkInterface(ctx context.Context, adapterID string, requestType guestrequest.RequestType, settings *hcn.HostComputeEndpoint) error {
+	modifyRequest := &hcsschema.ModifySettingRequest{
+		GuestRequest: guestrequest.ModificationRequest{
+			ResourceType: guestresource.ResourceTypeNetwork,
+			RequestType:  guestrequest.RequestTypeAdd,
+			Settings: guestrequest.NetworkModifyRequest{
+				AdapterId:   adapterID,
+				RequestType: requestType,
+				Settings:    settings, // endpoint configuration
+			},
+		},
+	}
+
+	err := gm.modify(ctx, modifyRequest.GuestRequest)
+	if err != nil {
+		return fmt.Errorf("failed to add network interface: %w", err)
+	}
+	return nil
+}
+
+// RemoveNetworkInterface removes a network interface from the WCOW guest.
+func (gm *Guest) RemoveNetworkInterface(ctx context.Context, adapterID string, requestType guestrequest.RequestType, settings *hcn.HostComputeEndpoint) error {
+	modifyRequest := &hcsschema.ModifySettingRequest{
+		GuestRequest: guestrequest.ModificationRequest{
+			ResourceType: guestresource.ResourceTypeNetwork,
+			RequestType:  guestrequest.RequestTypeRemove,
+			Settings: guestrequest.NetworkModifyRequest{
+				AdapterId:   adapterID,
+				RequestType: requestType,
+				Settings:    settings, // endpoint configuration
+			},
+		},
+	}
+
+	err := gm.modify(ctx, modifyRequest.GuestRequest)
+	if err != nil {
+		return fmt.Errorf("failed to remove network interface: %w", err)
+	}
+	return nil
+}

--- a/internal/vm/guestmanager/request_helpers.go
+++ b/internal/vm/guestmanager/request_helpers.go
@@ -1,0 +1,19 @@
+//go:build windows
+
+package guestmanager
+
+import (
+	"context"
+	"errors"
+)
+
+var errGuestConnectionUnavailable = errors.New("guest connection not initialized")
+
+// modify sends a guest modification request via the guest connection.
+// This is a helper method to avoid having to check for a nil guest connection in every method that needs to send a request.
+func (gm *Guest) modify(ctx context.Context, req interface{}) error {
+	if gm.gc == nil {
+		return errGuestConnectionUnavailable
+	}
+	return gm.gc.Modify(ctx, req)
+}

--- a/internal/vm/guestmanager/scsi.go
+++ b/internal/vm/guestmanager/scsi.go
@@ -1,0 +1,29 @@
+//go:build windows
+
+package guestmanager
+
+import (
+	"context"
+	"fmt"
+
+	hcsschema "github.com/Microsoft/hcsshim/internal/hcs/schema2"
+	"github.com/Microsoft/hcsshim/internal/protocol/guestrequest"
+	"github.com/Microsoft/hcsshim/internal/protocol/guestresource"
+)
+
+// RemoveSCSIDevice removes a SCSI device in the guest.
+func (gm *Guest) RemoveSCSIDevice(ctx context.Context, settings guestresource.SCSIDevice) error {
+	request := &hcsschema.ModifySettingRequest{
+		GuestRequest: guestrequest.ModificationRequest{
+			ResourceType: guestresource.ResourceTypeSCSIDevice,
+			RequestType:  guestrequest.RequestTypeRemove,
+			Settings:     settings,
+		},
+	}
+
+	err := gm.modify(ctx, request.GuestRequest)
+	if err != nil {
+		return fmt.Errorf("failed to remove SCSI device: %w", err)
+	}
+	return nil
+}

--- a/internal/vm/guestmanager/scsi_lcow.go
+++ b/internal/vm/guestmanager/scsi_lcow.go
@@ -1,0 +1,58 @@
+//go:build windows
+
+package guestmanager
+
+import (
+	"context"
+	"fmt"
+
+	hcsschema "github.com/Microsoft/hcsshim/internal/hcs/schema2"
+	"github.com/Microsoft/hcsshim/internal/protocol/guestrequest"
+	"github.com/Microsoft/hcsshim/internal/protocol/guestresource"
+)
+
+// LCOWScsiManager exposes mapped virtual disk and SCSI device operations in the LCOW guest.
+type LCOWScsiManager interface {
+	// AddLCOWMappedVirtualDisk maps a virtual disk into the LCOW guest.
+	AddLCOWMappedVirtualDisk(ctx context.Context, settings guestresource.LCOWMappedVirtualDisk) error
+	// RemoveLCOWMappedVirtualDisk unmaps a virtual disk from the LCOW guest.
+	RemoveLCOWMappedVirtualDisk(ctx context.Context, settings guestresource.LCOWMappedVirtualDisk) error
+	// RemoveSCSIDevice removes a SCSI device from the guest.
+	RemoveSCSIDevice(ctx context.Context, settings guestresource.SCSIDevice) error
+}
+
+var _ LCOWScsiManager = (*Guest)(nil)
+
+// AddLCOWMappedVirtualDisk maps a virtual disk into a LCOW guest.
+func (gm *Guest) AddLCOWMappedVirtualDisk(ctx context.Context, settings guestresource.LCOWMappedVirtualDisk) error {
+	request := &hcsschema.ModifySettingRequest{
+		GuestRequest: guestrequest.ModificationRequest{
+			ResourceType: guestresource.ResourceTypeMappedVirtualDisk,
+			RequestType:  guestrequest.RequestTypeAdd,
+			Settings:     settings,
+		},
+	}
+
+	err := gm.modify(ctx, request.GuestRequest)
+	if err != nil {
+		return fmt.Errorf("failed to add LCOW mapped virtual disk: %w", err)
+	}
+	return nil
+}
+
+// RemoveLCOWMappedVirtualDisk unmaps a virtual disk from the LCOW guest.
+func (gm *Guest) RemoveLCOWMappedVirtualDisk(ctx context.Context, settings guestresource.LCOWMappedVirtualDisk) error {
+	request := &hcsschema.ModifySettingRequest{
+		GuestRequest: guestrequest.ModificationRequest{
+			ResourceType: guestresource.ResourceTypeMappedVirtualDisk,
+			RequestType:  guestrequest.RequestTypeRemove,
+			Settings:     settings,
+		},
+	}
+
+	err := gm.modify(ctx, request.GuestRequest)
+	if err != nil {
+		return fmt.Errorf("failed to remove LCOW mapped virtual disk: %w", err)
+	}
+	return nil
+}

--- a/internal/vm/guestmanager/scsi_wcow.go
+++ b/internal/vm/guestmanager/scsi_wcow.go
@@ -1,0 +1,77 @@
+//go:build windows
+
+package guestmanager
+
+import (
+	"context"
+	"fmt"
+
+	hcsschema "github.com/Microsoft/hcsshim/internal/hcs/schema2"
+	"github.com/Microsoft/hcsshim/internal/protocol/guestrequest"
+	"github.com/Microsoft/hcsshim/internal/protocol/guestresource"
+)
+
+// WCOWScsiManager exposes mapped virtual disk and SCSI device operations in the WCOW guest.
+type WCOWScsiManager interface {
+	// AddWCOWMappedVirtualDisk maps a virtual disk into the WCOW guest.
+	AddWCOWMappedVirtualDisk(ctx context.Context, settings guestresource.WCOWMappedVirtualDisk) error
+	// AddWCOWMappedVirtualDiskForContainerScratch attaches a scratch disk in the WCOW guest.
+	AddWCOWMappedVirtualDiskForContainerScratch(ctx context.Context, settings guestresource.WCOWMappedVirtualDisk) error
+	// RemoveWCOWMappedVirtualDisk unmaps a virtual disk from the WCOW guest.
+	RemoveWCOWMappedVirtualDisk(ctx context.Context, settings guestresource.WCOWMappedVirtualDisk) error
+	// RemoveSCSIDevice removes a SCSI device from the guest.
+	RemoveSCSIDevice(ctx context.Context, settings guestresource.SCSIDevice) error
+}
+
+var _ WCOWScsiManager = (*Guest)(nil)
+
+// AddWCOWMappedVirtualDisk maps a virtual disk into a WCOW guest.
+func (gm *Guest) AddWCOWMappedVirtualDisk(ctx context.Context, settings guestresource.WCOWMappedVirtualDisk) error {
+	request := &hcsschema.ModifySettingRequest{
+		GuestRequest: guestrequest.ModificationRequest{
+			ResourceType: guestresource.ResourceTypeMappedVirtualDisk,
+			RequestType:  guestrequest.RequestTypeAdd,
+			Settings:     settings,
+		},
+	}
+
+	err := gm.modify(ctx, request.GuestRequest)
+	if err != nil {
+		return fmt.Errorf("failed to add WCOW mapped virtual disk: %w", err)
+	}
+	return nil
+}
+
+// AddWCOWMappedVirtualDiskForContainerScratch attaches a scratch disk in the WCOW guest.
+func (gm *Guest) AddWCOWMappedVirtualDiskForContainerScratch(ctx context.Context, settings guestresource.WCOWMappedVirtualDisk) error {
+	request := &hcsschema.ModifySettingRequest{
+		GuestRequest: guestrequest.ModificationRequest{
+			ResourceType: guestresource.ResourceTypeMappedVirtualDiskForContainerScratch,
+			RequestType:  guestrequest.RequestTypeAdd,
+			Settings:     settings,
+		},
+	}
+
+	err := gm.modify(ctx, request.GuestRequest)
+	if err != nil {
+		return fmt.Errorf("failed to add WCOW container scratch disk: %w", err)
+	}
+	return nil
+}
+
+// RemoveWCOWMappedVirtualDisk unmaps a virtual disk from the WCOW guest.
+func (gm *Guest) RemoveWCOWMappedVirtualDisk(ctx context.Context, settings guestresource.WCOWMappedVirtualDisk) error {
+	request := &hcsschema.ModifySettingRequest{
+		GuestRequest: guestrequest.ModificationRequest{
+			ResourceType: guestresource.ResourceTypeMappedVirtualDisk,
+			RequestType:  guestrequest.RequestTypeRemove,
+			Settings:     settings,
+		},
+	}
+
+	err := gm.modify(ctx, request.GuestRequest)
+	if err != nil {
+		return fmt.Errorf("failed to remove WCOW mapped virtual disk: %w", err)
+	}
+	return nil
+}

--- a/internal/vm/guestmanager/security_policy.go
+++ b/internal/vm/guestmanager/security_policy.go
@@ -1,0 +1,56 @@
+//go:build windows
+
+package guestmanager
+
+import (
+	"context"
+	"fmt"
+
+	hcsschema "github.com/Microsoft/hcsshim/internal/hcs/schema2"
+	"github.com/Microsoft/hcsshim/internal/protocol/guestrequest"
+	"github.com/Microsoft/hcsshim/internal/protocol/guestresource"
+)
+
+// SecurityPolicyManager exposes guest security policy operations.
+type SecurityPolicyManager interface {
+	// AddSecurityPolicy adds a security policy to the guest.
+	AddSecurityPolicy(ctx context.Context, settings guestresource.ConfidentialOptions) error
+	// InjectPolicyFragment injects a policy fragment into the guest.
+	InjectPolicyFragment(ctx context.Context, settings guestresource.SecurityPolicyFragment) error
+}
+
+var _ SecurityPolicyManager = (*Guest)(nil)
+
+// AddSecurityPolicy adds a security policy to the guest.
+func (gm *Guest) AddSecurityPolicy(ctx context.Context, settings guestresource.ConfidentialOptions) error {
+	request := &hcsschema.ModifySettingRequest{
+		GuestRequest: guestrequest.ModificationRequest{
+			ResourceType: guestresource.ResourceTypeSecurityPolicy,
+			RequestType:  guestrequest.RequestTypeAdd,
+			Settings:     settings,
+		},
+	}
+
+	err := gm.modify(ctx, request.GuestRequest)
+	if err != nil {
+		return fmt.Errorf("failed to add security policy: %w", err)
+	}
+	return nil
+}
+
+// InjectPolicyFragment injects a policy fragment into the guest.
+func (gm *Guest) InjectPolicyFragment(ctx context.Context, settings guestresource.SecurityPolicyFragment) error {
+	request := &hcsschema.ModifySettingRequest{
+		GuestRequest: guestrequest.ModificationRequest{
+			ResourceType: guestresource.ResourceTypePolicyFragment,
+			RequestType:  guestrequest.RequestTypeAdd,
+			Settings:     settings,
+		},
+	}
+
+	err := gm.modify(ctx, request.GuestRequest)
+	if err != nil {
+		return fmt.Errorf("failed to inject security policy fragment: %w", err)
+	}
+	return nil
+}

--- a/internal/vm/guestmanager/utils.go
+++ b/internal/vm/guestmanager/utils.go
@@ -1,0 +1,60 @@
+//go:build windows
+
+package guestmanager
+
+import (
+	"context"
+	"net"
+
+	"github.com/Microsoft/hcsshim/internal/vm/vmmanager"
+)
+
+// AcceptConnection accepts a connection and then closes a listener.
+// It monitors ctx.Done() and uvm.Wait() for early termination.
+func AcceptConnection(ctx context.Context, uvm vmmanager.LifetimeManager, l net.Listener, closeConnection bool) (net.Conn, error) {
+	// Channel to capture the accept result
+	type acceptResult struct {
+		conn net.Conn
+		err  error
+	}
+	resultCh := make(chan acceptResult)
+
+	go func() {
+		c, err := l.Accept()
+		resultCh <- acceptResult{c, err}
+	}()
+
+	// Channel to monitor VM exit
+	vmExitCh := make(chan error, 1)
+	go func() {
+		// Wait blocks until the VM terminates
+		vmExitCh <- uvm.Wait(ctx)
+	}()
+
+	select {
+	case res := <-resultCh:
+		if closeConnection {
+			_ = l.Close()
+		}
+		return res.conn, res.err
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-vmExitCh:
+	}
+
+	_ = l.Close()
+	res := <-resultCh
+	if res.err == nil {
+		return res.conn, res.err
+	}
+
+	// Prefer context error to VM error to accept error in order to return the
+	// most useful error.
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+	if uvm.ExitError() != nil {
+		return nil, uvm.ExitError()
+	}
+	return nil, res.err
+}


### PR DESCRIPTION
This pull request introduces a new `internal/vm/guestmanager` package that implements a clean guest-side management layer for utility VMs (UVMs), clearly separating guest operations from host-side management and configuration. All guest actions are issued over a GCS (Guest Compute Service) connection, while host-side VM lifecycle concerns remain in the sibling `vmmanager` package.

 **Note** This PR is dependent upon https://github.com/microsoft/hcsshim/pull/2597

---
### Key Changes

#### Guest Struct and Connection Lifecycle (guest.go)
Introduced the `Guest` struct, which holds the GCS connection (`gcs.GuestConnection`) and `HvSocket` listener. Its access to the UVM is intentionally restricted to `vmmanager.LifetimeManager` and `vmmanager.VMSocketManager` — host-side APIs outside that boundary are not accessible from this package.

- `New`: Creates a `Guest` and sets up the HvSocket listener, ready to accept the GCS connection.

- `CreateConnection`: Accepts the GCS connection, applies any `ConfigOption` options (e.g., `WithInitializationState`), starts the GCS protocol, and performs the initial HvSocket address setup.

- CloseConnection: Tears down the GCS connection and listener.

#### Manager Interface (manager.go)
Defines the top-level `Manager` interface that aggregates connection lifecycle with container and process operations:

- `CreateConnection`, `CloseConnection`, `Capabilities`, `CreateContainer`, `CreateProcess`, `DumpStacks`, and `DeleteContainerState`.

- Note: Guest implements Manager.

---

#### Resource-Scoped Manager Interfaces
Each file defines a typed interface and its `Guest` implementation for a specific guest resource, split by LCOW/WCOW where the request format differs:

File | Interface | Operations
-- | -- | --
network_lcow.go | LCOWNetworkManager | Add/remove network interfaces
network_wcow.go | WCOWNetworkManager | Add/remove network interfaces and namespaces
mapped_directory_lcow.go | LCOWDirectoryManager | Map/unmap directories
mapped_directory_wcow.go | WCOWDirectoryManager | Map directories
scsi_lcow.go | LCOWScsiManager | Add/remove mapped virtual disks and SCSI devices
scsi_wcow.go | WCOWScsiManager | Add/remove mapped virtual disks and SCSI devices
scsi.go | (Shared) | Remove SCSI devices (shared impl used by both)
combinedlayers_lcow.go | LCOWLayersManager | Add/remove combined layers
combinedlayers_wcow.go | WCOWLayersManager | Add/remove combined layers (WCOW and CWCOW)
block_cims.go | CIMsManager | Add/remove WCOW block CIM mounts
device_lcow.go | LCOWDeviceManager | Add/remove VPCI and VPMem devices
security_policy.go | SecurityPolicyManager | Add security policies and inject policy fragments

---

This refactor lays a foundation for clean separation between host and guest responsibilities.