### PR TITLE
`internal/hcs` cleanup; and `callbackNumber` type 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.1
+          version: v2.4
           args: >-
             --verbose
             --max-issues-per-linter=0

--- a/internal/hcs/process.go
+++ b/internal/hcs/process.go
@@ -12,14 +12,17 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/sirupsen/logrus"
 	"go.opencensus.io/trace"
 
 	"github.com/Microsoft/hcsshim/internal/cow"
 	hcsschema "github.com/Microsoft/hcsshim/internal/hcs/schema2"
 	"github.com/Microsoft/hcsshim/internal/log"
+	"github.com/Microsoft/hcsshim/internal/logfields"
 	"github.com/Microsoft/hcsshim/internal/oc"
 	"github.com/Microsoft/hcsshim/internal/protocol/guestrequest"
 	"github.com/Microsoft/hcsshim/internal/vmcompute"
+	"github.com/Microsoft/hcsshim/internal/winapi"
 )
 
 type Process struct {
@@ -97,7 +100,7 @@ func (process *Process) Signal(ctx context.Context, options interface{}) (bool, 
 
 	operation := "hcs::Process::Signal"
 
-	if process.handle == 0 {
+	if winapi.IsInvalidHandle(process.handle) {
 		return false, makeProcessError(process, operation, ErrAlreadyClosed, nil)
 	}
 
@@ -116,13 +119,21 @@ func (process *Process) Signal(ctx context.Context, options interface{}) (bool, 
 }
 
 // Kill signals the process to terminate but does not wait for it to finish terminating.
-func (process *Process) Kill(ctx context.Context) (bool, error) {
+func (process *Process) Kill(ctx context.Context) (_ bool, err error) {
+	operation := "hcs::Process::Kill"
+	ctx, span := oc.StartSpan(ctx, operation)
+	defer span.End()
+	defer func() { oc.SetSpanStatus(span, err) }()
+	span.AddAttributes(
+		trace.StringAttribute(logfields.SystemID, process.SystemID()),
+		trace.Int64Attribute(logfields.ProcessID, int64(process.processID)))
+
+	ctxNoCancel := context.WithoutCancel(ctx)
+
 	process.handleLock.RLock()
 	defer process.handleLock.RUnlock()
 
-	operation := "hcs::Process::Kill"
-
-	if process.handle == 0 {
+	if winapi.IsInvalidHandle(process.handle) {
 		return false, makeProcessError(process, operation, ErrAlreadyClosed, nil)
 	}
 
@@ -139,6 +150,9 @@ func (process *Process) Kill(ctx context.Context) (bool, error) {
 		return true, nil
 	}
 
+	// NOTE: this re-registers callbacks for the same underlying compute system and process,
+	// but with a different handle, which is ... excessive.
+
 	// HCS serializes the signals sent to a target pid per compute system handle.
 	// To avoid SIGKILL being serialized behind other signals, we open a new compute
 	// system handle to deliver the kill signal.
@@ -154,10 +168,10 @@ func (process *Process) Kill(ctx context.Context) (bool, error) {
 			log.G(ctx).WithField("err", err).Error("Terminate() call failed")
 			return false, err
 		}
-		process.system.Close()
+		process.system.CloseCtx(ctxNoCancel) //nolint:errcheck
 		return true, nil
 	}
-	defer hcsSystem.Close()
+	defer hcsSystem.CloseCtx(ctxNoCancel) //nolint:errcheck
 
 	newProcessHandle, err := hcsSystem.OpenProcess(ctx, process.Pid())
 	if err != nil {
@@ -169,7 +183,7 @@ func (process *Process) Kill(ctx context.Context) (bool, error) {
 			return false, err
 		}
 	}
-	defer newProcessHandle.Close()
+	defer newProcessHandle.CloseCtx(ctxNoCancel) //nolint:errcheck
 
 	resultJSON, err := vmcompute.HcsTerminateProcess(ctx, newProcessHandle.handle)
 	if err != nil {
@@ -214,8 +228,8 @@ func (process *Process) waitBackground() {
 	ctx, span := oc.StartSpan(context.Background(), operation)
 	defer span.End()
 	span.AddAttributes(
-		trace.StringAttribute("cid", process.SystemID()),
-		trace.Int64Attribute("pid", int64(process.processID)))
+		trace.StringAttribute(logfields.SystemID, process.SystemID()),
+		trace.Int64Attribute(logfields.ProcessID, int64(process.processID)))
 
 	var (
 		err            error
@@ -287,7 +301,7 @@ func (process *Process) ResizeConsole(ctx context.Context, width, height uint16)
 
 	operation := "hcs::Process::ResizeConsole"
 
-	if process.handle == 0 {
+	if winapi.IsInvalidHandle(process.handle) {
 		return makeProcessError(process, operation, ErrAlreadyClosed, nil)
 	}
 	modifyRequest := hcsschema.ProcessModifyRequest{
@@ -333,13 +347,13 @@ func (process *Process) StdioLegacy() (_ io.WriteCloser, _ io.ReadCloser, _ io.R
 	defer span.End()
 	defer func() { oc.SetSpanStatus(span, err) }()
 	span.AddAttributes(
-		trace.StringAttribute("cid", process.SystemID()),
-		trace.Int64Attribute("pid", int64(process.processID)))
+		trace.StringAttribute(logfields.SystemID, process.SystemID()),
+		trace.Int64Attribute(logfields.ProcessID, int64(process.processID)))
 
 	process.handleLock.RLock()
 	defer process.handleLock.RUnlock()
 
-	if process.handle == 0 {
+	if winapi.IsInvalidHandle(process.handle) {
 		return nil, nil, nil, makeProcessError(process, operation, ErrAlreadyClosed, nil)
 	}
 
@@ -382,13 +396,13 @@ func (process *Process) CloseStdin(ctx context.Context) (err error) {
 	defer span.End()
 	defer func() { oc.SetSpanStatus(span, err) }()
 	span.AddAttributes(
-		trace.StringAttribute("cid", process.SystemID()),
-		trace.Int64Attribute("pid", int64(process.processID)))
+		trace.StringAttribute(logfields.SystemID, process.SystemID()),
+		trace.Int64Attribute(logfields.ProcessID, int64(process.processID)))
 
 	process.handleLock.RLock()
 	defer process.handleLock.RUnlock()
 
-	if process.handle == 0 {
+	if winapi.IsInvalidHandle(process.handle) {
 		return makeProcessError(process, operation, ErrAlreadyClosed, nil)
 	}
 
@@ -428,13 +442,13 @@ func (process *Process) CloseStdout(ctx context.Context) (err error) {
 	defer span.End()
 	defer func() { oc.SetSpanStatus(span, err) }()
 	span.AddAttributes(
-		trace.StringAttribute("cid", process.SystemID()),
-		trace.Int64Attribute("pid", int64(process.processID)))
+		trace.StringAttribute(logfields.SystemID, process.SystemID()),
+		trace.Int64Attribute(logfields.ProcessID, int64(process.processID)))
 
 	process.handleLock.Lock()
 	defer process.handleLock.Unlock()
 
-	if process.handle == 0 {
+	if winapi.IsInvalidHandle(process.handle) {
 		return nil
 	}
 
@@ -452,13 +466,13 @@ func (process *Process) CloseStderr(ctx context.Context) (err error) {
 	defer span.End()
 	defer func() { oc.SetSpanStatus(span, err) }()
 	span.AddAttributes(
-		trace.StringAttribute("cid", process.SystemID()),
-		trace.Int64Attribute("pid", int64(process.processID)))
+		trace.StringAttribute(logfields.SystemID, process.SystemID()),
+		trace.Int64Attribute(logfields.ProcessID, int64(process.processID)))
 
 	process.handleLock.Lock()
 	defer process.handleLock.Unlock()
 
-	if process.handle == 0 {
+	if winapi.IsInvalidHandle(process.handle) {
 		return nil
 	}
 
@@ -473,20 +487,28 @@ func (process *Process) CloseStderr(ctx context.Context) (err error) {
 
 // Close cleans up any state associated with the process but does not kill
 // or wait on it.
-func (process *Process) Close() (err error) {
+func (process *Process) Close() error {
+	return process.CloseCtx(context.Background())
+}
+
+// CloseCtx is similar to [System.Close], but accepts a context.
+//
+// The context is used for all operations, including waits, so timeouts/cancellations may prevent
+// proper system cleanup.
+func (process *Process) CloseCtx(ctx context.Context) (err error) {
 	operation := "hcs::Process::Close"
-	ctx, span := oc.StartSpan(context.Background(), operation)
+	ctx, span := oc.StartSpan(ctx, operation)
 	defer span.End()
 	defer func() { oc.SetSpanStatus(span, err) }()
 	span.AddAttributes(
-		trace.StringAttribute("cid", process.SystemID()),
-		trace.Int64Attribute("pid", int64(process.processID)))
+		trace.StringAttribute(logfields.SystemID, process.SystemID()),
+		trace.Int64Attribute(logfields.ProcessID, int64(process.processID)))
 
 	process.handleLock.Lock()
 	defer process.handleLock.Unlock()
 
 	// Don't double free this
-	if process.handle == 0 {
+	if winapi.IsInvalidHandle(process.handle) {
 		return nil
 	}
 
@@ -559,7 +581,7 @@ func (process *Process) unregisterCallback(ctx context.Context) error {
 
 	handle := callbackContext.handle
 
-	if handle == 0 {
+	if winapi.IsInvalidHandle(handle) {
 		return nil
 	}
 

--- a/internal/hcs/utils.go
+++ b/internal/hcs/utils.go
@@ -5,13 +5,17 @@ package hcs
 import (
 	"context"
 	"io"
+	"sync/atomic"
 	"syscall"
+
+	"github.com/pkg/errors"
+	"golang.org/x/sys/windows"
 
 	"github.com/Microsoft/go-winio"
 	diskutil "github.com/Microsoft/go-winio/vhd"
+
 	"github.com/Microsoft/hcsshim/computestorage"
-	"github.com/pkg/errors"
-	"golang.org/x/sys/windows"
+	"github.com/Microsoft/hcsshim/internal/winapi"
 )
 
 // makeOpenFiles calls winio.NewOpenFile for each handle in a slice but closes all the handles
@@ -19,7 +23,7 @@ import (
 func makeOpenFiles(hs []syscall.Handle) (_ []io.ReadWriteCloser, err error) {
 	fs := make([]io.ReadWriteCloser, len(hs))
 	for i, h := range hs {
-		if h != syscall.Handle(0) {
+		if !winapi.IsInvalidHandle(h) {
 			if err == nil {
 				fs[i], err = winio.NewOpenFile(windows.Handle(h))
 			}

--- a/internal/hcs/utils.go
+++ b/internal/hcs/utils.go
@@ -5,7 +5,6 @@ package hcs
 import (
 	"context"
 	"io"
-	"sync/atomic"
 	"syscall"
 
 	"github.com/pkg/errors"

--- a/internal/hvsocket/hvsocket.go
+++ b/internal/hvsocket/hvsocket.go
@@ -6,12 +6,12 @@ package hvsocket
 import (
 	"context"
 	"fmt"
-	"github.com/Microsoft/hcsshim/internal/log"
 	"unsafe"
 
 	"github.com/Microsoft/go-winio/pkg/guid"
 	"golang.org/x/sys/windows"
 
+	"github.com/Microsoft/hcsshim/internal/log"
 	"github.com/Microsoft/hcsshim/internal/resources"
 )
 

--- a/internal/log/hook.go
+++ b/internal/log/hook.go
@@ -41,6 +41,8 @@ type Hook struct {
 
 	// AddSpanContext adds [logfields.TraceID] and [logfields.SpanID] fields to
 	// the entry from the span context stored in [logrus.Entry.Context], if it exists.
+	//
+	// Default is true.
 	AddSpanContext bool
 }
 

--- a/internal/logfields/fields.go
+++ b/internal/logfields/fields.go
@@ -14,6 +14,9 @@ const (
 	ProcessID   = "pid"
 	TaskID      = "tid"
 	UVMID       = "uvm-id"
+	SystemID    = "system-id"
+
+	CallbackNumber = "callback-number"
 
 	// networking and IO
 

--- a/internal/uvm/create_wcow.go
+++ b/internal/uvm/create_wcow.go
@@ -69,7 +69,7 @@ type OptionsWCOW struct {
 	// AdditionalRegistryKeys are Registry keys and their values to additionally add to the uVM.
 	AdditionalRegistryKeys []hcsschema.RegistryValue
 
-	OutputHandlerCreator OutputHandlerCreator // Creates an [OutputHandler] that controls how output received over HVSocket from the UVM is handled. Defaults to parsing output as ETW Log events
+	OutputHandlerCreator OutputHandlerCreator `json:"-"` // Creates an [OutputHandler] that controls how output received over HVSocket from the UVM is handled. Defaults to parsing output as ETW Log events
 	LogSources           string               // ETW providers to be set for the logging service
 	ForwardLogs          bool                 // Whether to forward logs to the host or not
 }

--- a/internal/uvm/start.go
+++ b/internal/uvm/start.go
@@ -172,7 +172,7 @@ func (uvm *UtilityVM) Start(ctx context.Context) (err error) {
 	// save parent context, without timeout to use in terminate
 	pCtx := ctx
 	ctx, cancel := context.WithTimeout(pCtx, timeout.GCSConnectionTimeout)
-	log.G(ctx).Debugf("using gcs connection timeout: %s\n", timeout.GCSConnectionTimeout)
+	log.G(ctx).Debugf("using gcs connection timeout: %s", timeout.GCSConnectionTimeout)
 
 	g, gctx := errgroup.WithContext(ctx)
 	defer func() {
@@ -215,7 +215,7 @@ func (uvm *UtilityVM) Start(ctx context.Context) (err error) {
 		switch uvm.operatingSystem {
 		case "windows":
 			// Windows specific handling
-			// For windows, the Listener can recieve a connection later, so we
+			// For windows, the Listener can receive a connection later, so we
 			// start the output handler in a goroutine with a non-timeout context.
 			// This allows the output handler to run independently of the UVM Create's
 			// lifecycle. The approach potentially allows to wait for reconnections too,

--- a/internal/winapi/doc.go
+++ b/internal/winapi/doc.go
@@ -1,3 +1,5 @@
 // Package winapi contains various low-level bindings to Windows APIs. It can
 // be thought of as an extension to golang.org/x/sys/windows.
 package winapi
+
+//go:generate go tool github.com/Microsoft/go-winio/tools/mkwinsyscall -output zsyscall_windows.go ./*.go

--- a/internal/winapi/utils.go
+++ b/internal/winapi/utils.go
@@ -10,6 +10,11 @@ import (
 	"golang.org/x/sys/windows"
 )
 
+// IsInvalidHandle returns true if the Handle is zero or [windows.InvalidHandle].
+func IsInvalidHandle[H ~uintptr](h H) bool {
+	return h == 0 || uintptr(h) == uintptr(windows.InvalidHandle)
+}
+
 // Uint16BufferToSlice wraps a uint16 pointer-and-length into a slice
 // for easier interop with Go APIs
 func Uint16BufferToSlice(buffer *uint16, bufferLength int) (result []uint16) {

--- a/internal/winapi/winapi.go
+++ b/internal/winapi/winapi.go
@@ -1,3 +1,0 @@
-package winapi
-
-//go:generate go tool github.com/Microsoft/go-winio/tools/mkwinsyscall -output zsyscall_windows.go ./*.go

--- a/test/functional/main_test.go
+++ b/test/functional/main_test.go
@@ -164,6 +164,7 @@ func runTests(m *testing.M) error {
 		return fmt.Errorf("tests must be run in an elevated context")
 	}
 
+	logrus.AddHook(log.NewHook())
 	trace.ApplyConfig(trace.Config{DefaultSampler: oc.DefaultSampler})
 	trace.RegisterExporter(&oc.LogrusExporter{})
 

--- a/test/gcs/main_test.go
+++ b/test/gcs/main_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/Microsoft/hcsshim/internal/guest/runtime/runc"
 	"github.com/Microsoft/hcsshim/internal/guest/transport"
 	"github.com/Microsoft/hcsshim/internal/guestpath"
+	"github.com/Microsoft/hcsshim/internal/log"
 	"github.com/Microsoft/hcsshim/internal/oc"
 	"github.com/Microsoft/hcsshim/pkg/securitypolicy"
 
@@ -109,6 +110,7 @@ func TestMain(m *testing.M) {
 func setup() (err error) {
 	_ = os.MkdirAll(guestpath.LCOWRootPrefixInUVM, 0755)
 
+	logrus.AddHook(log.NewHook())
 	trace.ApplyConfig(trace.Config{DefaultSampler: oc.DefaultSampler})
 	trace.RegisterExporter(&oc.LogrusExporter{})
 

--- a/test/internal/container/container.go
+++ b/test/internal/container/container.go
@@ -31,6 +31,7 @@ func Create(
 	name, owner string,
 ) (c cow.Container, r *resources.Resources, _ func()) {
 	tb.Helper()
+	tb.Logf("creating container: %q", name)
 
 	if spec.Windows == nil || spec.Windows.Network == nil || spec.Windows.LayerFolders == nil {
 		tb.Fatalf("improperly configured windows spec for container %q: %#+v", name, spec.Windows)
@@ -72,6 +73,8 @@ func Create(
 	}
 
 	f := func() {
+		tb.Logf("cleaning up container: %q", name)
+
 		if err := resources.ReleaseResources(ctx, r, vm, true); err != nil {
 			tb.Errorf("failed to release container resources: %v", err)
 		}
@@ -99,6 +102,8 @@ func Start(ctx context.Context, tb testing.TB, c cow.Container, io *testcmd.Buff
 
 func StartWithSpec(ctx context.Context, tb testing.TB, c cow.Container, p *specs.Process, io *testcmd.BufferedIO) *cmd.Cmd {
 	tb.Helper()
+	tb.Logf("starting container: %q", c.ID())
+
 	if err := c.Start(ctx); err != nil {
 		tb.Fatalf("could not start %q: %v", c.ID(), err)
 	}
@@ -111,6 +116,8 @@ func StartWithSpec(ctx context.Context, tb testing.TB, c cow.Container, p *specs
 
 func Wait(_ context.Context, tb testing.TB, c cow.Container) {
 	tb.Helper()
+	tb.Logf("waiting on container: %q", c.ID())
+
 	// todo: add wait on ctx.Done
 	if err := c.Wait(); err != nil {
 		tb.Fatalf("could not wait on container %q: %v", c.ID(), err)
@@ -119,6 +126,8 @@ func Wait(_ context.Context, tb testing.TB, c cow.Container) {
 
 func Kill(ctx context.Context, tb testing.TB, c cow.Container) {
 	tb.Helper()
+	tb.Logf("kill container: %q", c.ID())
+
 	if err := c.Shutdown(ctx); err != nil {
 		tb.Fatalf("could not terminate container %q: %v", c.ID(), err)
 	}

--- a/test/pkg/uvm/lcow.go
+++ b/test/pkg/uvm/lcow.go
@@ -77,6 +77,13 @@ func CreateAndStartLCOWFromOpts(ctx context.Context, tb testing.TB, opts *uvm.Op
 
 func CreateLCOW(ctx context.Context, tb testing.TB, opts *uvm.OptionsLCOW) (*uvm.UtilityVM, CleanupFn) {
 	tb.Helper()
+
+	if opts == nil {
+		tb.Fatalf("opts cannot be nil bet set with BootFiles")
+	}
+
+	tb.Logf("create LCOW uVM: %q", opts.ID)
+
 	vm, err := uvm.CreateLCOW(ctx, opts)
 	if err != nil {
 		tb.Fatalf("could not create LCOW UVM: %v", err)

--- a/test/pkg/uvm/lcow.go
+++ b/test/pkg/uvm/lcow.go
@@ -75,6 +75,7 @@ func CreateAndStartLCOWFromOpts(ctx context.Context, tb testing.TB, opts *uvm.Op
 	return vm
 }
 
+//nolint:staticcheck // SA5011: staticcheck thinks `opts` may be nil, even though we fail if it is
 func CreateLCOW(ctx context.Context, tb testing.TB, opts *uvm.OptionsLCOW) (*uvm.UtilityVM, CleanupFn) {
 	tb.Helper()
 

--- a/test/pkg/uvm/uvm.go
+++ b/test/pkg/uvm/uvm.go
@@ -60,15 +60,17 @@ func CreateAndStart(ctx context.Context, tb testing.TB, opts any) *uvm.UtilityVM
 
 func Start(ctx context.Context, tb testing.TB, vm *uvm.UtilityVM) {
 	tb.Helper()
-	err := vm.Start(ctx)
+	tb.Logf("start uVM: %q", vm.ID())
 
-	if err != nil {
+	if err := vm.Start(ctx); err != nil {
 		tb.Fatalf("could not start UVM: %v", err)
 	}
 }
 
 func Wait(ctx context.Context, tb testing.TB, vm *uvm.UtilityVM) {
 	tb.Helper()
+	tb.Logf("waiting on container: %q", vm.ID())
+
 	if err := vm.WaitCtx(ctx); err != nil {
 		tb.Fatalf("could not wait for uvm %q: %v", vm.ID(), err)
 	}
@@ -76,6 +78,8 @@ func Wait(ctx context.Context, tb testing.TB, vm *uvm.UtilityVM) {
 
 func Kill(ctx context.Context, tb testing.TB, vm *uvm.UtilityVM) {
 	tb.Helper()
+	tb.Logf("kill uVM: %q", vm.ID())
+
 	if err := vm.Terminate(ctx); err != nil {
 		tb.Fatalf("could not kill uvm %q: %v", vm.ID(), err)
 	}
@@ -83,6 +87,8 @@ func Kill(ctx context.Context, tb testing.TB, vm *uvm.UtilityVM) {
 
 func Close(ctx context.Context, tb testing.TB, vm *uvm.UtilityVM) {
 	tb.Helper()
+	tb.Logf("close uVM: %q", vm.ID())
+
 	if err := vm.CloseCtx(ctx); err != nil {
 		tb.Fatalf("could not close uvm %q: %v", vm.ID(), err)
 	}

--- a/test/pkg/uvm/wcow.go
+++ b/test/pkg/uvm/wcow.go
@@ -37,7 +37,13 @@ func CreateWCOWUVM(ctx context.Context, tb testing.TB, id, image string) (*uvm.U
 func CreateWCOW(ctx context.Context, tb testing.TB, opts *uvm.OptionsWCOW) (*uvm.UtilityVM, CleanupFn) {
 	tb.Helper()
 
-	if opts == nil || opts.BootFiles == nil {
+	if opts == nil {
+		tb.Fatalf("opts cannot be nil bet set with BootFiles")
+	}
+
+	tb.Logf("create WCOW uVM: %q", opts.ID)
+
+	if opts.BootFiles == nil {
 		tb.Fatalf("opts must bet set with BootFiles")
 	}
 

--- a/test/pkg/uvm/wcow.go
+++ b/test/pkg/uvm/wcow.go
@@ -34,6 +34,8 @@ func CreateWCOWUVM(ctx context.Context, tb testing.TB, id, image string) (*uvm.U
 }
 
 // CreateWCOW creates a WCOW utility VM with the passed opts.
+//
+//nolint:staticcheck // SA5011: staticcheck thinks `opts` may be nil, even though we fail if it is
 func CreateWCOW(ctx context.Context, tb testing.TB, opts *uvm.OptionsWCOW) (*uvm.UtilityVM, CleanupFn) {
 	tb.Helper()
 


### PR DESCRIPTION
Use dedicated callback number type and atomic counter

Add an explicit `callbackNumber` type and use an `atomic.Uintptr` to track callback numbers instead of the RWMutex `callbackMapLock`.

Add comment clarifying use of `callbackNumber` as callback context.

Add logs to `notificationWatcher` and `(*Process|*System).[un]registryCallback`.

Add `"internal/winapi".IsInvalidHandle` function to valid `Handle`s are neither `0` nor Invalid.

Add `(*Process).CloseCtx(context.Context)` and use that, along with `(*System).CloseCtx` where appropriate.

Minor code cleanup and doc fixes:
 - Clarify docs.
 - Fix spelling.
 - Remove newline from log.
 - Update CI lint version.
 - Suppress lint issues (skipped error checks for `Close()` calls are ignored automatically, but not for `CloseCtx(ctx)`).
 - Standardize system and process ID log/span field names.
 - Use `"system-id"` for system ID rather than `"cid"`, which can be interpreted as "container ID".
 - Don't serialize `OptionsWCOW.OutputHandlerCreator` to JSON.
 - Consolidate redundant `internal/winapi/winapi.go` with `internal/winapi/doc.go`.
 - Use `"internal/log".(*Hook)` to format logs and add span information in functional/gcs tests.
 - Add testing `nil`-checks and logs to uVM/container/process testing operations.

Required for #2526