### PR TITLE
jobcontainers: wire Windows CPU affinity to JobObject limits

### DIFF
--- a/internal/jobcontainers/oci_test.go
+++ b/internal/jobcontainers/oci_test.go
@@ -1,0 +1,100 @@
+//go:build windows
+
+package jobcontainers
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	specs "github.com/opencontainers/runtime-spec/specs-go"
+)
+
+func TestSpecToLimits_CPUAffinity_Group0MaskSet(t *testing.T) {
+	s := &specs.Spec{
+		Windows: &specs.Windows{
+			Resources: &specs.WindowsResources{
+				CPU: &specs.WindowsCPUResources{
+					Affinity: []specs.WindowsCPUGroupAffinity{
+						{Mask: 0x3, Group: 0},
+					},
+				},
+			},
+		},
+	}
+
+	limits, err := specToLimits(context.Background(), "cid", s)
+	if err != nil {
+		t.Fatalf("specToLimits failed: %v", err)
+	}
+	if limits.CPUAffinity != 0x3 {
+		t.Fatalf("unexpected cpu affinity: got %d want %d", limits.CPUAffinity, uint64(0x3))
+	}
+}
+
+func TestSpecToLimits_CPUAffinity_MultiGroupRejected(t *testing.T) {
+	s := &specs.Spec{
+		Windows: &specs.Windows{
+			Resources: &specs.WindowsResources{
+				CPU: &specs.WindowsCPUResources{
+					Affinity: []specs.WindowsCPUGroupAffinity{
+						{Mask: 0x1, Group: 0},
+						{Mask: 0x1, Group: 1},
+					},
+				},
+			},
+		},
+	}
+
+	_, err := specToLimits(context.Background(), "cid", s)
+	if err == nil {
+		t.Fatal("expected error for multiple affinity entries")
+	}
+	if !strings.Contains(err.Error(), "multiple processor groups") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestSpecToLimits_CPUAffinity_NonZeroGroupRejected(t *testing.T) {
+	s := &specs.Spec{
+		Windows: &specs.Windows{
+			Resources: &specs.WindowsResources{
+				CPU: &specs.WindowsCPUResources{
+					Affinity: []specs.WindowsCPUGroupAffinity{
+						{Mask: 0x1, Group: 1},
+					},
+				},
+			},
+		},
+	}
+
+	_, err := specToLimits(context.Background(), "cid", s)
+	if err == nil {
+		t.Fatal("expected error for non-zero affinity group")
+	}
+	if !strings.Contains(err.Error(), "processor group") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestSpecToLimits_CPUAffinity_ZeroMaskRejected(t *testing.T) {
+	s := &specs.Spec{
+		Windows: &specs.Windows{
+			Resources: &specs.WindowsResources{
+				CPU: &specs.WindowsCPUResources{
+					Affinity: []specs.WindowsCPUGroupAffinity{
+						{Mask: 0, Group: 0},
+					},
+				},
+			},
+		},
+	}
+
+	_, err := specToLimits(context.Background(), "cid", s)
+	if err == nil {
+		t.Fatal("expected error for zero affinity mask")
+	}
+	if !strings.Contains(err.Error(), "mask must be non-zero") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/internal/jobobject/jobobject.go
+++ b/internal/jobobject/jobobject.go
@@ -32,6 +32,7 @@ type JobObject struct {
 type JobLimits struct {
 	CPULimit           uint32
 	CPUWeight          uint32
+	CPUAffinity        uint64
 	MemoryLimitInBytes uint64
 	MaxIOPS            int64
 	MaxBandwidth       int64

--- a/internal/jobobject/jobobject_test.go
+++ b/internal/jobobject/jobobject_test.go
@@ -252,6 +252,27 @@ func TestSetMultipleExtendedLimits(t *testing.T) {
 	}
 }
 
+func TestSetResourceLimitsCPUAffinity(t *testing.T) {
+	job, err := Create(context.Background(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer job.Close()
+
+	limits := &JobLimits{CPUAffinity: 0x3}
+	if err := job.SetResourceLimits(limits); err != nil {
+		t.Fatalf("failed to set resource limits with cpu affinity: %v", err)
+	}
+
+	affinity, err := job.GetCPUAffinity()
+	if err != nil {
+		t.Fatalf("failed to query cpu affinity: %v", err)
+	}
+	if affinity != limits.CPUAffinity {
+		t.Fatalf("unexpected cpu affinity: got %d want %d", affinity, limits.CPUAffinity)
+	}
+}
+
 func TestNoMoreProcessesMessageKill(t *testing.T) {
 	// Test that we receive the no more processes in job message after killing all of
 	// the processes in the job.

--- a/internal/jobobject/limits.go
+++ b/internal/jobobject/limits.go
@@ -38,6 +38,12 @@ func (job *JobObject) SetResourceLimits(limits *JobLimits) error {
 		}
 	}
 
+	if limits.CPUAffinity != 0 {
+		if err := job.SetCPUAffinity(limits.CPUAffinity); err != nil {
+			return fmt.Errorf("failed to set job object cpu affinity: %w", err)
+		}
+	}
+
 	if limits.MaxBandwidth != 0 || limits.MaxIOPS != 0 {
 		if err := job.SetIOLimit(limits.MaxBandwidth, limits.MaxIOPS); err != nil {
 			return fmt.Errorf("failed to set io limit on job object: %w", err)


### PR DESCRIPTION
## Summary
- Wire OCI Windows CPU affinity into JobContainer limits translation (`specToLimits`).
- Extend `JobLimits` with `CPUAffinity` and apply it in `SetResourceLimits` via `SetCPUAffinity`.
- Add unit tests for affinity translation and resource-limit application.

## Motivation
This is the Phase 1 quick-win for Windows CPU affinity: unblock HostProcess pod scenarios that run through the JobContainer/JobObject path.

## Scope
- Files changed:
  - `internal/jobcontainers/oci.go`
  - `internal/jobcontainers/oci_test.go`
  - `internal/jobobject/jobobject.go`
  - `internal/jobobject/limits.go`
  - `internal/jobobject/jobobject_test.go`

## Behavior
- If `windows.resources.cpu.affinity` is specified as a single entry with `group=0` and non-zero `mask`, affinity is applied to the job object.
- Existing behavior is unchanged when affinity is not specified.

## Limitations (intentional for Phase 1)
- Multiple affinity entries are rejected.
- Non-zero processor groups are rejected.
- HCS silo container `Processor` schema affinity support is **not** part of this PR (Phase 2).

## Testing
- Added tests:
  - `TestSpecToLimits_CPUAffinity_Group0MaskSet`
  - `TestSpecToLimits_CPUAffinity_MultiGroupRejected`
  - `TestSpecToLimits_CPUAffinity_NonZeroGroupRejected`
  - `TestSpecToLimits_CPUAffinity_ZeroMaskRejected`
  - `TestSetResourceLimitsCPUAffinity`
- Validation command used:
  - `GOOS=windows go test ./internal/jobcontainers ./internal/jobobject -count=1 -v`
