### PR TITLE
[forwardport]populate resolv conf from right location for multipod

### DIFF
--- a/pkg/securitypolicy/securitypolicy_linux.go
+++ b/pkg/securitypolicy/securitypolicy_linux.go
@@ -20,7 +20,8 @@ const osType = "linux"
 
 func ExtendPolicyWithNetworkingMounts(sandboxID string, enforcer SecurityPolicyEnforcer, spec *oci.Spec) error {
 	roSpec := &oci.Spec{
-		Root: spec.Root,
+		Root:        spec.Root,
+		Annotations: spec.Annotations,
 	}
 	networkingMounts := specInternal.GenerateWorkloadContainerNetworkMounts(sandboxID, roSpec)
 	if err := enforcer.ExtendDefaultMounts(networkingMounts); err != nil {


### PR DESCRIPTION
populate resolv conf from right location(virtual pod dir)  for virtualpod.

issue: resolv.conf not getting populated with dns info incase of multi pod.
cause: populating from wrong sandbox location
fix: fix the read location

(cherry picked from commit e8194749b14e96478d0e1ad15e07e71b7b7b5440)