### PR TITLE
refactor common uvm code into vmutils package

### DIFF
--- a/cmd/containerd-shim-runhcs-v1/service_internal.go
+++ b/cmd/containerd-shim-runhcs-v1/service_internal.go
@@ -107,7 +107,7 @@ func (s *service) createInternal(ctx context.Context, req *task.CreateTaskReques
 
 	spec = oci.UpdateSpecFromOptions(spec, shimOpts)
 	// expand annotations after defaults have been loaded in from options
-	err = oci.ProcessAnnotations(ctx, &spec)
+	err = oci.ProcessAnnotations(ctx, spec.Annotations)
 	// since annotation expansion is used to toggle security features
 	// raise it rather than suppress and move on
 	if err != nil {

--- a/internal/oci/annotations.go
+++ b/internal/oci/annotations.go
@@ -24,7 +24,7 @@ var ErrAnnotationExpansionConflict = errors.New("annotation expansion conflict")
 var ErrGenericAnnotationConflict = errors.New("specified annotations conflict")
 
 // ProcessAnnotations expands annotations into their corresponding annotation groups.
-func ProcessAnnotations(ctx context.Context, s *specs.Spec) error {
+func ProcessAnnotations(ctx context.Context, specAnnotations map[string]string) error {
 	// Named `Process` and not `Expand` since this function may be expanded (pun intended) to
 	// deal with other annotation issues and validation.
 
@@ -36,11 +36,11 @@ func ProcessAnnotations(ctx context.Context, s *specs.Spec) error {
 	var errs []error
 	for key, exps := range annotations.AnnotationExpansionMap() {
 		// check if annotation is present
-		if val, ok := s.Annotations[key]; ok {
+		if val, ok := specAnnotations[key]; ok {
 			// ideally, some normalization would occur here (ie, "True" -> "true")
 			// but strings may be case-sensitive
 			for _, k := range exps {
-				if v, ok := s.Annotations[k]; ok && val != v {
+				if v, ok := specAnnotations[k]; ok && val != v {
 					err := fmt.Errorf("%w: %q = %q and %q = %q", ErrAnnotationExpansionConflict, key, val, k, v)
 					errs = append(errs, err)
 					log.G(ctx).WithFields(logrus.Fields{
@@ -51,26 +51,26 @@ func ProcessAnnotations(ctx context.Context, s *specs.Spec) error {
 					}).WithError(err).Warning("annotation expansion would overwrite conflicting value")
 					continue
 				}
-				s.Annotations[k] = val
+				specAnnotations[k] = val
 			}
 		}
 	}
 
 	// validate host process containers annotations are not conflicting
-	disableHPC := ParseAnnotationsBool(ctx, s.Annotations, annotations.DisableHostProcessContainer, false)
-	enableHPC := ParseAnnotationsBool(ctx, s.Annotations, annotations.HostProcessContainer, false)
+	disableHPC := ParseAnnotationsBool(ctx, specAnnotations, annotations.DisableHostProcessContainer, false)
+	enableHPC := ParseAnnotationsBool(ctx, specAnnotations, annotations.HostProcessContainer, false)
 	if disableHPC && enableHPC {
 		err := fmt.Errorf("%w: host process container annotations %q = %q and %q = %q",
 			ErrGenericAnnotationConflict,
-			annotations.DisableHostProcessContainer, s.Annotations[annotations.DisableHostProcessContainer],
-			annotations.HostProcessContainer, s.Annotations[annotations.HostProcessContainer])
+			annotations.DisableHostProcessContainer, specAnnotations[annotations.DisableHostProcessContainer],
+			annotations.HostProcessContainer, specAnnotations[annotations.HostProcessContainer])
 		errs = append(errs, err)
 
 		log.G(ctx).WithFields(logrus.Fields{
 			logfields.OCIAnnotation:               annotations.DisableHostProcessContainer,
-			logfields.Value:                       s.Annotations[annotations.DisableHostProcessContainer],
+			logfields.Value:                       specAnnotations[annotations.DisableHostProcessContainer],
 			logfields.OCIAnnotation + "-conflict": annotations.HostProcessContainer,
-			logfields.Value + "-conflict":         s.Annotations[annotations.HostProcessContainer],
+			logfields.Value + "-conflict":         specAnnotations[annotations.HostProcessContainer],
 		}).WithError(err).Warning("Host process container and disable host process container cannot both be true")
 	}
 
@@ -204,10 +204,10 @@ func parseAdditionalRegistryValues(ctx context.Context, a map[string]string) []h
 	return slices.Clip(rvs)
 }
 
-// parseHVSocketServiceTable extracts any additional Hyper-V socket service configurations from annotations.
+// ParseHVSocketServiceTable extracts any additional Hyper-V socket service configurations from annotations.
 //
 // Like the [parseAnnotation*] functions, this logs errors but does not return them.
-func parseHVSocketServiceTable(ctx context.Context, a map[string]string) map[string]hcsschema.HvSocketServiceConfig {
+func ParseHVSocketServiceTable(ctx context.Context, a map[string]string) map[string]hcsschema.HvSocketServiceConfig {
 	sc := make(map[string]hcsschema.HvSocketServiceConfig)
 	// TODO(go1.23) use range over functions to implement a functional `filter | map $ a`
 	for k, v := range a {

--- a/internal/oci/annotations_test.go
+++ b/internal/oci/annotations_test.go
@@ -117,11 +117,10 @@ func TestProccessAnnotations_HostProcessContainer(t *testing.T) {
 	for _, tt := range testAnnotations {
 		t.Run(tt.name, func(t *testing.T) {
 			spec := specs.Spec{
-				Windows:     &specs.Windows{},
 				Annotations: tt.an,
 			}
 
-			err := ProcessAnnotations(ctx, &spec)
+			err := ProcessAnnotations(ctx, spec.Annotations)
 			if err != nil && len(tt.errs) == 0 {
 				t.Fatalf("ProcessAnnotations should have succeeded, instead got %v", err)
 			}
@@ -181,7 +180,7 @@ func TestProccessAnnotations_Expansion(t *testing.T) {
 					annotations.DisableUnsafeOperations: v,
 				}
 
-				err := ProcessAnnotations(ctx, &tt.spec)
+				err := ProcessAnnotations(ctx, tt.spec.Annotations)
 				if err != nil {
 					subtest.Fatalf("could not update spec from options: %v", err)
 				}
@@ -206,7 +205,7 @@ func TestProccessAnnotations_Expansion(t *testing.T) {
 				annotations.DisableUnsafeOperations,
 				annotations.DisableWritableFileShares)
 
-			err := ProcessAnnotations(ctx, &tt.spec)
+			err := ProcessAnnotations(ctx, tt.spec.Annotations)
 			if !errors.Is(err, ErrAnnotationExpansionConflict) {
 				t.Fatalf("UpdateSpecFromOptions should have failed with %q, actual was %v", errExp, err)
 			}
@@ -460,7 +459,7 @@ func TestParseHVSocketServiceTable(t *testing.T) {
 			maps.Copy(annots, tt.give)
 			t.Logf("annotations:\n%v", annots)
 
-			rvs := parseHVSocketServiceTable(ctx, annots)
+			rvs := ParseHVSocketServiceTable(ctx, annots)
 			t.Logf("got %v", rvs)
 			want := tt.want
 			if want == nil {

--- a/internal/oci/uvm.go
+++ b/internal/oci/uvm.go
@@ -333,7 +333,7 @@ func specToUVMCreateOptionsCommon(ctx context.Context, opts *uvm.Options, s *spe
 	opts.NumaMemoryBlocksCounts = ParseAnnotationCommaSeparatedUint64(ctx, s.Annotations, annotations.NumaCountOfMemoryBlocks,
 		opts.NumaMemoryBlocksCounts)
 
-	maps.Copy(opts.AdditionalHyperVConfig, parseHVSocketServiceTable(ctx, s.Annotations))
+	maps.Copy(opts.AdditionalHyperVConfig, ParseHVSocketServiceTable(ctx, s.Annotations))
 
 	// parse error yielding annotations
 	var err error

--- a/internal/uvm/memory_update.go
+++ b/internal/uvm/memory_update.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Microsoft/hcsshim/internal/hcs/resourcepaths"
 	hcsschema "github.com/Microsoft/hcsshim/internal/hcs/schema2"
 	"github.com/Microsoft/hcsshim/internal/memory"
+	"github.com/Microsoft/hcsshim/internal/vm/vmutils"
 )
 
 const bytesPerPage = 4096
@@ -18,7 +19,7 @@ const bytesPerPage = 4096
 // pages to numa nodes evenly
 func (uvm *UtilityVM) UpdateMemory(ctx context.Context, sizeInBytes uint64) error {
 	requestedSizeInMB := sizeInBytes / memory.MiB
-	actual := uvm.normalizeMemorySize(ctx, requestedSizeInMB)
+	actual := vmutils.NormalizeMemorySize(ctx, uvm.id, requestedSizeInMB)
 	req := &hcsschema.ModifySettingRequest{
 		ResourcePath: resourcepaths.MemoryResourcePath,
 		Settings:     actual,

--- a/internal/uvm/start.go
+++ b/internal/uvm/start.go
@@ -30,6 +30,7 @@ import (
 	"github.com/Microsoft/hcsshim/internal/protocol/guestresource"
 	"github.com/Microsoft/hcsshim/internal/timeout"
 	"github.com/Microsoft/hcsshim/internal/uvm/scsi"
+	"github.com/Microsoft/hcsshim/internal/vm/vmutils"
 )
 
 // entropyBytes is the number of bytes of random data to send to a Linux UVM
@@ -379,7 +380,7 @@ func (uvm *UtilityVM) Start(ctx context.Context) (err error) {
 			policy = uvm.createOpts.(*OptionsLCOW).SecurityPolicy
 			enforcer = uvm.createOpts.(*OptionsLCOW).SecurityPolicyEnforcer
 			referenceInfoFilePath = uvm.createOpts.(*OptionsLCOW).UVMReferenceInfoFile
-			referenceInfoFileRoot = defaultLCOWOSBootFilesPath()
+			referenceInfoFileRoot = vmutils.DefaultLCOWOSBootFilesPath()
 		} else if uvm.OS() == "windows" {
 			policy = uvm.createOpts.(*OptionsWCOW).SecurityPolicy
 			enforcer = uvm.createOpts.(*OptionsWCOW).SecurityPolicyEnforcer

--- a/internal/vm/vmutils/doc.go
+++ b/internal/vm/vmutils/doc.go
@@ -1,0 +1,12 @@
+//go:build windows
+
+// Package vmutils provides shared utility functions for working with Utility VMs.
+//
+// This package contains stateless utility functions that can be used by both the
+// legacy UVM management code (internal/uvm) and the new controller-based architecture
+// (internal/controller). Functions in this package are designed to be decoupled from
+// specific UVM implementations.
+//
+// This allows different shims (containerd-shim-runhcs-v1, containerd-shim-lcow-v1)
+// to share common logic while maintaining their own orchestration patterns.
+package vmutils

--- a/internal/vm/vmutils/lcow.go
+++ b/internal/vm/vmutils/lcow.go
@@ -1,0 +1,20 @@
+//go:build windows
+
+package vmutils
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// DefaultLCOWOSBootFilesPath returns the default path used to locate the LCOW
+// OS kernel and root FS files. This default is the subdirectory
+// `LinuxBootFiles` in the directory of the executable that started the current
+// process; or, if it does not exist, `%ProgramFiles%\Linux Containers`.
+func DefaultLCOWOSBootFilesPath() string {
+	localDirPath := filepath.Join(filepath.Dir(os.Args[0]), "LinuxBootFiles")
+	if _, err := os.Stat(localDirPath); err == nil {
+		return localDirPath
+	}
+	return filepath.Join(os.Getenv("ProgramFiles"), "Linux Containers")
+}

--- a/internal/vm/vmutils/lcow_test.go
+++ b/internal/vm/vmutils/lcow_test.go
@@ -1,0 +1,88 @@
+//go:build windows
+
+package vmutils
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDefaultLCOWOSBootFilesPath(t *testing.T) {
+	tests := []struct {
+		name          string
+		setup         func(t *testing.T) (cleanup func())
+		expectedCheck func(t *testing.T, result string)
+	}{
+		{
+			name: "returns LinuxBootFiles subdirectory when it exists",
+			setup: func(t *testing.T) func() {
+				t.Helper()
+				// Create a temporary LinuxBootFiles directory next to the test executable
+				execDir := filepath.Dir(os.Args[0])
+				linuxBootFilesPath := filepath.Join(execDir, "LinuxBootFiles")
+
+				if err := os.MkdirAll(linuxBootFilesPath, 0755); err != nil {
+					t.Fatalf("Failed to create test directory: %v", err)
+				}
+
+				return func() {
+					_ = os.RemoveAll(linuxBootFilesPath)
+				}
+			},
+			expectedCheck: func(t *testing.T, result string) {
+				t.Helper()
+				execDir := filepath.Dir(os.Args[0])
+				expected := filepath.Join(execDir, "LinuxBootFiles")
+				if result != expected {
+					t.Errorf("DefaultLCOWOSBootFilesPath() = %q, expected %q", result, expected)
+				}
+			},
+		},
+		{
+			name: "returns ProgramFiles Linux Containers when LinuxBootFiles does not exist",
+			setup: func(t *testing.T) func() {
+				t.Helper()
+				// Make sure LinuxBootFiles does not exist
+				execDir := filepath.Dir(os.Args[0])
+				linuxBootFilesPath := filepath.Join(execDir, "LinuxBootFiles")
+				// Attempt to remove in case it exists
+				_ = os.RemoveAll(linuxBootFilesPath)
+				return func() {}
+			},
+			expectedCheck: func(t *testing.T, result string) {
+				t.Helper()
+				expected := filepath.Join(os.Getenv("ProgramFiles"), "Linux Containers")
+				if result != expected {
+					t.Errorf("DefaultLCOWOSBootFilesPath() = %q, expected %q", result, expected)
+				}
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cleanup := tc.setup(t)
+			defer cleanup()
+
+			result := DefaultLCOWOSBootFilesPath()
+			tc.expectedCheck(t, result)
+		})
+	}
+}
+
+func TestDefaultLCOWOSBootFilesPath_PathConstruction(t *testing.T) {
+	// This test verifies the path construction logic without relying on file system state
+	result := DefaultLCOWOSBootFilesPath()
+
+	// The result should always be an absolute path
+	if !filepath.IsAbs(result) {
+		t.Errorf("DefaultLCOWOSBootFilesPath() returned non-absolute path: %q", result)
+	}
+
+	// The result should end with either "LinuxBootFiles" or "Linux Containers"
+	base := filepath.Base(result)
+	if base != "LinuxBootFiles" && base != "Linux Containers" {
+		t.Errorf("DefaultLCOWOSBootFilesPath() returned unexpected base path: %q", base)
+	}
+}

--- a/internal/vm/vmutils/normalize.go
+++ b/internal/vm/vmutils/normalize.go
@@ -1,0 +1,57 @@
+//go:build windows
+
+package vmutils
+
+import (
+	"context"
+	"runtime"
+
+	hcsschema "github.com/Microsoft/hcsshim/internal/hcs/schema2"
+	"github.com/Microsoft/hcsshim/internal/log"
+	"github.com/Microsoft/hcsshim/internal/logfields"
+	"github.com/sirupsen/logrus"
+)
+
+// DefaultProcessorCountForUVM returns the default processor count to use for a utility VM.
+// If the system has only 1 logical processor, it returns 1. Otherwise, it returns 2.
+func DefaultProcessorCountForUVM() int32 {
+	if runtime.NumCPU() == 1 {
+		return 1
+	}
+	return 2
+}
+
+// NormalizeMemorySize aligns the requested memory size to an even number (2MB alignment).
+func NormalizeMemorySize(ctx context.Context, uvmID string, requested uint64) uint64 {
+	actual := (requested + 1) &^ 1 // align up to an even number
+	if requested != actual {
+		log.G(ctx).WithFields(logrus.Fields{
+			logfields.UVMID: uvmID,
+			"requested":     requested,
+			"assigned":      actual,
+		}).Warn("Changing user requested MemorySizeInMB to align to 2MB")
+	}
+	return actual
+}
+
+// NormalizeProcessorCount ensures that the requested processor count does not exceed the host's logical processor count as reported by HCS.
+func NormalizeProcessorCount(ctx context.Context, uvmID string, requested int32, processorTopology *hcsschema.ProcessorTopology) int32 {
+	// Use host processor information retrieved from HCS instead of runtime.NumCPU,
+	// GetMaximumProcessorCount or other OS level calls for two reasons.
+	// 1. Go uses GetProcessAffinityMask and falls back to GetSystemInfo both of
+	// which will not return LPs in another processor group.
+	// 2. GetMaximumProcessorCount will return all processors on the system
+	// but in configurations where the host partition doesn't see the full LP count
+	// i.e "Minroot" scenarios this won't be sufficient.
+	// (https://docs.microsoft.com/en-us/windows-server/virtualization/hyper-v/manage/manage-hyper-v-minroot-2016)
+	hostCount := int32(processorTopology.LogicalProcessorCount)
+	if requested > hostCount {
+		log.G(ctx).WithFields(logrus.Fields{
+			logfields.UVMID: uvmID,
+			"requested":     requested,
+			"assigned":      hostCount,
+		}).Warn("Changing user requested CPUCount to current number of processors")
+		return hostCount
+	}
+	return requested
+}

--- a/internal/vm/vmutils/normalize_test.go
+++ b/internal/vm/vmutils/normalize_test.go
@@ -1,0 +1,146 @@
+//go:build windows
+
+package vmutils
+
+import (
+	"context"
+	"testing"
+
+	hcsschema "github.com/Microsoft/hcsshim/internal/hcs/schema2"
+)
+
+func TestNormalizeMemorySize(t *testing.T) {
+	tests := []struct {
+		name      string
+		requested uint64
+		expected  uint64
+	}{
+		{
+			name:      "zero memory",
+			requested: 0,
+			expected:  0,
+		},
+		{
+			name:      "already aligned to 2",
+			requested: 2,
+			expected:  2,
+		},
+		{
+			name:      "odd number rounds up",
+			requested: 1,
+			expected:  2,
+		},
+		{
+			name:      "even number stays same",
+			requested: 4,
+			expected:  4,
+		},
+		{
+			name:      "large odd number rounds up",
+			requested: 1023,
+			expected:  1024,
+		},
+		{
+			name:      "large even number stays same",
+			requested: 1024,
+			expected:  1024,
+		},
+		{
+			name:      "very large odd number",
+			requested: 65535,
+			expected:  65536,
+		},
+		{
+			name:      "very large even number",
+			requested: 65536,
+			expected:  65536,
+		},
+		{
+			name:      "max uint64 minus 1 (even)",
+			requested: 0xFFFFFFFFFFFFFFFE,
+			expected:  0xFFFFFFFFFFFFFFFE,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			actual := NormalizeMemorySize(ctx, "test-uvm-id", tc.requested)
+			if actual != tc.expected {
+				t.Errorf("NormalizeMemorySize(%d) = %d, expected %d", tc.requested, actual, tc.expected)
+			}
+		})
+	}
+}
+
+func TestNormalizeProcessorCount(t *testing.T) {
+	tests := []struct {
+		name                 string
+		requested            int32
+		hostProcessorLPCount uint32
+		expected             int32
+	}{
+		{
+			name:                 "zero requested",
+			requested:            0,
+			hostProcessorLPCount: 8,
+			expected:             0,
+		},
+		{
+			name:                 "requested less than host count",
+			requested:            4,
+			hostProcessorLPCount: 8,
+			expected:             4,
+		},
+		{
+			name:                 "requested equals host count",
+			requested:            8,
+			hostProcessorLPCount: 8,
+			expected:             8,
+		},
+		{
+			name:                 "requested exceeds host count",
+			requested:            16,
+			hostProcessorLPCount: 8,
+			expected:             8,
+		},
+		{
+			name:                 "requested is 1 with single processor host",
+			requested:            1,
+			hostProcessorLPCount: 1,
+			expected:             1,
+		},
+		{
+			name:                 "requested is 2 with single processor host",
+			requested:            2,
+			hostProcessorLPCount: 1,
+			expected:             1,
+		},
+		{
+			name:                 "large requested exceeds large host count",
+			requested:            256,
+			hostProcessorLPCount: 128,
+			expected:             128,
+		},
+		{
+			name:                 "negative requested returns negative (edge case)",
+			requested:            -1,
+			hostProcessorLPCount: 8,
+			expected:             -1,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			topology := &hcsschema.ProcessorTopology{
+				LogicalProcessorCount: tc.hostProcessorLPCount,
+			}
+			actual := NormalizeProcessorCount(ctx, "test-uvm-id", tc.requested, topology)
+			if actual != tc.expected {
+				t.Errorf("NormalizeProcessorCount(%d, %d) = %d, expected %d",
+					tc.requested, tc.hostProcessorLPCount, actual, tc.expected)
+			}
+		})
+	}
+}

--- a/internal/vm/vmutils/numa_test.go
+++ b/internal/vm/vmutils/numa_test.go
@@ -1,0 +1,877 @@
+//go:build windows
+
+package vmutils
+
+import (
+	"context"
+	"testing"
+
+	hcsschema "github.com/Microsoft/hcsshim/internal/hcs/schema2"
+	"github.com/Microsoft/hcsshim/osversion"
+)
+
+func TestValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		numa    *hcsschema.Numa
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "empty settings is valid",
+			numa: &hcsschema.Numa{
+				Settings: []hcsschema.NumaSetting{},
+			},
+			wantErr: false,
+		},
+		{
+			name: "nil settings is valid",
+			numa: &hcsschema.Numa{
+				Settings: nil,
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid single node topology",
+			numa: &hcsschema.Numa{
+				VirtualNodeCount: 1,
+				Settings: []hcsschema.NumaSetting{
+					{
+						VirtualNodeNumber:   0,
+						PhysicalNodeNumber:  0,
+						VirtualSocketNumber: 0,
+						CountOfProcessors:   4,
+						CountOfMemoryBlocks: 1024,
+						MemoryBackingType:   hcsschema.MemoryBackingType_PHYSICAL,
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid multi-node topology",
+			numa: &hcsschema.Numa{
+				VirtualNodeCount: 2,
+				Settings: []hcsschema.NumaSetting{
+					{
+						VirtualNodeNumber:   0,
+						PhysicalNodeNumber:  0,
+						VirtualSocketNumber: 0,
+						CountOfProcessors:   4,
+						CountOfMemoryBlocks: 1024,
+						MemoryBackingType:   hcsschema.MemoryBackingType_PHYSICAL,
+					},
+					{
+						VirtualNodeNumber:   1,
+						PhysicalNodeNumber:  1,
+						VirtualSocketNumber: 1,
+						CountOfProcessors:   4,
+						CountOfMemoryBlocks: 1024,
+						MemoryBackingType:   hcsschema.MemoryBackingType_PHYSICAL,
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid wildcard physical nodes",
+			numa: &hcsschema.Numa{
+				VirtualNodeCount: 2,
+				Settings: []hcsschema.NumaSetting{
+					{
+						VirtualNodeNumber:   0,
+						PhysicalNodeNumber:  0xFF, // wildcard
+						VirtualSocketNumber: 0,
+						CountOfProcessors:   4,
+						CountOfMemoryBlocks: 1024,
+						MemoryBackingType:   hcsschema.MemoryBackingType_PHYSICAL,
+					},
+					{
+						VirtualNodeNumber:   1,
+						PhysicalNodeNumber:  0xFF, // wildcard
+						VirtualSocketNumber: 1,
+						CountOfProcessors:   4,
+						CountOfMemoryBlocks: 1024,
+						MemoryBackingType:   hcsschema.MemoryBackingType_PHYSICAL,
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "virtual node number exceeds max",
+			numa: &hcsschema.Numa{
+				VirtualNodeCount: 1,
+				Settings: []hcsschema.NumaSetting{
+					{
+						VirtualNodeNumber:   65, // exceeds numaChildNodeCountMax (64)
+						PhysicalNodeNumber:  0,
+						VirtualSocketNumber: 0,
+						CountOfProcessors:   4,
+						CountOfMemoryBlocks: 1024,
+						MemoryBackingType:   hcsschema.MemoryBackingType_PHYSICAL,
+					},
+				},
+			},
+			wantErr: true,
+			errMsg:  "vNUMA virtual node number 65 exceeds maximum allowed value 64",
+		},
+		{
+			name: "physical node number exceeds max (non-wildcard)",
+			numa: &hcsschema.Numa{
+				VirtualNodeCount: 1,
+				Settings: []hcsschema.NumaSetting{
+					{
+						VirtualNodeNumber:   0,
+						PhysicalNodeNumber:  64, // exceeds numaTopologyNodeCountMax (64)
+						VirtualSocketNumber: 0,
+						CountOfProcessors:   4,
+						CountOfMemoryBlocks: 1024,
+						MemoryBackingType:   hcsschema.MemoryBackingType_PHYSICAL,
+					},
+				},
+			},
+			wantErr: true,
+			errMsg:  "vNUMA physical node number 64 exceeds maximum allowed value 64",
+		},
+		{
+			name: "mixed wildcard and non-wildcard physical nodes",
+			numa: &hcsschema.Numa{
+				VirtualNodeCount: 2,
+				Settings: []hcsschema.NumaSetting{
+					{
+						VirtualNodeNumber:   0,
+						PhysicalNodeNumber:  0xFF, // wildcard
+						VirtualSocketNumber: 0,
+						CountOfProcessors:   4,
+						CountOfMemoryBlocks: 1024,
+						MemoryBackingType:   hcsschema.MemoryBackingType_PHYSICAL,
+					},
+					{
+						VirtualNodeNumber:   1,
+						PhysicalNodeNumber:  1, // non-wildcard
+						VirtualSocketNumber: 1,
+						CountOfProcessors:   4,
+						CountOfMemoryBlocks: 1024,
+						MemoryBackingType:   hcsschema.MemoryBackingType_PHYSICAL,
+					},
+				},
+			},
+			wantErr: true,
+			errMsg:  "vNUMA has a mix of wildcard",
+		},
+		{
+			name: "node with zero memory blocks",
+			numa: &hcsschema.Numa{
+				VirtualNodeCount: 1,
+				Settings: []hcsschema.NumaSetting{
+					{
+						VirtualNodeNumber:   0,
+						PhysicalNodeNumber:  0,
+						VirtualSocketNumber: 0,
+						CountOfProcessors:   4,
+						CountOfMemoryBlocks: 0, // not allowed
+						MemoryBackingType:   hcsschema.MemoryBackingType_PHYSICAL,
+					},
+				},
+			},
+			wantErr: true,
+			errMsg:  "vNUMA nodes with no memory are not allowed",
+		},
+		{
+			name: "duplicate virtual node numbers",
+			numa: &hcsschema.Numa{
+				VirtualNodeCount: 2,
+				Settings: []hcsschema.NumaSetting{
+					{
+						VirtualNodeNumber:   0,
+						PhysicalNodeNumber:  0,
+						VirtualSocketNumber: 0,
+						CountOfProcessors:   4,
+						CountOfMemoryBlocks: 1024,
+						MemoryBackingType:   hcsschema.MemoryBackingType_PHYSICAL,
+					},
+					{
+						VirtualNodeNumber:   0, // duplicate
+						PhysicalNodeNumber:  1,
+						VirtualSocketNumber: 1,
+						CountOfProcessors:   4,
+						CountOfMemoryBlocks: 1024,
+						MemoryBackingType:   hcsschema.MemoryBackingType_PHYSICAL,
+					},
+				},
+			},
+			wantErr: true,
+			errMsg:  "vNUMA virtual node number 0 is duplicated",
+		},
+		{
+			name: "partial resource allocation - memory only",
+			numa: &hcsschema.Numa{
+				VirtualNodeCount: 1,
+				Settings: []hcsschema.NumaSetting{
+					{
+						VirtualNodeNumber:   0,
+						PhysicalNodeNumber:  0,
+						VirtualSocketNumber: 0,
+						CountOfProcessors:   0,
+						CountOfMemoryBlocks: 1024,
+						MemoryBackingType:   hcsschema.MemoryBackingType_PHYSICAL,
+					},
+				},
+			},
+			wantErr: true,
+			errMsg:  "partial resource allocation is not allowed",
+		},
+		{
+			name: "completely empty topology with wildcard",
+			numa: &hcsschema.Numa{
+				VirtualNodeCount: 2,
+				Settings: []hcsschema.NumaSetting{
+					{
+						VirtualNodeNumber:   0,
+						PhysicalNodeNumber:  0xFF,
+						VirtualSocketNumber: 0,
+						CountOfProcessors:   0,
+						CountOfMemoryBlocks: 0,
+						MemoryBackingType:   hcsschema.MemoryBackingType_PHYSICAL,
+					},
+					{
+						VirtualNodeNumber:   1,
+						PhysicalNodeNumber:  0xFF,
+						VirtualSocketNumber: 1,
+						CountOfProcessors:   0,
+						CountOfMemoryBlocks: 0,
+						MemoryBackingType:   hcsschema.MemoryBackingType_PHYSICAL,
+					},
+				},
+			},
+			wantErr: true,
+			errMsg:  "vNUMA nodes with no memory are not allowed",
+		},
+		{
+			name: "valid - shared virtual socket number",
+			numa: &hcsschema.Numa{
+				VirtualNodeCount: 2,
+				Settings: []hcsschema.NumaSetting{
+					{
+						VirtualNodeNumber:   0,
+						PhysicalNodeNumber:  0,
+						VirtualSocketNumber: 0, // shared socket
+						CountOfProcessors:   4,
+						CountOfMemoryBlocks: 1024,
+						MemoryBackingType:   hcsschema.MemoryBackingType_PHYSICAL,
+					},
+					{
+						VirtualNodeNumber:   1,
+						PhysicalNodeNumber:  1,
+						VirtualSocketNumber: 0, // shared socket
+						CountOfProcessors:   4,
+						CountOfMemoryBlocks: 1024,
+						MemoryBackingType:   hcsschema.MemoryBackingType_PHYSICAL,
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "physical node at boundary (63)",
+			numa: &hcsschema.Numa{
+				VirtualNodeCount: 1,
+				Settings: []hcsschema.NumaSetting{
+					{
+						VirtualNodeNumber:   0,
+						PhysicalNodeNumber:  63, // numaTopologyNodeCountMax - 1
+						VirtualSocketNumber: 0,
+						CountOfProcessors:   4,
+						CountOfMemoryBlocks: 1024,
+						MemoryBackingType:   hcsschema.MemoryBackingType_PHYSICAL,
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "virtual node at boundary (64)",
+			numa: &hcsschema.Numa{
+				VirtualNodeCount: 1,
+				Settings: []hcsschema.NumaSetting{
+					{
+						VirtualNodeNumber:   64, // numaChildNodeCountMax
+						PhysicalNodeNumber:  0,
+						VirtualSocketNumber: 0,
+						CountOfProcessors:   4,
+						CountOfMemoryBlocks: 1024,
+						MemoryBackingType:   hcsschema.MemoryBackingType_PHYSICAL,
+					},
+				},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validate(tc.numa)
+			if tc.wantErr {
+				if err == nil {
+					t.Errorf("validate() expected error containing %q, got nil", tc.errMsg)
+				} else if tc.errMsg != "" && !containsSubstring(err.Error(), tc.errMsg) {
+					t.Errorf("validate() error = %q, expected to contain %q", err.Error(), tc.errMsg)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("validate() unexpected error: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestValidateNumaForVM(t *testing.T) {
+	tests := []struct {
+		name      string
+		numa      *hcsschema.Numa
+		procCount uint32
+		memInMb   uint64
+		wantErr   bool
+		errMsg    string
+	}{
+		{
+			name: "empty settings always valid",
+			numa: &hcsschema.Numa{
+				Settings: []hcsschema.NumaSetting{},
+			},
+			procCount: 8,
+			memInMb:   2048,
+			wantErr:   false,
+		},
+		{
+			name: "nil settings always valid",
+			numa: &hcsschema.Numa{
+				Settings: nil,
+			},
+			procCount: 8,
+			memInMb:   2048,
+			wantErr:   false,
+		},
+		{
+			name: "matching processor and memory",
+			numa: &hcsschema.Numa{
+				VirtualNodeCount: 2,
+				Settings: []hcsschema.NumaSetting{
+					{
+						VirtualNodeNumber:   0,
+						PhysicalNodeNumber:  0,
+						CountOfProcessors:   4,
+						CountOfMemoryBlocks: 1024,
+					},
+					{
+						VirtualNodeNumber:   1,
+						PhysicalNodeNumber:  1,
+						CountOfProcessors:   4,
+						CountOfMemoryBlocks: 1024,
+					},
+				},
+			},
+			procCount: 8,
+			memInMb:   2048,
+			wantErr:   false,
+		},
+		{
+			name: "mismatched processor count",
+			numa: &hcsschema.Numa{
+				VirtualNodeCount: 2,
+				Settings: []hcsschema.NumaSetting{
+					{
+						VirtualNodeNumber:   0,
+						PhysicalNodeNumber:  0,
+						CountOfProcessors:   4,
+						CountOfMemoryBlocks: 1024,
+					},
+					{
+						VirtualNodeNumber:   1,
+						PhysicalNodeNumber:  1,
+						CountOfProcessors:   4,
+						CountOfMemoryBlocks: 1024,
+					},
+				},
+			},
+			procCount: 16, // doesn't match total of 8
+			memInMb:   2048,
+			wantErr:   true,
+			errMsg:    "vNUMA total processor count 8 does not match UVM processor count 16",
+		},
+		{
+			name: "mismatched memory size",
+			numa: &hcsschema.Numa{
+				VirtualNodeCount: 2,
+				Settings: []hcsschema.NumaSetting{
+					{
+						VirtualNodeNumber:   0,
+						PhysicalNodeNumber:  0,
+						CountOfProcessors:   4,
+						CountOfMemoryBlocks: 1024,
+					},
+					{
+						VirtualNodeNumber:   1,
+						PhysicalNodeNumber:  1,
+						CountOfProcessors:   4,
+						CountOfMemoryBlocks: 1024,
+					},
+				},
+			},
+			procCount: 8,
+			memInMb:   4096, // doesn't match total of 2048
+			wantErr:   true,
+			errMsg:    "vNUMA total memory 2048 does not match UVM memory 4096",
+		},
+		{
+			name: "single node matching",
+			numa: &hcsschema.Numa{
+				VirtualNodeCount: 1,
+				Settings: []hcsschema.NumaSetting{
+					{
+						VirtualNodeNumber:   0,
+						PhysicalNodeNumber:  0,
+						CountOfProcessors:   16,
+						CountOfMemoryBlocks: 8192,
+					},
+				},
+			},
+			procCount: 16,
+			memInMb:   8192,
+			wantErr:   false,
+		},
+		{
+			name: "zero processor count in NUMA (allowed)",
+			numa: &hcsschema.Numa{
+				VirtualNodeCount: 1,
+				Settings: []hcsschema.NumaSetting{
+					{
+						VirtualNodeNumber:   0,
+						PhysicalNodeNumber:  0,
+						CountOfProcessors:   0,
+						CountOfMemoryBlocks: 1024,
+					},
+				},
+			},
+			procCount: 8,
+			memInMb:   1024,
+			wantErr:   false, // zero processor count bypasses the check
+		},
+		{
+			name: "zero memory in NUMA (allowed)",
+			numa: &hcsschema.Numa{
+				VirtualNodeCount: 1,
+				Settings: []hcsschema.NumaSetting{
+					{
+						VirtualNodeNumber:   0,
+						PhysicalNodeNumber:  0,
+						CountOfProcessors:   4,
+						CountOfMemoryBlocks: 0,
+					},
+				},
+			},
+			procCount: 4,
+			memInMb:   2048,
+			wantErr:   false, // zero memory bypasses the check
+		},
+		{
+			name: "uneven distribution across nodes",
+			numa: &hcsschema.Numa{
+				VirtualNodeCount: 3,
+				Settings: []hcsschema.NumaSetting{
+					{
+						VirtualNodeNumber:   0,
+						PhysicalNodeNumber:  0,
+						CountOfProcessors:   2,
+						CountOfMemoryBlocks: 512,
+					},
+					{
+						VirtualNodeNumber:   1,
+						PhysicalNodeNumber:  1,
+						CountOfProcessors:   4,
+						CountOfMemoryBlocks: 1024,
+					},
+					{
+						VirtualNodeNumber:   2,
+						PhysicalNodeNumber:  2,
+						CountOfProcessors:   2,
+						CountOfMemoryBlocks: 512,
+					},
+				},
+			},
+			procCount: 8,
+			memInMb:   2048,
+			wantErr:   false,
+		},
+		{
+			name: "large values matching",
+			numa: &hcsschema.Numa{
+				VirtualNodeCount: 4,
+				Settings: []hcsschema.NumaSetting{
+					{
+						VirtualNodeNumber:   0,
+						CountOfProcessors:   64,
+						CountOfMemoryBlocks: 65536,
+					},
+					{
+						VirtualNodeNumber:   1,
+						CountOfProcessors:   64,
+						CountOfMemoryBlocks: 65536,
+					},
+					{
+						VirtualNodeNumber:   2,
+						CountOfProcessors:   64,
+						CountOfMemoryBlocks: 65536,
+					},
+					{
+						VirtualNodeNumber:   3,
+						CountOfProcessors:   64,
+						CountOfMemoryBlocks: 65536,
+					},
+				},
+			},
+			procCount: 256,
+			memInMb:   262144,
+			wantErr:   false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateNumaForVM(tc.numa, tc.procCount, tc.memInMb)
+			if tc.wantErr {
+				if err == nil {
+					t.Errorf("ValidateNumaForVM() expected error containing %q, got nil", tc.errMsg)
+				} else if tc.errMsg != "" && !containsSubstring(err.Error(), tc.errMsg) {
+					t.Errorf("ValidateNumaForVM() error = %q, expected to contain %q", err.Error(), tc.errMsg)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("ValidateNumaForVM() unexpected error: %v", err)
+				}
+			}
+		})
+	}
+}
+
+// containsSubstring checks if s contains substr
+func containsSubstring(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(substr) == 0 ||
+		(len(s) > 0 && len(substr) > 0 && findSubstring(s, substr)))
+}
+
+func findSubstring(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}
+
+func TestPrepareVNumaTopology(t *testing.T) {
+	// Skip tests on older Windows versions that don't support vNUMA
+	if osversion.Build() < osversion.V25H1Server {
+		t.Skipf("Skipping vNUMA tests on Windows build %d (requires %d or later)", osversion.Build(), osversion.V25H1Server)
+	}
+
+	tests := []struct {
+		name               string
+		opts               *NumaConfig
+		wantNuma           bool
+		wantNumaProcessors bool
+		wantErr            bool
+		errMsg             string
+		validateNuma       func(t *testing.T, numa *hcsschema.Numa)
+		validateProc       func(t *testing.T, proc *hcsschema.NumaProcessors)
+	}{
+		{
+			name: "nil MaxProcessorsPerNumaNode and empty NumaMappedPhysicalNodes returns nil",
+			opts: &NumaConfig{
+				MaxProcessorsPerNumaNode:   0,
+				MaxMemorySizePerNumaNode:   0,
+				PreferredPhysicalNumaNodes: nil,
+				NumaMappedPhysicalNodes:    nil,
+				NumaProcessorCounts:        nil,
+				NumaMemoryBlocksCounts:     nil,
+			},
+			wantNuma:           false,
+			wantNumaProcessors: false,
+			wantErr:            false,
+		},
+		{
+			name: "implicit topology with MaxProcessorsPerNumaNode set",
+			opts: &NumaConfig{
+				MaxProcessorsPerNumaNode:   4,
+				MaxMemorySizePerNumaNode:   1024,
+				PreferredPhysicalNumaNodes: []uint32{0, 1},
+			},
+			wantNuma:           true,
+			wantNumaProcessors: true,
+			wantErr:            false,
+			validateNuma: func(t *testing.T, numa *hcsschema.Numa) {
+				t.Helper()
+				if numa.MaxSizePerNode != 1024 {
+					t.Errorf("expected MaxSizePerNode = 1024, got %d", numa.MaxSizePerNode)
+				}
+				if len(numa.PreferredPhysicalNodes) != 2 {
+					t.Errorf("expected 2 PreferredPhysicalNodes, got %d", len(numa.PreferredPhysicalNodes))
+				}
+				if numa.PreferredPhysicalNodes[0] != 0 || numa.PreferredPhysicalNodes[1] != 1 {
+					t.Errorf("unexpected PreferredPhysicalNodes values: %v", numa.PreferredPhysicalNodes)
+				}
+			},
+			validateProc: func(t *testing.T, proc *hcsschema.NumaProcessors) {
+				t.Helper()
+				if proc.CountPerNode.Max != 4 {
+					t.Errorf("expected CountPerNode.Max = 4, got %d", proc.CountPerNode.Max)
+				}
+			},
+		},
+		{
+			name: "implicit topology without max memory size per node errors",
+			opts: &NumaConfig{
+				MaxProcessorsPerNumaNode:   4,
+				MaxMemorySizePerNumaNode:   0, // missing
+				PreferredPhysicalNumaNodes: nil,
+			},
+			wantErr: true,
+			errMsg:  "max size per node must be set",
+		},
+		{
+			name: "explicit topology with matching slices",
+			opts: &NumaConfig{
+				NumaMappedPhysicalNodes: []uint32{0, 1},
+				NumaProcessorCounts:     []uint32{4, 4},
+				NumaMemoryBlocksCounts:  []uint64{1024, 1024},
+			},
+			wantNuma:           true,
+			wantNumaProcessors: false,
+			wantErr:            false,
+			validateNuma: func(t *testing.T, numa *hcsschema.Numa) {
+				t.Helper()
+				if numa.VirtualNodeCount != 2 {
+					t.Errorf("expected VirtualNodeCount = 2, got %d", numa.VirtualNodeCount)
+				}
+				if len(numa.Settings) != 2 {
+					t.Errorf("expected 2 settings, got %d", len(numa.Settings))
+				}
+				// Verify first setting
+				if numa.Settings[0].VirtualNodeNumber != 0 {
+					t.Errorf("expected VirtualNodeNumber = 0, got %d", numa.Settings[0].VirtualNodeNumber)
+				}
+				if numa.Settings[0].PhysicalNodeNumber != 0 {
+					t.Errorf("expected PhysicalNodeNumber = 0, got %d", numa.Settings[0].PhysicalNodeNumber)
+				}
+				if numa.Settings[0].CountOfProcessors != 4 {
+					t.Errorf("expected CountOfProcessors = 4, got %d", numa.Settings[0].CountOfProcessors)
+				}
+				if numa.Settings[0].CountOfMemoryBlocks != 1024 {
+					t.Errorf("expected CountOfMemoryBlocks = 1024, got %d", numa.Settings[0].CountOfMemoryBlocks)
+				}
+				if numa.Settings[0].MemoryBackingType != hcsschema.MemoryBackingType_PHYSICAL {
+					t.Errorf("expected MemoryBackingType = PHYSICAL, got %v", numa.Settings[0].MemoryBackingType)
+				}
+			},
+		},
+		{
+			name: "explicit topology with mismatched slice lengths",
+			opts: &NumaConfig{
+				NumaMappedPhysicalNodes: []uint32{0, 1, 2},
+				NumaProcessorCounts:     []uint32{4, 4},       // mismatched
+				NumaMemoryBlocksCounts:  []uint64{1024, 1024}, // mismatched
+			},
+			wantErr: true,
+			errMsg:  "mismatch in number of physical numa nodes",
+		},
+		{
+			name: "explicit topology with invalid settings (zero memory)",
+			opts: &NumaConfig{
+				NumaMappedPhysicalNodes: []uint32{0},
+				NumaProcessorCounts:     []uint32{4},
+				NumaMemoryBlocksCounts:  []uint64{0}, // zero memory
+			},
+			wantErr: true,
+			errMsg:  "vNUMA nodes with no memory are not allowed",
+		},
+		{
+			name: "explicit topology with wildcard physical nodes",
+			opts: &NumaConfig{
+				NumaMappedPhysicalNodes: []uint32{0xFF, 0xFF},
+				NumaProcessorCounts:     []uint32{4, 4},
+				NumaMemoryBlocksCounts:  []uint64{1024, 1024},
+			},
+			wantNuma:           true,
+			wantNumaProcessors: false,
+			wantErr:            false,
+			validateNuma: func(t *testing.T, numa *hcsschema.Numa) {
+				t.Helper()
+				for i, s := range numa.Settings {
+					if s.PhysicalNodeNumber != 0xFF {
+						t.Errorf("expected PhysicalNodeNumber = 0xFF for node %d, got %d", i, s.PhysicalNodeNumber)
+					}
+				}
+			},
+		},
+		{
+			name: "partial implicit vNUMA config warns but returns nil",
+			opts: &NumaConfig{
+				MaxProcessorsPerNumaNode:   0, // not set
+				MaxMemorySizePerNumaNode:   1024,
+				PreferredPhysicalNumaNodes: []uint32{0},
+			},
+			wantNuma:           false,
+			wantNumaProcessors: false,
+			wantErr:            false,
+		},
+		{
+			name: "partial explicit vNUMA config warns but returns nil",
+			opts: &NumaConfig{
+				NumaMappedPhysicalNodes: nil, // not set
+				NumaProcessorCounts:     []uint32{4},
+				NumaMemoryBlocksCounts:  []uint64{1024},
+			},
+			wantNuma:           false,
+			wantNumaProcessors: false,
+			wantErr:            false,
+		},
+		{
+			name: "explicit topology with preferred physical nodes",
+			opts: &NumaConfig{
+				NumaMappedPhysicalNodes:    []uint32{0, 1},
+				NumaProcessorCounts:        []uint32{4, 4},
+				NumaMemoryBlocksCounts:     []uint64{1024, 1024},
+				PreferredPhysicalNumaNodes: []uint32{2, 3},
+			},
+			wantNuma:           true,
+			wantNumaProcessors: false,
+			wantErr:            false,
+			validateNuma: func(t *testing.T, numa *hcsschema.Numa) {
+				t.Helper()
+				if len(numa.PreferredPhysicalNodes) != 2 {
+					t.Errorf("expected 2 PreferredPhysicalNodes, got %d", len(numa.PreferredPhysicalNodes))
+				}
+				if numa.PreferredPhysicalNodes[0] != 2 || numa.PreferredPhysicalNodes[1] != 3 {
+					t.Errorf("unexpected PreferredPhysicalNodes: %v", numa.PreferredPhysicalNodes)
+				}
+			},
+		},
+		{
+			name: "implicit topology without preferred nodes",
+			opts: &NumaConfig{
+				MaxProcessorsPerNumaNode:   8,
+				MaxMemorySizePerNumaNode:   2048,
+				PreferredPhysicalNumaNodes: nil,
+			},
+			wantNuma:           true,
+			wantNumaProcessors: true,
+			wantErr:            false,
+			validateNuma: func(t *testing.T, numa *hcsschema.Numa) {
+				t.Helper()
+				if numa.PreferredPhysicalNodes != nil {
+					t.Errorf("expected nil PreferredPhysicalNodes, got %v", numa.PreferredPhysicalNodes)
+				}
+			},
+		},
+		{
+			name: "single node explicit topology",
+			opts: &NumaConfig{
+				NumaMappedPhysicalNodes: []uint32{0},
+				NumaProcessorCounts:     []uint32{16},
+				NumaMemoryBlocksCounts:  []uint64{8192},
+			},
+			wantNuma:           true,
+			wantNumaProcessors: false,
+			wantErr:            false,
+			validateNuma: func(t *testing.T, numa *hcsschema.Numa) {
+				t.Helper()
+				if numa.VirtualNodeCount != 1 {
+					t.Errorf("expected VirtualNodeCount = 1, got %d", numa.VirtualNodeCount)
+				}
+			},
+		},
+		{
+			name: "explicit topology virtual socket numbers are sequential",
+			opts: &NumaConfig{
+				NumaMappedPhysicalNodes: []uint32{0, 1, 2},
+				NumaProcessorCounts:     []uint32{2, 2, 2},
+				NumaMemoryBlocksCounts:  []uint64{512, 512, 512},
+			},
+			wantNuma:           true,
+			wantNumaProcessors: false,
+			wantErr:            false,
+			validateNuma: func(t *testing.T, numa *hcsschema.Numa) {
+				t.Helper()
+				for i, s := range numa.Settings {
+					if s.VirtualSocketNumber != uint32(i) {
+						t.Errorf("expected VirtualSocketNumber = %d, got %d", i, s.VirtualSocketNumber)
+					}
+				}
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			numa, numaProc, err := PrepareVNumaTopology(ctx, tc.opts)
+
+			if tc.wantErr {
+				if err == nil {
+					t.Errorf("PrepareVNumaTopology() expected error containing %q, got nil", tc.errMsg)
+				} else if tc.errMsg != "" && !containsSubstring(err.Error(), tc.errMsg) {
+					t.Errorf("PrepareVNumaTopology() error = %q, expected to contain %q", err.Error(), tc.errMsg)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("PrepareVNumaTopology() unexpected error: %v", err)
+			}
+
+			if tc.wantNuma && numa == nil {
+				t.Error("PrepareVNumaTopology() expected Numa result, got nil")
+			}
+			if !tc.wantNuma && numa != nil {
+				t.Errorf("PrepareVNumaTopology() expected nil Numa, got %v", numa)
+			}
+
+			if tc.wantNumaProcessors && numaProc == nil {
+				t.Error("PrepareVNumaTopology() expected NumaProcessors result, got nil")
+			}
+			if !tc.wantNumaProcessors && numaProc != nil {
+				t.Errorf("PrepareVNumaTopology() expected nil NumaProcessors, got %v", numaProc)
+			}
+
+			if tc.validateNuma != nil && numa != nil {
+				tc.validateNuma(t, numa)
+			}
+			if tc.validateProc != nil && numaProc != nil {
+				tc.validateProc(t, numaProc)
+			}
+		})
+	}
+}
+
+func TestPrepareVNumaTopology_OldWindowsVersion(t *testing.T) {
+	// This test only runs on older Windows versions
+	if osversion.Build() >= osversion.V25H1Server {
+		t.Skip("Skipping test for old Windows version check - running on new Windows")
+	}
+
+	ctx := context.Background()
+	opts := &NumaConfig{
+		MaxProcessorsPerNumaNode: 4,
+		MaxMemorySizePerNumaNode: 1024,
+	}
+
+	_, _, err := PrepareVNumaTopology(ctx, opts)
+	if err == nil {
+		t.Fatal("PrepareVNumaTopology() expected error on old Windows version, got nil")
+	}
+	if !containsSubstring(err.Error(), "vNUMA topology is not supported") {
+		t.Errorf("PrepareVNumaTopology() error = %q, expected to contain 'vNUMA topology is not supported'", err.Error())
+	}
+}


### PR DESCRIPTION
Presently, all the utility methods for uvm building were coupled within the `internal/uvm` package. In order to enhance reusability across shims, we want to move these into a common package. This PR accomplishes that for methods in the `CreateUVM` path.

The most significant changes include updating the annotation expansion interface, moving and consolidating VM utility functions, and updating the `containerd-shim-runhcs-v1` to use these new utilities. These changes help reduce code duplication, clarify responsibilities, and make it easier to maintain and extend the code in the future.

**Annotation processing refactor:**

* Changed the signature of `ProcessAnnotations` in `internal/oci/annotations.go` to take a map of annotations instead of a full OCI spec, and updated all call sites and tests accordingly. This clarifies the function's purpose and makes it more flexible. 
* Exported and renamed `parseHVSocketServiceTable` to `ParseHVSocketServiceTable` for consistency and updated all usages. 
* Moved default processor count, processor count normalization, memory size normalization, and vNUMA topology preparation/validation functions into a new `internal/vm/vmutils` package. Updated all usages in LCOW and WCOW VM creation code to use these shared utilities.
* Moved the logic for determining the default LCOW OS boot files path to `vmutils.DefaultLCOWOSBootFilesPath` for reuse and clarity.
* Added unit tests for all the utility methods. 
