### PR TITLE
shim: skip SandboxPlatform validation when platform is not explicitly set

### DIFF
--- a/cmd/containerd-shim-runhcs-v1/service_internal.go
+++ b/cmd/containerd-shim-runhcs-v1/service_internal.go
@@ -129,7 +129,7 @@ func (s *service) createInternal(ctx context.Context, req *task.CreateTaskReques
 		return nil, fmt.Errorf("invalid runtime sandbox isolation (%s) for hypervisor isolated OCI spec", isolation.String())
 	}
 
-	if !emptyShimOpts {
+	if !emptyShimOpts && shimOpts.GetSandboxPlatform() != "" {
 		// validate runtime platform
 		plat, err := platforms.Parse(shimOpts.GetSandboxPlatform())
 		if err != nil {


### PR DESCRIPTION
## Summary

Fixes #2619

When containerd's default `runhcs-wcow-hypervisor` runtime config sets `SandboxIsolation=1` without `SandboxPlatform`, the shim options are non-empty but `SandboxPlatform` is `""`. The platform validation added in PR #2473 unconditionally calls `platforms.Parse("")` which fails, breaking all Hyper-V isolated containers on stock containerd v2.2.1+.

## Changes

In `createInternal()`, add a guard to skip platform validation when `SandboxPlatform` is empty:

```go
-if !emptyShimOpts {
+if !emptyShimOpts && shimOpts.GetSandboxPlatform() != "" {
```

When `SandboxPlatform` is not explicitly configured, there is nothing meaningful to validate -- inferring the platform from the OCI spec and then validating the spec against the inference would be tautologically true (as noted by @helsaawy in review).

## Root Cause

containerd's [`config_windows.go`](https://github.com/containerd/containerd/blob/v2.2.1/internal/cri/config/config_windows.go#L63-L80) defaults:

```go
"runhcs-wcow-hypervisor": {
    Options: map[string]interface{}{
        "SandboxIsolation": 1,         // set
        // SandboxPlatform is NOT set  // missing!
    },
},
```

This makes `emptyShimOpts = false` (options are non-empty due to `SandboxIsolation`), but `SandboxPlatform` is `""`, causing the validation to fail.

## Testing

- Tested on Windows Server 2022 and 2025 CAPZ clusters with containerd v2.2.1
- Before fix: `invalid runtime sandbox platform: ""` error on every Hyper-V pod
- After fix: Hyper-V pods create and run successfully
- Full Kubernetes e2e `[Feature:WindowsHyperVContainers]` test suite passes with the patched shim
