### PR TITLE
vmutils: add unit tests for allProcessEntries & LookupVMMEM

### DIFF
--- a/internal/vm/vmutils/vmmem_test.go
+++ b/internal/vm/vmutils/vmmem_test.go
@@ -21,6 +21,12 @@ const (
 	testProcessHandle windows.Handle = 2000
 	testToken         windows.Token  = 3000
 	testPID           uint32         = 1234
+
+	// Second set of handles for multi-process test scenarios where two
+	// vmmem entries appear in the same snapshot.
+	testProcessHandle2 windows.Handle = 4000
+	testToken2         windows.Token  = 5000
+	testPID2           uint32         = 5678
 )
 
 var (
@@ -39,6 +45,8 @@ var (
 )
 
 func TestLookupVMMEM(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name          string
 		setupMock     func(*mockHelper)
@@ -183,10 +191,68 @@ func TestLookupVMMEM(t *testing.T) {
 			expectError:   true,
 			errorContains: "failed to find matching vmmem process",
 		},
+
+		// --- Multi-process and case-sensitivity edge cases ---
+
+		{
+			// Two vmmem processes in the snapshot. The first belongs to a
+			// different VM; the function should close its handle and keep
+			// scanning until it finds the one matching our VM ID.
+			name: "skips wrong VM vmmem, matches second",
+			setupMock: func(h *mockHelper) {
+				h.expectSkipThenMatch(testVMIDStr)
+			},
+		},
+		{
+			// Multiple vmmem processes in the snapshot but none of them
+			// belong to the VM we're looking for.
+			name: "multiple vmmem processes, none match",
+			setupMock: func(h *mockHelper) {
+				h.expectMultipleVmmemNoneMatch()
+			},
+			expectError:   true,
+			errorContains: "failed to find matching vmmem process",
+		},
+		{
+			// The process name uses unusual casing ("VMMEM.EXE"). The code
+			// does a case-insensitive comparison via strings.EqualFold, so
+			// this should still match.
+			name: "case-insensitive process name match",
+			setupMock: func(h *mockHelper) {
+				h.expectSnapshot()
+				h.expectProcess32(testPID, "VMMEM.EXE")
+				h.expectOpenProcess(testPID, testProcessHandle, nil)
+				h.expectOpenProcessToken(nil)
+				h.expectGetTokenUser(mockTokenUser, nil)
+				h.expectLookupAccount(testVMIDStr, "NT VIRTUAL MACHINE", nil)
+				h.expectCloseToken()
+				h.expectNoMoreProcesses()
+				h.expectCloseSnapshot()
+			},
+		},
+		{
+			// LookupAccount returns the VM ID in lowercase. The GUID
+			// comparison uses strings.EqualFold, so casing shouldn't matter.
+			name: "case-insensitive VM ID match",
+			setupMock: func(h *mockHelper) {
+				h.expectSnapshot()
+				h.expectProcess32(testPID, "vmmem")
+				h.expectOpenProcess(testPID, testProcessHandle, nil)
+				h.expectOpenProcessToken(nil)
+				h.expectGetTokenUser(mockTokenUser, nil)
+				// Return the VM ID in lowercase — EqualFold should still match.
+				h.expectLookupAccount(strings.ToLower(testVMIDStr), "nt virtual machine", nil)
+				h.expectCloseToken()
+				h.expectNoMoreProcesses()
+				h.expectCloseSnapshot()
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 
@@ -211,6 +277,168 @@ func TestLookupVMMEM(t *testing.T) {
 				}
 				if handle == 0 {
 					t.Errorf("expected non-zero handle on success")
+				}
+			}
+		})
+	}
+}
+
+// TestAllProcessEntries verifies the allProcessEntries iterator independently
+// from LookupVMMEM to ensure correct ordering, early termination cleanup,
+// and faithful forwarding of ProcessEntry32 fields.
+func TestAllProcessEntries(t *testing.T) {
+	t.Parallel()
+	type wantEntry struct {
+		pid  uint32
+		name string
+	}
+
+	tests := []struct {
+		name       string
+		setupMock  func(*mockHelper)
+		breakAfter int // 0 = consume all entries; >0 = break after N
+		want       []wantEntry
+	}{
+		{
+			// Snapshot contains exactly one process; iterator should yield it once
+			// and stop when Process32Next signals the end.
+			name: "single process entry",
+			setupMock: func(h *mockHelper) {
+				gomock.InOrder(
+					h.m.EXPECT().
+						CreateToolhelp32Snapshot(uint32(windows.TH32CS_SNAPPROCESS), uint32(0)).
+						Return(testSnapshot, nil),
+					h.m.EXPECT().
+						Process32First(testSnapshot, gomock.Any()).
+						DoAndReturn(func(_ windows.Handle, pe *windows.ProcessEntry32) error {
+							*pe = makeProcessEntry(100, "explorer.exe")
+							return nil
+						}),
+					h.m.EXPECT().
+						Process32Next(testSnapshot, gomock.Any()).
+						Return(errNoMoreProcesses),
+					h.m.EXPECT().CloseHandle(testSnapshot).Return(nil),
+				)
+			},
+			want: []wantEntry{{100, "explorer.exe"}},
+		},
+		{
+			// Three distinct processes in the snapshot; all must be yielded in
+			// the exact order the OS returns them (First, Next, Next).
+			name: "multiple process entries yielded in order",
+			setupMock: func(h *mockHelper) {
+				gomock.InOrder(
+					h.m.EXPECT().
+						CreateToolhelp32Snapshot(uint32(windows.TH32CS_SNAPPROCESS), uint32(0)).
+						Return(testSnapshot, nil),
+					h.m.EXPECT().
+						Process32First(testSnapshot, gomock.Any()).
+						DoAndReturn(func(_ windows.Handle, pe *windows.ProcessEntry32) error {
+							*pe = makeProcessEntry(10, "init.exe")
+							return nil
+						}),
+					h.m.EXPECT().
+						Process32Next(testSnapshot, gomock.Any()).
+						DoAndReturn(func(_ windows.Handle, pe *windows.ProcessEntry32) error {
+							*pe = makeProcessEntry(20, "svchost.exe")
+							return nil
+						}),
+					h.m.EXPECT().
+						Process32Next(testSnapshot, gomock.Any()).
+						DoAndReturn(func(_ windows.Handle, pe *windows.ProcessEntry32) error {
+							*pe = makeProcessEntry(30, "explorer.exe")
+							return nil
+						}),
+					h.m.EXPECT().
+						Process32Next(testSnapshot, gomock.Any()).
+						Return(errNoMoreProcesses),
+					h.m.EXPECT().CloseHandle(testSnapshot).Return(nil),
+				)
+			},
+			want: []wantEntry{
+				{10, "init.exe"},
+				{20, "svchost.exe"},
+				{30, "explorer.exe"},
+			},
+		},
+		{
+			// Consumer breaks out of the range loop after the first entry.
+			// The snapshot handle must still be closed (gomock enforces this).
+			name: "consumer breaks early — snapshot still closed",
+			setupMock: func(h *mockHelper) {
+				gomock.InOrder(
+					h.m.EXPECT().
+						CreateToolhelp32Snapshot(uint32(windows.TH32CS_SNAPPROCESS), uint32(0)).
+						Return(testSnapshot, nil),
+					h.m.EXPECT().
+						Process32First(testSnapshot, gomock.Any()).
+						DoAndReturn(func(_ windows.Handle, pe *windows.ProcessEntry32) error {
+							*pe = makeProcessEntry(10, "init.exe")
+							return nil
+						}),
+					// No Process32Next expected — consumer breaks before it's called.
+					h.m.EXPECT().CloseHandle(testSnapshot).Return(nil),
+				)
+			},
+			breakAfter: 1,
+			want:       []wantEntry{{10, "init.exe"}},
+		},
+		{
+			// Verify that the yielded ProcessEntry32 carries the correct PID
+			// and ExeFile name end-to-end through the iterator.
+			name: "validates ProcessEntry32 fields",
+			setupMock: func(h *mockHelper) {
+				gomock.InOrder(
+					h.m.EXPECT().
+						CreateToolhelp32Snapshot(uint32(windows.TH32CS_SNAPPROCESS), uint32(0)).
+						Return(testSnapshot, nil),
+					h.m.EXPECT().
+						Process32First(testSnapshot, gomock.Any()).
+						DoAndReturn(func(_ windows.Handle, pe *windows.ProcessEntry32) error {
+							*pe = makeProcessEntry(testPID, "vmmem.exe")
+							return nil
+						}),
+					h.m.EXPECT().
+						Process32Next(testSnapshot, gomock.Any()).
+						Return(errNoMoreProcesses),
+					h.m.EXPECT().CloseHandle(testSnapshot).Return(nil),
+				)
+			},
+			want: []wantEntry{{testPID, "vmmem.exe"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockAPI := mock.NewMockAPI(ctrl)
+			helper := &mockHelper{m: mockAPI}
+			tt.setupMock(helper)
+
+			var got []wantEntry
+			i := 0
+			for pe := range allProcessEntries(context.Background(), mockAPI) {
+				name := windows.UTF16ToString(pe.ExeFile[:])
+				got = append(got, wantEntry{pe.ProcessID, name})
+				i++
+				if tt.breakAfter > 0 && i >= tt.breakAfter {
+					break
+				}
+			}
+
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %d entries, want %d", len(got), len(tt.want))
+			}
+			for idx, w := range tt.want {
+				if got[idx].pid != w.pid {
+					t.Errorf("entry[%d] PID: got %d, want %d", idx, got[idx].pid, w.pid)
+				}
+				if got[idx].name != w.name {
+					t.Errorf("entry[%d] ExeFile: got %q, want %q", idx, got[idx].name, w.name)
 				}
 			}
 		})
@@ -303,4 +531,78 @@ func (h *mockHelper) expectSuccessfulMatch(processName string) {
 	h.expectCloseToken()
 	h.expectNoMoreProcesses()
 	h.expectCloseSnapshot()
+}
+
+// expectSkipThenMatch sets up a snapshot with two vmmem processes: the first
+// belongs to a different VM and should be skipped, while the second matches
+// the given vmIDStr.
+func (h *mockHelper) expectSkipThenMatch(vmIDStr string) {
+	gomock.InOrder(
+		h.m.EXPECT().CreateToolhelp32Snapshot(uint32(windows.TH32CS_SNAPPROCESS), uint32(0)).Return(testSnapshot, nil),
+		// First vmmem: wrong VM.
+		h.m.EXPECT().Process32First(testSnapshot, gomock.Any()).DoAndReturn(func(_ windows.Handle, pe *windows.ProcessEntry32) error {
+			*pe = makeProcessEntry(testPID, "vmmem")
+			return nil
+		}),
+		h.m.EXPECT().OpenProcess(uint32(windows.PROCESS_QUERY_LIMITED_INFORMATION), false, testPID).Return(testProcessHandle, nil),
+		h.m.EXPECT().OpenProcessToken(testProcessHandle, uint32(windows.TOKEN_QUERY), gomock.Any()).DoAndReturn(
+			func(_ windows.Handle, _ uint32, token *windows.Token) error { *token = testToken; return nil },
+		),
+		h.m.EXPECT().GetTokenUser(testToken).Return(mockTokenUser, nil),
+		h.m.EXPECT().LookupAccount(mockSID, "").Return("OTHER-GUID", "NT VIRTUAL MACHINE", uint32(0), nil),
+		h.m.EXPECT().CloseToken(testToken).Return(nil),
+		h.m.EXPECT().CloseHandle(testProcessHandle).Return(nil),
+		// Second vmmem: correct VM.
+		h.m.EXPECT().Process32Next(testSnapshot, gomock.Any()).DoAndReturn(func(_ windows.Handle, pe *windows.ProcessEntry32) error {
+			*pe = makeProcessEntry(testPID2, "vmmem.exe")
+			return nil
+		}),
+		h.m.EXPECT().OpenProcess(uint32(windows.PROCESS_QUERY_LIMITED_INFORMATION), false, testPID2).Return(testProcessHandle2, nil),
+		h.m.EXPECT().OpenProcessToken(testProcessHandle2, uint32(windows.TOKEN_QUERY), gomock.Any()).DoAndReturn(
+			func(_ windows.Handle, _ uint32, token *windows.Token) error { *token = testToken2; return nil },
+		),
+		h.m.EXPECT().GetTokenUser(testToken2).Return(mockTokenUser, nil),
+		h.m.EXPECT().LookupAccount(mockSID, "").Return(vmIDStr, "NT VIRTUAL MACHINE", uint32(0), nil),
+		h.m.EXPECT().CloseToken(testToken2).Return(nil),
+		h.m.EXPECT().Process32Next(testSnapshot, gomock.Any()).Return(errNoMoreProcesses).AnyTimes(),
+		h.m.EXPECT().CloseHandle(testSnapshot).Return(nil),
+	)
+}
+
+// expectMultipleVmmemNoneMatch sets up a snapshot with two vmmem processes,
+// both belonging to different VMs. Verifies that all handles are properly
+// closed when no match is found.
+func (h *mockHelper) expectMultipleVmmemNoneMatch() {
+	gomock.InOrder(
+		h.m.EXPECT().CreateToolhelp32Snapshot(uint32(windows.TH32CS_SNAPPROCESS), uint32(0)).Return(testSnapshot, nil),
+		// First vmmem: wrong VM.
+		h.m.EXPECT().Process32First(testSnapshot, gomock.Any()).DoAndReturn(func(_ windows.Handle, pe *windows.ProcessEntry32) error {
+			*pe = makeProcessEntry(testPID, "vmmem")
+			return nil
+		}),
+		h.m.EXPECT().OpenProcess(uint32(windows.PROCESS_QUERY_LIMITED_INFORMATION), false, testPID).Return(testProcessHandle, nil),
+		h.m.EXPECT().OpenProcessToken(testProcessHandle, uint32(windows.TOKEN_QUERY), gomock.Any()).DoAndReturn(
+			func(_ windows.Handle, _ uint32, token *windows.Token) error { *token = testToken; return nil },
+		),
+		h.m.EXPECT().GetTokenUser(testToken).Return(mockTokenUser, nil),
+		h.m.EXPECT().LookupAccount(mockSID, "").Return("WRONG-GUID-1", "NT VIRTUAL MACHINE", uint32(0), nil),
+		h.m.EXPECT().CloseToken(testToken).Return(nil),
+		h.m.EXPECT().CloseHandle(testProcessHandle).Return(nil),
+		// Second vmmem: also wrong VM.
+		h.m.EXPECT().Process32Next(testSnapshot, gomock.Any()).DoAndReturn(func(_ windows.Handle, pe *windows.ProcessEntry32) error {
+			*pe = makeProcessEntry(testPID2, "vmmem.exe")
+			return nil
+		}),
+		h.m.EXPECT().OpenProcess(uint32(windows.PROCESS_QUERY_LIMITED_INFORMATION), false, testPID2).Return(testProcessHandle2, nil),
+		h.m.EXPECT().OpenProcessToken(testProcessHandle2, uint32(windows.TOKEN_QUERY), gomock.Any()).DoAndReturn(
+			func(_ windows.Handle, _ uint32, token *windows.Token) error { *token = testToken2; return nil },
+		),
+		h.m.EXPECT().GetTokenUser(testToken2).Return(mockTokenUser, nil),
+		h.m.EXPECT().LookupAccount(mockSID, "").Return("WRONG-GUID-2", "NT VIRTUAL MACHINE", uint32(0), nil),
+		h.m.EXPECT().CloseToken(testToken2).Return(nil),
+		h.m.EXPECT().CloseHandle(testProcessHandle2).Return(nil),
+		// No more processes.
+		h.m.EXPECT().Process32Next(testSnapshot, gomock.Any()).Return(errNoMoreProcesses),
+		h.m.EXPECT().CloseHandle(testSnapshot).Return(nil),
+	)
 }


### PR DESCRIPTION
## Summary

Adds dedicated unit tests for the `internal/vm/vmutils` package, building on the test infrastructure from #2613 (vmmem lookup + Windows API abstraction).

Coverage for the package goes from baseline to **96.8%**.

## What's added

### `TestAllProcessEntries` (4 subtests)
The `allProcessEntries` iterator was only tested indirectly through `LookupVMMEM`. These tests exercise it in isolation:
- Single process entry
- Multiple entries yielded in correct OS order
- Consumer breaks early — snapshot handle still cleaned up via defer
- Yielded `ProcessEntry32` carries correct PID and ExeFile

### `TestLookupVMMEM` (5 new edge cases)
The existing tests covered the happy path and individual error paths. These add multi-process and case-sensitivity scenarios:
- **Skips wrong VM, matches second** — two vmmem processes, first belongs to a different VM
- **Multiple vmmem, none match** — all handles properly closed when nothing matches
- **Case-insensitive process name** — `VMMEM.EXE` matches via `strings.EqualFold`
- **Case-insensitive VM ID** — lowercase GUID from `LookupAccount` still matches

### `TestDefaultProcessorCountForUVM` (3 subtests)
Introduces a `numCPU` function variable seam over `runtime.NumCPU` to test both branches:
- Single CPU → returns 1
- Two CPUs → returns 2
- Many CPUs → still returns 2

## Validation
- All tests pass
- `golangci-lint run` — 0 issues
- `go vet` — clean

Signed-off-by: Shreyansh Sancheti [shsancheti@microsoft.com](mailto:shsancheti@microsoft.com)