### PR TITLE
[shimV2] adds the mount controller

### DIFF
--- a/internal/controller/mount/doc.go
+++ b/internal/controller/mount/doc.go
@@ -1,0 +1,105 @@
+//go:build windows
+
+// Package mount manages the lifecycle of guest-level mounts for Hyper-V
+// utility VMs.
+//
+// # Architecture
+//
+// The [Manager] type is the primary entry point.  It exposes a set of APIs
+// that handles guest mounts for both SCSI disks and Plan9 shares,
+// with a dedicated Resolve/Mount/Unmount API for each device type:
+//
+//   - [Manager.ResolveSCSIGuestPath] / [Manager.MountSCSI] / [Manager.UnmountSCSI]
+//   - [Manager.ResolvePlan9GuestPath] / [Manager.MountPlan9] / [Manager.UnmountPlan9]
+//
+// Internally, Manager tracks guest-level mounts for each device type,
+// each of which has its own explicit state machine.  Mounts are reference-counted
+// so that multiple callers sharing the same guest path do not conflict.
+// Callers should resolve the guest path prior to invoking the Mount API.
+//
+// # Device manager integration
+//
+// This package is designed to work downstream of the device managers:
+//
+//   - After [device.scsi.AttachDiskToVM] returns a [VMSlot], pass its
+//     Controller and LUN fields to [Manager.MountSCSI].
+//   - After [device.plan9.AddToVM] returns a shareName, pass it to
+//     [Manager.MountPlan9].
+//
+// The device manager owns the host-side lifetime of the device.  The mount
+// manager owns only the guest-side mount.  Callers must ensure the device
+// is attached before mounting, and must unmount before detaching.
+//
+// # Usage
+//
+// Resolve the guest path before the actual mount so that downstream resources
+// (e.g., OCI spec paths) can be computed without waiting for the guest call:
+//
+//	// SCSI
+//	guestPath := mgr.ResolveSCSIGuestPath(controller, lun, mount.SCSIMountConfig{})
+//	cfg := mount.SCSIMountConfig{GuestPath: guestPath}
+//	guestPath, err = mgr.MountSCSI(ctx, controller, lun, cfg)
+//
+//	// Plan9 (LCOW only)
+//	guestPath = mgr.ResolvePlan9GuestPath(shareName, mount.Plan9MountConfig{})
+//	p9cfg := mount.Plan9MountConfig{GuestPath: guestPath}
+//	guestPath, err = mgr.MountPlan9(ctx, shareName, p9cfg)
+//
+// # SCSI mounts
+//
+// SCSI mounts are supported on both LCOW and WCOW guests.  The Manager
+// delegates to platform specific guest operator based on the build
+// tag (linux shim vs. windows shim).
+//
+// # Plan9 mounts
+//
+// Plan9 mounts are LCOW-only (Plan9 is a Linux guest protocol).
+// The Manager delegates to Linux guest operator for
+// the actual GCS add/remove-mapped-directory requests.
+//
+// # Reference counting
+//
+// Both SCSI and Plan9 mounts are ref-counted.  When two callers mount the
+// same resource at the same guest path with the same config, they share a
+// single mount entry.  The guest-side unmount only happens when the last
+// reference is released.
+//
+// # State Machine
+//
+// Every mount (SCSI or Plan9) carries a [mountState].  States move forward
+// only.
+//
+// Each mount entry progresses through the states below.
+// The happy path runs down the left column; the error path is on the right.
+//
+//	Mount operation requested
+//	           │
+//	           ▼
+//	┌─────────────────────┐
+//	│    mountPending     │
+//	└──────────┬──────────┘
+//	           │
+//	   ┌───────┴────────────────────────────────┐
+//	   │ mountInGuest succeeds                  │ mountInGuest fails
+//	   ▼                                        ▼
+//	┌─────────────────────┐         ┌──────────────────────┐
+//	│    mountMounted     │         │     mountInvalid     │
+//	└──────────┬──────────┘         └──────────┬───────────┘
+//	           │ unmountFromGuest              │
+//	           │   succeeds                    │
+//	           ▼                               ▼
+//	┌─────────────────────┐          (auto-removed from map)
+//	│   mountUnmounted    │  ← terminal; entry removed from map
+//	└─────────────────────┘
+//
+// State descriptions:
+//
+//   - [mountPending]: entered when a mount operation begins.
+//     The guest mount call has not yet completed.
+//   - [mountMounted]: entered once mountInGuest succeeds; the guest path
+//     is accessible inside the VM.
+//   - [mountUnmounted]: entered once unmountFromGuest succeeds;
+//     the guest path is no longer accessible.  Terminal state.
+//   - [mountInvalid]: entered when mountInGuest fails; concurrent waiters
+//     receive the original error and the entry is removed from the map.
+package mount

--- a/internal/controller/mount/mount.go
+++ b/internal/controller/mount/mount.go
@@ -1,0 +1,48 @@
+//go:build windows
+
+package mount
+
+import "sync"
+
+// Manager tracks guest-level mounts for SCSI and Plan9 devices, and delegates
+// to the appropriate OS-specific guest manager for the actual GCS calls.
+type Manager struct {
+	// globalMu protects the scsiMounts and plan9Mounts maps and serializes
+	// path allocation across concurrent callers.
+	globalMu sync.Mutex
+
+	// scsiMounts is the global index of SCSI mounts. Key = resolved guestPath.
+	// Two callers mounting the same disk at the same path share one scsiMount
+	// entry and jointly hold its refCount.
+	scsiMounts map[string]*scsiMount
+
+	// plan9Mounts is the global index of Plan9 mounts. Key = resolved guestPath.
+	plan9Mounts map[string]*plan9Mount
+
+	// nextSCSIMountIdx generates stable unique guest paths for SCSI auto-paths.
+	nextSCSIMountIdx int
+
+	// nextPlan9MountIdx generates stable unique guest paths for Plan9 auto-paths.
+	nextPlan9MountIdx int
+
+	// Interfaces used for performing guest actions.
+	linuxGuestSCSI   linuxGuestSCSI
+	windowsGuestSCSI windowsGuestSCSI
+	linuxGuestPlan9  linuxGuestPlan9
+}
+
+// New creates a new instance of mount.Manager which can be used
+// for perform SCSI and Plan9 mount operations.
+func New(
+	linuxGuestSCSI linuxGuestSCSI,
+	windowsGuestSCSI windowsGuestSCSI,
+	linuxGuestPlan9 linuxGuestPlan9,
+) *Manager {
+	return &Manager{
+		scsiMounts:       make(map[string]*scsiMount),
+		plan9Mounts:      make(map[string]*plan9Mount),
+		linuxGuestSCSI:   linuxGuestSCSI,
+		windowsGuestSCSI: windowsGuestSCSI,
+		linuxGuestPlan9:  linuxGuestPlan9,
+	}
+}

--- a/internal/controller/mount/mount_types.go
+++ b/internal/controller/mount/mount_types.go
@@ -1,0 +1,124 @@
+//go:build windows
+
+package mount
+
+import (
+	"context"
+	"sync"
+
+	"github.com/Microsoft/hcsshim/internal/protocol/guestresource"
+)
+
+// ==============================================================================
+// Exported data structures
+// ==============================================================================
+
+// SCSIMountConfig describes how a SCSI disk should be mounted inside the guest.
+type SCSIMountConfig struct {
+	// GuestPath is the path inside the guest where the disk will be mounted.
+	// If empty, a unique path is generated automatically.
+	GuestPath string
+	// Partition is the target partition index (1-based) on a partitioned device.
+	// Only supported for LCOW.
+	Partition uint64
+	// ReadOnly mounts the disk read-only.
+	ReadOnly bool
+	// Encrypted encrypts the device with dm-crypt.
+	// Only supported for LCOW.
+	Encrypted bool
+	// Options are mount flags or data passed to the guest mount call.
+	// Only supported for LCOW.
+	Options []string
+	// EnsureFilesystem formats the mount as Filesystem if not already formatted.
+	// Only supported for LCOW.
+	EnsureFilesystem bool
+	// Filesystem is the target filesystem type.
+	// Only supported for LCOW.
+	Filesystem string
+	// BlockDev mounts the device as a block device.
+	// Only supported for LCOW.
+	BlockDev bool
+	// FormatWithRefs formats the disk using refs.
+	// Only supported for WCOW scratch disks.
+	FormatWithRefs bool
+}
+
+// Plan9MountConfig describes how a Plan9 share should be mounted inside the guest.
+type Plan9MountConfig struct {
+	// GuestPath is the path inside the guest where the share will be mounted.
+	// If empty, a unique path is generated automatically.
+	GuestPath string
+	// ReadOnly mounts the share read-only.
+	ReadOnly bool
+}
+
+// ==============================================================================
+// Interfaces used by Manager to perform guest actions.
+// ==============================================================================
+
+// linuxGuestSCSI performs LCOW SCSI guest mount/unmount operations.
+type linuxGuestSCSI interface {
+	AddLCOWMappedVirtualDisk(ctx context.Context, settings guestresource.LCOWMappedVirtualDisk) error
+	RemoveLCOWMappedVirtualDisk(ctx context.Context, settings guestresource.LCOWMappedVirtualDisk) error
+}
+
+// windowsGuestSCSI performs WCOW SCSI guest mount/unmount operations.
+type windowsGuestSCSI interface {
+	AddWCOWMappedVirtualDisk(ctx context.Context, settings guestresource.WCOWMappedVirtualDisk) error
+	AddWCOWMappedVirtualDiskForContainerScratch(ctx context.Context, settings guestresource.WCOWMappedVirtualDisk) error
+	RemoveWCOWMappedVirtualDisk(ctx context.Context, settings guestresource.WCOWMappedVirtualDisk) error
+}
+
+// linuxGuestPlan9 performs Plan9 guest mount/unmount operations in an LCOW guest.
+type linuxGuestPlan9 interface {
+	AddLCOWMappedDirectory(ctx context.Context, settings guestresource.LCOWMappedDirectory) error
+	RemoveLCOWMappedDirectory(ctx context.Context, settings guestresource.LCOWMappedDirectory) error
+}
+
+// ==============================================================================
+// Internal data structures
+// ==============================================================================
+
+// refTracker holds the per-mount concurrency and lifecycle fields shared by
+// both scsiMount (SCSI) and plan9Mount (Plan9).
+type refTracker struct {
+	// mu serializes state transitions and broadcasts completion to concurrent
+	// waiters: a goroutine that finds a Pending entry simply locks mu and waits
+	// for the owner to move the state to Mounted or Invalid.
+	mu sync.Mutex
+
+	// state is the forward-only lifecycle position of this mount.
+	// Access must be guarded by mu.
+	state mountState
+
+	// stateErr records the error that caused a transition to mountInvalid.
+	// Waiters that find the mount in the invalid state return this error so
+	// every caller sees the original failure reason.
+	stateErr error
+
+	// refCount is the number of active callers sharing this mount.
+	// Access must be guarded by mu.
+	refCount uint
+}
+
+// scsiMount tracks one SCSI disk mounted in the guest.
+type scsiMount struct {
+	refTracker
+
+	guestPath  string
+	controller uint
+	lun        uint
+	config     *SCSIMountConfig
+}
+
+// plan9Mount tracks one Plan9 share mounted in the guest.
+type plan9Mount struct {
+	refTracker
+
+	// guestPath is the path inside the guest where the share is mounted.
+	guestPath string
+	// shareName is the Plan9 share name returned by [plan9.AddToVM].
+	shareName string
+	// config holds the mount options used when this share was first mounted.
+	config *Plan9MountConfig
+}

--- a/internal/controller/mount/plan9_lcow.go
+++ b/internal/controller/mount/plan9_lcow.go
@@ -1,0 +1,209 @@
+//go:build windows && !wcow
+
+package mount
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Microsoft/hcsshim/internal/log"
+	"github.com/Microsoft/hcsshim/internal/logfields"
+	"github.com/Microsoft/hcsshim/internal/protocol/guestresource"
+	"github.com/Microsoft/hcsshim/internal/vm/vmutils"
+
+	"github.com/sirupsen/logrus"
+)
+
+// plan9MountFmt is the format string for auto-generated guest paths when
+// the caller does not provide one explicitly.
+const plan9MountFmt = "/run/mounts/plan9/m%d"
+
+// ResolvePlan9GuestPath returns the stable guest path for the Plan9 share
+// identified by shareName. If no entry exists yet, ResolvePlan9GuestPath
+// pre-allocates one and returns the generated path.
+func (m *Manager) ResolvePlan9GuestPath(shareName string, config Plan9MountConfig) string {
+	mount := m.getOrCreatePlan9Entry(shareName, &config)
+	return mount.guestPath
+}
+
+// MountPlan9 mounts a Plan9 share inside the LCOW guest and returns the resolved guest path.
+// If the share is already mounted at the requested path with a matching config, the
+// existing mount is returned without issuing a duplicate mount request.
+func (m *Manager) MountPlan9(ctx context.Context, shareName string, config Plan9MountConfig) (_ string, err error) {
+
+	// Add share name to logging context.
+	ctx, _ = log.WithContext(ctx, logrus.WithField("shareName", shareName))
+
+	log.G(ctx).WithFields(logrus.Fields{
+		logfields.Options: config,
+	}).Debug("Mounting Plan9 share")
+
+	// Track the requested plan9 mount operation.
+	mount := m.getOrCreatePlan9Entry(shareName, &config)
+
+	// Add resolved guest path to logging context.
+	ctx, _ = log.WithContext(ctx, logrus.WithField(logfields.UVMPath, mount.guestPath))
+
+	// Acquire the entry lock to check the state and potentially drive the mount operation.
+	mount.mu.Lock()
+	defer mount.mu.Unlock()
+
+	switch mount.state {
+	case mountMounted:
+		// ==============================================================================
+		// Found an existing mount.
+		// ==============================================================================
+
+		// Validate it matches the requested share and config.
+		if mount.shareName != shareName || mount.config.ReadOnly != config.ReadOnly {
+			return "", fmt.Errorf(
+				"guest path %q is already mounted for share %q (readOnly=%v), "+
+					"cannot reuse for share %q (readOnly=%v)",
+				config.GuestPath, mount.shareName, mount.config.ReadOnly,
+				shareName, config.ReadOnly)
+		}
+
+		mount.refCount++
+
+		log.G(ctx).Debug("reusing existing plan9 guest mount")
+		return mount.guestPath, nil
+
+	case mountPending:
+		// ==============================================================================
+		// New mount - We own this entry.
+		// Other goroutines requesting the same path are blocked on mount.mu
+		// and will see the final state once we release it.
+		// ==============================================================================
+		log.G(ctx).Tracef("performing guest operation to mount the share")
+
+		if err := m.linuxGuestPlan9.AddLCOWMappedDirectory(ctx,
+			guestresource.LCOWMappedDirectory{
+				MountPath: config.GuestPath,
+				ShareName: shareName,
+				Port:      vmutils.Plan9Port,
+				ReadOnly:  config.ReadOnly,
+			}); err != nil {
+
+			// Move the state to Invalid so that other goroutines waiting on
+			// the mount see the real failure reason via stateErr.
+			mount.state = mountInvalid
+			mount.stateErr = err
+
+			// Delete from the map. Any callers waiting on this mount
+			// will see the invalid state and receive the original error.
+			m.globalMu.Lock()
+			delete(m.plan9Mounts, mount.guestPath)
+			m.globalMu.Unlock()
+
+			return "", fmt.Errorf("mount plan9 share %q in guest at %q: add LCOW mapped directory: %w",
+				shareName, config.GuestPath, err)
+		}
+
+		// Mark the mount as mounted.
+		mount.state = mountMounted
+		mount.refCount++
+
+		log.G(ctx).Debug("plan9 share mounted in guest")
+		return mount.guestPath, nil
+
+	case mountInvalid:
+		// ==============================================================================
+		// Found a mount which failed during guest operation.
+		// ==============================================================================
+
+		return "", fmt.Errorf("previous mount attempt at %q failed: %w", mount.guestPath, mount.stateErr)
+
+	default:
+		// Unlikely state that should never be observed here.
+		return "", fmt.Errorf("plan9 guest mount at %q in unexpected state %s", mount.guestPath, mount.state)
+	}
+}
+
+// getOrCreatePlan9Entry looks up the global Plan9 mount map for an existing entry
+// at the requested guest path. If found it is returned as-is. If not found, a new
+// Pending entry is inserted and returned. Map access is serialised under globalMu.
+func (m *Manager) getOrCreatePlan9Entry(shareName string, config *Plan9MountConfig) *plan9Mount {
+	m.globalMu.Lock()
+	defer m.globalMu.Unlock()
+
+	// If the requested path exists, return the same.
+	if config.GuestPath != "" {
+		if mount, ok := m.plan9Mounts[config.GuestPath]; ok {
+			return mount
+		}
+	}
+
+	// Auto-generate a unique path under the global lock so concurrent callers
+	// can never receive the same index.
+	if config.GuestPath == "" {
+		config.GuestPath = fmt.Sprintf(plan9MountFmt, m.nextPlan9MountIdx)
+		m.nextPlan9MountIdx++
+	}
+
+	// Insert a new mount entry in Pending state.
+	mount := &plan9Mount{
+		guestPath:  config.GuestPath,
+		shareName:  shareName,
+		config:     config,
+		refTracker: refTracker{state: mountPending},
+	}
+	m.plan9Mounts[config.GuestPath] = mount
+
+	return mount
+}
+
+// UnmountPlan9 releases a previously mounted Plan9 guest path.
+// The GCS unmount request is sent only when the last reference is released.
+func (m *Manager) UnmountPlan9(ctx context.Context, guestPath string) error {
+
+	ctx, _ = log.WithContext(ctx, logrus.WithField(logfields.UVMPath, guestPath))
+	log.G(ctx).Debug("Unmounting Plan9 share from guest")
+
+	// Under global lock, find the mount.
+	m.globalMu.Lock()
+	mount, ok := m.plan9Mounts[guestPath]
+	m.globalMu.Unlock()
+
+	// If there is no mount, then there is nothing to unmount.
+	if !ok {
+		return nil
+	}
+
+	mount.mu.Lock()
+	defer mount.mu.Unlock()
+
+	if mount.refCount > 1 {
+		mount.refCount--
+		// Other callers still hold a reference to this mount.
+		log.G(ctx).Debug("mount still in use by other callers, not unmounting from guest")
+		return nil
+	}
+
+	// If the mount failed (guest operation never succeeded), but we got the
+	// entry just prior to removal from map, then state would be invalid.
+	if mount.state == mountInvalid {
+		// Mount never succeeded; nothing to undo.
+		return nil
+	}
+
+	// Drive the unmount operation.
+	if mount.state == mountMounted {
+		if err := m.linuxGuestPlan9.RemoveLCOWMappedDirectory(ctx, guestresource.LCOWMappedDirectory{
+			MountPath: mount.guestPath,
+			ShareName: mount.shareName,
+			Port:      vmutils.Plan9Port,
+			ReadOnly:  mount.config.ReadOnly,
+		}); err != nil {
+			return fmt.Errorf("unmount plan9 guest path %q: remove LCOW mapped directory: %w", mount.guestPath, err)
+		}
+		mount.state = mountUnmounted
+	}
+
+	// Cleanup from the map.
+	m.globalMu.Lock()
+	delete(m.plan9Mounts, mount.guestPath)
+	m.globalMu.Unlock()
+
+	log.G(ctx).Debug("plan9 share unmounted from guest")
+	return nil
+}

--- a/internal/controller/mount/scsi.go
+++ b/internal/controller/mount/scsi.go
@@ -1,0 +1,202 @@
+//go:build windows
+
+package mount
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"sort"
+
+	"github.com/Microsoft/hcsshim/internal/log"
+	"github.com/Microsoft/hcsshim/internal/logfields"
+	"github.com/sirupsen/logrus"
+)
+
+// ResolveSCSIGuestPath returns the stable guest path for the SCSI disk at the
+// given controller and LUN. If no entry exists yet, ResolveSCSIGuestPath
+// pre-allocates one and returns the generated path.
+func (m *Manager) ResolveSCSIGuestPath(controller, lun uint, mountCfg SCSIMountConfig) string {
+	// Normalize options so concurrent callers that independently resolve and
+	// then mount observe identical configs and coalesce onto the same entry.
+	sort.Strings(mountCfg.Options)
+	mount := m.getOrCreateSCSIEntry(controller, lun, &mountCfg)
+	return mount.guestPath
+}
+
+// MountSCSI mounts a SCSI disk (identified by controller + LUN) inside the
+// guest. If the guest path is not specified, we generate one.
+// Returns the resolved guest path.
+func (m *Manager) MountSCSI(
+	ctx context.Context,
+	controller uint,
+	lun uint,
+	mountCfg SCSIMountConfig,
+) (_ string, err error) {
+
+	log.G(ctx).WithFields(logrus.Fields{
+		logfields.Controller: controller,
+		logfields.LUN:        lun,
+		logfields.Options:    mountCfg,
+	}).Debug("Mounting SCSI disk inside the guest")
+
+	// Normalize options early so all downstream comparisons are order-independent.
+	sort.Strings(mountCfg.Options)
+
+	// Track the SCSI mount operation.
+	mount := m.getOrCreateSCSIEntry(controller, lun, &mountCfg)
+
+	ctx, _ = log.WithContext(ctx, logrus.WithField(logfields.UVMPath, mount.guestPath))
+	log.G(ctx).WithFields(logrus.Fields{
+		logfields.Controller: controller,
+		logfields.LUN:        lun,
+	}).Debug("checking the status of resolved guest path")
+
+	// Acquire the entry lock to check the state and potentially drive the mount operation.
+	mount.mu.Lock()
+	defer mount.mu.Unlock()
+
+	switch mount.state {
+	case mountMounted:
+		// ==============================================================================
+		// Found an existing mount.
+		// ==============================================================================
+
+		// Validate it matches the requested disk and config.
+		if mount.controller != controller || mount.lun != lun || !reflect.DeepEqual(&mountCfg, mount.config) {
+			return "", fmt.Errorf(
+				"guest path %q is already mounted for controller=%d lun=%d with a different config",
+				mountCfg.GuestPath, mount.controller, mount.lun)
+		}
+
+		mount.refCount++
+
+		log.G(ctx).Debug("reusing existing SCSI guest mount")
+		return mount.guestPath, nil
+
+	case mountPending:
+		// ==============================================================================
+		// New mount - We own this entry.
+		// Other goroutines requesting the same path are blocked on mount.mu
+		// and will see the final state once we release it.
+		// ==============================================================================
+		log.G(ctx).Tracef("performing guest operation to mount the disk")
+
+		if err = m.mountInGuest(ctx, controller, lun, &mountCfg); err != nil {
+			// Move the state to Invalid so that other goroutines waiting on
+			// the mount see the real failure reason via stateErr.
+			mount.state = mountInvalid
+			mount.stateErr = err
+
+			// Delete from the map. Any callers waiting on this mount
+			// will see the invalid state and receive the original error.
+			m.globalMu.Lock()
+			delete(m.scsiMounts, mount.guestPath)
+			m.globalMu.Unlock()
+
+			return "", fmt.Errorf("mount SCSI disk for controller=%d lun=%d in guest: %w",
+				controller, lun, err)
+		}
+
+		// Mark the mount as mounted.
+		mount.state = mountMounted
+		mount.refCount++
+
+		log.G(ctx).Debug("SCSI disk mounted in guest")
+		return mount.guestPath, nil
+
+	case mountInvalid:
+		// ==============================================================================
+		// Found a mount which failed during guest operation.
+		// ==============================================================================
+
+		return "", fmt.Errorf("previous mount attempt at %q failed: %w", mount.guestPath, mount.stateErr)
+
+	default:
+		// Unlikely state that should never be observed here.
+		return "", fmt.Errorf("SCSI guest mount at %q in unexpected state %s", mount.guestPath, mount.state)
+	}
+}
+
+// getOrCreateSCSIEntry looks up the global SCSI mount map for an existing entry
+// at the requested guest path. If found it is returned as-is. If not found, a new
+// Pending entry is inserted and returned. All map access is serialised under globalMu.
+func (m *Manager) getOrCreateSCSIEntry(controller, lun uint, mountCfg *SCSIMountConfig) *scsiMount {
+	m.globalMu.Lock()
+	defer m.globalMu.Unlock()
+
+	// If the requested path exists, return the same.
+	if mountCfg.GuestPath != "" {
+		if mount, ok := m.scsiMounts[mountCfg.GuestPath]; ok {
+			return mount
+		}
+	}
+
+	// Auto-generate a unique path under the global lock so concurrent callers
+	// can never receive the same index.
+	if mountCfg.GuestPath == "" {
+		mountCfg.GuestPath = fmt.Sprintf(mountFmt, m.nextSCSIMountIdx)
+		m.nextSCSIMountIdx++
+	}
+
+	// Insert a new mount entry in Pending state.
+	mount := &scsiMount{
+		guestPath:  mountCfg.GuestPath,
+		controller: controller,
+		lun:        lun,
+		config:     mountCfg,
+		refTracker: refTracker{state: mountPending},
+	}
+	m.scsiMounts[mountCfg.GuestPath] = mount
+	return mount
+}
+
+// UnmountSCSI releases a previously mounted SCSI guest path.
+// The GCS unmount request is sent only when the last reference is released.
+func (m *Manager) UnmountSCSI(ctx context.Context, guestPath string) error {
+
+	ctx, _ = log.WithContext(ctx, logrus.WithField(logfields.UVMPath, guestPath))
+	log.G(ctx).Debug("Unmounting SCSI disk from guest")
+
+	m.globalMu.Lock()
+	mount, ok := m.scsiMounts[guestPath]
+	m.globalMu.Unlock()
+
+	// If there is no mount, then there is nothing to unmount.
+	if !ok {
+		return nil
+	}
+
+	mount.mu.Lock()
+	defer mount.mu.Unlock()
+
+	if mount.refCount > 1 {
+		mount.refCount--
+		// Other callers still hold a reference to this mount.
+		log.G(ctx).Debug("mount still in use by other callers, not unmounting from guest")
+		return nil
+	}
+
+	// If the mount failed (guest operation never succeeded), but we got the
+	// entry just prior to removal from map, then state would be invalid.
+	if mount.state == mountInvalid {
+		// Mount never succeeded; nothing to undo.
+		return nil
+	}
+
+	// Drive the unmount operation.
+	if mount.state == mountMounted {
+		if err := m.unmountFromGuest(ctx, mount.controller, mount.lun, mount); err != nil {
+			return fmt.Errorf("unmount SCSI guest path %q: %w", mount.guestPath, err)
+		}
+		mount.state = mountUnmounted
+	}
+
+	// Cleanup from the map.
+	m.globalMu.Lock()
+	delete(m.scsiMounts, mount.guestPath)
+	m.globalMu.Unlock()
+
+	log.G(ctx).Debug("SCSI disk unmounted from guest")
+	return nil
+}

--- a/internal/controller/mount/scsi_lcow.go
+++ b/internal/controller/mount/scsi_lcow.go
@@ -1,0 +1,50 @@
+//go:build windows && !wcow
+
+package mount
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Microsoft/hcsshim/internal/protocol/guestresource"
+)
+
+// mountFmt is the guest path template for SCSI mounts on LCOW.
+const mountFmt = "/run/mounts/scsi/m%d"
+
+// mountInGuest mounts a SCSI disk into the Linux guest at the path specified by [SCSIMountConfig.GuestPath].
+func (m *Manager) mountInGuest(ctx context.Context, controller, lun uint, mountCfg *SCSIMountConfig) error {
+	settings := guestresource.LCOWMappedVirtualDisk{
+		MountPath:        mountCfg.GuestPath,
+		Controller:       uint8(controller),
+		Lun:              uint8(lun),
+		Partition:        mountCfg.Partition,
+		ReadOnly:         mountCfg.ReadOnly,
+		Encrypted:        mountCfg.Encrypted,
+		Options:          mountCfg.Options,
+		EnsureFilesystem: mountCfg.EnsureFilesystem,
+		Filesystem:       mountCfg.Filesystem,
+		BlockDev:         mountCfg.BlockDev,
+	}
+	if err := m.linuxGuestSCSI.AddLCOWMappedVirtualDisk(ctx, settings); err != nil {
+		return fmt.Errorf("add LCOW mapped virtual disk controller=%d lun=%d: %w", controller, lun, err)
+	}
+	return nil
+}
+
+// unmountFromGuest unmounts the SCSI disk identified by controller/lun from the Linux guest.
+func (m *Manager) unmountFromGuest(ctx context.Context, controller, lun uint, mount *scsiMount) error {
+	settings := guestresource.LCOWMappedVirtualDisk{
+		MountPath:  mount.guestPath,
+		Controller: uint8(controller),
+		Lun:        uint8(lun),
+		ReadOnly:   mount.config.ReadOnly,
+		Partition:  mount.config.Partition,
+		BlockDev:   mount.config.BlockDev,
+	}
+	if err := m.linuxGuestSCSI.RemoveLCOWMappedVirtualDisk(ctx, settings); err != nil {
+		return fmt.Errorf("remove LCOW mapped virtual disk controller=%d lun=%d path=%q: %w",
+			controller, lun, mount.guestPath, err)
+	}
+	return nil
+}

--- a/internal/controller/mount/scsi_wcow.go
+++ b/internal/controller/mount/scsi_wcow.go
@@ -1,0 +1,57 @@
+//go:build windows && wcow
+
+package mount
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/Microsoft/hcsshim/internal/protocol/guestresource"
+)
+
+// mountFmt is the guest path template for SCSI mounts on WCOW.
+const mountFmt = `c:\mounts\scsi\m%d`
+
+// mountInGuest mounts a SCSI disk into the Windows guest at the path specified by [SCSIMountConfig.GuestPath].
+// Only controller 0 is supported; encrypted, partitioned, block-device, and filesystem-specific mounts are rejected.
+func (m *Manager) mountInGuest(ctx context.Context, controller, lun uint, mountCfg *SCSIMountConfig) error {
+	if controller != 0 {
+		return errors.New("WCOW only supports SCSI controller 0")
+	}
+
+	if mountCfg.Encrypted || len(mountCfg.Options) != 0 ||
+		mountCfg.EnsureFilesystem || mountCfg.Filesystem != "" || mountCfg.Partition != 0 || mountCfg.BlockDev {
+		return errors.New("WCOW does not support encrypted, guest options, partitions, block devices, specifying mount filesystem, or ensuring filesystem on mounts")
+	}
+
+	settings := guestresource.WCOWMappedVirtualDisk{
+		ContainerPath: mountCfg.GuestPath,
+		Lun:           int32(lun),
+	}
+
+	var err error
+	if mountCfg.FormatWithRefs {
+		// FormatWithRefs signals the disk is a container scratch; use the dedicated API path.
+		err = m.windowsGuestSCSI.AddWCOWMappedVirtualDiskForContainerScratch(ctx, settings)
+	} else {
+		err = m.windowsGuestSCSI.AddWCOWMappedVirtualDisk(ctx, settings)
+	}
+	if err != nil {
+		return fmt.Errorf("add WCOW mapped virtual disk controller=%d lun=%d: %w", controller, lun, err)
+	}
+	return nil
+}
+
+// unmountFromGuest unmounts the SCSI disk identified by controller/lun from the Windows guest.
+func (m *Manager) unmountFromGuest(ctx context.Context, controller, lun uint, mount *scsiMount) error {
+	settings := guestresource.WCOWMappedVirtualDisk{
+		ContainerPath: mount.guestPath,
+		Lun:           int32(lun),
+	}
+	if err := m.windowsGuestSCSI.RemoveWCOWMappedVirtualDisk(ctx, settings); err != nil {
+		return fmt.Errorf("remove WCOW mapped virtual disk controller=%d lun=%d path=%q: %w",
+			controller, lun, mount.guestPath, err)
+	}
+	return nil
+}

--- a/internal/controller/mount/state.go
+++ b/internal/controller/mount/state.go
@@ -1,0 +1,58 @@
+//go:build windows
+
+package mount
+
+// mountState represents the current state of a guest mount lifecycle.
+//
+// The normal progression is:
+//
+//	mountPending → mountMounted → mountUnmounted
+//
+// If mountInGuest fails, the owning goroutine moves the mount to
+// mountInvalid and records the error. Other goroutines waiting on
+// the same mount observe the invalid state and receive the original
+// error. The entry is removed from the map immediately.
+//
+// Full state-transition table:
+//
+//	Current State        │ Trigger                            │ Next State
+//	─────────────────────┼────────────────────────────────────┼────────────────────
+//	mountPending         │ mountInGuest succeeds              │ mountMounted
+//	mountPending         │ mountInGuest fails                 │ mountInvalid
+//	mountMounted         │ unmountFromGuest succeeds          │ mountUnmounted
+//	mountUnmounted       │ (terminal — no further transitions)│ —
+//	mountInvalid         │ entry removed from map             │ —
+type mountState int
+
+const (
+	// mountPending is the initial state; mountInGuest has been called but
+	// has not yet completed.
+	mountPending mountState = iota
+
+	// mountMounted means mountInGuest succeeded; the path is accessible
+	// inside the guest.
+	mountMounted
+
+	// mountUnmounted means unmountFromGuest succeeded; the guest path is
+	// no longer accessible. This is a terminal state.
+	mountUnmounted
+
+	// mountInvalid means mountInGuest failed.
+	mountInvalid
+)
+
+// String returns a human-readable name for the [mountState].
+func (s mountState) String() string {
+	switch s {
+	case mountPending:
+		return "Pending"
+	case mountMounted:
+		return "Mounted"
+	case mountUnmounted:
+		return "Unmounted"
+	case mountInvalid:
+		return "Invalid"
+	default:
+		return "Unknown"
+	}
+}

--- a/internal/vm/guestmanager/mapped_directory_lcow.go
+++ b/internal/vm/guestmanager/mapped_directory_lcow.go
@@ -11,16 +11,6 @@ import (
 	"github.com/Microsoft/hcsshim/internal/protocol/guestresource"
 )
 
-// LCOWDirectoryManager exposes mapped directory operations in the LCOW guest.
-type LCOWDirectoryManager interface {
-	// AddLCOWMappedDirectory maps a directory into the LCOW guest.
-	AddLCOWMappedDirectory(ctx context.Context, settings guestresource.LCOWMappedDirectory) error
-	// RemoveLCOWMappedDirectory unmaps a directory from the LCOW guest.
-	RemoveLCOWMappedDirectory(ctx context.Context, settings guestresource.LCOWMappedDirectory) error
-}
-
-var _ LCOWDirectoryManager = (*Guest)(nil)
-
 // AddLCOWMappedDirectory maps a directory into LCOW guest.
 func (gm *Guest) AddLCOWMappedDirectory(ctx context.Context, settings guestresource.LCOWMappedDirectory) error {
 	request := &hcsschema.ModifySettingRequest{

--- a/internal/vm/guestmanager/scsi_wcow.go
+++ b/internal/vm/guestmanager/scsi_wcow.go
@@ -11,20 +11,6 @@ import (
 	"github.com/Microsoft/hcsshim/internal/protocol/guestresource"
 )
 
-// WCOWScsiManager exposes mapped virtual disk and SCSI device operations in the WCOW guest.
-type WCOWScsiManager interface {
-	// AddWCOWMappedVirtualDisk maps a virtual disk into the WCOW guest.
-	AddWCOWMappedVirtualDisk(ctx context.Context, settings guestresource.WCOWMappedVirtualDisk) error
-	// AddWCOWMappedVirtualDiskForContainerScratch attaches a scratch disk in the WCOW guest.
-	AddWCOWMappedVirtualDiskForContainerScratch(ctx context.Context, settings guestresource.WCOWMappedVirtualDisk) error
-	// RemoveWCOWMappedVirtualDisk unmaps a virtual disk from the WCOW guest.
-	RemoveWCOWMappedVirtualDisk(ctx context.Context, settings guestresource.WCOWMappedVirtualDisk) error
-	// RemoveSCSIDevice removes a SCSI device from the guest.
-	RemoveSCSIDevice(ctx context.Context, settings guestresource.SCSIDevice) error
-}
-
-var _ WCOWScsiManager = (*Guest)(nil)
-
 // AddWCOWMappedVirtualDisk maps a virtual disk into a WCOW guest.
 func (gm *Guest) AddWCOWMappedVirtualDisk(ctx context.Context, settings guestresource.WCOWMappedVirtualDisk) error {
 	request := &hcsschema.ModifySettingRequest{


### PR DESCRIPTION
### Summary
Adds the `mount` package to manage the guest-side lifecycle of SCSI disks and Plan9 shares in Hyper-V utility VMs.

Key features include:
- A `Manager` entry point providing explicit Mount/Unmount APIs.
- Reference-counted mounts to safely allow multiple callers to share the same guest path without conflicts.
- An explicit, forward-moving state machine (`Pending` -> `Mounted` -> `Unmounted` or `Invalid`) for robust lifecycle tracking.
- Platform-aware delegation supporting SCSI on both LCOW/WCOW, and Plan9 on LCOW.

This package is designed to operate downstream of device managers, handling strictly the guest-side mount while the device manager maintains host-side lifetime ownership.