### PR TITLE
[shimV2] adds SCSI disk manager

### DIFF
--- a/internal/controller/device/scsi/doc.go
+++ b/internal/controller/device/scsi/doc.go
@@ -1,0 +1,138 @@
+//go:build windows
+
+// Package scsi manages the full lifecycle of SCSI disk mappings on a
+// Hyper-V VM, from host-side slot allocation through guest-side mounting.
+//
+// # Architecture
+//
+// [Manager] is the primary entry point, exposing two methods:
+//
+//   - [Manager.MapToGuest]: allocates a SCSI slot (if needed), attaches the
+//     disk to the VM's SCSI bus, and mounts the specified partition inside the
+//     guest. The caller supplies a stable mappingID that identifies the mapping
+//     across retries.
+//   - [Manager.UnmapFromGuest]: unmounts the partition from the guest, and
+//     when all mappings for an attachment are released, unplugs the SCSI
+//     device and detaches the disk from the VM.
+//
+// All operations are serialized by a single mutex on the [Manager]. Guest
+// paths are always auto-generated; callers cannot supply their own.
+//
+// # Layered State Model
+//
+// The state is tracked at two layers:
+//
+//   - [attachment]: represents a disk on the VM's SCSI bus (one per [VMSlot]).
+//     States: attachPending → attachAttached → attachDetaching → attachUnplugged → attachDetached.
+//   - [mount]: represents a partition mounted inside the guest (keyed by
+//     partition index within an attachment).
+//     States: mountPending → mountMounted → mountUnmounted.
+//
+// A third structure, [mapping], links a caller-supplied mappingID to an
+// [attachment] and partition index. It carries no lifecycle state of its own;
+// the [attachment] and [mount] state machines drive all transitions.
+//
+// # Retry / Idempotency
+//
+// Both [Manager.MapToGuest] and [Manager.UnmapFromGuest] are designed to be
+// retriable. On failure, the [attachment] and [mount] states remain at their
+// pre-operation position (no poisoning). A subsequent call with the same
+// mappingID resumes from where the previous attempt stopped.
+//
+// Calling [Manager.MapToGuest] with the same mappingID after a successful call
+// is a no-op that returns the existing guest path.
+//
+// # Attachment Lifecycle
+//
+//	┌──────────────────┐
+//	│  attachPending   │ ← stays here on attach failure (retriable)
+//	└────────┬─────────┘
+//	         │ disk added to VM SCSI bus
+//	         ▼
+//	┌──────────────────┐
+//	│ attachAttached   │
+//	└────────┬─────────┘
+//	  (mounts driven here)
+//	         │ all partitions released;
+//	         │ detach initiated
+//	         ▼
+//	┌──────────────────┐
+//	│ attachDetaching  │ ← stays here on unplug failure (retriable)
+//	└────────┬─────────┘
+//	         │ SCSI device unplugged from guest
+//	         ▼
+//	┌──────────────────┐
+//	│ attachUnplugged  │
+//	└────────┬─────────┘
+//	         │ disk removed from VM SCSI bus
+//	         ▼
+//	┌──────────────────┐
+//	│ attachDetached   │
+//	└──────────────────┘
+//	  (entry removed from map)
+//
+//	┌──────────────────┐
+//	│ attachReserved   │  ← no transitions; pre-reserved at construction
+//	└──────────────────┘
+//
+// # Mount Lifecycle
+//
+//	┌──────────────────┐
+//	│  mountPending    │ ← stays here on mount failure (retriable)
+//	└────────┬─────────┘
+//	         │ guest mount succeeds
+//	         ▼
+//	┌──────────────────┐
+//	│  mountMounted    │
+//	└────────┬─────────┘
+//	         │ refCount → 0;
+//	         │ guest unmount
+//	         ▼
+//	┌──────────────────┐
+//	│ mountUnmounted   │
+//	└──────────────────┘
+//	  (partition entry removed from attachment)
+//
+// # Reference Counting
+//
+// Multiple mappingIDs may target the same disk and partition. [Manager.MapToGuest]
+// detects duplicates and increments a reference count on the [mount] instead of
+// issuing duplicate guest operations; the guest path is shared.
+//
+// [Manager.UnmapFromGuest] decrements the count and only unmounts when it reaches
+// zero.
+//
+// # Platform Variants
+//
+// Guest-side mount, unmount, and unplug steps differ between LCOW and WCOW
+// guests and are selected via build tags (default for the LCOW shim;
+// "wcow" tag for the WCOW shim):
+//
+//   - LCOW: mounts via AddLCOWMappedVirtualDisk, unmounts via
+//     RemoveLCOWMappedVirtualDisk, and unplugs via RemoveSCSIDevice.
+//   - WCOW: mounts via AddWCOWMappedVirtualDisk (or
+//     AddWCOWMappedVirtualDiskForContainerScratch for scratch disks),
+//     unmounts via RemoveWCOWMappedVirtualDisk; unplug is a no-op because
+//     Windows handles SCSI hot-unplug automatically when the host removes
+//     the disk from the VM.
+//
+// # Usage
+//
+//	mgr := scsi.New(vmID, vmScsi, linuxGuestScsi, windowsGuestScsi, numControllers, reservedSlots)
+//
+//	diskConfig := scsi.DiskConfig{HostPath: "/path/to/disk.vhdx", Type: scsi.DiskTypeVirtualDisk}
+//	mountConfig := scsi.MountConfig{ReadOnly: true}
+//
+//	// Map the disk to the guest (allocate slot + attach + mount):
+//	guestPath, err := mgr.MapToGuest(ctx, "container-abc/layer-0", diskConfig, mountConfig)
+//	if err != nil {
+//	    // Retry with the same mappingID to resume:
+//	    guestPath, err = mgr.MapToGuest(ctx, "container-abc/layer-0", diskConfig, mountConfig)
+//	}
+//
+//	// Unmap (unmount + unplug + detach when last mapping):
+//	if err := mgr.UnmapFromGuest(ctx, "container-abc/layer-0"); err != nil {
+//	    // Retry:
+//	    _ = mgr.UnmapFromGuest(ctx, "container-abc/layer-0")
+//	}
+package scsi

--- a/internal/controller/device/scsi/scsi.go
+++ b/internal/controller/device/scsi/scsi.go
@@ -1,0 +1,71 @@
+//go:build windows
+
+package scsi
+
+import (
+	"sync"
+)
+
+// Manager implements the methods to manage the full SCSI disk lifecycle —
+// slot allocation, VM attach, guest mount, and teardown — across one or more
+// controllers on a Hyper-V VM. All operations are serialized by a single mutex.
+type Manager struct {
+	// mu serializes all public operations on the Manager.
+	mu sync.Mutex
+
+	// vmID identifies the HCS compute system. Immutable after construction.
+	vmID string
+
+	// numControllers is the number of SCSI controllers on the VM. Immutable after construction.
+	numControllers int
+
+	// attachmentMap tracks SCSI slot occupancy keyed by controller and LUN. Guarded by mu.
+	attachmentMap map[VMSlot]*attachment
+
+	// mappingMap indexes active mappings by caller-supplied ID. Guarded by mu.
+	mappingMap map[string]*mapping
+
+	// nextMountIdx is a monotonic counter for generating unique guest mount paths. Guarded by mu.
+	nextMountIdx int
+
+	// vmSCSI is the host-side interface for adding and removing disks from the VM. Immutable after construction.
+	vmSCSI vmSCSI
+
+	// linuxGuestSCSI is the guest-side interface for SCSI operations in LCOW guests. Immutable after construction.
+	linuxGuestSCSI linuxGuestSCSI
+
+	// windowsGuestSCSI is the guest-side interface for SCSI operations in WCOW guests. Immutable after construction.
+	windowsGuestSCSI windowsGuestSCSI
+}
+
+// New creates a new [Manager] for the given VM and controllers.
+func New(
+	vmID string,
+	vmScsi vmSCSI,
+	linuxGuestScsi linuxGuestSCSI,
+	windowsGuestScsi windowsGuestSCSI,
+	numControllers int,
+	reservedSlots []VMSlot,
+) *Manager {
+	m := &Manager{
+		vmID:             vmID,
+		numControllers:   numControllers,
+		attachmentMap:    make(map[VMSlot]*attachment),
+		mappingMap:       make(map[string]*mapping),
+		vmSCSI:           vmScsi,
+		linuxGuestSCSI:   linuxGuestScsi,
+		windowsGuestSCSI: windowsGuestScsi,
+	}
+
+	// Pre-populate attachmentMap with reserved slots so they are never allocated.
+	for _, s := range reservedSlots {
+		m.attachmentMap[s] = &attachment{
+			controller: s.Controller,
+			lun:        s.LUN,
+			state:      attachReserved,
+			partitions: make(map[uint64]*mount),
+		}
+	}
+
+	return m
+}

--- a/internal/controller/device/scsi/scsi_lcow.go
+++ b/internal/controller/device/scsi/scsi_lcow.go
@@ -1,0 +1,71 @@
+//go:build windows && !wcow
+
+package scsi
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Microsoft/hcsshim/internal/protocol/guestresource"
+)
+
+// mountFmt is the guest path template for SCSI mounts on LCOW.
+const mountFmt = "/run/mounts/scsi/m%d"
+
+// mountInGuest mounts a SCSI disk partition into the Linux guest at the path
+// stored in [mount.guestPath].
+func (m *Manager) mountInGuest(ctx context.Context, controller, lun uint, mnt *mount) error {
+	settings := guestresource.LCOWMappedVirtualDisk{
+		MountPath:        mnt.guestPath,
+		Controller:       uint8(controller),
+		Lun:              uint8(lun),
+		Partition:        mnt.config.Partition,
+		ReadOnly:         mnt.config.ReadOnly,
+		Encrypted:        mnt.config.Encrypted,
+		Options:          mnt.config.Options,
+		EnsureFilesystem: mnt.config.EnsureFilesystem,
+		Filesystem:       mnt.config.Filesystem,
+		BlockDev:         mnt.config.BlockDev,
+	}
+	if err := m.linuxGuestSCSI.AddLCOWMappedVirtualDisk(ctx, settings); err != nil {
+		return fmt.Errorf("add LCOW mapped virtual disk controller=%d lun=%d: %w", controller, lun, err)
+	}
+	return nil
+}
+
+// unmountFromGuest unmounts the SCSI disk partition from the Linux guest.
+func (m *Manager) unmountFromGuest(ctx context.Context, controller, lun uint, mnt *mount) error {
+	settings := guestresource.LCOWMappedVirtualDisk{
+		MountPath:  mnt.guestPath,
+		Controller: uint8(controller),
+		Lun:        uint8(lun),
+		ReadOnly:   mnt.config.ReadOnly,
+		Partition:  mnt.config.Partition,
+		BlockDev:   mnt.config.BlockDev,
+	}
+	if err := m.linuxGuestSCSI.RemoveLCOWMappedVirtualDisk(ctx, settings); err != nil {
+		return fmt.Errorf("remove LCOW mapped virtual disk controller=%d lun=%d path=%q: %w",
+			controller, lun, mnt.guestPath, err)
+	}
+	return nil
+}
+
+// unplugFromGuest ejects a SCSI device from the Linux guest before the host
+// removes it from the VM.
+func (m *Manager) unplugFromGuest(ctx context.Context, controller, lun uint) error {
+	settings := guestresource.SCSIDevice{
+		Controller: uint8(controller),
+		Lun:        uint8(lun),
+	}
+
+	// RemoveSCSIDevice sends a guest modification request that the GCS handles
+	// by first remapping the logical controller number to the actual kernel-visible
+	// controller index (HCS and the Linux kernel assign them independently), then
+	// writing "1" to /sys/bus/scsi/devices/<id>/delete. That sysfs write is a
+	// guest-initiated hot-unplug: the kernel removes the device from its bus and
+	// flushes any in-flight I/O before the host removes the disk from the VM.
+	if err := m.linuxGuestSCSI.RemoveSCSIDevice(ctx, settings); err != nil {
+		return fmt.Errorf("remove scsi device at controller=%d lun=%d from lcow guest: %w", controller, lun, err)
+	}
+	return nil
+}

--- a/internal/controller/device/scsi/scsi_map.go
+++ b/internal/controller/device/scsi/scsi_map.go
@@ -1,0 +1,314 @@
+//go:build windows
+
+package scsi
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	hcsschema "github.com/Microsoft/hcsshim/internal/hcs/schema2"
+	"github.com/Microsoft/hcsshim/internal/log"
+	"github.com/Microsoft/hcsshim/internal/logfields"
+	"github.com/Microsoft/hcsshim/internal/wclayer"
+
+	"github.com/sirupsen/logrus"
+)
+
+// MapToGuest attaches a SCSI disk to the VM and mounts the requested partition
+// in the guest, returning the guest path. The call is idempotent for the same
+// mappingID and supports multiple mappings sharing a single disk or partition.
+func (m *Manager) MapToGuest(
+	ctx context.Context,
+	mappingID string,
+	diskConfig DiskConfig,
+	mountConfig MountConfig,
+) (string, error) {
+
+	log.G(ctx).WithFields(logrus.Fields{
+		logfields.MappingID: mappingID,
+		logfields.HostPath:  diskConfig.HostPath,
+		logfields.DiskType:  diskConfig.Type,
+	}).Debug("mapping SCSI disk to guest")
+
+	// Parse EVD-specific fields out of the host path so that the HostPath key
+	// used for deduplication is the underlying mount path, not the evd:// URI.
+	if diskConfig.Type == DiskTypeExtensibleVirtualDisk {
+		evdType, mountPath, parseErr := parseEVDPath(diskConfig.HostPath)
+		if parseErr != nil {
+			return "", parseErr
+		}
+		diskConfig.HostPath = mountPath
+		diskConfig.EVDType = evdType
+	}
+
+	// Hold global lock.
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	// Resolve the attachment, mount, and mapping for this request.
+	res, isAlreadyMounted, err := m.resolveMapping(ctx, mappingID, &diskConfig, &mountConfig)
+	if err != nil {
+		return "", err
+	}
+	// If this was a duplicate idempotent call for same mapping,
+	// we return the mounted guest path.
+	if isAlreadyMounted {
+		return res.att.partitions[res.partition].guestPath, nil
+	}
+
+	att := res.att
+	controller, lun := att.controller, att.lun
+	partition := res.partition
+
+	ctx, _ = log.WithContext(ctx, logrus.WithFields(logrus.Fields{
+		logfields.MappingID:  mappingID,
+		logfields.Controller: controller,
+		logfields.LUN:        lun,
+		"partition":          partition,
+	}))
+
+	// Drive the attachment state machine. On error the state stays at
+	// [attachPending] so a retry with the same mappingID re-enters this case.
+	switch att.state {
+	case attachPending:
+		// ==============================================================================
+		// Pending state: we need to attach the disk to the VM and create a new mount.
+		// ==============================================================================
+
+		// Grant VM access for virtual and physical disks before attaching.
+		if att.diskConfig.Type == DiskTypeVirtualDisk || att.diskConfig.Type == DiskTypePassThru {
+			log.G(ctx).WithField(logfields.HostPath, att.diskConfig.HostPath).Debug("granting VM access to disk")
+
+			if err := wclayer.GrantVmAccess(ctx, m.vmID, att.diskConfig.HostPath); err != nil {
+				return "", fmt.Errorf("grant vm access to %q: %w", att.diskConfig.HostPath, err)
+			}
+		}
+
+		log.G(ctx).Debug("attaching disk to VM SCSI bus")
+
+		// Attach the disk to VM bus.
+		if err := m.vmSCSI.AddSCSIDisk(ctx, hcsschema.Attachment{
+			Path:                      att.diskConfig.HostPath,
+			Type_:                     string(att.diskConfig.Type),
+			ReadOnly:                  att.diskConfig.ReadOnly,
+			ExtensibleVirtualDiskType: att.diskConfig.EVDType,
+		}, controller, lun); err != nil {
+			// The attachment and mapping entries remain in the maps in attachPending
+			// state so the call is retriable. Caller can retry by calling MapToGuest again with
+			// the same mappingID, or call UnmapFromGuest to release the entries.
+			return "", fmt.Errorf("add scsi disk %q to vm at controller=%d lun=%d: %w",
+				att.diskConfig.HostPath, controller, lun, err)
+		}
+
+		// We move to attached state.
+		att.state = attachAttached
+		log.G(ctx).Debug("SCSI disk attached to VM")
+
+	case attachAttached:
+		// ==============================================================================
+		// Attached state: Nothing to do. The mount ref-count (mnt.refCount) is
+		// incremented below; len(att.partitions) is used by UnmapFromGuest to decide
+		// when to detach the disk.
+		// ==============================================================================
+		log.G(ctx).Debug("disk already attached to VM, skipping attach")
+
+	default:
+		// ==============================================================================
+		// Other states: we need to attach the disk to the VM and create a new mount.
+		// ==============================================================================
+		return "", fmt.Errorf("attachment at controller=%d lun=%d in state %s, cannot map",
+			controller, lun, att.state)
+	}
+
+	// Resolve the mount for the requested partition.
+	mnt, ok := att.partitions[partition]
+	if !ok {
+		return "", fmt.Errorf("no mount for partition %d at controller=%d lun=%d",
+			partition, controller, lun)
+	}
+
+	// Drive the mount state machine. On error the state is unchanged, so a retry re-enters
+	// the same case.
+	switch mnt.state {
+	// ==============================================================================
+	// Pending state: we need to perform guest mount.
+	// ==============================================================================
+	case mountPending:
+		log.G(ctx).Debug("mounting partition in guest")
+
+		// Perform platform specific mount operation.
+		if err := m.mountInGuest(ctx, controller, lun, mnt); err != nil {
+			return "", fmt.Errorf("mount scsi disk in guest at %q controller=%d lun=%d partition=%d: %w",
+				mnt.guestPath, controller, lun, partition, err)
+		}
+
+		// Mark the state as mounted and increment the ref-count.
+		mnt.state = mountMounted
+		mnt.refCount++
+		log.G(ctx).WithField(logfields.UVMPath, mnt.guestPath).Debug("partition mounted in guest")
+
+	case mountMounted:
+		// ==============================================================================
+		// Mounted state: we need to increment ref-count.
+		// ==============================================================================
+		mnt.refCount++
+
+	default:
+		// We can reach here is the mount was unmounted during UnmountFromGuest
+		// but then operation failed during attachment unplug.
+		return "", fmt.Errorf("mount for partition %d at controller=%d lun=%d in state %s, cannot map",
+			partition, controller, lun, mnt.state)
+	}
+
+	return mnt.guestPath, nil
+}
+
+// resolveMapping resolves a mapping ID to a concrete mapping, creating the underlying
+// attachment, mount, and mapping entries as needed.
+func (m *Manager) resolveMapping(
+	ctx context.Context,
+	mappingID string,
+	diskConfig *DiskConfig,
+	mountConfig *MountConfig,
+) (*mapping, bool, error) {
+	// Check for a mapping conflict before touching any other maps.
+	if existing, ok := m.mappingMap[mappingID]; ok {
+		if existing.att.diskConfig.HostPath != diskConfig.HostPath || existing.partition != mountConfig.Partition {
+
+			return nil, false, fmt.Errorf(
+				"mapping %q conflicts: existing hostPath=%q partition=%d, requested hostPath=%q partition=%d",
+				mappingID, existing.att.diskConfig.HostPath, existing.partition, diskConfig.HostPath, mountConfig.Partition)
+		}
+	}
+
+	// Get or create the attachment for this disk.
+	att, err := m.getOrCreateAttachment(ctx, diskConfig)
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to create/get attachment: %w", err)
+	}
+
+	// Get or create a new mount in the attachment partition.
+	if _, err = m.getOrCreateMount(att, mountConfig); err != nil {
+		return nil, false, fmt.Errorf("failed to create/get mount: %w", err)
+	}
+
+	// Look up or create the mapping. The early guard above already verified
+	// that any pre-existing mapping is compatible.
+	resolvedMapping, isExisting := m.mappingMap[mappingID]
+	if !isExisting {
+		resolvedMapping = &mapping{att: att, partition: mountConfig.Partition}
+		m.mappingMap[mappingID] = resolvedMapping
+	}
+
+	// If the mapping already existed and the disk is fully attached and mounted,
+	// this is an idempotent re-call — signal the caller to return the existing guest path.
+	if isExisting && att.state == attachAttached {
+		if mnt, ok := att.partitions[resolvedMapping.partition]; ok && mnt.state == mountMounted {
+			return resolvedMapping, true, nil
+		}
+	}
+
+	return resolvedMapping, false, nil
+}
+
+// getOrCreateAttachment returns the existing attachment for the given host path
+// or allocates the first free SCSI slot and creates a new one.
+func (m *Manager) getOrCreateAttachment(ctx context.Context, diskConfig *DiskConfig) (*attachment, error) {
+	// Look for an existing attachment whose host path matches.
+	for _, existing := range m.attachmentMap {
+		if existing == nil || existing.diskConfig == nil ||
+			existing.diskConfig.HostPath != diskConfig.HostPath {
+			continue
+		}
+
+		// A matching host path was found. If the attachment is in teardown state
+		// it must not be re-used. Surface the state so the
+		// caller can finish tearing down (via UnmapFromGuest) before re-mapping.
+		if existing.state != attachPending && existing.state != attachAttached {
+			return nil, fmt.Errorf(
+				"attachment for %q is in state %s: complete teardown via UnmapFromGuest before re-mapping",
+				diskConfig.HostPath, existing.state)
+		}
+
+		// Reusable attachment found; verify the full config is identical.
+		if !existing.diskConfig.equals(*diskConfig) {
+			return nil, fmt.Errorf("disk config conflict for %q: existing and requested configs differ", diskConfig.HostPath)
+		}
+		return existing, nil
+	}
+
+	// No reusable attachment exists. Scan controller/LUN pairs for a free slot.
+	for controller := range m.numControllers {
+		for lun := range numLUNsPerController {
+			slot := VMSlot{Controller: uint(controller), LUN: uint(lun)}
+			if _, occupied := m.attachmentMap[slot]; occupied {
+				continue
+			}
+
+			log.G(ctx).WithFields(logrus.Fields{
+				logfields.Controller: controller,
+				logfields.LUN:        lun,
+			}).Debug("allocating new SCSI slot")
+
+			// Create the attachment in pending state; it will transition to
+			// attached once the disk is added to the VM SCSI bus.
+			att := &attachment{
+				controller: uint(controller),
+				lun:        uint(lun),
+				diskConfig: diskConfig,
+				state:      attachPending,
+				partitions: make(map[uint64]*mount),
+			}
+			m.attachmentMap[slot] = att
+			return att, nil
+		}
+	}
+
+	return nil, errors.New("no available scsi slot")
+}
+
+// getOrCreateMount returns either an existing mount or creates a new one in
+// the requested partition of the attachment.
+func (m *Manager) getOrCreateMount(att *attachment, mountConfig *MountConfig) (*mount, error) {
+	// Try to find the existing partition in the attachment.
+	partition := mountConfig.Partition
+	if existing, ok := att.partitions[partition]; ok {
+		// If we found the partition, ensure that the config is same as requested.
+		if !existing.config.equals(*mountConfig) {
+			return nil, fmt.Errorf("mount config conflict for partition %d at controller=%d lun=%d: existing and requested configs differ",
+				partition, att.controller, att.lun)
+		}
+		return existing, nil
+	}
+
+	// We did not find an existing partition, create a new guest path
+	// and add the mount into the attachment partition.
+	guestPath := fmt.Sprintf(mountFmt, m.nextMountIdx)
+	m.nextMountIdx++
+
+	mnt := &mount{
+		config:    mountConfig,
+		guestPath: guestPath,
+		state:     mountPending,
+		refCount:  0, // ref-count incremented after mount.
+	}
+	att.partitions[partition] = mnt
+	return mnt, nil
+}
+
+// parseEVDPath splits an EVD host path of the form "evd://<type>/<mountPath>" into
+// its EVD provider type and the underlying mount path.
+func parseEVDPath(hostPath string) (evdType, mountPath string, err error) {
+	if !strings.HasPrefix(hostPath, "evd://") {
+		return "", "", fmt.Errorf("invalid extensible vhd path: %q", hostPath)
+	}
+
+	trimmedPath := strings.TrimPrefix(hostPath, "evd://")
+	separatorIndex := strings.Index(trimmedPath, "/")
+	if separatorIndex <= 0 {
+		return "", "", fmt.Errorf("invalid extensible vhd path: %q", hostPath)
+	}
+	return trimmedPath[:separatorIndex], trimmedPath[separatorIndex+1:], nil
+}

--- a/internal/controller/device/scsi/scsi_unmap.go
+++ b/internal/controller/device/scsi/scsi_unmap.go
@@ -1,0 +1,146 @@
+//go:build windows
+
+package scsi
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Microsoft/hcsshim/internal/log"
+	"github.com/Microsoft/hcsshim/internal/logfields"
+
+	"github.com/sirupsen/logrus"
+)
+
+// UnmapFromGuest tears down the mount and attachment associated with mappingID.
+func (m *Manager) UnmapFromGuest(
+	ctx context.Context,
+	mappingID string,
+) error {
+	ctx, _ = log.WithContext(ctx, logrus.WithField(logfields.MappingID, mappingID))
+	log.G(ctx).Debug("unmapping SCSI disk from guest")
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	// Look up the mapping by ID.
+	mp, ok := m.mappingMap[mappingID]
+	if !ok {
+		return fmt.Errorf("mapping %q not found", mappingID)
+	}
+
+	att := mp.att
+	controller, lun := att.controller, att.lun
+	partition := mp.partition
+	// Create the attachment identifier.
+	slot := VMSlot{Controller: controller, LUN: lun}
+
+	ctx, _ = log.WithContext(ctx, logrus.WithFields(logrus.Fields{
+		logfields.Controller: controller,
+		logfields.LUN:        lun,
+		"partition":          partition,
+	}))
+
+	// Reserved attachments must never be torn down.
+	if att.state == attachReserved {
+		return fmt.Errorf("cannot unmap reserved slot at controller=%d lun=%d", controller, lun)
+	}
+
+	// ==============================================================================
+	// Mount teardown
+	// ==============================================================================
+
+	// Handle the mount for this partition.
+	mnt := att.partitions[partition]
+	// Mount can be nil if we released the mount in prior failed UnmapFromGuest call.
+	if mnt != nil {
+
+		// ==============================================================================
+		// Mounted state: decrease refCount and drive unmount if required.
+		// ==============================================================================
+		if mnt.state == mountMounted {
+			if mnt.refCount > 0 {
+				mnt.refCount--
+			}
+
+			if mnt.refCount > 0 {
+				// Mount is still used by other callers.
+				// The unmap operation for this mapping is complete.
+				log.G(ctx).Debug("mount used by other mappings, unmap complete")
+
+				delete(m.mappingMap, mappingID)
+				return nil
+			}
+
+			// Drive unmount if this was last reference of the mount.
+			if err := m.unmountFromGuest(ctx, controller, lun, mnt); err != nil {
+				// If we fail here, restore the ref-count since we are already mounted.
+				mnt.refCount++
+				return fmt.Errorf("unmount scsi disk from guest at %q: %w", mnt.guestPath, err)
+			}
+
+			mnt.state = mountUnmounted
+			log.G(ctx).Debug("partition unmounted from guest")
+		}
+
+		// ==============================================================================
+		// Pending or Unmounted state: release the partition.
+		// ==============================================================================
+		if mnt.state == mountPending || mnt.state == mountUnmounted {
+			delete(att.partitions, partition)
+			log.G(ctx).Debug("partition released")
+		}
+	}
+
+	// ==============================================================================
+	// Attachment teardown
+	// ==============================================================================
+
+	// Drive the attachment teardown when no partitions remain on this disk.
+	if len(att.partitions) == 0 {
+
+		// ==============================================================================
+		// Attached or Detaching state: unplug the device from the guest.
+		// ==============================================================================
+		if att.state == attachAttached || att.state == attachDetaching {
+			att.state = attachDetaching
+
+			if err := m.unplugFromGuest(ctx, controller, lun); err != nil {
+				return fmt.Errorf("unplug scsi device at controller=%d lun=%d from guest: %w",
+					controller, lun, err)
+			}
+
+			att.state = attachUnplugged
+			log.G(ctx).Debug("SCSI device unplugged from guest")
+		}
+
+		// ==============================================================================
+		// Unplugged state: remove the disk from the VM's SCSI bus.
+		// ==============================================================================
+		if att.state == attachUnplugged {
+			if err := m.vmSCSI.RemoveSCSIDisk(ctx, controller, lun); err != nil {
+				return fmt.Errorf("remove scsi disk at controller=%d lun=%d from vm: %w",
+					controller, lun, err)
+			}
+
+			att.state = attachDetached
+			log.G(ctx).Debug("SCSI disk detached from VM")
+		}
+
+		// ==============================================================================
+		// Pending or Detached state: release the SCSI slot.
+		// ==============================================================================
+		if att.state == attachPending || att.state == attachDetached {
+			delete(m.attachmentMap, slot)
+			log.G(ctx).Debug("SCSI slot released")
+		}
+	}
+
+	// Remove the mapping entry last so that it remains available for retries
+	// if any earlier step fails.
+	delete(m.mappingMap, mappingID)
+
+	log.G(ctx).Debug("unmap operation complete")
+
+	return nil
+}

--- a/internal/controller/device/scsi/scsi_wcow.go
+++ b/internal/controller/device/scsi/scsi_wcow.go
@@ -1,0 +1,66 @@
+//go:build windows && wcow
+
+package scsi
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/Microsoft/hcsshim/internal/protocol/guestresource"
+)
+
+// mountFmt is the guest path template for SCSI mounts on WCOW.
+const mountFmt = `c:\mounts\scsi\m%d`
+
+// mountInGuest mounts a SCSI disk into the Windows guest at the path stored
+// in [mount.guestPath].
+func (m *Manager) mountInGuest(ctx context.Context, controller, lun uint, mnt *mount) error {
+	// Only controller 0 is supported on WCOW.
+	if controller != 0 {
+		return errors.New("WCOW only supports SCSI controller 0")
+	}
+
+	// Reject features not supported on WCOW.
+	if mnt.config.Encrypted || len(mnt.config.Options) != 0 ||
+		mnt.config.EnsureFilesystem || mnt.config.Filesystem != "" ||
+		mnt.config.Partition != 0 || mnt.config.BlockDev {
+		return errors.New("WCOW does not support encrypted, guest options, partitions, block devices, specifying mount filesystem, or ensuring filesystem on mounts")
+	}
+
+	settings := guestresource.WCOWMappedVirtualDisk{
+		ContainerPath: mnt.guestPath,
+		Lun:           int32(lun),
+	}
+
+	var err error
+	if mnt.config.FormatWithRefs {
+		// FormatWithRefs signals the disk is a container scratch; use the dedicated API path.
+		err = m.windowsGuestSCSI.AddWCOWMappedVirtualDiskForContainerScratch(ctx, settings)
+	} else {
+		err = m.windowsGuestSCSI.AddWCOWMappedVirtualDisk(ctx, settings)
+	}
+	if err != nil {
+		return fmt.Errorf("add WCOW mapped virtual disk controller=%d lun=%d: %w", controller, lun, err)
+	}
+	return nil
+}
+
+// unmountFromGuest unmounts the SCSI disk from the Windows guest.
+func (m *Manager) unmountFromGuest(ctx context.Context, controller, lun uint, mnt *mount) error {
+	settings := guestresource.WCOWMappedVirtualDisk{
+		ContainerPath: mnt.guestPath,
+		Lun:           int32(lun),
+	}
+	if err := m.windowsGuestSCSI.RemoveWCOWMappedVirtualDisk(ctx, settings); err != nil {
+		return fmt.Errorf("remove WCOW mapped virtual disk controller=%d lun=%d path=%q: %w",
+			controller, lun, mnt.guestPath, err)
+	}
+	return nil
+}
+
+// unplugFromGuest is a no-op on Windows guests.
+func (m *Manager) unplugFromGuest(_ context.Context, _, _ uint) error {
+	// Windows handles SCSI hot-unplug automatically when the host removes the disk from the VM.
+	return nil
+}

--- a/internal/controller/device/scsi/state.go
+++ b/internal/controller/device/scsi/state.go
@@ -1,0 +1,121 @@
+//go:build windows
+
+package scsi
+
+// attachState represents the current state of a SCSI disk attachment lifecycle.
+//
+// The normal progression is:
+//
+//	attachPending → attachAttached → attachDetaching → attachUnplugged → attachDetached
+//
+// If the attach operation fails, the state remains at attachPending so
+// the caller can retry. attachReserved is a terminal state for
+// pre-reserved slots.
+//
+// Full state-transition table:
+//
+//	Current State        │ Trigger                            │ Next State
+//	─────────────────────┼────────────────────────────────────┼────────────────────
+//	attachPending        │ attach succeeds                    │ attachAttached
+//	attachPending        │ attach fails                       │ attachPending
+//	attachAttached       │ detach begins                      │ attachDetaching
+//	attachDetaching      │ guest unplug succeeds              │ attachUnplugged
+//	attachUnplugged      │ bus removal succeeds               │ attachDetached
+//	attachDetached       │ (terminal — no further transitions)│ —
+//	attachReserved       │ (terminal — no further transitions)│ —
+type attachState int
+
+const (
+	// attachPending is the initial state; the slot has been allocated but
+	// the disk has not yet been added to the VM's SCSI bus.
+	attachPending attachState = iota
+
+	// attachAttached means the disk has been added to the VM's SCSI bus.
+	attachAttached
+
+	// attachDetaching means a detach has been initiated but the guest has
+	// not yet unplugged the device.
+	attachDetaching
+
+	// attachUnplugged means the guest has unplugged the device but it has
+	// not yet been removed from the VM's SCSI bus.
+	attachUnplugged
+
+	// attachDetached means the disk has been fully removed from the VM's
+	// SCSI bus. This is a terminal state.
+	attachDetached
+
+	// attachReserved marks a slot pre-reserved at manager construction
+	// time. This is a terminal state.
+	attachReserved
+)
+
+// String returns a human-readable name for the [attachState].
+func (s attachState) String() string {
+	switch s {
+	case attachPending:
+		return "Pending"
+	case attachAttached:
+		return "Attached"
+	case attachDetaching:
+		return "Detaching"
+	case attachUnplugged:
+		return "Unplugged"
+	case attachDetached:
+		return "Detached"
+	case attachReserved:
+		return "Reserved"
+	default:
+		return "Unknown"
+	}
+}
+
+// mountState represents the current state of a partition mount inside the guest.
+//
+// The normal progression is:
+//
+//	mountPending → mountMounted → mountUnmounted
+//
+// If the mount operation fails, the state remains at mountPending so
+// the caller can retry. Once a mount reaches mountUnmounted its entry is
+// deleted from the attachment's partition map; a subsequent MapToGuest call
+// creates a fresh mount struct from scratch rather than transitioning out of
+// this state.
+//
+// Full state-transition table:
+//
+//	Current State        │ Trigger                            │ Next State
+//	─────────────────────┼────────────────────────────────────┼────────────────────
+//	mountPending         │ guest mount succeeds               │ mountMounted
+//	mountPending         │ guest mount fails                  │ mountPending
+//	mountMounted         │ guest unmount succeeds             │ mountUnmounted
+//	mountUnmounted       │ (terminal — entry removed from map)│ —
+type mountState int
+
+const (
+	// mountPending is the initial state; the mount entry has been reserved
+	// but the guest mount operation has not yet succeeded.
+	mountPending mountState = iota
+
+	// mountMounted means the partition has been successfully mounted inside
+	// the guest.
+	mountMounted
+
+	// mountUnmounted means the guest has unmounted the partition but the
+	// SCSI device may still be attached to the VM. This is a terminal state.
+	mountUnmounted
+)
+
+// String returns a human-readable name for the [mountState].
+func (s mountState) String() string {
+	switch s {
+	case mountPending:
+		return "Pending"
+	case mountMounted:
+		return "Mounted"
+	case mountUnmounted:
+		return "Unmounted"
+	default:
+		return "Unknown"
+	}
+}

--- a/internal/controller/device/scsi/types.go
+++ b/internal/controller/device/scsi/types.go
@@ -1,0 +1,179 @@
+//go:build windows
+
+package scsi
+
+import (
+	"context"
+	"slices"
+
+	hcsschema "github.com/Microsoft/hcsshim/internal/hcs/schema2"
+	"github.com/Microsoft/hcsshim/internal/protocol/guestresource"
+)
+
+// DiskType identifies the attachment protocol used when adding a disk to the VM's SCSI bus.
+type DiskType string
+
+const (
+	// DiskTypeVirtualDisk attaches the disk as a virtual hard disk (VHD/VHDX).
+	DiskTypeVirtualDisk DiskType = "VirtualDisk"
+
+	// DiskTypePassThru attaches a physical disk directly to the VM with pass-through access.
+	DiskTypePassThru DiskType = "PassThru"
+
+	// DiskTypeExtensibleVirtualDisk attaches a disk via an extensible virtual disk (EVD) provider.
+	// The hostPath must be in the form evd://<type>/<mountPath>.
+	DiskTypeExtensibleVirtualDisk DiskType = "ExtensibleVirtualDisk"
+)
+
+// DiskConfig describes the host-side disk to attach to the VM's SCSI bus.
+type DiskConfig struct {
+	// HostPath is the path on the host to the disk to be attached.
+	HostPath string
+	// ReadOnly specifies whether the disk should be attached with read-only access.
+	ReadOnly bool
+	// Type specifies the attachment protocol to use when attaching the disk.
+	Type DiskType
+	// EVDType is the EVD provider name.
+	// Only populated when Type is [DiskTypeExtensibleVirtualDisk].
+	EVDType string
+}
+
+// MountConfig describes how a partition of a SCSI disk should be mounted inside the guest.
+type MountConfig struct {
+	// Partition is the target partition index (1-based) on a partitioned device.
+	// Zero means the whole disk.
+	Partition uint64
+	// ReadOnly mounts the disk read-only.
+	ReadOnly bool
+	// Encrypted encrypts the device with dm-crypt.
+	// Only supported for LCOW.
+	Encrypted bool
+	// Options are mount flags or data passed to the guest mount call.
+	// Only supported for LCOW.
+	Options []string
+	// EnsureFilesystem formats the mount as Filesystem if not already formatted.
+	// Only supported for LCOW.
+	EnsureFilesystem bool
+	// Filesystem is the target filesystem type.
+	// Only supported for LCOW.
+	Filesystem string
+	// BlockDev mounts the device as a block device.
+	// Only supported for LCOW.
+	BlockDev bool
+	// FormatWithRefs formats the disk using refs.
+	// Only supported for WCOW scratch disks.
+	FormatWithRefs bool
+}
+
+// VMSlot identifies a disk's hardware address on the VM's SCSI bus.
+type VMSlot struct {
+	// Controller is the zero-based SCSI controller index.
+	Controller uint
+	// LUN is the logical unit number within the controller.
+	LUN uint
+}
+
+// equals reports whether two DiskConfig values describe the same attachment parameters.
+func (d DiskConfig) equals(other DiskConfig) bool {
+	return d.HostPath == other.HostPath &&
+		d.ReadOnly == other.ReadOnly &&
+		d.Type == other.Type &&
+		d.EVDType == other.EVDType
+}
+
+// equals reports whether two MountConfig values describe the same mount parameters.
+func (mc MountConfig) equals(other MountConfig) bool {
+	return mc.ReadOnly == other.ReadOnly &&
+		mc.Encrypted == other.Encrypted &&
+		mc.EnsureFilesystem == other.EnsureFilesystem &&
+		mc.Filesystem == other.Filesystem &&
+		mc.BlockDev == other.BlockDev &&
+		mc.FormatWithRefs == other.FormatWithRefs &&
+		slices.Equal(mc.Options, other.Options)
+}
+
+// ==============================================================================
+// Interfaces used by Manager to perform actions on VM and Guest.
+// ==============================================================================
+
+// vmSCSI manages adding and removing SCSI devices for a Utility VM.
+type vmSCSI interface {
+	// AddSCSIDisk hot adds a SCSI disk to the Utility VM.
+	AddSCSIDisk(ctx context.Context, disk hcsschema.Attachment, controller uint, lun uint) error
+	// RemoveSCSIDisk removes a SCSI disk from a Utility VM.
+	RemoveSCSIDisk(ctx context.Context, controller uint, lun uint) error
+}
+
+// linuxGuestSCSI exposes guest-side SCSI operations for LCOW guests,
+// including mount, unmount, and device-level unplug.
+type linuxGuestSCSI interface {
+	// AddLCOWMappedVirtualDisk maps a virtual disk into the LCOW guest.
+	AddLCOWMappedVirtualDisk(ctx context.Context, settings guestresource.LCOWMappedVirtualDisk) error
+	// RemoveLCOWMappedVirtualDisk unmaps a virtual disk from the LCOW guest.
+	RemoveLCOWMappedVirtualDisk(ctx context.Context, settings guestresource.LCOWMappedVirtualDisk) error
+	// RemoveSCSIDevice removes a SCSI device from the guest.
+	RemoveSCSIDevice(ctx context.Context, settings guestresource.SCSIDevice) error
+}
+
+// windowsGuestSCSI performs WCOW SCSI guest mount/unmount operations.
+type windowsGuestSCSI interface {
+	// AddWCOWMappedVirtualDisk maps a virtual disk into the WCOW guest.
+	AddWCOWMappedVirtualDisk(ctx context.Context, settings guestresource.WCOWMappedVirtualDisk) error
+	// AddWCOWMappedVirtualDiskForContainerScratch maps a virtual disk as a container scratch in the WCOW guest.
+	AddWCOWMappedVirtualDiskForContainerScratch(ctx context.Context, settings guestresource.WCOWMappedVirtualDisk) error
+	// RemoveWCOWMappedVirtualDisk unmaps a virtual disk from the WCOW guest.
+	RemoveWCOWMappedVirtualDisk(ctx context.Context, settings guestresource.WCOWMappedVirtualDisk) error
+}
+
+// ==============================================================================
+// INTERNAL DATA STRUCTURES
+// Types and constants below this line are unexported and used for state tracking.
+// ==============================================================================
+
+// numLUNsPerController is the maximum number of LUNs per controller, fixed by Hyper-V.
+const numLUNsPerController = 64
+
+// attachment records the lifecycle state of a SCSI disk on the VM's SCSI bus.
+// Access must be guarded by Manager.mu.
+type attachment struct {
+	// controller and lun are the allocated hardware address on the SCSI bus.
+	controller uint
+	lun        uint
+
+	// diskConfig is the immutable host-side disk parameters.
+	diskConfig *DiskConfig
+
+	// state tracks the lifecycle position of this attachment.
+	state attachState
+
+	// partitions maps a partition index to its guest mount state.
+	// Partition 0 represents the whole disk.
+	partitions map[uint64]*mount
+}
+
+// mount records the lifecycle state of a single partition mount inside the guest.
+// Access must be guarded by Manager.mu.
+type mount struct {
+	// config is the immutable guest-side mount parameters.
+	config *MountConfig
+
+	// guestPath is the auto-generated path inside the guest where the partition
+	// is mounted.
+	guestPath string
+
+	// refCount is the number of active callers sharing this mount.
+	refCount uint
+
+	// state tracks the lifecycle position of this mount.
+	state mountState
+}
+
+// mapping links a caller-supplied mappingID to an attachment and partition
+// index. Access must be guarded by Manager.mu.
+type mapping struct {
+	// att is the SCSI attachment this mapping references.
+	att *attachment
+
+	// partition is the partition index on the device (0 = whole disk).
+	partition uint64
+}

--- a/internal/logfields/fields.go
+++ b/internal/logfields/fields.go
@@ -27,6 +27,13 @@ const (
 	Attempt = "attemptNo"
 	JSON    = "json"
 
+	// SCSI Constants
+
+	Controller = "controller"
+	LUN        = "lun"
+	DiskType   = "disk-type"
+	MappingID  = "mapping-id"
+
 	// Time
 
 	StartTime = "startTime"

--- a/internal/vm/guestmanager/scsi_lcow.go
+++ b/internal/vm/guestmanager/scsi_lcow.go
@@ -11,18 +11,6 @@ import (
 	"github.com/Microsoft/hcsshim/internal/protocol/guestresource"
 )
 
-// LCOWScsiManager exposes mapped virtual disk and SCSI device operations in the LCOW guest.
-type LCOWScsiManager interface {
-	// AddLCOWMappedVirtualDisk maps a virtual disk into the LCOW guest.
-	AddLCOWMappedVirtualDisk(ctx context.Context, settings guestresource.LCOWMappedVirtualDisk) error
-	// RemoveLCOWMappedVirtualDisk unmaps a virtual disk from the LCOW guest.
-	RemoveLCOWMappedVirtualDisk(ctx context.Context, settings guestresource.LCOWMappedVirtualDisk) error
-	// RemoveSCSIDevice removes a SCSI device from the guest.
-	RemoveSCSIDevice(ctx context.Context, settings guestresource.SCSIDevice) error
-}
-
-var _ LCOWScsiManager = (*Guest)(nil)
-
 // AddLCOWMappedVirtualDisk maps a virtual disk into a LCOW guest.
 func (gm *Guest) AddLCOWMappedVirtualDisk(ctx context.Context, settings guestresource.LCOWMappedVirtualDisk) error {
 	request := &hcsschema.ModifySettingRequest{

--- a/internal/vm/vmmanager/scsi.go
+++ b/internal/vm/vmmanager/scsi.go
@@ -11,17 +11,6 @@ import (
 	"github.com/Microsoft/hcsshim/internal/protocol/guestrequest"
 )
 
-// SCSIManager manages adding and removing SCSI devices for a Utility VM.
-type SCSIManager interface {
-	// AddSCSIDisk hot adds a SCSI disk to the Utility VM.
-	AddSCSIDisk(ctx context.Context, disk hcsschema.Attachment, controller uint, lun uint) error
-
-	// RemoveSCSIDisk removes a SCSI disk from a Utility VM.
-	RemoveSCSIDisk(ctx context.Context, controller uint, lun uint) error
-}
-
-var _ SCSIManager = (*UtilityVM)(nil)
-
 func (uvm *UtilityVM) AddSCSIDisk(ctx context.Context, disk hcsschema.Attachment, controller uint, lun uint) error {
 	request := &hcsschema.ModifySettingRequest{
 		RequestType:  guestrequest.RequestTypeAdd,


### PR DESCRIPTION
### Summary

Adds the `internal/controller/device/scsi` package, which manages the full lifecycle of SCSI disk mappings on a Hyper-V VM — from host-side slot allocation, through guest-side mounting, to teardown.

#### Key changes include:

* Added a `Manager` type that exposes two operations: `MapToGuest` (allocate a slot, attach the disk, and mount a partition inside the guest) and `UnmapFromGuest` (unmount, unplug, and detach). All operations are serialized by a single mutex.

* Introduced a layered state model with two forward-only state machines — one for **attachment** (`Pending → Attached → Detaching → Unplugged → Detached`, plus a terminal `Reserved` state for pre-allocated slots) and one for **mount** (`Pending → Mounted → Unmounted`). A separate `mapping` structure links caller-supplied IDs to an attachment and partition.

* Both operations are retriable: on failure the state stays in place so a subsequent call with the same `mappingID` resumes where the previous attempt stopped. Duplicate requests for the same disk and partition share a single slot and guest path via reference counting; teardown only runs when the count reaches zero.

#### Platform-Specific Guest Operations
* **LCOW** (`scsi_lcow.go`): mounts/unmounts via `LCOWMappedVirtualDisk` guest requests, and performs an explicit guest-side SCSI device unplug before host removal.
* **WCOW** (`scsi_wcow.go`): mounts/unmounts via `WCOWMappedVirtualDisk` guest requests (with a dedicated scratch-disk path); unplug is a no-op since Windows handles hot-remove automatically.
* Platform selection is driven by build tags (`windows && !wcow` vs `windows && wcow`).
