### PR TITLE
Fixes the go fmt for internal/hcs/schema2

### DIFF
--- a/internal/hcs/schema2/com_port.go
+++ b/internal/hcs/schema2/com_port.go
@@ -9,7 +9,7 @@
 
 package hcsschema
 
-//  ComPort specifies the named pipe that will be used for the port, with empty string indicating a disconnected port.
+// ComPort specifies the named pipe that will be used for the port, with empty string indicating a disconnected port.
 type ComPort struct {
 	NamedPipe string `json:"NamedPipe,omitempty"`
 

--- a/internal/hcs/schema2/container_memory_information.go
+++ b/internal/hcs/schema2/container_memory_information.go
@@ -9,7 +9,7 @@
 
 package hcsschema
 
-//  memory usage as viewed from within the container
+// memory usage as viewed from within the container
 type ContainerMemoryInformation struct {
 	TotalPhysicalBytes int32 `json:"TotalPhysicalBytes,omitempty"`
 

--- a/internal/hcs/schema2/guest_connection_info.go
+++ b/internal/hcs/schema2/guest_connection_info.go
@@ -9,7 +9,7 @@
 
 package hcsschema
 
-//  Information about the guest.
+// Information about the guest.
 type GuestConnectionInfo struct {
 
 	//  Each schema version x.y stands for the range of versions a.b where a==x  and b<=y. This list comes from the SupportedSchemaVersions field in  GcsCapabilities.

--- a/internal/hcs/schema2/hv_socket_2.go
+++ b/internal/hcs/schema2/hv_socket_2.go
@@ -9,7 +9,7 @@
 
 package hcsschema
 
-//  HvSocket configuration for a VM
+// HvSocket configuration for a VM
 type HvSocket2 struct {
 	HvSocketConfig *HvSocketSystemConfig `json:"HvSocketConfig,omitempty"`
 }

--- a/internal/hcs/schema2/hv_socket_address.go
+++ b/internal/hcs/schema2/hv_socket_address.go
@@ -9,8 +9,8 @@
 
 package hcsschema
 
-//  This class defines address settings applied to a VM
-//  by the GCS every time a VM starts or restores.
+// This class defines address settings applied to a VM
+// by the GCS every time a VM starts or restores.
 type HvSocketAddress struct {
 	LocalAddress  string `json:"LocalAddress,omitempty"`
 	ParentAddress string `json:"ParentAddress,omitempty"`

--- a/internal/hcs/schema2/hv_socket_system_config.go
+++ b/internal/hcs/schema2/hv_socket_system_config.go
@@ -9,7 +9,7 @@
 
 package hcsschema
 
-//  This is the HCS Schema version of the HvSocket configuration. The VMWP version is  located in Config.Devices.IC in V1.
+// This is the HCS Schema version of the HvSocket configuration. The VMWP version is  located in Config.Devices.IC in V1.
 type HvSocketSystemConfig struct {
 
 	//  SDDL string that HvSocket will check before allowing a host process to bind  to an unlisted service for this specific container/VM (not wildcard binds).

--- a/internal/hcs/schema2/memory_stats.go
+++ b/internal/hcs/schema2/memory_stats.go
@@ -9,7 +9,7 @@
 
 package hcsschema
 
-//  Memory runtime statistics
+// Memory runtime statistics
 type MemoryStats struct {
 	MemoryUsageCommitBytes uint64 `json:"MemoryUsageCommitBytes,omitempty"`
 

--- a/internal/hcs/schema2/numa_setting.go
+++ b/internal/hcs/schema2/numa_setting.go
@@ -12,10 +12,10 @@
 package hcsschema
 
 type NumaSetting struct {
-	VirtualNodeNumber        uint32            `json:"VirtualNodeNumber,omitempty"`
-	PhysicalNodeNumber       uint32            `json:"PhysicalNodeNumber,omitempty"`
-	VirtualSocketNumber      uint32            `json:"VirtualSocketNumber,omitempty"`
-	CountOfProcessors        uint32            `json:"CountOfProcessors,omitempty"`
-	CountOfMemoryBlocks      uint64            `json:"CountOfMemoryBlocks,omitempty"`
-	MemoryBackingType        MemoryBackingType `json:"MemoryBackingType,omitempty"`
+	VirtualNodeNumber   uint32            `json:"VirtualNodeNumber,omitempty"`
+	PhysicalNodeNumber  uint32            `json:"PhysicalNodeNumber,omitempty"`
+	VirtualSocketNumber uint32            `json:"VirtualSocketNumber,omitempty"`
+	CountOfProcessors   uint32            `json:"CountOfProcessors,omitempty"`
+	CountOfMemoryBlocks uint64            `json:"CountOfMemoryBlocks,omitempty"`
+	MemoryBackingType   MemoryBackingType `json:"MemoryBackingType,omitempty"`
 }

--- a/internal/hcs/schema2/pause_notification.go
+++ b/internal/hcs/schema2/pause_notification.go
@@ -9,7 +9,7 @@
 
 package hcsschema
 
-//  Notification data that is indicated to components running in the Virtual Machine.
+// Notification data that is indicated to components running in the Virtual Machine.
 type PauseNotification struct {
 	Reason string `json:"Reason,omitempty"`
 }

--- a/internal/hcs/schema2/pause_options.go
+++ b/internal/hcs/schema2/pause_options.go
@@ -9,7 +9,7 @@
 
 package hcsschema
 
-//  Options for HcsPauseComputeSystem
+// Options for HcsPauseComputeSystem
 type PauseOptions struct {
 	SuspensionLevel string `json:"SuspensionLevel,omitempty"`
 

--- a/internal/hcs/schema2/process_details.go
+++ b/internal/hcs/schema2/process_details.go
@@ -13,7 +13,7 @@ import (
 	"time"
 )
 
-//  Information about a process running in a container
+// Information about a process running in a container
 type ProcessDetails struct {
 	ProcessId int32 `json:"ProcessId,omitempty"`
 

--- a/internal/hcs/schema2/processor_stats.go
+++ b/internal/hcs/schema2/processor_stats.go
@@ -9,7 +9,7 @@
 
 package hcsschema
 
-//  CPU runtime statistics
+// CPU runtime statistics
 type ProcessorStats struct {
 	TotalRuntime100ns uint64 `json:"TotalRuntime100ns,omitempty"`
 

--- a/internal/hcs/schema2/property_query.go
+++ b/internal/hcs/schema2/property_query.go
@@ -9,7 +9,7 @@
 
 package hcsschema
 
-//   By default the basic properties will be returned. This query provides a way to  request specific properties.
+// By default the basic properties will be returned. This query provides a way to  request specific properties.
 type PropertyQuery struct {
 	PropertyTypes []PropertyType `json:"PropertyTypes,omitempty"`
 }

--- a/internal/hcs/schema2/silo_properties.go
+++ b/internal/hcs/schema2/silo_properties.go
@@ -9,7 +9,7 @@
 
 package hcsschema
 
-//  Silo job information
+// Silo job information
 type SiloProperties struct {
 	Enabled bool `json:"Enabled,omitempty"`
 

--- a/internal/hcs/schema2/statistics.go
+++ b/internal/hcs/schema2/statistics.go
@@ -13,7 +13,7 @@ import (
 	"time"
 )
 
-//  Runtime statistics for a container
+// Runtime statistics for a container
 type Statistics struct {
 	Timestamp time.Time `json:"Timestamp,omitempty"`
 

--- a/internal/hcs/schema2/storage_stats.go
+++ b/internal/hcs/schema2/storage_stats.go
@@ -9,7 +9,7 @@
 
 package hcsschema
 
-//  Storage runtime statistics
+// Storage runtime statistics
 type StorageStats struct {
 	ReadCountNormalized uint64 `json:"ReadCountNormalized,omitempty"`
 

--- a/internal/hcs/schema2/topology.go
+++ b/internal/hcs/schema2/topology.go
@@ -12,7 +12,7 @@
 package hcsschema
 
 type Topology struct {
-	Memory        *VirtualMachineMemory                `json:"Memory,omitempty"`
-	Processor     *VirtualMachineProcessor             `json:"Processor,omitempty"`
-	Numa          *Numa                                `json:"Numa,omitempty"`
+	Memory    *VirtualMachineMemory    `json:"Memory,omitempty"`
+	Processor *VirtualMachineProcessor `json:"Processor,omitempty"`
+	Numa      *Numa                    `json:"Numa,omitempty"`
 }

--- a/internal/hcs/schema2/virtual_machine.go
+++ b/internal/hcs/schema2/virtual_machine.go
@@ -15,15 +15,15 @@ package hcsschema
 type VirtualMachine struct {
 	Version *Version `json:"Version,omitempty"`
 	// When set to true, the virtual machine will treat a reset as a stop, releasing resources and cleaning up state.
-	StopOnReset     bool             `json:"StopOnReset,omitempty"`
-	Chipset         *Chipset         `json:"Chipset,omitempty"`
-	ComputeTopology *Topology        `json:"ComputeTopology,omitempty"`
-	Devices         *Devices         `json:"Devices,omitempty"`
-	GuestState      *GuestState      `json:"GuestState,omitempty"`
-	RestoreState    *RestoreState    `json:"RestoreState,omitempty"`
-	RegistryChanges *RegistryChanges `json:"RegistryChanges,omitempty"`
-	StorageQoS      *StorageQoS      `json:"StorageQoS,omitempty"`
-	DebugOptions    *DebugOptions    `json:"DebugOptions,omitempty"`
-	GuestConnection *GuestConnection `json:"GuestConnection,omitempty"`
-	SecuritySettings  *SecuritySettings `json:"SecuritySettings,omitempty"`
+	StopOnReset      bool              `json:"StopOnReset,omitempty"`
+	Chipset          *Chipset          `json:"Chipset,omitempty"`
+	ComputeTopology  *Topology         `json:"ComputeTopology,omitempty"`
+	Devices          *Devices          `json:"Devices,omitempty"`
+	GuestState       *GuestState       `json:"GuestState,omitempty"`
+	RestoreState     *RestoreState     `json:"RestoreState,omitempty"`
+	RegistryChanges  *RegistryChanges  `json:"RegistryChanges,omitempty"`
+	StorageQoS       *StorageQoS       `json:"StorageQoS,omitempty"`
+	DebugOptions     *DebugOptions     `json:"DebugOptions,omitempty"`
+	GuestConnection  *GuestConnection  `json:"GuestConnection,omitempty"`
+	SecuritySettings *SecuritySettings `json:"SecuritySettings,omitempty"`
 }

--- a/internal/hcs/schema2/virtual_machine_memory.go
+++ b/internal/hcs/schema2/virtual_machine_memory.go
@@ -15,7 +15,7 @@ type VirtualMachineMemory struct {
 	SizeInMB uint64             `json:"SizeInMB,omitempty"`
 	Backing  *MemoryBackingType `json:"Backing,omitempty"`
 	// If enabled, then the VM's memory is backed by the Windows pagefile rather than physically backed, statically allocated memory.
-	AllowOvercommit bool                   `json:"AllowOvercommit,omitempty"`
+	AllowOvercommit bool `json:"AllowOvercommit,omitempty"`
 	// If enabled, then the memory hot hint feature is exposed to the VM, allowing it to prefetch pages into its working set. (if supported by the guest operating system).
 	EnableHotHint bool `json:"EnableHotHint,omitempty"`
 	// If enabled, then the memory cold hint feature is exposed to the VM, allowing it to trim zeroed pages from its working set (if supported by the guest operating system).
@@ -27,7 +27,7 @@ type VirtualMachineMemory struct {
 	// Low MMIO region allocated below 4GB
 	LowMMIOGapInMB uint64 `json:"LowMmioGapInMB,omitempty"`
 	// High MMIO region allocated above 4GB (base and size)
-	HighMMIOBaseInMB         uint64                 `json:"HighMmioBaseInMB,omitempty"`
-	HighMMIOGapInMB          uint64                 `json:"HighMmioGapInMB,omitempty"`
-	SlitType                   *VirtualSlitType                   `json:"SlitType,omitempty"`
+	HighMMIOBaseInMB uint64           `json:"HighMmioBaseInMB,omitempty"`
+	HighMMIOGapInMB  uint64           `json:"HighMmioGapInMB,omitempty"`
+	SlitType         *VirtualSlitType `json:"SlitType,omitempty"`
 }

--- a/internal/hcs/schema2/virtual_machine_processor.go
+++ b/internal/hcs/schema2/virtual_machine_processor.go
@@ -12,10 +12,10 @@
 package hcsschema
 
 type VirtualMachineProcessor struct {
-	Count       uint32 `json:"Count,omitempty"`
-	Limit       uint64 `json:"Limit,omitempty"`
-	Weight      uint64 `json:"Weight,omitempty"`
-	Reservation uint64 `json:"Reservation,omitempty"`
-	CpuGroup                   *CpuGroup            `json:"CpuGroup,omitempty"`
-	NumaProcessorsSettings     *NumaProcessors      `json:"NumaProcessorsSettings,omitempty"`
+	Count                  uint32          `json:"Count,omitempty"`
+	Limit                  uint64          `json:"Limit,omitempty"`
+	Weight                 uint64          `json:"Weight,omitempty"`
+	Reservation            uint64          `json:"Reservation,omitempty"`
+	CpuGroup               *CpuGroup       `json:"CpuGroup,omitempty"`
+	NumaProcessorsSettings *NumaProcessors `json:"NumaProcessorsSettings,omitempty"`
 }

--- a/internal/hcs/schema2/virtual_pci_device.go
+++ b/internal/hcs/schema2/virtual_pci_device.go
@@ -12,6 +12,6 @@ package hcsschema
 // TODO: PropagateNumaAffinity is pre-release/experimental field in schema 2.11. Need to add build number
 // docs when a public build with this is out.
 type VirtualPciDevice struct {
-	Functions []VirtualPciFunction `json:",omitempty"`
-	PropagateNumaAffinity *bool	`json:"PropagateNumaAffinity,omitempty"`
+	Functions             []VirtualPciFunction `json:",omitempty"`
+	PropagateNumaAffinity *bool                `json:"PropagateNumaAffinity,omitempty"`
 }


### PR DESCRIPTION
These files were incorrectly formatted such that go fmt ./... from the root always marks them as changed.