### PR TITLE
[live-migration] replace event/error strings with structured MigrationNotification

### DIFF
--- a/pkg/migration/migration.pb.go
+++ b/pkg/migration/migration.pb.go
@@ -438,15 +438,14 @@ type TransferSandboxResponse struct {
 	// Monotonically increasing per-message counter on this stream. Useful
 	// for de-duplication if the client reconnects mid-transfer.
 	MessageID uint32 `protobuf:"varint,1,opt,name=message_id,json=messageId,proto3" json:"message_id,omitempty"`
-	// Event-specific message describing the current migration notification.
-	Event string `protobuf:"bytes,2,opt,name=event,proto3" json:"event,omitempty"`
-	// Populated when `event` indicates an error or a timeout; empty
-	// otherwise.
-	Error string `protobuf:"bytes,3,opt,name=error,proto3" json:"error,omitempty"`
+	// Structured notification describing the current migration event. This
+	// mirrors the HCS OperationSystemMigrationNotificationInfo payload
+	// emitted by the underlying compute system as the transfer progresses.
+	Notification *MigrationNotification `protobuf:"bytes,2,opt,name=notification,proto3" json:"notification,omitempty"`
 	// Server-side timestamp of when the transfer began.
-	StartTime *timestamppb.Timestamp `protobuf:"bytes,4,opt,name=start_time,json=startTime,proto3" json:"start_time,omitempty"`
+	StartTime *timestamppb.Timestamp `protobuf:"bytes,3,opt,name=start_time,json=startTime,proto3" json:"start_time,omitempty"`
 	// Server-side timestamp of when this particular update was produced.
-	UpdateTime    *timestamppb.Timestamp `protobuf:"bytes,5,opt,name=update_time,json=updateTime,proto3" json:"update_time,omitempty"`
+	UpdateTime    *timestamppb.Timestamp `protobuf:"bytes,4,opt,name=update_time,json=updateTime,proto3" json:"update_time,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -488,18 +487,11 @@ func (x *TransferSandboxResponse) GetMessageID() uint32 {
 	return 0
 }
 
-func (x *TransferSandboxResponse) GetEvent() string {
+func (x *TransferSandboxResponse) GetNotification() *MigrationNotification {
 	if x != nil {
-		return x.Event
+		return x.Notification
 	}
-	return ""
-}
-
-func (x *TransferSandboxResponse) GetError() string {
-	if x != nil {
-		return x.Error
-	}
-	return ""
+	return nil
 }
 
 func (x *TransferSandboxResponse) GetStartTime() *timestamppb.Timestamp {
@@ -727,15 +719,14 @@ const file_github_com_Microsoft_hcsshim_pkg_migration_migration_proto_rawDesc = 
 	"\x16TransferSandboxRequest\x12\x1d\n" +
 	"\n" +
 	"session_id\x18\x01 \x01(\tR\tsessionId\x123\n" +
-	"\atimeout\x18\x02 \x01(\v2\x19.google.protobuf.DurationR\atimeout\"\xdc\x01\n" +
+	"\atimeout\x18\x02 \x01(\v2\x19.google.protobuf.DurationR\atimeout\"\xec\x01\n" +
 	"\x17TransferSandboxResponse\x12\x1d\n" +
 	"\n" +
-	"message_id\x18\x01 \x01(\rR\tmessageId\x12\x14\n" +
-	"\x05event\x18\x02 \x01(\tR\x05event\x12\x14\n" +
-	"\x05error\x18\x03 \x01(\tR\x05error\x129\n" +
+	"message_id\x18\x01 \x01(\rR\tmessageId\x12:\n" +
+	"\fnotification\x18\x02 \x01(\v2\x16.MigrationNotificationR\fnotification\x129\n" +
 	"\n" +
-	"start_time\x18\x04 \x01(\v2\x1a.google.protobuf.TimestampR\tstartTime\x12;\n" +
-	"\vupdate_time\x18\x05 \x01(\v2\x1a.google.protobuf.TimestampR\n" +
+	"start_time\x18\x03 \x01(\v2\x1a.google.protobuf.TimestampR\tstartTime\x12;\n" +
+	"\vupdate_time\x18\x04 \x01(\v2\x1a.google.protobuf.TimestampR\n" +
 	"updateTime\"`\n" +
 	"\x16FinalizeSandboxRequest\x12\x1d\n" +
 	"\n" +
@@ -790,7 +781,8 @@ var file_github_com_Microsoft_hcsshim_pkg_migration_migration_proto_goTypes = []
 	(*MigrationInitializeOptions)(nil),      // 13: MigrationInitializeOptions
 	(*anypb.Any)(nil),                       // 14: google.protobuf.Any
 	(*durationpb.Duration)(nil),             // 15: google.protobuf.Duration
-	(*timestamppb.Timestamp)(nil),           // 16: google.protobuf.Timestamp
+	(*MigrationNotification)(nil),           // 16: MigrationNotification
+	(*timestamppb.Timestamp)(nil),           // 17: google.protobuf.Timestamp
 }
 var file_github_com_Microsoft_hcsshim_pkg_migration_migration_proto_depIdxs = []int32{
 	13, // 0: PrepareAndExportSandboxRequest.init_options:type_name -> MigrationInitializeOptions
@@ -798,26 +790,27 @@ var file_github_com_Microsoft_hcsshim_pkg_migration_migration_proto_depIdxs = []
 	14, // 2: ImportSandboxRequest.config:type_name -> google.protobuf.Any
 	13, // 3: PrepareSandboxRequest.init_options:type_name -> MigrationInitializeOptions
 	15, // 4: TransferSandboxRequest.timeout:type_name -> google.protobuf.Duration
-	16, // 5: TransferSandboxResponse.start_time:type_name -> google.protobuf.Timestamp
-	16, // 6: TransferSandboxResponse.update_time:type_name -> google.protobuf.Timestamp
-	0,  // 7: FinalizeSandboxRequest.action:type_name -> FinalizeAction
-	1,  // 8: Migration.PrepareAndExportSandbox:input_type -> PrepareAndExportSandboxRequest
-	3,  // 9: Migration.ImportSandbox:input_type -> ImportSandboxRequest
-	5,  // 10: Migration.PrepareSandbox:input_type -> PrepareSandboxRequest
-	7,  // 11: Migration.TransferSandbox:input_type -> TransferSandboxRequest
-	9,  // 12: Migration.FinalizeSandbox:input_type -> FinalizeSandboxRequest
-	11, // 13: Migration.CreateDuplicateSocket:input_type -> CreateDuplicateSocketRequest
-	2,  // 14: Migration.PrepareAndExportSandbox:output_type -> PrepareAndExportSandboxResponse
-	4,  // 15: Migration.ImportSandbox:output_type -> ImportSandboxResponse
-	6,  // 16: Migration.PrepareSandbox:output_type -> PrepareSandboxResponse
-	8,  // 17: Migration.TransferSandbox:output_type -> TransferSandboxResponse
-	10, // 18: Migration.FinalizeSandbox:output_type -> FinalizeSandboxResponse
-	12, // 19: Migration.CreateDuplicateSocket:output_type -> CreateDuplicateSocketResponse
-	14, // [14:20] is the sub-list for method output_type
-	8,  // [8:14] is the sub-list for method input_type
-	8,  // [8:8] is the sub-list for extension type_name
-	8,  // [8:8] is the sub-list for extension extendee
-	0,  // [0:8] is the sub-list for field type_name
+	16, // 5: TransferSandboxResponse.notification:type_name -> MigrationNotification
+	17, // 6: TransferSandboxResponse.start_time:type_name -> google.protobuf.Timestamp
+	17, // 7: TransferSandboxResponse.update_time:type_name -> google.protobuf.Timestamp
+	0,  // 8: FinalizeSandboxRequest.action:type_name -> FinalizeAction
+	1,  // 9: Migration.PrepareAndExportSandbox:input_type -> PrepareAndExportSandboxRequest
+	3,  // 10: Migration.ImportSandbox:input_type -> ImportSandboxRequest
+	5,  // 11: Migration.PrepareSandbox:input_type -> PrepareSandboxRequest
+	7,  // 12: Migration.TransferSandbox:input_type -> TransferSandboxRequest
+	9,  // 13: Migration.FinalizeSandbox:input_type -> FinalizeSandboxRequest
+	11, // 14: Migration.CreateDuplicateSocket:input_type -> CreateDuplicateSocketRequest
+	2,  // 15: Migration.PrepareAndExportSandbox:output_type -> PrepareAndExportSandboxResponse
+	4,  // 16: Migration.ImportSandbox:output_type -> ImportSandboxResponse
+	6,  // 17: Migration.PrepareSandbox:output_type -> PrepareSandboxResponse
+	8,  // 18: Migration.TransferSandbox:output_type -> TransferSandboxResponse
+	10, // 19: Migration.FinalizeSandbox:output_type -> FinalizeSandboxResponse
+	12, // 20: Migration.CreateDuplicateSocket:output_type -> CreateDuplicateSocketResponse
+	15, // [15:21] is the sub-list for method output_type
+	9,  // [9:15] is the sub-list for method input_type
+	9,  // [9:9] is the sub-list for extension type_name
+	9,  // [9:9] is the sub-list for extension extendee
+	0,  // [0:9] is the sub-list for field type_name
 }
 
 func init() { file_github_com_Microsoft_hcsshim_pkg_migration_migration_proto_init() }

--- a/pkg/migration/migration.pb.go
+++ b/pkg/migration/migration.pb.go
@@ -93,7 +93,7 @@ type PrepareAndExportSandboxRequest struct {
 	SessionID string `protobuf:"bytes,1,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
 	// Source-side options that control how live migration is initialized
 	// on the compute system.
-	InitOptions   *MigrationInitializeOptions `protobuf:"bytes,2,opt,name=init_options,json=initOptions,proto3" json:"init_options,omitempty"`
+	InitOptions   *InitializeOptions `protobuf:"bytes,2,opt,name=init_options,json=initOptions,proto3" json:"init_options,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -135,7 +135,7 @@ func (x *PrepareAndExportSandboxRequest) GetSessionID() string {
 	return ""
 }
 
-func (x *PrepareAndExportSandboxRequest) GetInitOptions() *MigrationInitializeOptions {
+func (x *PrepareAndExportSandboxRequest) GetInitOptions() *InitializeOptions {
 	if x != nil {
 		return x.InitOptions
 	}
@@ -290,7 +290,7 @@ type PrepareSandboxRequest struct {
 	SessionID string `protobuf:"bytes,1,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
 	// Destination-side options that control how live migration is
 	// initialized when the HCS compute system is created.
-	InitOptions   *MigrationInitializeOptions `protobuf:"bytes,2,opt,name=init_options,json=initOptions,proto3" json:"init_options,omitempty"`
+	InitOptions   *InitializeOptions `protobuf:"bytes,2,opt,name=init_options,json=initOptions,proto3" json:"init_options,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -332,7 +332,7 @@ func (x *PrepareSandboxRequest) GetSessionID() string {
 	return ""
 }
 
-func (x *PrepareSandboxRequest) GetInitOptions() *MigrationInitializeOptions {
+func (x *PrepareSandboxRequest) GetInitOptions() *InitializeOptions {
 	if x != nil {
 		return x.InitOptions
 	}
@@ -616,7 +616,7 @@ type NotificationsResponse struct {
 	// Structured notification describing the current migration event. This
 	// mirrors the HCS OperationSystemMigrationNotificationInfo payload
 	// emitted by the underlying compute system as the transfer progresses.
-	Notification *MigrationNotification `protobuf:"bytes,2,opt,name=notification,proto3" json:"notification,omitempty"`
+	Notification *Notification `protobuf:"bytes,2,opt,name=notification,proto3" json:"notification,omitempty"`
 	// Server-side timestamp of when the transfer began.
 	StartTime *timestamppb.Timestamp `protobuf:"bytes,3,opt,name=start_time,json=startTime,proto3" json:"start_time,omitempty"`
 	// Server-side timestamp of when this particular update was produced.
@@ -662,7 +662,7 @@ func (x *NotificationsResponse) GetMessageID() uint32 {
 	return 0
 }
 
-func (x *NotificationsResponse) GetNotification() *MigrationNotification {
+func (x *NotificationsResponse) GetNotification() *Notification {
 	if x != nil {
 		return x.Notification
 	}
@@ -781,22 +781,22 @@ var File_github_com_Microsoft_hcsshim_pkg_migration_migration_proto protoreflect
 
 const file_github_com_Microsoft_hcsshim_pkg_migration_migration_proto_rawDesc = "" +
 	"\n" +
-	":github.com/Microsoft/hcsshim/pkg/migration/migration.proto\x1a\x19google/protobuf/any.proto\x1a\x1egoogle/protobuf/duration.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1aBgithub.com/Microsoft/hcsshim/pkg/migration/migration_options.proto\"\x7f\n" +
+	":github.com/Microsoft/hcsshim/pkg/migration/migration.proto\x1a\x19google/protobuf/any.proto\x1a\x1egoogle/protobuf/duration.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1aBgithub.com/Microsoft/hcsshim/pkg/migration/migration_options.proto\"v\n" +
 	"\x1ePrepareAndExportSandboxRequest\x12\x1d\n" +
 	"\n" +
-	"session_id\x18\x01 \x01(\tR\tsessionId\x12>\n" +
-	"\finit_options\x18\x02 \x01(\v2\x1b.MigrationInitializeOptionsR\vinitOptions\"O\n" +
+	"session_id\x18\x01 \x01(\tR\tsessionId\x125\n" +
+	"\finit_options\x18\x02 \x01(\v2\x12.InitializeOptionsR\vinitOptions\"O\n" +
 	"\x1fPrepareAndExportSandboxResponse\x12,\n" +
 	"\x06config\x18\x01 \x01(\v2\x14.google.protobuf.AnyR\x06config\"c\n" +
 	"\x14ImportSandboxRequest\x12\x1d\n" +
 	"\n" +
 	"session_id\x18\x01 \x01(\tR\tsessionId\x12,\n" +
 	"\x06config\x18\x02 \x01(\v2\x14.google.protobuf.AnyR\x06config\"\x17\n" +
-	"\x15ImportSandboxResponse\"v\n" +
+	"\x15ImportSandboxResponse\"m\n" +
 	"\x15PrepareSandboxRequest\x12\x1d\n" +
 	"\n" +
-	"session_id\x18\x01 \x01(\tR\tsessionId\x12>\n" +
-	"\finit_options\x18\x02 \x01(\v2\x1b.MigrationInitializeOptionsR\vinitOptions\"\x18\n" +
+	"session_id\x18\x01 \x01(\tR\tsessionId\x125\n" +
+	"\finit_options\x18\x02 \x01(\v2\x12.InitializeOptionsR\vinitOptions\"\x18\n" +
 	"\x16PrepareSandboxResponse\"l\n" +
 	"\x16TransferSandboxRequest\x12\x1d\n" +
 	"\n" +
@@ -810,11 +810,11 @@ const file_github_com_Microsoft_hcsshim_pkg_migration_migration_proto_rawDesc = 
 	"\x17FinalizeSandboxResponse\"5\n" +
 	"\x14NotificationsRequest\x12\x1d\n" +
 	"\n" +
-	"session_id\x18\x01 \x01(\tR\tsessionId\"\xea\x01\n" +
+	"session_id\x18\x01 \x01(\tR\tsessionId\"\xe1\x01\n" +
 	"\x15NotificationsResponse\x12\x1d\n" +
 	"\n" +
-	"message_id\x18\x01 \x01(\rR\tmessageId\x12:\n" +
-	"\fnotification\x18\x02 \x01(\v2\x16.MigrationNotificationR\fnotification\x129\n" +
+	"message_id\x18\x01 \x01(\rR\tmessageId\x121\n" +
+	"\fnotification\x18\x02 \x01(\v2\r.NotificationR\fnotification\x129\n" +
 	"\n" +
 	"start_time\x18\x03 \x01(\v2\x1a.google.protobuf.TimestampR\tstartTime\x12;\n" +
 	"\vupdate_time\x18\x04 \x01(\v2\x1a.google.protobuf.TimestampR\n" +
@@ -867,20 +867,20 @@ var file_github_com_Microsoft_hcsshim_pkg_migration_migration_proto_goTypes = []
 	(*NotificationsResponse)(nil),           // 12: NotificationsResponse
 	(*CreateDuplicateSocketRequest)(nil),    // 13: CreateDuplicateSocketRequest
 	(*CreateDuplicateSocketResponse)(nil),   // 14: CreateDuplicateSocketResponse
-	(*MigrationInitializeOptions)(nil),      // 15: MigrationInitializeOptions
+	(*InitializeOptions)(nil),               // 15: InitializeOptions
 	(*anypb.Any)(nil),                       // 16: google.protobuf.Any
 	(*durationpb.Duration)(nil),             // 17: google.protobuf.Duration
-	(*MigrationNotification)(nil),           // 18: MigrationNotification
+	(*Notification)(nil),                    // 18: Notification
 	(*timestamppb.Timestamp)(nil),           // 19: google.protobuf.Timestamp
 }
 var file_github_com_Microsoft_hcsshim_pkg_migration_migration_proto_depIdxs = []int32{
-	15, // 0: PrepareAndExportSandboxRequest.init_options:type_name -> MigrationInitializeOptions
+	15, // 0: PrepareAndExportSandboxRequest.init_options:type_name -> InitializeOptions
 	16, // 1: PrepareAndExportSandboxResponse.config:type_name -> google.protobuf.Any
 	16, // 2: ImportSandboxRequest.config:type_name -> google.protobuf.Any
-	15, // 3: PrepareSandboxRequest.init_options:type_name -> MigrationInitializeOptions
+	15, // 3: PrepareSandboxRequest.init_options:type_name -> InitializeOptions
 	17, // 4: TransferSandboxRequest.timeout:type_name -> google.protobuf.Duration
 	0,  // 5: FinalizeSandboxRequest.action:type_name -> FinalizeAction
-	18, // 6: NotificationsResponse.notification:type_name -> MigrationNotification
+	18, // 6: NotificationsResponse.notification:type_name -> Notification
 	19, // 7: NotificationsResponse.start_time:type_name -> google.protobuf.Timestamp
 	19, // 8: NotificationsResponse.update_time:type_name -> google.protobuf.Timestamp
 	1,  // 9: Migration.PrepareAndExportSandbox:input_type -> PrepareAndExportSandboxRequest

--- a/pkg/migration/migration.pb.go
+++ b/pkg/migration/migration.pb.go
@@ -381,9 +381,9 @@ type TransferSandboxRequest struct {
 	// for the rest of this LM on this side.
 	SessionID string `protobuf:"bytes,1,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
 	// Maximum time to wait for the migration socket / underlying transport
-	// to become ready before the server gives up and reports a TIMEOUT
-	// event on the response stream. If unset, the server applies a sensible
-	// default (e.g. 10 minutes).
+	// to become ready before the server gives up and fails the transfer
+	// with a TIMEOUT. If unset, the server applies a sensible default
+	// (e.g. 10 minutes).
 	Timeout       *durationpb.Duration `protobuf:"bytes,2,opt,name=timeout,proto3" json:"timeout,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -434,18 +434,7 @@ func (x *TransferSandboxRequest) GetTimeout() *durationpb.Duration {
 }
 
 type TransferSandboxResponse struct {
-	state protoimpl.MessageState `protogen:"open.v1"`
-	// Monotonically increasing per-message counter on this stream. Useful
-	// for de-duplication if the client reconnects mid-transfer.
-	MessageID uint32 `protobuf:"varint,1,opt,name=message_id,json=messageId,proto3" json:"message_id,omitempty"`
-	// Structured notification describing the current migration event. This
-	// mirrors the HCS OperationSystemMigrationNotificationInfo payload
-	// emitted by the underlying compute system as the transfer progresses.
-	Notification *MigrationNotification `protobuf:"bytes,2,opt,name=notification,proto3" json:"notification,omitempty"`
-	// Server-side timestamp of when the transfer began.
-	StartTime *timestamppb.Timestamp `protobuf:"bytes,3,opt,name=start_time,json=startTime,proto3" json:"start_time,omitempty"`
-	// Server-side timestamp of when this particular update was produced.
-	UpdateTime    *timestamppb.Timestamp `protobuf:"bytes,4,opt,name=update_time,json=updateTime,proto3" json:"update_time,omitempty"`
+	state         protoimpl.MessageState `protogen:"open.v1"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -478,34 +467,6 @@ func (x *TransferSandboxResponse) ProtoReflect() protoreflect.Message {
 // Deprecated: Use TransferSandboxResponse.ProtoReflect.Descriptor instead.
 func (*TransferSandboxResponse) Descriptor() ([]byte, []int) {
 	return file_github_com_Microsoft_hcsshim_pkg_migration_migration_proto_rawDescGZIP(), []int{7}
-}
-
-func (x *TransferSandboxResponse) GetMessageID() uint32 {
-	if x != nil {
-		return x.MessageID
-	}
-	return 0
-}
-
-func (x *TransferSandboxResponse) GetNotification() *MigrationNotification {
-	if x != nil {
-		return x.Notification
-	}
-	return nil
-}
-
-func (x *TransferSandboxResponse) GetStartTime() *timestamppb.Timestamp {
-	if x != nil {
-		return x.StartTime
-	}
-	return nil
-}
-
-func (x *TransferSandboxResponse) GetUpdateTime() *timestamppb.Timestamp {
-	if x != nil {
-		return x.UpdateTime
-	}
-	return nil
 }
 
 type FinalizeSandboxRequest struct {
@@ -601,6 +562,127 @@ func (*FinalizeSandboxResponse) Descriptor() ([]byte, []int) {
 	return file_github_com_Microsoft_hcsshim_pkg_migration_migration_proto_rawDescGZIP(), []int{9}
 }
 
+type NotificationsRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Identifier for the migration session. Must match the session_id used
+	// for the rest of this LM on this side.
+	SessionID     string `protobuf:"bytes,1,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *NotificationsRequest) Reset() {
+	*x = NotificationsRequest{}
+	mi := &file_github_com_Microsoft_hcsshim_pkg_migration_migration_proto_msgTypes[10]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *NotificationsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*NotificationsRequest) ProtoMessage() {}
+
+func (x *NotificationsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_github_com_Microsoft_hcsshim_pkg_migration_migration_proto_msgTypes[10]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use NotificationsRequest.ProtoReflect.Descriptor instead.
+func (*NotificationsRequest) Descriptor() ([]byte, []int) {
+	return file_github_com_Microsoft_hcsshim_pkg_migration_migration_proto_rawDescGZIP(), []int{10}
+}
+
+func (x *NotificationsRequest) GetSessionID() string {
+	if x != nil {
+		return x.SessionID
+	}
+	return ""
+}
+
+type NotificationsResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Monotonically increasing per-message counter on this stream. Useful
+	// for de-duplication if the client reconnects mid-transfer.
+	MessageID uint32 `protobuf:"varint,1,opt,name=message_id,json=messageId,proto3" json:"message_id,omitempty"`
+	// Structured notification describing the current migration event. This
+	// mirrors the HCS OperationSystemMigrationNotificationInfo payload
+	// emitted by the underlying compute system as the transfer progresses.
+	Notification *MigrationNotification `protobuf:"bytes,2,opt,name=notification,proto3" json:"notification,omitempty"`
+	// Server-side timestamp of when the transfer began.
+	StartTime *timestamppb.Timestamp `protobuf:"bytes,3,opt,name=start_time,json=startTime,proto3" json:"start_time,omitempty"`
+	// Server-side timestamp of when this particular update was produced.
+	UpdateTime    *timestamppb.Timestamp `protobuf:"bytes,4,opt,name=update_time,json=updateTime,proto3" json:"update_time,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *NotificationsResponse) Reset() {
+	*x = NotificationsResponse{}
+	mi := &file_github_com_Microsoft_hcsshim_pkg_migration_migration_proto_msgTypes[11]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *NotificationsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*NotificationsResponse) ProtoMessage() {}
+
+func (x *NotificationsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_github_com_Microsoft_hcsshim_pkg_migration_migration_proto_msgTypes[11]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use NotificationsResponse.ProtoReflect.Descriptor instead.
+func (*NotificationsResponse) Descriptor() ([]byte, []int) {
+	return file_github_com_Microsoft_hcsshim_pkg_migration_migration_proto_rawDescGZIP(), []int{11}
+}
+
+func (x *NotificationsResponse) GetMessageID() uint32 {
+	if x != nil {
+		return x.MessageID
+	}
+	return 0
+}
+
+func (x *NotificationsResponse) GetNotification() *MigrationNotification {
+	if x != nil {
+		return x.Notification
+	}
+	return nil
+}
+
+func (x *NotificationsResponse) GetStartTime() *timestamppb.Timestamp {
+	if x != nil {
+		return x.StartTime
+	}
+	return nil
+}
+
+func (x *NotificationsResponse) GetUpdateTime() *timestamppb.Timestamp {
+	if x != nil {
+		return x.UpdateTime
+	}
+	return nil
+}
+
 type CreateDuplicateSocketRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Identifier for the active LM session. Must match the session_id used
@@ -617,7 +699,7 @@ type CreateDuplicateSocketRequest struct {
 
 func (x *CreateDuplicateSocketRequest) Reset() {
 	*x = CreateDuplicateSocketRequest{}
-	mi := &file_github_com_Microsoft_hcsshim_pkg_migration_migration_proto_msgTypes[10]
+	mi := &file_github_com_Microsoft_hcsshim_pkg_migration_migration_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -629,7 +711,7 @@ func (x *CreateDuplicateSocketRequest) String() string {
 func (*CreateDuplicateSocketRequest) ProtoMessage() {}
 
 func (x *CreateDuplicateSocketRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_github_com_Microsoft_hcsshim_pkg_migration_migration_proto_msgTypes[10]
+	mi := &file_github_com_Microsoft_hcsshim_pkg_migration_migration_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -642,7 +724,7 @@ func (x *CreateDuplicateSocketRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateDuplicateSocketRequest.ProtoReflect.Descriptor instead.
 func (*CreateDuplicateSocketRequest) Descriptor() ([]byte, []int) {
-	return file_github_com_Microsoft_hcsshim_pkg_migration_migration_proto_rawDescGZIP(), []int{10}
+	return file_github_com_Microsoft_hcsshim_pkg_migration_migration_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *CreateDuplicateSocketRequest) GetSessionID() string {
@@ -667,7 +749,7 @@ type CreateDuplicateSocketResponse struct {
 
 func (x *CreateDuplicateSocketResponse) Reset() {
 	*x = CreateDuplicateSocketResponse{}
-	mi := &file_github_com_Microsoft_hcsshim_pkg_migration_migration_proto_msgTypes[11]
+	mi := &file_github_com_Microsoft_hcsshim_pkg_migration_migration_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -679,7 +761,7 @@ func (x *CreateDuplicateSocketResponse) String() string {
 func (*CreateDuplicateSocketResponse) ProtoMessage() {}
 
 func (x *CreateDuplicateSocketResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_github_com_Microsoft_hcsshim_pkg_migration_migration_proto_msgTypes[11]
+	mi := &file_github_com_Microsoft_hcsshim_pkg_migration_migration_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -692,7 +774,7 @@ func (x *CreateDuplicateSocketResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateDuplicateSocketResponse.ProtoReflect.Descriptor instead.
 func (*CreateDuplicateSocketResponse) Descriptor() ([]byte, []int) {
-	return file_github_com_Microsoft_hcsshim_pkg_migration_migration_proto_rawDescGZIP(), []int{11}
+	return file_github_com_Microsoft_hcsshim_pkg_migration_migration_proto_rawDescGZIP(), []int{13}
 }
 
 var File_github_com_Microsoft_hcsshim_pkg_migration_migration_proto protoreflect.FileDescriptor
@@ -719,20 +801,24 @@ const file_github_com_Microsoft_hcsshim_pkg_migration_migration_proto_rawDesc = 
 	"\x16TransferSandboxRequest\x12\x1d\n" +
 	"\n" +
 	"session_id\x18\x01 \x01(\tR\tsessionId\x123\n" +
-	"\atimeout\x18\x02 \x01(\v2\x19.google.protobuf.DurationR\atimeout\"\xec\x01\n" +
-	"\x17TransferSandboxResponse\x12\x1d\n" +
+	"\atimeout\x18\x02 \x01(\v2\x19.google.protobuf.DurationR\atimeout\"\x19\n" +
+	"\x17TransferSandboxResponse\"`\n" +
+	"\x16FinalizeSandboxRequest\x12\x1d\n" +
+	"\n" +
+	"session_id\x18\x01 \x01(\tR\tsessionId\x12'\n" +
+	"\x06action\x18\x02 \x01(\x0e2\x0f.FinalizeActionR\x06action\"\x19\n" +
+	"\x17FinalizeSandboxResponse\"5\n" +
+	"\x14NotificationsRequest\x12\x1d\n" +
+	"\n" +
+	"session_id\x18\x01 \x01(\tR\tsessionId\"\xea\x01\n" +
+	"\x15NotificationsResponse\x12\x1d\n" +
 	"\n" +
 	"message_id\x18\x01 \x01(\rR\tmessageId\x12:\n" +
 	"\fnotification\x18\x02 \x01(\v2\x16.MigrationNotificationR\fnotification\x129\n" +
 	"\n" +
 	"start_time\x18\x03 \x01(\v2\x1a.google.protobuf.TimestampR\tstartTime\x12;\n" +
 	"\vupdate_time\x18\x04 \x01(\v2\x1a.google.protobuf.TimestampR\n" +
-	"updateTime\"`\n" +
-	"\x16FinalizeSandboxRequest\x12\x1d\n" +
-	"\n" +
-	"session_id\x18\x01 \x01(\tR\tsessionId\x12'\n" +
-	"\x06action\x18\x02 \x01(\x0e2\x0f.FinalizeActionR\x06action\"\x19\n" +
-	"\x17FinalizeSandboxResponse\"b\n" +
+	"updateTime\"b\n" +
 	"\x1cCreateDuplicateSocketRequest\x12\x1d\n" +
 	"\n" +
 	"session_id\x18\x01 \x01(\tR\tsessionId\x12#\n" +
@@ -741,13 +827,14 @@ const file_github_com_Microsoft_hcsshim_pkg_migration_migration_proto_rawDesc = 
 	"\x0eFinalizeAction\x12\x1f\n" +
 	"\x1bFINALIZE_ACTION_UNSPECIFIED\x10\x00\x12\x18\n" +
 	"\x14FINALIZE_ACTION_STOP\x10\x01\x12\x1a\n" +
-	"\x16FINALIZE_ACTION_RESUME\x10\x022\xd2\x03\n" +
+	"\x16FINALIZE_ACTION_RESUME\x10\x022\x92\x04\n" +
 	"\tMigration\x12\\\n" +
 	"\x17PrepareAndExportSandbox\x12\x1f.PrepareAndExportSandboxRequest\x1a .PrepareAndExportSandboxResponse\x12>\n" +
 	"\rImportSandbox\x12\x15.ImportSandboxRequest\x1a\x16.ImportSandboxResponse\x12A\n" +
-	"\x0ePrepareSandbox\x12\x16.PrepareSandboxRequest\x1a\x17.PrepareSandboxResponse\x12F\n" +
-	"\x0fTransferSandbox\x12\x17.TransferSandboxRequest\x1a\x18.TransferSandboxResponse0\x01\x12D\n" +
-	"\x0fFinalizeSandbox\x12\x17.FinalizeSandboxRequest\x1a\x18.FinalizeSandboxResponse\x12V\n" +
+	"\x0ePrepareSandbox\x12\x16.PrepareSandboxRequest\x1a\x17.PrepareSandboxResponse\x12D\n" +
+	"\x0fTransferSandbox\x12\x17.TransferSandboxRequest\x1a\x18.TransferSandboxResponse\x12D\n" +
+	"\x0fFinalizeSandbox\x12\x17.FinalizeSandboxRequest\x1a\x18.FinalizeSandboxResponse\x12@\n" +
+	"\rNotifications\x12\x15.NotificationsRequest\x1a\x16.NotificationsResponse0\x01\x12V\n" +
 	"\x15CreateDuplicateSocket\x12\x1d.CreateDuplicateSocketRequest\x1a\x1e.CreateDuplicateSocketResponseB6Z4github.com/Microsoft/hcsshim/pkg/migration;migrationb\x06proto3"
 
 var (
@@ -763,7 +850,7 @@ func file_github_com_Microsoft_hcsshim_pkg_migration_migration_proto_rawDescGZIP
 }
 
 var file_github_com_Microsoft_hcsshim_pkg_migration_migration_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_github_com_Microsoft_hcsshim_pkg_migration_migration_proto_msgTypes = make([]protoimpl.MessageInfo, 12)
+var file_github_com_Microsoft_hcsshim_pkg_migration_migration_proto_msgTypes = make([]protoimpl.MessageInfo, 14)
 var file_github_com_Microsoft_hcsshim_pkg_migration_migration_proto_goTypes = []any{
 	(FinalizeAction)(0),                     // 0: FinalizeAction
 	(*PrepareAndExportSandboxRequest)(nil),  // 1: PrepareAndExportSandboxRequest
@@ -776,38 +863,42 @@ var file_github_com_Microsoft_hcsshim_pkg_migration_migration_proto_goTypes = []
 	(*TransferSandboxResponse)(nil),         // 8: TransferSandboxResponse
 	(*FinalizeSandboxRequest)(nil),          // 9: FinalizeSandboxRequest
 	(*FinalizeSandboxResponse)(nil),         // 10: FinalizeSandboxResponse
-	(*CreateDuplicateSocketRequest)(nil),    // 11: CreateDuplicateSocketRequest
-	(*CreateDuplicateSocketResponse)(nil),   // 12: CreateDuplicateSocketResponse
-	(*MigrationInitializeOptions)(nil),      // 13: MigrationInitializeOptions
-	(*anypb.Any)(nil),                       // 14: google.protobuf.Any
-	(*durationpb.Duration)(nil),             // 15: google.protobuf.Duration
-	(*MigrationNotification)(nil),           // 16: MigrationNotification
-	(*timestamppb.Timestamp)(nil),           // 17: google.protobuf.Timestamp
+	(*NotificationsRequest)(nil),            // 11: NotificationsRequest
+	(*NotificationsResponse)(nil),           // 12: NotificationsResponse
+	(*CreateDuplicateSocketRequest)(nil),    // 13: CreateDuplicateSocketRequest
+	(*CreateDuplicateSocketResponse)(nil),   // 14: CreateDuplicateSocketResponse
+	(*MigrationInitializeOptions)(nil),      // 15: MigrationInitializeOptions
+	(*anypb.Any)(nil),                       // 16: google.protobuf.Any
+	(*durationpb.Duration)(nil),             // 17: google.protobuf.Duration
+	(*MigrationNotification)(nil),           // 18: MigrationNotification
+	(*timestamppb.Timestamp)(nil),           // 19: google.protobuf.Timestamp
 }
 var file_github_com_Microsoft_hcsshim_pkg_migration_migration_proto_depIdxs = []int32{
-	13, // 0: PrepareAndExportSandboxRequest.init_options:type_name -> MigrationInitializeOptions
-	14, // 1: PrepareAndExportSandboxResponse.config:type_name -> google.protobuf.Any
-	14, // 2: ImportSandboxRequest.config:type_name -> google.protobuf.Any
-	13, // 3: PrepareSandboxRequest.init_options:type_name -> MigrationInitializeOptions
-	15, // 4: TransferSandboxRequest.timeout:type_name -> google.protobuf.Duration
-	16, // 5: TransferSandboxResponse.notification:type_name -> MigrationNotification
-	17, // 6: TransferSandboxResponse.start_time:type_name -> google.protobuf.Timestamp
-	17, // 7: TransferSandboxResponse.update_time:type_name -> google.protobuf.Timestamp
-	0,  // 8: FinalizeSandboxRequest.action:type_name -> FinalizeAction
+	15, // 0: PrepareAndExportSandboxRequest.init_options:type_name -> MigrationInitializeOptions
+	16, // 1: PrepareAndExportSandboxResponse.config:type_name -> google.protobuf.Any
+	16, // 2: ImportSandboxRequest.config:type_name -> google.protobuf.Any
+	15, // 3: PrepareSandboxRequest.init_options:type_name -> MigrationInitializeOptions
+	17, // 4: TransferSandboxRequest.timeout:type_name -> google.protobuf.Duration
+	0,  // 5: FinalizeSandboxRequest.action:type_name -> FinalizeAction
+	18, // 6: NotificationsResponse.notification:type_name -> MigrationNotification
+	19, // 7: NotificationsResponse.start_time:type_name -> google.protobuf.Timestamp
+	19, // 8: NotificationsResponse.update_time:type_name -> google.protobuf.Timestamp
 	1,  // 9: Migration.PrepareAndExportSandbox:input_type -> PrepareAndExportSandboxRequest
 	3,  // 10: Migration.ImportSandbox:input_type -> ImportSandboxRequest
 	5,  // 11: Migration.PrepareSandbox:input_type -> PrepareSandboxRequest
 	7,  // 12: Migration.TransferSandbox:input_type -> TransferSandboxRequest
 	9,  // 13: Migration.FinalizeSandbox:input_type -> FinalizeSandboxRequest
-	11, // 14: Migration.CreateDuplicateSocket:input_type -> CreateDuplicateSocketRequest
-	2,  // 15: Migration.PrepareAndExportSandbox:output_type -> PrepareAndExportSandboxResponse
-	4,  // 16: Migration.ImportSandbox:output_type -> ImportSandboxResponse
-	6,  // 17: Migration.PrepareSandbox:output_type -> PrepareSandboxResponse
-	8,  // 18: Migration.TransferSandbox:output_type -> TransferSandboxResponse
-	10, // 19: Migration.FinalizeSandbox:output_type -> FinalizeSandboxResponse
-	12, // 20: Migration.CreateDuplicateSocket:output_type -> CreateDuplicateSocketResponse
-	15, // [15:21] is the sub-list for method output_type
-	9,  // [9:15] is the sub-list for method input_type
+	11, // 14: Migration.Notifications:input_type -> NotificationsRequest
+	13, // 15: Migration.CreateDuplicateSocket:input_type -> CreateDuplicateSocketRequest
+	2,  // 16: Migration.PrepareAndExportSandbox:output_type -> PrepareAndExportSandboxResponse
+	4,  // 17: Migration.ImportSandbox:output_type -> ImportSandboxResponse
+	6,  // 18: Migration.PrepareSandbox:output_type -> PrepareSandboxResponse
+	8,  // 19: Migration.TransferSandbox:output_type -> TransferSandboxResponse
+	10, // 20: Migration.FinalizeSandbox:output_type -> FinalizeSandboxResponse
+	12, // 21: Migration.Notifications:output_type -> NotificationsResponse
+	14, // 22: Migration.CreateDuplicateSocket:output_type -> CreateDuplicateSocketResponse
+	16, // [16:23] is the sub-list for method output_type
+	9,  // [9:16] is the sub-list for method input_type
 	9,  // [9:9] is the sub-list for extension type_name
 	9,  // [9:9] is the sub-list for extension extendee
 	0,  // [0:9] is the sub-list for field type_name
@@ -825,7 +916,7 @@ func file_github_com_Microsoft_hcsshim_pkg_migration_migration_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_github_com_Microsoft_hcsshim_pkg_migration_migration_proto_rawDesc), len(file_github_com_Microsoft_hcsshim_pkg_migration_migration_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   12,
+			NumMessages:   14,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/pkg/migration/migration.proto
+++ b/pkg/migration/migration.proto
@@ -132,7 +132,7 @@ message PrepareAndExportSandboxRequest {
     string session_id = 1;
     // Source-side options that control how live migration is initialized
     // on the compute system.
-    MigrationInitializeOptions init_options = 2;
+    InitializeOptions init_options = 2;
 }
 
 message PrepareAndExportSandboxResponse {
@@ -161,7 +161,7 @@ message PrepareSandboxRequest {
     string session_id = 1;
     // Destination-side options that control how live migration is
     // initialized when the HCS compute system is created.
-    MigrationInitializeOptions init_options = 2;
+    InitializeOptions init_options = 2;
 }
 
 message PrepareSandboxResponse {}
@@ -221,7 +221,7 @@ message NotificationsResponse {
     // Structured notification describing the current migration event. This
     // mirrors the HCS OperationSystemMigrationNotificationInfo payload
     // emitted by the underlying compute system as the transfer progresses.
-    MigrationNotification notification = 2;
+    Notification notification = 2;
     // Server-side timestamp of when the transfer began.
     google.protobuf.Timestamp start_time = 3;
     // Server-side timestamp of when this particular update was produced.

--- a/pkg/migration/migration.proto
+++ b/pkg/migration/migration.proto
@@ -170,15 +170,14 @@ message TransferSandboxResponse {
     // Monotonically increasing per-message counter on this stream. Useful
     // for de-duplication if the client reconnects mid-transfer.
     uint32 message_id = 1;
-    // Event-specific message describing the current migration notification.
-    string event = 2;
-    // Populated when `event` indicates an error or a timeout; empty
-    // otherwise.
-    string error = 3;
+    // Structured notification describing the current migration event. This
+    // mirrors the HCS OperationSystemMigrationNotificationInfo payload
+    // emitted by the underlying compute system as the transfer progresses.
+    MigrationNotification notification = 2;
     // Server-side timestamp of when the transfer began.
-    google.protobuf.Timestamp start_time = 4;
+    google.protobuf.Timestamp start_time = 3;
     // Server-side timestamp of when this particular update was produced.
-    google.protobuf.Timestamp update_time = 5;
+    google.protobuf.Timestamp update_time = 4;
 }
 
 message FinalizeSandboxRequest {

--- a/pkg/migration/migration.proto
+++ b/pkg/migration/migration.proto
@@ -19,8 +19,9 @@ import "github.com/Microsoft/hcsshim/pkg/migration/migration_options.proto";
 //                                           3. NewTask (per container, repeated)
 //                                           4. PrepareSandbox
 //   5. CreateDuplicateSocket                5. CreateDuplicateSocket
-//   6. TransferSandbox          ◄────────►  6. TransferSandbox
-//   7. FinalizeSandbox                      7. FinalizeSandbox
+//   6. Notifications (stream)               6. Notifications (stream)
+//   7. TransferSandbox          ◄────────►  7. TransferSandbox
+//   8. FinalizeSandbox                      8. FinalizeSandbox
 //
 // NewTask is part of the existing task service (not this service) and is what
 // the destination uses to attach updated resource paths to the rehydrated
@@ -68,13 +69,13 @@ service Migration {
     rpc PrepareSandbox(PrepareSandboxRequest) returns (PrepareSandboxResponse);
 
     // TransferSandbox drives the actual memory transfer between source and
-    // destination. It is called on BOTH sides and returns a stream of
-    // progress / status updates so the caller can observe the transfer.
+    // destination. It is called on BOTH sides and blocks until the transfer
+    // either completes, fails, or times out.
     //
-    // The stream remains open for the duration of the transfer and emits
-    // TransferSandboxResponse messages as state changes (progress, error,
-    // timeout, completion).
-    rpc TransferSandbox(TransferSandboxRequest) returns (stream TransferSandboxResponse);
+    // Progress and status updates produced during the transfer are NOT
+    // returned by this RPC. Callers that wish to observe those updates must
+    // separately subscribe via Notifications.
+    rpc TransferSandbox(TransferSandboxRequest) returns (TransferSandboxResponse);
 
     // FinalizeSandbox terminates a live migration session. It is called on
     // BOTH the source and the destination, and the meaning of the action
@@ -92,6 +93,16 @@ service Migration {
     //     - RESUME : Migration completed successfully; bring the migrated
     //                VM back to a running state on the destination.
     rpc FinalizeSandbox(FinalizeSandboxRequest) returns (FinalizeSandboxResponse);
+
+    // Notifications opens a server-streaming subscription to migration
+    // events for this session. It can be called on BOTH the source and
+    // destination shims and will emit NotificationsResponse messages as
+    // the underlying compute system reports state changes (progress,
+    // error, timeout, completion) for the duration of the migration.
+    //
+    // Callers typically open this stream prior to invoking TransferSandbox
+    // so that no notifications are missed while the transfer is in flight.
+    rpc Notifications(NotificationsRequest) returns (stream NotificationsResponse);
 
     // CreateDuplicateSocket is called on BOTH the source and destination
     // shims, after the caller has created the underlying
@@ -160,25 +171,13 @@ message TransferSandboxRequest {
     // for the rest of this LM on this side.
     string session_id = 1;
     // Maximum time to wait for the migration socket / underlying transport
-    // to become ready before the server gives up and reports a TIMEOUT
-    // event on the response stream. If unset, the server applies a sensible
-    // default (e.g. 10 minutes).
+    // to become ready before the server gives up and fails the transfer
+    // with a TIMEOUT. If unset, the server applies a sensible default
+    // (e.g. 10 minutes).
     google.protobuf.Duration timeout = 2;
 }
 
-message TransferSandboxResponse {
-    // Monotonically increasing per-message counter on this stream. Useful
-    // for de-duplication if the client reconnects mid-transfer.
-    uint32 message_id = 1;
-    // Structured notification describing the current migration event. This
-    // mirrors the HCS OperationSystemMigrationNotificationInfo payload
-    // emitted by the underlying compute system as the transfer progresses.
-    MigrationNotification notification = 2;
-    // Server-side timestamp of when the transfer began.
-    google.protobuf.Timestamp start_time = 3;
-    // Server-side timestamp of when this particular update was produced.
-    google.protobuf.Timestamp update_time = 4;
-}
+message TransferSandboxResponse {}
 
 message FinalizeSandboxRequest {
     // Identifier for the migration session. Must match the session_id used
@@ -208,6 +207,26 @@ enum FinalizeAction {
 }
 
 message FinalizeSandboxResponse {}
+
+message NotificationsRequest {
+    // Identifier for the migration session. Must match the session_id used
+    // for the rest of this LM on this side.
+    string session_id = 1;
+}
+
+message NotificationsResponse {
+    // Monotonically increasing per-message counter on this stream. Useful
+    // for de-duplication if the client reconnects mid-transfer.
+    uint32 message_id = 1;
+    // Structured notification describing the current migration event. This
+    // mirrors the HCS OperationSystemMigrationNotificationInfo payload
+    // emitted by the underlying compute system as the transfer progresses.
+    MigrationNotification notification = 2;
+    // Server-side timestamp of when the transfer began.
+    google.protobuf.Timestamp start_time = 3;
+    // Server-side timestamp of when this particular update was produced.
+    google.protobuf.Timestamp update_time = 4;
+}
 
 message CreateDuplicateSocketRequest {
     // Identifier for the active LM session. Must match the session_id used

--- a/pkg/migration/migration_options.pb.go
+++ b/pkg/migration/migration_options.pb.go
@@ -22,256 +22,323 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
-// MigrationMemoryTransport is the transport protocol used for memory transfer during migration.
-type MigrationMemoryTransport int32
+// MemoryTransport is the transport protocol used for memory transfer during migration.
+type MemoryTransport int32
 
 const (
-	MigrationMemoryTransport_MIGRATION_MEMORY_TRANSPORT_UNSPECIFIED MigrationMemoryTransport = 0
+	MemoryTransport_MEMORY_TRANSPORT_UNSPECIFIED MemoryTransport = 0
 	// VM memory is copied over a TCP/IP connection.
-	MigrationMemoryTransport_MIGRATION_MEMORY_TRANSPORT_TCP MigrationMemoryTransport = 1
+	MemoryTransport_MEMORY_TRANSPORT_TCP MemoryTransport = 1
 )
 
-// Enum value maps for MigrationMemoryTransport.
+// Enum value maps for MemoryTransport.
 var (
-	MigrationMemoryTransport_name = map[int32]string{
-		0: "MIGRATION_MEMORY_TRANSPORT_UNSPECIFIED",
-		1: "MIGRATION_MEMORY_TRANSPORT_TCP",
+	MemoryTransport_name = map[int32]string{
+		0: "MEMORY_TRANSPORT_UNSPECIFIED",
+		1: "MEMORY_TRANSPORT_TCP",
 	}
-	MigrationMemoryTransport_value = map[string]int32{
-		"MIGRATION_MEMORY_TRANSPORT_UNSPECIFIED": 0,
-		"MIGRATION_MEMORY_TRANSPORT_TCP":         1,
+	MemoryTransport_value = map[string]int32{
+		"MEMORY_TRANSPORT_UNSPECIFIED": 0,
+		"MEMORY_TRANSPORT_TCP":         1,
 	}
 )
 
-func (x MigrationMemoryTransport) Enum() *MigrationMemoryTransport {
-	p := new(MigrationMemoryTransport)
+func (x MemoryTransport) Enum() *MemoryTransport {
+	p := new(MemoryTransport)
 	*p = x
 	return p
 }
 
-func (x MigrationMemoryTransport) String() string {
+func (x MemoryTransport) String() string {
 	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
 }
 
-func (MigrationMemoryTransport) Descriptor() protoreflect.EnumDescriptor {
+func (MemoryTransport) Descriptor() protoreflect.EnumDescriptor {
 	return file_github_com_Microsoft_hcsshim_pkg_migration_migration_options_proto_enumTypes[0].Descriptor()
 }
 
-func (MigrationMemoryTransport) Type() protoreflect.EnumType {
+func (MemoryTransport) Type() protoreflect.EnumType {
 	return &file_github_com_Microsoft_hcsshim_pkg_migration_migration_options_proto_enumTypes[0]
 }
 
-func (x MigrationMemoryTransport) Number() protoreflect.EnumNumber {
+func (x MemoryTransport) Number() protoreflect.EnumNumber {
 	return protoreflect.EnumNumber(x)
 }
 
-// Deprecated: Use MigrationMemoryTransport.Descriptor instead.
-func (MigrationMemoryTransport) EnumDescriptor() ([]byte, []int) {
+// Deprecated: Use MemoryTransport.Descriptor instead.
+func (MemoryTransport) EnumDescriptor() ([]byte, []int) {
 	return file_github_com_Microsoft_hcsshim_pkg_migration_migration_options_proto_rawDescGZIP(), []int{0}
 }
 
-// MigrationOrigin indicates which side of a live migration an operation or
+// Origin indicates which side of a live migration an operation or
 // notification pertains to.
-type MigrationOrigin int32
+type Origin int32
 
 const (
-	MigrationOrigin_MIGRATION_ORIGIN_UNSPECIFIED MigrationOrigin = 0
+	Origin_ORIGIN_UNSPECIFIED Origin = 0
 	// Source side of the live migration.
-	MigrationOrigin_MIGRATION_ORIGIN_SOURCE MigrationOrigin = 1
+	Origin_ORIGIN_SOURCE Origin = 1
 	// Destination side of the live migration.
-	MigrationOrigin_MIGRATION_ORIGIN_DESTINATION MigrationOrigin = 2
+	Origin_ORIGIN_DESTINATION Origin = 2
 )
 
-// Enum value maps for MigrationOrigin.
+// Enum value maps for Origin.
 var (
-	MigrationOrigin_name = map[int32]string{
-		0: "MIGRATION_ORIGIN_UNSPECIFIED",
-		1: "MIGRATION_ORIGIN_SOURCE",
-		2: "MIGRATION_ORIGIN_DESTINATION",
+	Origin_name = map[int32]string{
+		0: "ORIGIN_UNSPECIFIED",
+		1: "ORIGIN_SOURCE",
+		2: "ORIGIN_DESTINATION",
 	}
-	MigrationOrigin_value = map[string]int32{
-		"MIGRATION_ORIGIN_UNSPECIFIED": 0,
-		"MIGRATION_ORIGIN_SOURCE":      1,
-		"MIGRATION_ORIGIN_DESTINATION": 2,
+	Origin_value = map[string]int32{
+		"ORIGIN_UNSPECIFIED": 0,
+		"ORIGIN_SOURCE":      1,
+		"ORIGIN_DESTINATION": 2,
 	}
 )
 
-func (x MigrationOrigin) Enum() *MigrationOrigin {
-	p := new(MigrationOrigin)
+func (x Origin) Enum() *Origin {
+	p := new(Origin)
 	*p = x
 	return p
 }
 
-func (x MigrationOrigin) String() string {
+func (x Origin) String() string {
 	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
 }
 
-func (MigrationOrigin) Descriptor() protoreflect.EnumDescriptor {
+func (Origin) Descriptor() protoreflect.EnumDescriptor {
 	return file_github_com_Microsoft_hcsshim_pkg_migration_migration_options_proto_enumTypes[1].Descriptor()
 }
 
-func (MigrationOrigin) Type() protoreflect.EnumType {
+func (Origin) Type() protoreflect.EnumType {
 	return &file_github_com_Microsoft_hcsshim_pkg_migration_migration_options_proto_enumTypes[1]
 }
 
-func (x MigrationOrigin) Number() protoreflect.EnumNumber {
+func (x Origin) Number() protoreflect.EnumNumber {
 	return protoreflect.EnumNumber(x)
 }
 
-// Deprecated: Use MigrationOrigin.Descriptor instead.
-func (MigrationOrigin) EnumDescriptor() ([]byte, []int) {
+// Deprecated: Use Origin.Descriptor instead.
+func (Origin) EnumDescriptor() ([]byte, []int) {
 	return file_github_com_Microsoft_hcsshim_pkg_migration_migration_options_proto_rawDescGZIP(), []int{1}
 }
 
-// MigrationEvent describes a live migration event reported by HCS during the
+// Phase describes a live migration phase reported by HCS during the
 // transfer phase of a live migration.
-type MigrationEvent int32
+type Phase int32
 
 const (
-	MigrationEvent_MIGRATION_EVENT_UNSPECIFIED MigrationEvent = 0
-	// Migration has completed.
-	MigrationEvent_MIGRATION_EVENT_MIGRATION_DONE MigrationEvent = 1
-	// The VM has entered the blackout phase.
-	MigrationEvent_MIGRATION_EVENT_BLACKOUT_STARTED MigrationEvent = 2
-	// Taking the VM offline has completed.
-	MigrationEvent_MIGRATION_EVENT_OFFLINE_DONE MigrationEvent = 3
+	Phase_PHASE_UNSPECIFIED Phase = 0
+	// The live migration setup has completed on the HCS side. Reported
+	// by the source; after this, clients can either start the memory
+	// transfer or set up SMB before performing the memory transfer.
+	Phase_PHASE_SETUP_DONE Phase = 1
+	// The VM is transferring memory and other necessary state. Reported
+	// periodically by the source as a progress signal while the VM state
+	// is being transferred to the destination.
+	Phase_PHASE_TRANSFER_IN_PROGRESS Phase = 2
+	// The VM has entered the blackout phase. Reported by the source
+	// immediately before the VM is paused for the final state transfer;
+	// from this point on the VM is not running on either host.
+	Phase_PHASE_BLACKOUT_STARTED Phase = 3
+	// Taking the VM offline has completed. Reported by the source after
+	// VMWP has transitioned itself to the MigratingSuspended (MTS) state,
+	// but before waiting for the VMWP client to signal that it is ready
+	// to enter MTS state at its layer. Always paired with
+	// PhaseState = PHASE_STATE_SUCCESS; offline failures are reported via
+	// PHASE_FAILED instead.
+	Phase_PHASE_OFFLINE_DONE Phase = 4
 	// The VM has successfully started again after the blackout phase.
-	MigrationEvent_MIGRATION_EVENT_BLACKOUT_EXITED MigrationEvent = 4
-	// The live migration setup has completed.
-	MigrationEvent_MIGRATION_EVENT_SETUP_DONE MigrationEvent = 5
-	// The VM is still transferring memory and other necessary state.
-	MigrationEvent_MIGRATION_EVENT_TRANSFER_IN_PROGRESS MigrationEvent = 6
-	// Migration recovery has been performed.
-	MigrationEvent_MIGRATION_EVENT_MIGRATION_RECOVERY_DONE MigrationEvent = 7
-	// Migration failed.
-	MigrationEvent_MIGRATION_EVENT_MIGRATION_FAILED MigrationEvent = 8
+	Phase_PHASE_BLACKOUT_EXITED Phase = 5
+	// Migration has completed (terminal phase). The accompanying
+	// PhaseState describes whether the migration succeeded or failed,
+	// and on which side the failure was observed.
+	Phase_PHASE_DONE Phase = 6
+	// Migration recovery has been performed. Reported by the source
+	// after attempting to recover the VM following a failed or cancelled
+	// migration. The accompanying PhaseState is PHASE_STATE_SUCCESS if
+	// the VM was successfully resumed on the source, or
+	// PHASE_STATE_RECOVERY_FAILED if recovery itself failed.
+	Phase_PHASE_RECOVERY_DONE Phase = 7
+	// Migration failed (terminal phase). Reported by the source for
+	// non-success outcomes of the offline step (and equivalent failure
+	// points). The accompanying PhaseState carries the reason:
+	// PHASE_STATE_SOURCE_FAILED, PHASE_STATE_DESTINATION_FAILED,
+	// PHASE_STATE_CANCELLED, or PHASE_STATE_GUEST_INITIATED_CANCELLATION.
+	Phase_PHASE_FAILED Phase = 8
 )
 
-// Enum value maps for MigrationEvent.
+// Enum value maps for Phase.
 var (
-	MigrationEvent_name = map[int32]string{
-		0: "MIGRATION_EVENT_UNSPECIFIED",
-		1: "MIGRATION_EVENT_MIGRATION_DONE",
-		2: "MIGRATION_EVENT_BLACKOUT_STARTED",
-		3: "MIGRATION_EVENT_OFFLINE_DONE",
-		4: "MIGRATION_EVENT_BLACKOUT_EXITED",
-		5: "MIGRATION_EVENT_SETUP_DONE",
-		6: "MIGRATION_EVENT_TRANSFER_IN_PROGRESS",
-		7: "MIGRATION_EVENT_MIGRATION_RECOVERY_DONE",
-		8: "MIGRATION_EVENT_MIGRATION_FAILED",
+	Phase_name = map[int32]string{
+		0: "PHASE_UNSPECIFIED",
+		1: "PHASE_SETUP_DONE",
+		2: "PHASE_TRANSFER_IN_PROGRESS",
+		3: "PHASE_BLACKOUT_STARTED",
+		4: "PHASE_OFFLINE_DONE",
+		5: "PHASE_BLACKOUT_EXITED",
+		6: "PHASE_DONE",
+		7: "PHASE_RECOVERY_DONE",
+		8: "PHASE_FAILED",
 	}
-	MigrationEvent_value = map[string]int32{
-		"MIGRATION_EVENT_UNSPECIFIED":             0,
-		"MIGRATION_EVENT_MIGRATION_DONE":          1,
-		"MIGRATION_EVENT_BLACKOUT_STARTED":        2,
-		"MIGRATION_EVENT_OFFLINE_DONE":            3,
-		"MIGRATION_EVENT_BLACKOUT_EXITED":         4,
-		"MIGRATION_EVENT_SETUP_DONE":              5,
-		"MIGRATION_EVENT_TRANSFER_IN_PROGRESS":    6,
-		"MIGRATION_EVENT_MIGRATION_RECOVERY_DONE": 7,
-		"MIGRATION_EVENT_MIGRATION_FAILED":        8,
+	Phase_value = map[string]int32{
+		"PHASE_UNSPECIFIED":          0,
+		"PHASE_SETUP_DONE":           1,
+		"PHASE_TRANSFER_IN_PROGRESS": 2,
+		"PHASE_BLACKOUT_STARTED":     3,
+		"PHASE_OFFLINE_DONE":         4,
+		"PHASE_BLACKOUT_EXITED":      5,
+		"PHASE_DONE":                 6,
+		"PHASE_RECOVERY_DONE":        7,
+		"PHASE_FAILED":               8,
 	}
 )
 
-func (x MigrationEvent) Enum() *MigrationEvent {
-	p := new(MigrationEvent)
+func (x Phase) Enum() *Phase {
+	p := new(Phase)
 	*p = x
 	return p
 }
 
-func (x MigrationEvent) String() string {
+func (x Phase) String() string {
 	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
 }
 
-func (MigrationEvent) Descriptor() protoreflect.EnumDescriptor {
+func (Phase) Descriptor() protoreflect.EnumDescriptor {
 	return file_github_com_Microsoft_hcsshim_pkg_migration_migration_options_proto_enumTypes[2].Descriptor()
 }
 
-func (MigrationEvent) Type() protoreflect.EnumType {
+func (Phase) Type() protoreflect.EnumType {
 	return &file_github_com_Microsoft_hcsshim_pkg_migration_migration_options_proto_enumTypes[2]
 }
 
-func (x MigrationEvent) Number() protoreflect.EnumNumber {
+func (x Phase) Number() protoreflect.EnumNumber {
 	return protoreflect.EnumNumber(x)
 }
 
-// Deprecated: Use MigrationEvent.Descriptor instead.
-func (MigrationEvent) EnumDescriptor() ([]byte, []int) {
+// Deprecated: Use Phase.Descriptor instead.
+func (Phase) EnumDescriptor() ([]byte, []int) {
 	return file_github_com_Microsoft_hcsshim_pkg_migration_migration_options_proto_rawDescGZIP(), []int{2}
 }
 
-// MigrationResult describes the possible result of a migration operation,
-// typically populated for terminal events such as MIGRATION_EVENT_MIGRATION_DONE
-// or MIGRATION_EVENT_MIGRATION_FAILED.
-type MigrationResult int32
+// PhaseState describes the possible state of a migration phase,
+// typically populated for terminal phases such as PHASE_DONE
+// or PHASE_FAILED.
+type PhaseState int32
 
 const (
-	MigrationResult_MIGRATION_RESULT_UNSPECIFIED                  MigrationResult = 0
-	MigrationResult_MIGRATION_RESULT_SUCCESS                      MigrationResult = 1
-	MigrationResult_MIGRATION_RESULT_MIGRATION_CANCELLED          MigrationResult = 2
-	MigrationResult_MIGRATION_RESULT_GUEST_INITIATED_CANCELLATION MigrationResult = 3
-	MigrationResult_MIGRATION_RESULT_SOURCE_MIGRATION_FAILED      MigrationResult = 4
-	MigrationResult_MIGRATION_RESULT_DESTINATION_MIGRATION_FAILED MigrationResult = 5
-	MigrationResult_MIGRATION_RESULT_MIGRATION_RECOVERY_FAILED    MigrationResult = 6
+	// No state reported. Used as the default zero value and for
+	// non-terminal phases that do not carry an outcome.
+	PhaseState_PHASE_STATE_UNSPECIFIED PhaseState = 0
+	// The reported phase completed successfully. Emitted in several
+	// places, including:
+	//   - Phase = PHASE_DONE: by the source after a successful
+	//     migrate-to-suspended (MTS) workflow, and by the destination
+	//     once the VM has been fully restored on the target host.
+	//   - Phase = PHASE_OFFLINE_DONE: by the source after VMWP
+	//     successfully takes the VM offline so migration can continue.
+	//   - Phase = PHASE_RECOVERY_DONE: by the source after the VM has
+	//     been successfully rolled back to its pre-migration running
+	//     state following a failed or cancelled migration.
+	PhaseState_PHASE_STATE_SUCCESS PhaseState = 1
+	// Migration was cancelled. Reported with:
+	//   - Phase = PHASE_FAILED by the source when its offline step
+	//     observes a non-guest cancellation
+	//     (MigrationSourceOfflineCanceled).
+	//   - Phase = PHASE_DONE by the destination when, after the setup
+	//     phase has completed, the migration target detects a
+	//     cancellation (MigrationTargetCanceled).
+	PhaseState_PHASE_STATE_CANCELLED PhaseState = 2
+	// Migration was cancelled because the guest initiated a shutdown or
+	// reset of the VM. Reported by the source with Phase = PHASE_FAILED
+	// (MigrationSourceOfflineGuestCanceled). VMWP performs the
+	// shutdown/reset on its own; this state exists to inform clients
+	// that LM was cancelled as a result of guest action.
+	PhaseState_PHASE_STATE_GUEST_INITIATED_CANCELLATION PhaseState = 3
+	// Migration failed and the failure originated on the source. Reported
+	// with:
+	//   - Phase = PHASE_FAILED by the source when its offline step fails
+	//     (MigrationSourceOfflineFailed).
+	//   - Phase = PHASE_DONE by the source when, after the offline phase
+	//     but before the VM has been restored on the target, the source
+	//     fails for a reason that is not destination-attributable.
+	//   - Phase = PHASE_DONE by the destination when, after the setup
+	//     phase has completed, the migration target observes a
+	//     non-cancellation failure that came from the source.
+	PhaseState_PHASE_STATE_SOURCE_FAILED PhaseState = 4
+	// Migration failed and the failure originated on the destination.
+	// Reported by the source with:
+	//   - Phase = PHASE_FAILED when its offline step observes a
+	//     destination-side failure (MigrationSourceOfflineDestinationFailed).
+	//   - Phase = PHASE_DONE when, after the offline phase but before the
+	//     VM has been restored on the target, the source detects that
+	//     the destination failed
+	//     (m_FailureReason == FailureDestinationFailed).
+	PhaseState_PHASE_STATE_DESTINATION_FAILED PhaseState = 5
+	// Migration recovery failed. Reported by the source with
+	// Phase = PHASE_RECOVERY_DONE when the attempt to recover the VM
+	// after a failed or cancelled migration did not succeed (the source
+	// could not be returned to its pre-migration running state).
+	PhaseState_PHASE_STATE_RECOVERY_FAILED PhaseState = 6
 )
 
-// Enum value maps for MigrationResult.
+// Enum value maps for PhaseState.
 var (
-	MigrationResult_name = map[int32]string{
-		0: "MIGRATION_RESULT_UNSPECIFIED",
-		1: "MIGRATION_RESULT_SUCCESS",
-		2: "MIGRATION_RESULT_MIGRATION_CANCELLED",
-		3: "MIGRATION_RESULT_GUEST_INITIATED_CANCELLATION",
-		4: "MIGRATION_RESULT_SOURCE_MIGRATION_FAILED",
-		5: "MIGRATION_RESULT_DESTINATION_MIGRATION_FAILED",
-		6: "MIGRATION_RESULT_MIGRATION_RECOVERY_FAILED",
+	PhaseState_name = map[int32]string{
+		0: "PHASE_STATE_UNSPECIFIED",
+		1: "PHASE_STATE_SUCCESS",
+		2: "PHASE_STATE_CANCELLED",
+		3: "PHASE_STATE_GUEST_INITIATED_CANCELLATION",
+		4: "PHASE_STATE_SOURCE_FAILED",
+		5: "PHASE_STATE_DESTINATION_FAILED",
+		6: "PHASE_STATE_RECOVERY_FAILED",
 	}
-	MigrationResult_value = map[string]int32{
-		"MIGRATION_RESULT_UNSPECIFIED":                  0,
-		"MIGRATION_RESULT_SUCCESS":                      1,
-		"MIGRATION_RESULT_MIGRATION_CANCELLED":          2,
-		"MIGRATION_RESULT_GUEST_INITIATED_CANCELLATION": 3,
-		"MIGRATION_RESULT_SOURCE_MIGRATION_FAILED":      4,
-		"MIGRATION_RESULT_DESTINATION_MIGRATION_FAILED": 5,
-		"MIGRATION_RESULT_MIGRATION_RECOVERY_FAILED":    6,
+	PhaseState_value = map[string]int32{
+		"PHASE_STATE_UNSPECIFIED":                  0,
+		"PHASE_STATE_SUCCESS":                      1,
+		"PHASE_STATE_CANCELLED":                    2,
+		"PHASE_STATE_GUEST_INITIATED_CANCELLATION": 3,
+		"PHASE_STATE_SOURCE_FAILED":                4,
+		"PHASE_STATE_DESTINATION_FAILED":           5,
+		"PHASE_STATE_RECOVERY_FAILED":              6,
 	}
 )
 
-func (x MigrationResult) Enum() *MigrationResult {
-	p := new(MigrationResult)
+func (x PhaseState) Enum() *PhaseState {
+	p := new(PhaseState)
 	*p = x
 	return p
 }
 
-func (x MigrationResult) String() string {
+func (x PhaseState) String() string {
 	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
 }
 
-func (MigrationResult) Descriptor() protoreflect.EnumDescriptor {
+func (PhaseState) Descriptor() protoreflect.EnumDescriptor {
 	return file_github_com_Microsoft_hcsshim_pkg_migration_migration_options_proto_enumTypes[3].Descriptor()
 }
 
-func (MigrationResult) Type() protoreflect.EnumType {
+func (PhaseState) Type() protoreflect.EnumType {
 	return &file_github_com_Microsoft_hcsshim_pkg_migration_migration_options_proto_enumTypes[3]
 }
 
-func (x MigrationResult) Number() protoreflect.EnumNumber {
+func (x PhaseState) Number() protoreflect.EnumNumber {
 	return protoreflect.EnumNumber(x)
 }
 
-// Deprecated: Use MigrationResult.Descriptor instead.
-func (MigrationResult) EnumDescriptor() ([]byte, []int) {
+// Deprecated: Use PhaseState.Descriptor instead.
+func (PhaseState) EnumDescriptor() ([]byte, []int) {
 	return file_github_com_Microsoft_hcsshim_pkg_migration_migration_options_proto_rawDescGZIP(), []int{3}
 }
 
-type MigrationInitializeOptions struct {
+type InitializeOptions struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// MemoryTransport specifies the transport protocol for memory transfer during migration.
-	MemoryTransport MigrationMemoryTransport `protobuf:"varint,1,opt,name=memory_transport,json=memoryTransport,proto3,enum=MigrationMemoryTransport" json:"memory_transport,omitempty"`
+	MemoryTransport MemoryTransport `protobuf:"varint,1,opt,name=memory_transport,json=memoryTransport,proto3,enum=MemoryTransport" json:"memory_transport,omitempty"`
 	// MemoryTransferThrottleParams specifies settings for throttling during memory transfer.
-	MemoryTransferThrottleParams *MemoryMigrationTransferThrottleParams `protobuf:"bytes,2,opt,name=memory_transfer_throttle_params,json=memoryTransferThrottleParams,proto3,oneof" json:"memory_transfer_throttle_params,omitempty"`
+	MemoryTransferThrottleParams *MemoryTransferThrottleParams `protobuf:"bytes,2,opt,name=memory_transfer_throttle_params,json=memoryTransferThrottleParams,proto3,oneof" json:"memory_transfer_throttle_params,omitempty"`
 	// CompressionSettings specifies additional settings when compression is enabled.
-	CompressionSettings *MigrationCompressionSettings `protobuf:"bytes,3,opt,name=compression_settings,json=compressionSettings,proto3,oneof" json:"compression_settings,omitempty"`
+	CompressionSettings *CompressionSettings `protobuf:"bytes,3,opt,name=compression_settings,json=compressionSettings,proto3,oneof" json:"compression_settings,omitempty"`
 	// ChecksumVerification enables memory checksum verification.
 	ChecksumVerification bool `protobuf:"varint,4,opt,name=checksum_verification,json=checksumVerification,proto3" json:"checksum_verification,omitempty"`
 	// PerfTracingEnabled enables performance tracing during migration.
@@ -286,20 +353,20 @@ type MigrationInitializeOptions struct {
 	sizeCache         protoimpl.SizeCache
 }
 
-func (x *MigrationInitializeOptions) Reset() {
-	*x = MigrationInitializeOptions{}
+func (x *InitializeOptions) Reset() {
+	*x = InitializeOptions{}
 	mi := &file_github_com_Microsoft_hcsshim_pkg_migration_migration_options_proto_msgTypes[0]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *MigrationInitializeOptions) String() string {
+func (x *InitializeOptions) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*MigrationInitializeOptions) ProtoMessage() {}
+func (*InitializeOptions) ProtoMessage() {}
 
-func (x *MigrationInitializeOptions) ProtoReflect() protoreflect.Message {
+func (x *InitializeOptions) ProtoReflect() protoreflect.Message {
 	mi := &file_github_com_Microsoft_hcsshim_pkg_migration_migration_options_proto_msgTypes[0]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -311,61 +378,61 @@ func (x *MigrationInitializeOptions) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use MigrationInitializeOptions.ProtoReflect.Descriptor instead.
-func (*MigrationInitializeOptions) Descriptor() ([]byte, []int) {
+// Deprecated: Use InitializeOptions.ProtoReflect.Descriptor instead.
+func (*InitializeOptions) Descriptor() ([]byte, []int) {
 	return file_github_com_Microsoft_hcsshim_pkg_migration_migration_options_proto_rawDescGZIP(), []int{0}
 }
 
-func (x *MigrationInitializeOptions) GetMemoryTransport() MigrationMemoryTransport {
+func (x *InitializeOptions) GetMemoryTransport() MemoryTransport {
 	if x != nil {
 		return x.MemoryTransport
 	}
-	return MigrationMemoryTransport_MIGRATION_MEMORY_TRANSPORT_UNSPECIFIED
+	return MemoryTransport_MEMORY_TRANSPORT_UNSPECIFIED
 }
 
-func (x *MigrationInitializeOptions) GetMemoryTransferThrottleParams() *MemoryMigrationTransferThrottleParams {
+func (x *InitializeOptions) GetMemoryTransferThrottleParams() *MemoryTransferThrottleParams {
 	if x != nil {
 		return x.MemoryTransferThrottleParams
 	}
 	return nil
 }
 
-func (x *MigrationInitializeOptions) GetCompressionSettings() *MigrationCompressionSettings {
+func (x *InitializeOptions) GetCompressionSettings() *CompressionSettings {
 	if x != nil {
 		return x.CompressionSettings
 	}
 	return nil
 }
 
-func (x *MigrationInitializeOptions) GetChecksumVerification() bool {
+func (x *InitializeOptions) GetChecksumVerification() bool {
 	if x != nil {
 		return x.ChecksumVerification
 	}
 	return false
 }
 
-func (x *MigrationInitializeOptions) GetPerfTracingEnabled() bool {
+func (x *InitializeOptions) GetPerfTracingEnabled() bool {
 	if x != nil {
 		return x.PerfTracingEnabled
 	}
 	return false
 }
 
-func (x *MigrationInitializeOptions) GetCancelIfBlackoutThresholdExceeds() bool {
+func (x *InitializeOptions) GetCancelIfBlackoutThresholdExceeds() bool {
 	if x != nil {
 		return x.CancelIfBlackoutThresholdExceeds
 	}
 	return false
 }
 
-func (x *MigrationInitializeOptions) GetPrepareMemoryTransferMode() bool {
+func (x *InitializeOptions) GetPrepareMemoryTransferMode() bool {
 	if x != nil {
 		return x.PrepareMemoryTransferMode
 	}
 	return false
 }
 
-func (x *MigrationInitializeOptions) GetCompatibilityData() *CompatibilityInfo {
+func (x *InitializeOptions) GetCompatibilityData() *CompatibilityInfo {
 	if x != nil {
 		return x.CompatibilityData
 	}
@@ -418,7 +485,7 @@ func (x *CompatibilityInfo) GetData() []byte {
 	return nil
 }
 
-type MemoryMigrationTransferThrottleParams struct {
+type MemoryTransferThrottleParams struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// A flag indicating if throttling should be skipped.
 	SkipThrottling *bool `protobuf:"varint,1,opt,name=skip_throttling,json=skipThrottling,proto3,oneof" json:"skip_throttling,omitempty"`
@@ -432,28 +499,30 @@ type MemoryMigrationTransferThrottleParams struct {
 	StartingBrownoutPassNumberForThrottling *uint32 `protobuf:"varint,5,opt,name=starting_brownout_pass_number_for_throttling,json=startingBrownoutPassNumberForThrottling,proto3,oneof" json:"starting_brownout_pass_number_for_throttling,omitempty"`
 	// Maximum number of memory transfer passes before forcing the VM to enter blackout.
 	MaximumNumberOfBrownoutTransferPasses *uint32 `protobuf:"varint,6,opt,name=maximum_number_of_brownout_transfer_passes,json=maximumNumberOfBrownoutTransferPasses,proto3,oneof" json:"maximum_number_of_brownout_transfer_passes,omitempty"`
-	// Expected duration for blackout transfer time.
+	// Expected duration, in milliseconds, for the blackout memory
+	// transfer to complete.
 	TargetBlackoutTransferTime *uint32 `protobuf:"varint,7,opt,name=target_blackout_transfer_time,json=targetBlackoutTransferTime,proto3,oneof" json:"target_blackout_transfer_time,omitempty"`
-	// Threshold for blackout duration prior to cancelling migration.
+	// Threshold, in milliseconds, for blackout duration prior to
+	// cancelling migration.
 	BlackoutTimeThresholdForCancellingMigration *uint32 `protobuf:"varint,8,opt,name=blackout_time_threshold_for_cancelling_migration,json=blackoutTimeThresholdForCancellingMigration,proto3,oneof" json:"blackout_time_threshold_for_cancelling_migration,omitempty"`
 	unknownFields                               protoimpl.UnknownFields
 	sizeCache                                   protoimpl.SizeCache
 }
 
-func (x *MemoryMigrationTransferThrottleParams) Reset() {
-	*x = MemoryMigrationTransferThrottleParams{}
+func (x *MemoryTransferThrottleParams) Reset() {
+	*x = MemoryTransferThrottleParams{}
 	mi := &file_github_com_Microsoft_hcsshim_pkg_migration_migration_options_proto_msgTypes[2]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *MemoryMigrationTransferThrottleParams) String() string {
+func (x *MemoryTransferThrottleParams) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*MemoryMigrationTransferThrottleParams) ProtoMessage() {}
+func (*MemoryTransferThrottleParams) ProtoMessage() {}
 
-func (x *MemoryMigrationTransferThrottleParams) ProtoReflect() protoreflect.Message {
+func (x *MemoryTransferThrottleParams) ProtoReflect() protoreflect.Message {
 	mi := &file_github_com_Microsoft_hcsshim_pkg_migration_migration_options_proto_msgTypes[2]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -465,68 +534,68 @@ func (x *MemoryMigrationTransferThrottleParams) ProtoReflect() protoreflect.Mess
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use MemoryMigrationTransferThrottleParams.ProtoReflect.Descriptor instead.
-func (*MemoryMigrationTransferThrottleParams) Descriptor() ([]byte, []int) {
+// Deprecated: Use MemoryTransferThrottleParams.ProtoReflect.Descriptor instead.
+func (*MemoryTransferThrottleParams) Descriptor() ([]byte, []int) {
 	return file_github_com_Microsoft_hcsshim_pkg_migration_migration_options_proto_rawDescGZIP(), []int{2}
 }
 
-func (x *MemoryMigrationTransferThrottleParams) GetSkipThrottling() bool {
+func (x *MemoryTransferThrottleParams) GetSkipThrottling() bool {
 	if x != nil && x.SkipThrottling != nil {
 		return *x.SkipThrottling
 	}
 	return false
 }
 
-func (x *MemoryMigrationTransferThrottleParams) GetThrottlingScale() float64 {
+func (x *MemoryTransferThrottleParams) GetThrottlingScale() float64 {
 	if x != nil && x.ThrottlingScale != nil {
 		return *x.ThrottlingScale
 	}
 	return 0
 }
 
-func (x *MemoryMigrationTransferThrottleParams) GetMinimumThrottlePercentage() uint32 {
+func (x *MemoryTransferThrottleParams) GetMinimumThrottlePercentage() uint32 {
 	if x != nil && x.MinimumThrottlePercentage != nil {
 		return *x.MinimumThrottlePercentage
 	}
 	return 0
 }
 
-func (x *MemoryMigrationTransferThrottleParams) GetTargetNumberOfBrownoutTransferPasses() uint32 {
+func (x *MemoryTransferThrottleParams) GetTargetNumberOfBrownoutTransferPasses() uint32 {
 	if x != nil && x.TargetNumberOfBrownoutTransferPasses != nil {
 		return *x.TargetNumberOfBrownoutTransferPasses
 	}
 	return 0
 }
 
-func (x *MemoryMigrationTransferThrottleParams) GetStartingBrownoutPassNumberForThrottling() uint32 {
+func (x *MemoryTransferThrottleParams) GetStartingBrownoutPassNumberForThrottling() uint32 {
 	if x != nil && x.StartingBrownoutPassNumberForThrottling != nil {
 		return *x.StartingBrownoutPassNumberForThrottling
 	}
 	return 0
 }
 
-func (x *MemoryMigrationTransferThrottleParams) GetMaximumNumberOfBrownoutTransferPasses() uint32 {
+func (x *MemoryTransferThrottleParams) GetMaximumNumberOfBrownoutTransferPasses() uint32 {
 	if x != nil && x.MaximumNumberOfBrownoutTransferPasses != nil {
 		return *x.MaximumNumberOfBrownoutTransferPasses
 	}
 	return 0
 }
 
-func (x *MemoryMigrationTransferThrottleParams) GetTargetBlackoutTransferTime() uint32 {
+func (x *MemoryTransferThrottleParams) GetTargetBlackoutTransferTime() uint32 {
 	if x != nil && x.TargetBlackoutTransferTime != nil {
 		return *x.TargetBlackoutTransferTime
 	}
 	return 0
 }
 
-func (x *MemoryMigrationTransferThrottleParams) GetBlackoutTimeThresholdForCancellingMigration() uint32 {
+func (x *MemoryTransferThrottleParams) GetBlackoutTimeThresholdForCancellingMigration() uint32 {
 	if x != nil && x.BlackoutTimeThresholdForCancellingMigration != nil {
 		return *x.BlackoutTimeThresholdForCancellingMigration
 	}
 	return 0
 }
 
-type MigrationCompressionSettings struct {
+type CompressionSettings struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Number of worker threads used for [de]compression. Values higher than what the host
 	// and VM configuration can support will be adjusted. The value should be non-zero.
@@ -535,20 +604,20 @@ type MigrationCompressionSettings struct {
 	sizeCache           protoimpl.SizeCache
 }
 
-func (x *MigrationCompressionSettings) Reset() {
-	*x = MigrationCompressionSettings{}
+func (x *CompressionSettings) Reset() {
+	*x = CompressionSettings{}
 	mi := &file_github_com_Microsoft_hcsshim_pkg_migration_migration_options_proto_msgTypes[3]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *MigrationCompressionSettings) String() string {
+func (x *CompressionSettings) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*MigrationCompressionSettings) ProtoMessage() {}
+func (*CompressionSettings) ProtoMessage() {}
 
-func (x *MigrationCompressionSettings) ProtoReflect() protoreflect.Message {
+func (x *CompressionSettings) ProtoReflect() protoreflect.Message {
 	mi := &file_github_com_Microsoft_hcsshim_pkg_migration_migration_options_proto_msgTypes[3]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -560,52 +629,52 @@ func (x *MigrationCompressionSettings) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use MigrationCompressionSettings.ProtoReflect.Descriptor instead.
-func (*MigrationCompressionSettings) Descriptor() ([]byte, []int) {
+// Deprecated: Use CompressionSettings.ProtoReflect.Descriptor instead.
+func (*CompressionSettings) Descriptor() ([]byte, []int) {
 	return file_github_com_Microsoft_hcsshim_pkg_migration_migration_options_proto_rawDescGZIP(), []int{3}
 }
 
-func (x *MigrationCompressionSettings) GetThrottleWorkerCount() uint32 {
+func (x *CompressionSettings) GetThrottleWorkerCount() uint32 {
 	if x != nil && x.ThrottleWorkerCount != nil {
 		return *x.ThrottleWorkerCount
 	}
 	return 0
 }
 
-// MigrationNotification is a notification payload describing the current
+// Notification is a notification payload describing the current
 // state of an in-progress live migration operation. It mirrors the HCS
 // OperationSystemMigrationNotificationInfo schema.
-type MigrationNotification struct {
+type Notification struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Origin indicates which side of the live migration this notification
 	// pertains to.
-	Origin MigrationOrigin `protobuf:"varint,1,opt,name=origin,proto3,enum=MigrationOrigin" json:"origin,omitempty"`
-	// Event is the type of live migration event being reported.
-	Event MigrationEvent `protobuf:"varint,2,opt,name=event,proto3,enum=MigrationEvent" json:"event,omitempty"`
-	// Result is an optional outcome accompanying the event. Typically
-	// populated for terminal events.
-	Result MigrationResult `protobuf:"varint,3,opt,name=result,proto3,enum=MigrationResult" json:"result,omitempty"`
-	// AdditionalDetails carries extra event-specific information whose
-	// schema depends on the event being reported.
+	Origin Origin `protobuf:"varint,1,opt,name=origin,proto3,enum=Origin" json:"origin,omitempty"`
+	// Phase is the live migration phase being reported.
+	Phase Phase `protobuf:"varint,2,opt,name=phase,proto3,enum=Phase" json:"phase,omitempty"`
+	// State is an optional outcome accompanying the phase. Typically
+	// populated for terminal phases.
+	State PhaseState `protobuf:"varint,3,opt,name=state,proto3,enum=PhaseState" json:"state,omitempty"`
+	// AdditionalDetails carries extra phase-specific information whose
+	// schema depends on the phase being reported.
 	AdditionalDetails *anypb.Any `protobuf:"bytes,4,opt,name=additional_details,json=additionalDetails,proto3" json:"additional_details,omitempty"`
 	unknownFields     protoimpl.UnknownFields
 	sizeCache         protoimpl.SizeCache
 }
 
-func (x *MigrationNotification) Reset() {
-	*x = MigrationNotification{}
+func (x *Notification) Reset() {
+	*x = Notification{}
 	mi := &file_github_com_Microsoft_hcsshim_pkg_migration_migration_options_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *MigrationNotification) String() string {
+func (x *Notification) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*MigrationNotification) ProtoMessage() {}
+func (*Notification) ProtoMessage() {}
 
-func (x *MigrationNotification) ProtoReflect() protoreflect.Message {
+func (x *Notification) ProtoReflect() protoreflect.Message {
 	mi := &file_github_com_Microsoft_hcsshim_pkg_migration_migration_options_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -617,33 +686,33 @@ func (x *MigrationNotification) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use MigrationNotification.ProtoReflect.Descriptor instead.
-func (*MigrationNotification) Descriptor() ([]byte, []int) {
+// Deprecated: Use Notification.ProtoReflect.Descriptor instead.
+func (*Notification) Descriptor() ([]byte, []int) {
 	return file_github_com_Microsoft_hcsshim_pkg_migration_migration_options_proto_rawDescGZIP(), []int{4}
 }
 
-func (x *MigrationNotification) GetOrigin() MigrationOrigin {
+func (x *Notification) GetOrigin() Origin {
 	if x != nil {
 		return x.Origin
 	}
-	return MigrationOrigin_MIGRATION_ORIGIN_UNSPECIFIED
+	return Origin_ORIGIN_UNSPECIFIED
 }
 
-func (x *MigrationNotification) GetEvent() MigrationEvent {
+func (x *Notification) GetPhase() Phase {
 	if x != nil {
-		return x.Event
+		return x.Phase
 	}
-	return MigrationEvent_MIGRATION_EVENT_UNSPECIFIED
+	return Phase_PHASE_UNSPECIFIED
 }
 
-func (x *MigrationNotification) GetResult() MigrationResult {
+func (x *Notification) GetState() PhaseState {
 	if x != nil {
-		return x.Result
+		return x.State
 	}
-	return MigrationResult_MIGRATION_RESULT_UNSPECIFIED
+	return PhaseState_PHASE_STATE_UNSPECIFIED
 }
 
-func (x *MigrationNotification) GetAdditionalDetails() *anypb.Any {
+func (x *Notification) GetAdditionalDetails() *anypb.Any {
 	if x != nil {
 		return x.AdditionalDetails
 	}
@@ -654,11 +723,11 @@ var File_github_com_Microsoft_hcsshim_pkg_migration_migration_options_proto prot
 
 const file_github_com_Microsoft_hcsshim_pkg_migration_migration_options_proto_rawDesc = "" +
 	"\n" +
-	"Bgithub.com/Microsoft/hcsshim/pkg/migration/migration_options.proto\x1a\x19google/protobuf/any.proto\"\xc1\x05\n" +
-	"\x1aMigrationInitializeOptions\x12D\n" +
-	"\x10memory_transport\x18\x01 \x01(\x0e2\x19.MigrationMemoryTransportR\x0fmemoryTransport\x12r\n" +
-	"\x1fmemory_transfer_throttle_params\x18\x02 \x01(\v2&.MemoryMigrationTransferThrottleParamsH\x00R\x1cmemoryTransferThrottleParams\x88\x01\x01\x12U\n" +
-	"\x14compression_settings\x18\x03 \x01(\v2\x1d.MigrationCompressionSettingsH\x01R\x13compressionSettings\x88\x01\x01\x123\n" +
+	"Bgithub.com/Microsoft/hcsshim/pkg/migration/migration_options.proto\x1a\x19google/protobuf/any.proto\"\x9d\x05\n" +
+	"\x11InitializeOptions\x12;\n" +
+	"\x10memory_transport\x18\x01 \x01(\x0e2\x10.MemoryTransportR\x0fmemoryTransport\x12i\n" +
+	"\x1fmemory_transfer_throttle_params\x18\x02 \x01(\v2\x1d.MemoryTransferThrottleParamsH\x00R\x1cmemoryTransferThrottleParams\x88\x01\x01\x12L\n" +
+	"\x14compression_settings\x18\x03 \x01(\v2\x14.CompressionSettingsH\x01R\x13compressionSettings\x88\x01\x01\x123\n" +
 	"\x15checksum_verification\x18\x04 \x01(\bR\x14checksumVerification\x120\n" +
 	"\x14perf_tracing_enabled\x18\x05 \x01(\bR\x12perfTracingEnabled\x12N\n" +
 	"$cancel_if_blackout_threshold_exceeds\x18\x06 \x01(\bR cancelIfBlackoutThresholdExceeds\x12?\n" +
@@ -668,8 +737,8 @@ const file_github_com_Microsoft_hcsshim_pkg_migration_migration_options_proto_ra
 	"\x15_compression_settingsB\x15\n" +
 	"\x13_compatibility_data\"'\n" +
 	"\x11CompatibilityInfo\x12\x12\n" +
-	"\x04data\x18\x01 \x01(\fR\x04data\"\xce\a\n" +
-	"%MemoryMigrationTransferThrottleParams\x12,\n" +
+	"\x04data\x18\x01 \x01(\fR\x04data\"\xc5\a\n" +
+	"\x1cMemoryTransferThrottleParams\x12,\n" +
 	"\x0fskip_throttling\x18\x01 \x01(\bH\x00R\x0eskipThrottling\x88\x01\x01\x12.\n" +
 	"\x10throttling_scale\x18\x02 \x01(\x01H\x01R\x0fthrottlingScale\x88\x01\x01\x12C\n" +
 	"\x1bminimum_throttle_percentage\x18\x03 \x01(\rH\x02R\x19minimumThrottlePercentage\x88\x01\x01\x12\\\n" +
@@ -685,40 +754,42 @@ const file_github_com_Microsoft_hcsshim_pkg_migration_migration_options_proto_ra
 	"-_starting_brownout_pass_number_for_throttlingB-\n" +
 	"+_maximum_number_of_brownout_transfer_passesB \n" +
 	"\x1e_target_blackout_transfer_timeB3\n" +
-	"1_blackout_time_threshold_for_cancelling_migration\"q\n" +
-	"\x1cMigrationCompressionSettings\x127\n" +
+	"1_blackout_time_threshold_for_cancelling_migration\"h\n" +
+	"\x13CompressionSettings\x127\n" +
 	"\x15throttle_worker_count\x18\x01 \x01(\rH\x00R\x13throttleWorkerCount\x88\x01\x01B\x18\n" +
-	"\x16_throttle_worker_count\"\xd7\x01\n" +
-	"\x15MigrationNotification\x12(\n" +
-	"\x06origin\x18\x01 \x01(\x0e2\x10.MigrationOriginR\x06origin\x12%\n" +
-	"\x05event\x18\x02 \x01(\x0e2\x0f.MigrationEventR\x05event\x12(\n" +
-	"\x06result\x18\x03 \x01(\x0e2\x10.MigrationResultR\x06result\x12C\n" +
-	"\x12additional_details\x18\x04 \x01(\v2\x14.google.protobuf.AnyR\x11additionalDetails*j\n" +
-	"\x18MigrationMemoryTransport\x12*\n" +
-	"&MIGRATION_MEMORY_TRANSPORT_UNSPECIFIED\x10\x00\x12\"\n" +
-	"\x1eMIGRATION_MEMORY_TRANSPORT_TCP\x10\x01*r\n" +
-	"\x0fMigrationOrigin\x12 \n" +
-	"\x1cMIGRATION_ORIGIN_UNSPECIFIED\x10\x00\x12\x1b\n" +
-	"\x17MIGRATION_ORIGIN_SOURCE\x10\x01\x12 \n" +
-	"\x1cMIGRATION_ORIGIN_DESTINATION\x10\x02*\xdf\x02\n" +
-	"\x0eMigrationEvent\x12\x1f\n" +
-	"\x1bMIGRATION_EVENT_UNSPECIFIED\x10\x00\x12\"\n" +
-	"\x1eMIGRATION_EVENT_MIGRATION_DONE\x10\x01\x12$\n" +
-	" MIGRATION_EVENT_BLACKOUT_STARTED\x10\x02\x12 \n" +
-	"\x1cMIGRATION_EVENT_OFFLINE_DONE\x10\x03\x12#\n" +
-	"\x1fMIGRATION_EVENT_BLACKOUT_EXITED\x10\x04\x12\x1e\n" +
-	"\x1aMIGRATION_EVENT_SETUP_DONE\x10\x05\x12(\n" +
-	"$MIGRATION_EVENT_TRANSFER_IN_PROGRESS\x10\x06\x12+\n" +
-	"'MIGRATION_EVENT_MIGRATION_RECOVERY_DONE\x10\a\x12$\n" +
-	" MIGRATION_EVENT_MIGRATION_FAILED\x10\b*\xbf\x02\n" +
-	"\x0fMigrationResult\x12 \n" +
-	"\x1cMIGRATION_RESULT_UNSPECIFIED\x10\x00\x12\x1c\n" +
-	"\x18MIGRATION_RESULT_SUCCESS\x10\x01\x12(\n" +
-	"$MIGRATION_RESULT_MIGRATION_CANCELLED\x10\x02\x121\n" +
-	"-MIGRATION_RESULT_GUEST_INITIATED_CANCELLATION\x10\x03\x12,\n" +
-	"(MIGRATION_RESULT_SOURCE_MIGRATION_FAILED\x10\x04\x121\n" +
-	"-MIGRATION_RESULT_DESTINATION_MIGRATION_FAILED\x10\x05\x12.\n" +
-	"*MIGRATION_RESULT_MIGRATION_RECOVERY_FAILED\x10\x06B6Z4github.com/Microsoft/hcsshim/pkg/migration;migrationb\x06proto3"
+	"\x16_throttle_worker_count\"\xb5\x01\n" +
+	"\fNotification\x12\x1f\n" +
+	"\x06origin\x18\x01 \x01(\x0e2\a.OriginR\x06origin\x12\x1c\n" +
+	"\x05phase\x18\x02 \x01(\x0e2\x06.PhaseR\x05phase\x12!\n" +
+	"\x05state\x18\x03 \x01(\x0e2\v.PhaseStateR\x05state\x12C\n" +
+	"\x12additional_details\x18\x04 \x01(\v2\x14.google.protobuf.AnyR\x11additionalDetails*M\n" +
+	"\x0fMemoryTransport\x12 \n" +
+	"\x1cMEMORY_TRANSPORT_UNSPECIFIED\x10\x00\x12\x18\n" +
+	"\x14MEMORY_TRANSPORT_TCP\x10\x01*K\n" +
+	"\x06Origin\x12\x16\n" +
+	"\x12ORIGIN_UNSPECIFIED\x10\x00\x12\x11\n" +
+	"\rORIGIN_SOURCE\x10\x01\x12\x16\n" +
+	"\x12ORIGIN_DESTINATION\x10\x02*\xde\x01\n" +
+	"\x05Phase\x12\x15\n" +
+	"\x11PHASE_UNSPECIFIED\x10\x00\x12\x14\n" +
+	"\x10PHASE_SETUP_DONE\x10\x01\x12\x1e\n" +
+	"\x1aPHASE_TRANSFER_IN_PROGRESS\x10\x02\x12\x1a\n" +
+	"\x16PHASE_BLACKOUT_STARTED\x10\x03\x12\x16\n" +
+	"\x12PHASE_OFFLINE_DONE\x10\x04\x12\x19\n" +
+	"\x15PHASE_BLACKOUT_EXITED\x10\x05\x12\x0e\n" +
+	"\n" +
+	"PHASE_DONE\x10\x06\x12\x17\n" +
+	"\x13PHASE_RECOVERY_DONE\x10\a\x12\x10\n" +
+	"\fPHASE_FAILED\x10\b*\xef\x01\n" +
+	"\n" +
+	"PhaseState\x12\x1b\n" +
+	"\x17PHASE_STATE_UNSPECIFIED\x10\x00\x12\x17\n" +
+	"\x13PHASE_STATE_SUCCESS\x10\x01\x12\x19\n" +
+	"\x15PHASE_STATE_CANCELLED\x10\x02\x12,\n" +
+	"(PHASE_STATE_GUEST_INITIATED_CANCELLATION\x10\x03\x12\x1d\n" +
+	"\x19PHASE_STATE_SOURCE_FAILED\x10\x04\x12\"\n" +
+	"\x1ePHASE_STATE_DESTINATION_FAILED\x10\x05\x12\x1f\n" +
+	"\x1bPHASE_STATE_RECOVERY_FAILED\x10\x06B6Z4github.com/Microsoft/hcsshim/pkg/migration;migrationb\x06proto3"
 
 var (
 	file_github_com_Microsoft_hcsshim_pkg_migration_migration_options_proto_rawDescOnce sync.Once
@@ -735,26 +806,26 @@ func file_github_com_Microsoft_hcsshim_pkg_migration_migration_options_proto_raw
 var file_github_com_Microsoft_hcsshim_pkg_migration_migration_options_proto_enumTypes = make([]protoimpl.EnumInfo, 4)
 var file_github_com_Microsoft_hcsshim_pkg_migration_migration_options_proto_msgTypes = make([]protoimpl.MessageInfo, 5)
 var file_github_com_Microsoft_hcsshim_pkg_migration_migration_options_proto_goTypes = []any{
-	(MigrationMemoryTransport)(0),                 // 0: MigrationMemoryTransport
-	(MigrationOrigin)(0),                          // 1: MigrationOrigin
-	(MigrationEvent)(0),                           // 2: MigrationEvent
-	(MigrationResult)(0),                          // 3: MigrationResult
-	(*MigrationInitializeOptions)(nil),            // 4: MigrationInitializeOptions
-	(*CompatibilityInfo)(nil),                     // 5: CompatibilityInfo
-	(*MemoryMigrationTransferThrottleParams)(nil), // 6: MemoryMigrationTransferThrottleParams
-	(*MigrationCompressionSettings)(nil),          // 7: MigrationCompressionSettings
-	(*MigrationNotification)(nil),                 // 8: MigrationNotification
-	(*anypb.Any)(nil),                             // 9: google.protobuf.Any
+	(MemoryTransport)(0),                 // 0: MemoryTransport
+	(Origin)(0),                          // 1: Origin
+	(Phase)(0),                           // 2: Phase
+	(PhaseState)(0),                      // 3: PhaseState
+	(*InitializeOptions)(nil),            // 4: InitializeOptions
+	(*CompatibilityInfo)(nil),            // 5: CompatibilityInfo
+	(*MemoryTransferThrottleParams)(nil), // 6: MemoryTransferThrottleParams
+	(*CompressionSettings)(nil),          // 7: CompressionSettings
+	(*Notification)(nil),                 // 8: Notification
+	(*anypb.Any)(nil),                    // 9: google.protobuf.Any
 }
 var file_github_com_Microsoft_hcsshim_pkg_migration_migration_options_proto_depIdxs = []int32{
-	0, // 0: MigrationInitializeOptions.memory_transport:type_name -> MigrationMemoryTransport
-	6, // 1: MigrationInitializeOptions.memory_transfer_throttle_params:type_name -> MemoryMigrationTransferThrottleParams
-	7, // 2: MigrationInitializeOptions.compression_settings:type_name -> MigrationCompressionSettings
-	5, // 3: MigrationInitializeOptions.compatibility_data:type_name -> CompatibilityInfo
-	1, // 4: MigrationNotification.origin:type_name -> MigrationOrigin
-	2, // 5: MigrationNotification.event:type_name -> MigrationEvent
-	3, // 6: MigrationNotification.result:type_name -> MigrationResult
-	9, // 7: MigrationNotification.additional_details:type_name -> google.protobuf.Any
+	0, // 0: InitializeOptions.memory_transport:type_name -> MemoryTransport
+	6, // 1: InitializeOptions.memory_transfer_throttle_params:type_name -> MemoryTransferThrottleParams
+	7, // 2: InitializeOptions.compression_settings:type_name -> CompressionSettings
+	5, // 3: InitializeOptions.compatibility_data:type_name -> CompatibilityInfo
+	1, // 4: Notification.origin:type_name -> Origin
+	2, // 5: Notification.phase:type_name -> Phase
+	3, // 6: Notification.state:type_name -> PhaseState
+	9, // 7: Notification.additional_details:type_name -> google.protobuf.Any
 	8, // [8:8] is the sub-list for method output_type
 	8, // [8:8] is the sub-list for method input_type
 	8, // [8:8] is the sub-list for extension type_name

--- a/pkg/migration/migration_options.pb.go
+++ b/pkg/migration/migration_options.pb.go
@@ -9,7 +9,7 @@ package migration
 import (
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
-	anypb "google.golang.org/protobuf/types/known/anypb"
+	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
 	reflect "reflect"
 	sync "sync"
 	unsafe "unsafe"
@@ -641,6 +641,63 @@ func (x *CompressionSettings) GetThrottleWorkerCount() uint32 {
 	return 0
 }
 
+// BlackoutExitedEventDetails carries additional details reported alongside
+// PHASE_BLACKOUT_EXITED, describing the blackout that just ended. Mirrors
+// the HCS MigrationBlackoutExitedEventDetails schema.
+type BlackoutExitedEventDetails struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Duration of the blackout phase, in milliseconds.
+	BlackoutDurationMilliseconds uint64 `protobuf:"varint,1,opt,name=blackout_duration_milliseconds,json=blackoutDurationMilliseconds,proto3" json:"blackout_duration_milliseconds,omitempty"`
+	// Timestamp at which the blackout phase ended.
+	BlackoutStopTimestamp *timestamppb.Timestamp `protobuf:"bytes,2,opt,name=blackout_stop_timestamp,json=blackoutStopTimestamp,proto3" json:"blackout_stop_timestamp,omitempty"`
+	unknownFields         protoimpl.UnknownFields
+	sizeCache             protoimpl.SizeCache
+}
+
+func (x *BlackoutExitedEventDetails) Reset() {
+	*x = BlackoutExitedEventDetails{}
+	mi := &file_github_com_Microsoft_hcsshim_pkg_migration_migration_options_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *BlackoutExitedEventDetails) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*BlackoutExitedEventDetails) ProtoMessage() {}
+
+func (x *BlackoutExitedEventDetails) ProtoReflect() protoreflect.Message {
+	mi := &file_github_com_Microsoft_hcsshim_pkg_migration_migration_options_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use BlackoutExitedEventDetails.ProtoReflect.Descriptor instead.
+func (*BlackoutExitedEventDetails) Descriptor() ([]byte, []int) {
+	return file_github_com_Microsoft_hcsshim_pkg_migration_migration_options_proto_rawDescGZIP(), []int{4}
+}
+
+func (x *BlackoutExitedEventDetails) GetBlackoutDurationMilliseconds() uint64 {
+	if x != nil {
+		return x.BlackoutDurationMilliseconds
+	}
+	return 0
+}
+
+func (x *BlackoutExitedEventDetails) GetBlackoutStopTimestamp() *timestamppb.Timestamp {
+	if x != nil {
+		return x.BlackoutStopTimestamp
+	}
+	return nil
+}
+
 // Notification is a notification payload describing the current
 // state of an in-progress live migration operation. It mirrors the HCS
 // OperationSystemMigrationNotificationInfo schema.
@@ -654,16 +711,20 @@ type Notification struct {
 	// State is an optional outcome accompanying the phase. Typically
 	// populated for terminal phases.
 	State PhaseState `protobuf:"varint,3,opt,name=state,proto3,enum=PhaseState" json:"state,omitempty"`
-	// AdditionalDetails carries extra phase-specific information whose
-	// schema depends on the phase being reported.
-	AdditionalDetails *anypb.Any `protobuf:"bytes,4,opt,name=additional_details,json=additionalDetails,proto3" json:"additional_details,omitempty"`
-	unknownFields     protoimpl.UnknownFields
-	sizeCache         protoimpl.SizeCache
+	// PhaseDetails carries extra phase-specific information whose concrete
+	// type depends on the phase being reported.
+	//
+	// Types that are valid to be assigned to PhaseDetails:
+	//
+	//	*Notification_BlackoutExited
+	PhaseDetails  isNotification_PhaseDetails `protobuf_oneof:"phase_details"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *Notification) Reset() {
 	*x = Notification{}
-	mi := &file_github_com_Microsoft_hcsshim_pkg_migration_migration_options_proto_msgTypes[4]
+	mi := &file_github_com_Microsoft_hcsshim_pkg_migration_migration_options_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -675,7 +736,7 @@ func (x *Notification) String() string {
 func (*Notification) ProtoMessage() {}
 
 func (x *Notification) ProtoReflect() protoreflect.Message {
-	mi := &file_github_com_Microsoft_hcsshim_pkg_migration_migration_options_proto_msgTypes[4]
+	mi := &file_github_com_Microsoft_hcsshim_pkg_migration_migration_options_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -688,7 +749,7 @@ func (x *Notification) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Notification.ProtoReflect.Descriptor instead.
 func (*Notification) Descriptor() ([]byte, []int) {
-	return file_github_com_Microsoft_hcsshim_pkg_migration_migration_options_proto_rawDescGZIP(), []int{4}
+	return file_github_com_Microsoft_hcsshim_pkg_migration_migration_options_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *Notification) GetOrigin() Origin {
@@ -712,18 +773,38 @@ func (x *Notification) GetState() PhaseState {
 	return PhaseState_PHASE_STATE_UNSPECIFIED
 }
 
-func (x *Notification) GetAdditionalDetails() *anypb.Any {
+func (x *Notification) GetPhaseDetails() isNotification_PhaseDetails {
 	if x != nil {
-		return x.AdditionalDetails
+		return x.PhaseDetails
 	}
 	return nil
 }
+
+func (x *Notification) GetBlackoutExited() *BlackoutExitedEventDetails {
+	if x != nil {
+		if x, ok := x.PhaseDetails.(*Notification_BlackoutExited); ok {
+			return x.BlackoutExited
+		}
+	}
+	return nil
+}
+
+type isNotification_PhaseDetails interface {
+	isNotification_PhaseDetails()
+}
+
+type Notification_BlackoutExited struct {
+	// Details reported with PHASE_BLACKOUT_EXITED.
+	BlackoutExited *BlackoutExitedEventDetails `protobuf:"bytes,4,opt,name=blackout_exited,json=blackoutExited,proto3,oneof"`
+}
+
+func (*Notification_BlackoutExited) isNotification_PhaseDetails() {}
 
 var File_github_com_Microsoft_hcsshim_pkg_migration_migration_options_proto protoreflect.FileDescriptor
 
 const file_github_com_Microsoft_hcsshim_pkg_migration_migration_options_proto_rawDesc = "" +
 	"\n" +
-	"Bgithub.com/Microsoft/hcsshim/pkg/migration/migration_options.proto\x1a\x19google/protobuf/any.proto\"\x9d\x05\n" +
+	"Bgithub.com/Microsoft/hcsshim/pkg/migration/migration_options.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\x9d\x05\n" +
 	"\x11InitializeOptions\x12;\n" +
 	"\x10memory_transport\x18\x01 \x01(\x0e2\x10.MemoryTransportR\x0fmemoryTransport\x12i\n" +
 	"\x1fmemory_transfer_throttle_params\x18\x02 \x01(\v2\x1d.MemoryTransferThrottleParamsH\x00R\x1cmemoryTransferThrottleParams\x88\x01\x01\x12L\n" +
@@ -757,12 +838,16 @@ const file_github_com_Microsoft_hcsshim_pkg_migration_migration_options_proto_ra
 	"1_blackout_time_threshold_for_cancelling_migration\"h\n" +
 	"\x13CompressionSettings\x127\n" +
 	"\x15throttle_worker_count\x18\x01 \x01(\rH\x00R\x13throttleWorkerCount\x88\x01\x01B\x18\n" +
-	"\x16_throttle_worker_count\"\xb5\x01\n" +
+	"\x16_throttle_worker_count\"\xb6\x01\n" +
+	"\x1aBlackoutExitedEventDetails\x12D\n" +
+	"\x1eblackout_duration_milliseconds\x18\x01 \x01(\x04R\x1cblackoutDurationMilliseconds\x12R\n" +
+	"\x17blackout_stop_timestamp\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\x15blackoutStopTimestamp\"\xc9\x01\n" +
 	"\fNotification\x12\x1f\n" +
 	"\x06origin\x18\x01 \x01(\x0e2\a.OriginR\x06origin\x12\x1c\n" +
 	"\x05phase\x18\x02 \x01(\x0e2\x06.PhaseR\x05phase\x12!\n" +
-	"\x05state\x18\x03 \x01(\x0e2\v.PhaseStateR\x05state\x12C\n" +
-	"\x12additional_details\x18\x04 \x01(\v2\x14.google.protobuf.AnyR\x11additionalDetails*M\n" +
+	"\x05state\x18\x03 \x01(\x0e2\v.PhaseStateR\x05state\x12F\n" +
+	"\x0fblackout_exited\x18\x04 \x01(\v2\x1b.BlackoutExitedEventDetailsH\x00R\x0eblackoutExitedB\x0f\n" +
+	"\rphase_details*M\n" +
 	"\x0fMemoryTransport\x12 \n" +
 	"\x1cMEMORY_TRANSPORT_UNSPECIFIED\x10\x00\x12\x18\n" +
 	"\x14MEMORY_TRANSPORT_TCP\x10\x01*K\n" +
@@ -804,7 +889,7 @@ func file_github_com_Microsoft_hcsshim_pkg_migration_migration_options_proto_raw
 }
 
 var file_github_com_Microsoft_hcsshim_pkg_migration_migration_options_proto_enumTypes = make([]protoimpl.EnumInfo, 4)
-var file_github_com_Microsoft_hcsshim_pkg_migration_migration_options_proto_msgTypes = make([]protoimpl.MessageInfo, 5)
+var file_github_com_Microsoft_hcsshim_pkg_migration_migration_options_proto_msgTypes = make([]protoimpl.MessageInfo, 6)
 var file_github_com_Microsoft_hcsshim_pkg_migration_migration_options_proto_goTypes = []any{
 	(MemoryTransport)(0),                 // 0: MemoryTransport
 	(Origin)(0),                          // 1: Origin
@@ -814,23 +899,25 @@ var file_github_com_Microsoft_hcsshim_pkg_migration_migration_options_proto_goTy
 	(*CompatibilityInfo)(nil),            // 5: CompatibilityInfo
 	(*MemoryTransferThrottleParams)(nil), // 6: MemoryTransferThrottleParams
 	(*CompressionSettings)(nil),          // 7: CompressionSettings
-	(*Notification)(nil),                 // 8: Notification
-	(*anypb.Any)(nil),                    // 9: google.protobuf.Any
+	(*BlackoutExitedEventDetails)(nil),   // 8: BlackoutExitedEventDetails
+	(*Notification)(nil),                 // 9: Notification
+	(*timestamppb.Timestamp)(nil),        // 10: google.protobuf.Timestamp
 }
 var file_github_com_Microsoft_hcsshim_pkg_migration_migration_options_proto_depIdxs = []int32{
-	0, // 0: InitializeOptions.memory_transport:type_name -> MemoryTransport
-	6, // 1: InitializeOptions.memory_transfer_throttle_params:type_name -> MemoryTransferThrottleParams
-	7, // 2: InitializeOptions.compression_settings:type_name -> CompressionSettings
-	5, // 3: InitializeOptions.compatibility_data:type_name -> CompatibilityInfo
-	1, // 4: Notification.origin:type_name -> Origin
-	2, // 5: Notification.phase:type_name -> Phase
-	3, // 6: Notification.state:type_name -> PhaseState
-	9, // 7: Notification.additional_details:type_name -> google.protobuf.Any
-	8, // [8:8] is the sub-list for method output_type
-	8, // [8:8] is the sub-list for method input_type
-	8, // [8:8] is the sub-list for extension type_name
-	8, // [8:8] is the sub-list for extension extendee
-	0, // [0:8] is the sub-list for field type_name
+	0,  // 0: InitializeOptions.memory_transport:type_name -> MemoryTransport
+	6,  // 1: InitializeOptions.memory_transfer_throttle_params:type_name -> MemoryTransferThrottleParams
+	7,  // 2: InitializeOptions.compression_settings:type_name -> CompressionSettings
+	5,  // 3: InitializeOptions.compatibility_data:type_name -> CompatibilityInfo
+	10, // 4: BlackoutExitedEventDetails.blackout_stop_timestamp:type_name -> google.protobuf.Timestamp
+	1,  // 5: Notification.origin:type_name -> Origin
+	2,  // 6: Notification.phase:type_name -> Phase
+	3,  // 7: Notification.state:type_name -> PhaseState
+	8,  // 8: Notification.blackout_exited:type_name -> BlackoutExitedEventDetails
+	9,  // [9:9] is the sub-list for method output_type
+	9,  // [9:9] is the sub-list for method input_type
+	9,  // [9:9] is the sub-list for extension type_name
+	9,  // [9:9] is the sub-list for extension extendee
+	0,  // [0:9] is the sub-list for field type_name
 }
 
 func init() { file_github_com_Microsoft_hcsshim_pkg_migration_migration_options_proto_init() }
@@ -841,13 +928,16 @@ func file_github_com_Microsoft_hcsshim_pkg_migration_migration_options_proto_ini
 	file_github_com_Microsoft_hcsshim_pkg_migration_migration_options_proto_msgTypes[0].OneofWrappers = []any{}
 	file_github_com_Microsoft_hcsshim_pkg_migration_migration_options_proto_msgTypes[2].OneofWrappers = []any{}
 	file_github_com_Microsoft_hcsshim_pkg_migration_migration_options_proto_msgTypes[3].OneofWrappers = []any{}
+	file_github_com_Microsoft_hcsshim_pkg_migration_migration_options_proto_msgTypes[5].OneofWrappers = []any{
+		(*Notification_BlackoutExited)(nil),
+	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_github_com_Microsoft_hcsshim_pkg_migration_migration_options_proto_rawDesc), len(file_github_com_Microsoft_hcsshim_pkg_migration_migration_options_proto_rawDesc)),
 			NumEnums:      4,
-			NumMessages:   5,
+			NumMessages:   6,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/pkg/migration/migration_options.pb.go
+++ b/pkg/migration/migration_options.pb.go
@@ -9,6 +9,7 @@ package migration
 import (
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+	anypb "google.golang.org/protobuf/types/known/anypb"
 	reflect "reflect"
 	sync "sync"
 	unsafe "unsafe"
@@ -67,6 +68,200 @@ func (x MigrationMemoryTransport) Number() protoreflect.EnumNumber {
 // Deprecated: Use MigrationMemoryTransport.Descriptor instead.
 func (MigrationMemoryTransport) EnumDescriptor() ([]byte, []int) {
 	return file_github_com_Microsoft_hcsshim_pkg_migration_migration_options_proto_rawDescGZIP(), []int{0}
+}
+
+// MigrationOrigin indicates which side of a live migration an operation or
+// notification pertains to.
+type MigrationOrigin int32
+
+const (
+	MigrationOrigin_MIGRATION_ORIGIN_UNSPECIFIED MigrationOrigin = 0
+	// Source side of the live migration.
+	MigrationOrigin_MIGRATION_ORIGIN_SOURCE MigrationOrigin = 1
+	// Destination side of the live migration.
+	MigrationOrigin_MIGRATION_ORIGIN_DESTINATION MigrationOrigin = 2
+)
+
+// Enum value maps for MigrationOrigin.
+var (
+	MigrationOrigin_name = map[int32]string{
+		0: "MIGRATION_ORIGIN_UNSPECIFIED",
+		1: "MIGRATION_ORIGIN_SOURCE",
+		2: "MIGRATION_ORIGIN_DESTINATION",
+	}
+	MigrationOrigin_value = map[string]int32{
+		"MIGRATION_ORIGIN_UNSPECIFIED": 0,
+		"MIGRATION_ORIGIN_SOURCE":      1,
+		"MIGRATION_ORIGIN_DESTINATION": 2,
+	}
+)
+
+func (x MigrationOrigin) Enum() *MigrationOrigin {
+	p := new(MigrationOrigin)
+	*p = x
+	return p
+}
+
+func (x MigrationOrigin) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (MigrationOrigin) Descriptor() protoreflect.EnumDescriptor {
+	return file_github_com_Microsoft_hcsshim_pkg_migration_migration_options_proto_enumTypes[1].Descriptor()
+}
+
+func (MigrationOrigin) Type() protoreflect.EnumType {
+	return &file_github_com_Microsoft_hcsshim_pkg_migration_migration_options_proto_enumTypes[1]
+}
+
+func (x MigrationOrigin) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use MigrationOrigin.Descriptor instead.
+func (MigrationOrigin) EnumDescriptor() ([]byte, []int) {
+	return file_github_com_Microsoft_hcsshim_pkg_migration_migration_options_proto_rawDescGZIP(), []int{1}
+}
+
+// MigrationEvent describes a live migration event reported by HCS during the
+// transfer phase of a live migration.
+type MigrationEvent int32
+
+const (
+	MigrationEvent_MIGRATION_EVENT_UNSPECIFIED MigrationEvent = 0
+	// Migration has completed.
+	MigrationEvent_MIGRATION_EVENT_MIGRATION_DONE MigrationEvent = 1
+	// The VM has entered the blackout phase.
+	MigrationEvent_MIGRATION_EVENT_BLACKOUT_STARTED MigrationEvent = 2
+	// Taking the VM offline has completed.
+	MigrationEvent_MIGRATION_EVENT_OFFLINE_DONE MigrationEvent = 3
+	// The VM has successfully started again after the blackout phase.
+	MigrationEvent_MIGRATION_EVENT_BLACKOUT_EXITED MigrationEvent = 4
+	// The live migration setup has completed.
+	MigrationEvent_MIGRATION_EVENT_SETUP_DONE MigrationEvent = 5
+	// The VM is still transferring memory and other necessary state.
+	MigrationEvent_MIGRATION_EVENT_TRANSFER_IN_PROGRESS MigrationEvent = 6
+	// Migration recovery has been performed.
+	MigrationEvent_MIGRATION_EVENT_MIGRATION_RECOVERY_DONE MigrationEvent = 7
+	// Migration failed.
+	MigrationEvent_MIGRATION_EVENT_MIGRATION_FAILED MigrationEvent = 8
+)
+
+// Enum value maps for MigrationEvent.
+var (
+	MigrationEvent_name = map[int32]string{
+		0: "MIGRATION_EVENT_UNSPECIFIED",
+		1: "MIGRATION_EVENT_MIGRATION_DONE",
+		2: "MIGRATION_EVENT_BLACKOUT_STARTED",
+		3: "MIGRATION_EVENT_OFFLINE_DONE",
+		4: "MIGRATION_EVENT_BLACKOUT_EXITED",
+		5: "MIGRATION_EVENT_SETUP_DONE",
+		6: "MIGRATION_EVENT_TRANSFER_IN_PROGRESS",
+		7: "MIGRATION_EVENT_MIGRATION_RECOVERY_DONE",
+		8: "MIGRATION_EVENT_MIGRATION_FAILED",
+	}
+	MigrationEvent_value = map[string]int32{
+		"MIGRATION_EVENT_UNSPECIFIED":             0,
+		"MIGRATION_EVENT_MIGRATION_DONE":          1,
+		"MIGRATION_EVENT_BLACKOUT_STARTED":        2,
+		"MIGRATION_EVENT_OFFLINE_DONE":            3,
+		"MIGRATION_EVENT_BLACKOUT_EXITED":         4,
+		"MIGRATION_EVENT_SETUP_DONE":              5,
+		"MIGRATION_EVENT_TRANSFER_IN_PROGRESS":    6,
+		"MIGRATION_EVENT_MIGRATION_RECOVERY_DONE": 7,
+		"MIGRATION_EVENT_MIGRATION_FAILED":        8,
+	}
+)
+
+func (x MigrationEvent) Enum() *MigrationEvent {
+	p := new(MigrationEvent)
+	*p = x
+	return p
+}
+
+func (x MigrationEvent) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (MigrationEvent) Descriptor() protoreflect.EnumDescriptor {
+	return file_github_com_Microsoft_hcsshim_pkg_migration_migration_options_proto_enumTypes[2].Descriptor()
+}
+
+func (MigrationEvent) Type() protoreflect.EnumType {
+	return &file_github_com_Microsoft_hcsshim_pkg_migration_migration_options_proto_enumTypes[2]
+}
+
+func (x MigrationEvent) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use MigrationEvent.Descriptor instead.
+func (MigrationEvent) EnumDescriptor() ([]byte, []int) {
+	return file_github_com_Microsoft_hcsshim_pkg_migration_migration_options_proto_rawDescGZIP(), []int{2}
+}
+
+// MigrationResult describes the possible result of a migration operation,
+// typically populated for terminal events such as MIGRATION_EVENT_MIGRATION_DONE
+// or MIGRATION_EVENT_MIGRATION_FAILED.
+type MigrationResult int32
+
+const (
+	MigrationResult_MIGRATION_RESULT_UNSPECIFIED                  MigrationResult = 0
+	MigrationResult_MIGRATION_RESULT_SUCCESS                      MigrationResult = 1
+	MigrationResult_MIGRATION_RESULT_MIGRATION_CANCELLED          MigrationResult = 2
+	MigrationResult_MIGRATION_RESULT_GUEST_INITIATED_CANCELLATION MigrationResult = 3
+	MigrationResult_MIGRATION_RESULT_SOURCE_MIGRATION_FAILED      MigrationResult = 4
+	MigrationResult_MIGRATION_RESULT_DESTINATION_MIGRATION_FAILED MigrationResult = 5
+	MigrationResult_MIGRATION_RESULT_MIGRATION_RECOVERY_FAILED    MigrationResult = 6
+)
+
+// Enum value maps for MigrationResult.
+var (
+	MigrationResult_name = map[int32]string{
+		0: "MIGRATION_RESULT_UNSPECIFIED",
+		1: "MIGRATION_RESULT_SUCCESS",
+		2: "MIGRATION_RESULT_MIGRATION_CANCELLED",
+		3: "MIGRATION_RESULT_GUEST_INITIATED_CANCELLATION",
+		4: "MIGRATION_RESULT_SOURCE_MIGRATION_FAILED",
+		5: "MIGRATION_RESULT_DESTINATION_MIGRATION_FAILED",
+		6: "MIGRATION_RESULT_MIGRATION_RECOVERY_FAILED",
+	}
+	MigrationResult_value = map[string]int32{
+		"MIGRATION_RESULT_UNSPECIFIED":                  0,
+		"MIGRATION_RESULT_SUCCESS":                      1,
+		"MIGRATION_RESULT_MIGRATION_CANCELLED":          2,
+		"MIGRATION_RESULT_GUEST_INITIATED_CANCELLATION": 3,
+		"MIGRATION_RESULT_SOURCE_MIGRATION_FAILED":      4,
+		"MIGRATION_RESULT_DESTINATION_MIGRATION_FAILED": 5,
+		"MIGRATION_RESULT_MIGRATION_RECOVERY_FAILED":    6,
+	}
+)
+
+func (x MigrationResult) Enum() *MigrationResult {
+	p := new(MigrationResult)
+	*p = x
+	return p
+}
+
+func (x MigrationResult) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (MigrationResult) Descriptor() protoreflect.EnumDescriptor {
+	return file_github_com_Microsoft_hcsshim_pkg_migration_migration_options_proto_enumTypes[3].Descriptor()
+}
+
+func (MigrationResult) Type() protoreflect.EnumType {
+	return &file_github_com_Microsoft_hcsshim_pkg_migration_migration_options_proto_enumTypes[3]
+}
+
+func (x MigrationResult) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use MigrationResult.Descriptor instead.
+func (MigrationResult) EnumDescriptor() ([]byte, []int) {
+	return file_github_com_Microsoft_hcsshim_pkg_migration_migration_options_proto_rawDescGZIP(), []int{3}
 }
 
 type MigrationInitializeOptions struct {
@@ -377,11 +572,89 @@ func (x *MigrationCompressionSettings) GetThrottleWorkerCount() uint32 {
 	return 0
 }
 
+// MigrationNotification is a notification payload describing the current
+// state of an in-progress live migration operation. It mirrors the HCS
+// OperationSystemMigrationNotificationInfo schema.
+type MigrationNotification struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Origin indicates which side of the live migration this notification
+	// pertains to.
+	Origin MigrationOrigin `protobuf:"varint,1,opt,name=origin,proto3,enum=MigrationOrigin" json:"origin,omitempty"`
+	// Event is the type of live migration event being reported.
+	Event MigrationEvent `protobuf:"varint,2,opt,name=event,proto3,enum=MigrationEvent" json:"event,omitempty"`
+	// Result is an optional outcome accompanying the event. Typically
+	// populated for terminal events.
+	Result MigrationResult `protobuf:"varint,3,opt,name=result,proto3,enum=MigrationResult" json:"result,omitempty"`
+	// AdditionalDetails carries extra event-specific information whose
+	// schema depends on the event being reported.
+	AdditionalDetails *anypb.Any `protobuf:"bytes,4,opt,name=additional_details,json=additionalDetails,proto3" json:"additional_details,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
+}
+
+func (x *MigrationNotification) Reset() {
+	*x = MigrationNotification{}
+	mi := &file_github_com_Microsoft_hcsshim_pkg_migration_migration_options_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *MigrationNotification) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*MigrationNotification) ProtoMessage() {}
+
+func (x *MigrationNotification) ProtoReflect() protoreflect.Message {
+	mi := &file_github_com_Microsoft_hcsshim_pkg_migration_migration_options_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use MigrationNotification.ProtoReflect.Descriptor instead.
+func (*MigrationNotification) Descriptor() ([]byte, []int) {
+	return file_github_com_Microsoft_hcsshim_pkg_migration_migration_options_proto_rawDescGZIP(), []int{4}
+}
+
+func (x *MigrationNotification) GetOrigin() MigrationOrigin {
+	if x != nil {
+		return x.Origin
+	}
+	return MigrationOrigin_MIGRATION_ORIGIN_UNSPECIFIED
+}
+
+func (x *MigrationNotification) GetEvent() MigrationEvent {
+	if x != nil {
+		return x.Event
+	}
+	return MigrationEvent_MIGRATION_EVENT_UNSPECIFIED
+}
+
+func (x *MigrationNotification) GetResult() MigrationResult {
+	if x != nil {
+		return x.Result
+	}
+	return MigrationResult_MIGRATION_RESULT_UNSPECIFIED
+}
+
+func (x *MigrationNotification) GetAdditionalDetails() *anypb.Any {
+	if x != nil {
+		return x.AdditionalDetails
+	}
+	return nil
+}
+
 var File_github_com_Microsoft_hcsshim_pkg_migration_migration_options_proto protoreflect.FileDescriptor
 
 const file_github_com_Microsoft_hcsshim_pkg_migration_migration_options_proto_rawDesc = "" +
 	"\n" +
-	"Bgithub.com/Microsoft/hcsshim/pkg/migration/migration_options.proto\"\xc1\x05\n" +
+	"Bgithub.com/Microsoft/hcsshim/pkg/migration/migration_options.proto\x1a\x19google/protobuf/any.proto\"\xc1\x05\n" +
 	"\x1aMigrationInitializeOptions\x12D\n" +
 	"\x10memory_transport\x18\x01 \x01(\x0e2\x19.MigrationMemoryTransportR\x0fmemoryTransport\x12r\n" +
 	"\x1fmemory_transfer_throttle_params\x18\x02 \x01(\v2&.MemoryMigrationTransferThrottleParamsH\x00R\x1cmemoryTransferThrottleParams\x88\x01\x01\x12U\n" +
@@ -415,10 +688,37 @@ const file_github_com_Microsoft_hcsshim_pkg_migration_migration_options_proto_ra
 	"1_blackout_time_threshold_for_cancelling_migration\"q\n" +
 	"\x1cMigrationCompressionSettings\x127\n" +
 	"\x15throttle_worker_count\x18\x01 \x01(\rH\x00R\x13throttleWorkerCount\x88\x01\x01B\x18\n" +
-	"\x16_throttle_worker_count*j\n" +
+	"\x16_throttle_worker_count\"\xd7\x01\n" +
+	"\x15MigrationNotification\x12(\n" +
+	"\x06origin\x18\x01 \x01(\x0e2\x10.MigrationOriginR\x06origin\x12%\n" +
+	"\x05event\x18\x02 \x01(\x0e2\x0f.MigrationEventR\x05event\x12(\n" +
+	"\x06result\x18\x03 \x01(\x0e2\x10.MigrationResultR\x06result\x12C\n" +
+	"\x12additional_details\x18\x04 \x01(\v2\x14.google.protobuf.AnyR\x11additionalDetails*j\n" +
 	"\x18MigrationMemoryTransport\x12*\n" +
 	"&MIGRATION_MEMORY_TRANSPORT_UNSPECIFIED\x10\x00\x12\"\n" +
-	"\x1eMIGRATION_MEMORY_TRANSPORT_TCP\x10\x01B6Z4github.com/Microsoft/hcsshim/pkg/migration;migrationb\x06proto3"
+	"\x1eMIGRATION_MEMORY_TRANSPORT_TCP\x10\x01*r\n" +
+	"\x0fMigrationOrigin\x12 \n" +
+	"\x1cMIGRATION_ORIGIN_UNSPECIFIED\x10\x00\x12\x1b\n" +
+	"\x17MIGRATION_ORIGIN_SOURCE\x10\x01\x12 \n" +
+	"\x1cMIGRATION_ORIGIN_DESTINATION\x10\x02*\xdf\x02\n" +
+	"\x0eMigrationEvent\x12\x1f\n" +
+	"\x1bMIGRATION_EVENT_UNSPECIFIED\x10\x00\x12\"\n" +
+	"\x1eMIGRATION_EVENT_MIGRATION_DONE\x10\x01\x12$\n" +
+	" MIGRATION_EVENT_BLACKOUT_STARTED\x10\x02\x12 \n" +
+	"\x1cMIGRATION_EVENT_OFFLINE_DONE\x10\x03\x12#\n" +
+	"\x1fMIGRATION_EVENT_BLACKOUT_EXITED\x10\x04\x12\x1e\n" +
+	"\x1aMIGRATION_EVENT_SETUP_DONE\x10\x05\x12(\n" +
+	"$MIGRATION_EVENT_TRANSFER_IN_PROGRESS\x10\x06\x12+\n" +
+	"'MIGRATION_EVENT_MIGRATION_RECOVERY_DONE\x10\a\x12$\n" +
+	" MIGRATION_EVENT_MIGRATION_FAILED\x10\b*\xbf\x02\n" +
+	"\x0fMigrationResult\x12 \n" +
+	"\x1cMIGRATION_RESULT_UNSPECIFIED\x10\x00\x12\x1c\n" +
+	"\x18MIGRATION_RESULT_SUCCESS\x10\x01\x12(\n" +
+	"$MIGRATION_RESULT_MIGRATION_CANCELLED\x10\x02\x121\n" +
+	"-MIGRATION_RESULT_GUEST_INITIATED_CANCELLATION\x10\x03\x12,\n" +
+	"(MIGRATION_RESULT_SOURCE_MIGRATION_FAILED\x10\x04\x121\n" +
+	"-MIGRATION_RESULT_DESTINATION_MIGRATION_FAILED\x10\x05\x12.\n" +
+	"*MIGRATION_RESULT_MIGRATION_RECOVERY_FAILED\x10\x06B6Z4github.com/Microsoft/hcsshim/pkg/migration;migrationb\x06proto3"
 
 var (
 	file_github_com_Microsoft_hcsshim_pkg_migration_migration_options_proto_rawDescOnce sync.Once
@@ -432,25 +732,34 @@ func file_github_com_Microsoft_hcsshim_pkg_migration_migration_options_proto_raw
 	return file_github_com_Microsoft_hcsshim_pkg_migration_migration_options_proto_rawDescData
 }
 
-var file_github_com_Microsoft_hcsshim_pkg_migration_migration_options_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_github_com_Microsoft_hcsshim_pkg_migration_migration_options_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
+var file_github_com_Microsoft_hcsshim_pkg_migration_migration_options_proto_enumTypes = make([]protoimpl.EnumInfo, 4)
+var file_github_com_Microsoft_hcsshim_pkg_migration_migration_options_proto_msgTypes = make([]protoimpl.MessageInfo, 5)
 var file_github_com_Microsoft_hcsshim_pkg_migration_migration_options_proto_goTypes = []any{
 	(MigrationMemoryTransport)(0),                 // 0: MigrationMemoryTransport
-	(*MigrationInitializeOptions)(nil),            // 1: MigrationInitializeOptions
-	(*CompatibilityInfo)(nil),                     // 2: CompatibilityInfo
-	(*MemoryMigrationTransferThrottleParams)(nil), // 3: MemoryMigrationTransferThrottleParams
-	(*MigrationCompressionSettings)(nil),          // 4: MigrationCompressionSettings
+	(MigrationOrigin)(0),                          // 1: MigrationOrigin
+	(MigrationEvent)(0),                           // 2: MigrationEvent
+	(MigrationResult)(0),                          // 3: MigrationResult
+	(*MigrationInitializeOptions)(nil),            // 4: MigrationInitializeOptions
+	(*CompatibilityInfo)(nil),                     // 5: CompatibilityInfo
+	(*MemoryMigrationTransferThrottleParams)(nil), // 6: MemoryMigrationTransferThrottleParams
+	(*MigrationCompressionSettings)(nil),          // 7: MigrationCompressionSettings
+	(*MigrationNotification)(nil),                 // 8: MigrationNotification
+	(*anypb.Any)(nil),                             // 9: google.protobuf.Any
 }
 var file_github_com_Microsoft_hcsshim_pkg_migration_migration_options_proto_depIdxs = []int32{
 	0, // 0: MigrationInitializeOptions.memory_transport:type_name -> MigrationMemoryTransport
-	3, // 1: MigrationInitializeOptions.memory_transfer_throttle_params:type_name -> MemoryMigrationTransferThrottleParams
-	4, // 2: MigrationInitializeOptions.compression_settings:type_name -> MigrationCompressionSettings
-	2, // 3: MigrationInitializeOptions.compatibility_data:type_name -> CompatibilityInfo
-	4, // [4:4] is the sub-list for method output_type
-	4, // [4:4] is the sub-list for method input_type
-	4, // [4:4] is the sub-list for extension type_name
-	4, // [4:4] is the sub-list for extension extendee
-	0, // [0:4] is the sub-list for field type_name
+	6, // 1: MigrationInitializeOptions.memory_transfer_throttle_params:type_name -> MemoryMigrationTransferThrottleParams
+	7, // 2: MigrationInitializeOptions.compression_settings:type_name -> MigrationCompressionSettings
+	5, // 3: MigrationInitializeOptions.compatibility_data:type_name -> CompatibilityInfo
+	1, // 4: MigrationNotification.origin:type_name -> MigrationOrigin
+	2, // 5: MigrationNotification.event:type_name -> MigrationEvent
+	3, // 6: MigrationNotification.result:type_name -> MigrationResult
+	9, // 7: MigrationNotification.additional_details:type_name -> google.protobuf.Any
+	8, // [8:8] is the sub-list for method output_type
+	8, // [8:8] is the sub-list for method input_type
+	8, // [8:8] is the sub-list for extension type_name
+	8, // [8:8] is the sub-list for extension extendee
+	0, // [0:8] is the sub-list for field type_name
 }
 
 func init() { file_github_com_Microsoft_hcsshim_pkg_migration_migration_options_proto_init() }
@@ -466,8 +775,8 @@ func file_github_com_Microsoft_hcsshim_pkg_migration_migration_options_proto_ini
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_github_com_Microsoft_hcsshim_pkg_migration_migration_options_proto_rawDesc), len(file_github_com_Microsoft_hcsshim_pkg_migration_migration_options_proto_rawDesc)),
-			NumEnums:      1,
-			NumMessages:   4,
+			NumEnums:      4,
+			NumMessages:   5,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/pkg/migration/migration_options.proto
+++ b/pkg/migration/migration_options.proto
@@ -4,20 +4,20 @@ option go_package = "github.com/Microsoft/hcsshim/pkg/migration;migration";
 
 import "google/protobuf/any.proto";
 
-// MigrationMemoryTransport is the transport protocol used for memory transfer during migration.
-enum MigrationMemoryTransport {
-    MIGRATION_MEMORY_TRANSPORT_UNSPECIFIED = 0;
+// MemoryTransport is the transport protocol used for memory transfer during migration.
+enum MemoryTransport {
+    MEMORY_TRANSPORT_UNSPECIFIED = 0;
     // VM memory is copied over a TCP/IP connection.
-    MIGRATION_MEMORY_TRANSPORT_TCP = 1;
+    MEMORY_TRANSPORT_TCP = 1;
 }
 
-message MigrationInitializeOptions {
+message InitializeOptions {
     // MemoryTransport specifies the transport protocol for memory transfer during migration.
-    MigrationMemoryTransport memory_transport = 1;
+    MemoryTransport memory_transport = 1;
     // MemoryTransferThrottleParams specifies settings for throttling during memory transfer.
-    optional MemoryMigrationTransferThrottleParams memory_transfer_throttle_params = 2;
+    optional MemoryTransferThrottleParams memory_transfer_throttle_params = 2;
     // CompressionSettings specifies additional settings when compression is enabled.
-    optional MigrationCompressionSettings compression_settings = 3;
+    optional CompressionSettings compression_settings = 3;
     // ChecksumVerification enables memory checksum verification.
     bool checksum_verification = 4;
     // PerfTracingEnabled enables performance tracing during migration.
@@ -36,7 +36,7 @@ message CompatibilityInfo {
     bytes data = 1;
 }
 
-message MemoryMigrationTransferThrottleParams {
+message MemoryTransferThrottleParams {
     // A flag indicating if throttling should be skipped.
     optional bool skip_throttling = 1;
     // The scale of the throttling. The value is in percentage (1-100).
@@ -49,76 +49,145 @@ message MemoryMigrationTransferThrottleParams {
     optional uint32 starting_brownout_pass_number_for_throttling = 5;
     // Maximum number of memory transfer passes before forcing the VM to enter blackout.
     optional uint32 maximum_number_of_brownout_transfer_passes = 6;
-    // Expected duration for blackout transfer time.
+    // Expected duration, in milliseconds, for the blackout memory
+    // transfer to complete.
     optional uint32 target_blackout_transfer_time = 7;
-    // Threshold for blackout duration prior to cancelling migration.
+    // Threshold, in milliseconds, for blackout duration prior to
+    // cancelling migration.
     optional uint32 blackout_time_threshold_for_cancelling_migration = 8;
 }
 
-message MigrationCompressionSettings {
+message CompressionSettings {
     // Number of worker threads used for [de]compression. Values higher than what the host
     // and VM configuration can support will be adjusted. The value should be non-zero.
     optional uint32 throttle_worker_count = 1;
 }
 
-// MigrationOrigin indicates which side of a live migration an operation or
+// Origin indicates which side of a live migration an operation or
 // notification pertains to.
-enum MigrationOrigin {
-    MIGRATION_ORIGIN_UNSPECIFIED = 0;
+enum Origin {
+    ORIGIN_UNSPECIFIED = 0;
     // Source side of the live migration.
-    MIGRATION_ORIGIN_SOURCE = 1;
+    ORIGIN_SOURCE = 1;
     // Destination side of the live migration.
-    MIGRATION_ORIGIN_DESTINATION = 2;
+    ORIGIN_DESTINATION = 2;
 }
 
-// MigrationEvent describes a live migration event reported by HCS during the
+// Phase describes a live migration phase reported by HCS during the
 // transfer phase of a live migration.
-enum MigrationEvent {
-    MIGRATION_EVENT_UNSPECIFIED = 0;
-    // Migration has completed.
-    MIGRATION_EVENT_MIGRATION_DONE = 1;
-    // The VM has entered the blackout phase.
-    MIGRATION_EVENT_BLACKOUT_STARTED = 2;
-    // Taking the VM offline has completed.
-    MIGRATION_EVENT_OFFLINE_DONE = 3;
+enum Phase {
+    PHASE_UNSPECIFIED = 0;
+    // The live migration setup has completed on the HCS side. Reported
+    // by the source; after this, clients can either start the memory
+    // transfer or set up SMB before performing the memory transfer.
+    PHASE_SETUP_DONE = 1;
+    // The VM is transferring memory and other necessary state. Reported
+    // periodically by the source as a progress signal while the VM state
+    // is being transferred to the destination.
+    PHASE_TRANSFER_IN_PROGRESS = 2;
+    // The VM has entered the blackout phase. Reported by the source
+    // immediately before the VM is paused for the final state transfer;
+    // from this point on the VM is not running on either host.
+    PHASE_BLACKOUT_STARTED = 3;
+    // Taking the VM offline has completed. Reported by the source after
+    // VMWP has transitioned itself to the MigratingSuspended (MTS) state,
+    // but before waiting for the VMWP client to signal that it is ready
+    // to enter MTS state at its layer. Always paired with
+    // PhaseState = PHASE_STATE_SUCCESS; offline failures are reported via
+    // PHASE_FAILED instead.
+    PHASE_OFFLINE_DONE = 4;
     // The VM has successfully started again after the blackout phase.
-    MIGRATION_EVENT_BLACKOUT_EXITED = 4;
-    // The live migration setup has completed.
-    MIGRATION_EVENT_SETUP_DONE = 5;
-    // The VM is still transferring memory and other necessary state.
-    MIGRATION_EVENT_TRANSFER_IN_PROGRESS = 6;
-    // Migration recovery has been performed.
-    MIGRATION_EVENT_MIGRATION_RECOVERY_DONE = 7;
-    // Migration failed.
-    MIGRATION_EVENT_MIGRATION_FAILED = 8;
+    PHASE_BLACKOUT_EXITED = 5;
+    // Migration has completed (terminal phase). The accompanying
+    // PhaseState describes whether the migration succeeded or failed,
+    // and on which side the failure was observed.
+    PHASE_DONE = 6;
+    // Migration recovery has been performed. Reported by the source
+    // after attempting to recover the VM following a failed or cancelled
+    // migration. The accompanying PhaseState is PHASE_STATE_SUCCESS if
+    // the VM was successfully resumed on the source, or
+    // PHASE_STATE_RECOVERY_FAILED if recovery itself failed.
+    PHASE_RECOVERY_DONE = 7;
+    // Migration failed (terminal phase). Reported by the source for
+    // non-success outcomes of the offline step (and equivalent failure
+    // points). The accompanying PhaseState carries the reason:
+    // PHASE_STATE_SOURCE_FAILED, PHASE_STATE_DESTINATION_FAILED,
+    // PHASE_STATE_CANCELLED, or PHASE_STATE_GUEST_INITIATED_CANCELLATION.
+    PHASE_FAILED = 8;
 }
 
-// MigrationResult describes the possible result of a migration operation,
-// typically populated for terminal events such as MIGRATION_EVENT_MIGRATION_DONE
-// or MIGRATION_EVENT_MIGRATION_FAILED.
-enum MigrationResult {
-    MIGRATION_RESULT_UNSPECIFIED = 0;
-    MIGRATION_RESULT_SUCCESS = 1;
-    MIGRATION_RESULT_MIGRATION_CANCELLED = 2;
-    MIGRATION_RESULT_GUEST_INITIATED_CANCELLATION = 3;
-    MIGRATION_RESULT_SOURCE_MIGRATION_FAILED = 4;
-    MIGRATION_RESULT_DESTINATION_MIGRATION_FAILED = 5;
-    MIGRATION_RESULT_MIGRATION_RECOVERY_FAILED = 6;
+// PhaseState describes the possible state of a migration phase,
+// typically populated for terminal phases such as PHASE_DONE
+// or PHASE_FAILED.
+enum PhaseState {
+    // No state reported. Used as the default zero value and for
+    // non-terminal phases that do not carry an outcome.
+    PHASE_STATE_UNSPECIFIED = 0;
+    // The reported phase completed successfully. Emitted in several
+    // places, including:
+    //   - Phase = PHASE_DONE: by the source after a successful
+    //     migrate-to-suspended (MTS) workflow, and by the destination
+    //     once the VM has been fully restored on the target host.
+    //   - Phase = PHASE_OFFLINE_DONE: by the source after VMWP
+    //     successfully takes the VM offline so migration can continue.
+    //   - Phase = PHASE_RECOVERY_DONE: by the source after the VM has
+    //     been successfully rolled back to its pre-migration running
+    //     state following a failed or cancelled migration.
+    PHASE_STATE_SUCCESS = 1;
+    // Migration was cancelled. Reported with:
+    //   - Phase = PHASE_FAILED by the source when its offline step
+    //     observes a non-guest cancellation
+    //     (MigrationSourceOfflineCanceled).
+    //   - Phase = PHASE_DONE by the destination when, after the setup
+    //     phase has completed, the migration target detects a
+    //     cancellation (MigrationTargetCanceled).
+    PHASE_STATE_CANCELLED = 2;
+    // Migration was cancelled because the guest initiated a shutdown or
+    // reset of the VM. Reported by the source with Phase = PHASE_FAILED
+    // (MigrationSourceOfflineGuestCanceled). VMWP performs the
+    // shutdown/reset on its own; this state exists to inform clients
+    // that LM was cancelled as a result of guest action.
+    PHASE_STATE_GUEST_INITIATED_CANCELLATION = 3;
+    // Migration failed and the failure originated on the source. Reported
+    // with:
+    //   - Phase = PHASE_FAILED by the source when its offline step fails
+    //     (MigrationSourceOfflineFailed).
+    //   - Phase = PHASE_DONE by the source when, after the offline phase
+    //     but before the VM has been restored on the target, the source
+    //     fails for a reason that is not destination-attributable.
+    //   - Phase = PHASE_DONE by the destination when, after the setup
+    //     phase has completed, the migration target observes a
+    //     non-cancellation failure that came from the source.
+    PHASE_STATE_SOURCE_FAILED = 4;
+    // Migration failed and the failure originated on the destination.
+    // Reported by the source with:
+    //   - Phase = PHASE_FAILED when its offline step observes a
+    //     destination-side failure (MigrationSourceOfflineDestinationFailed).
+    //   - Phase = PHASE_DONE when, after the offline phase but before the
+    //     VM has been restored on the target, the source detects that
+    //     the destination failed
+    //     (m_FailureReason == FailureDestinationFailed).
+    PHASE_STATE_DESTINATION_FAILED = 5;
+    // Migration recovery failed. Reported by the source with
+    // Phase = PHASE_RECOVERY_DONE when the attempt to recover the VM
+    // after a failed or cancelled migration did not succeed (the source
+    // could not be returned to its pre-migration running state).
+    PHASE_STATE_RECOVERY_FAILED = 6;
 }
 
-// MigrationNotification is a notification payload describing the current
+// Notification is a notification payload describing the current
 // state of an in-progress live migration operation. It mirrors the HCS
 // OperationSystemMigrationNotificationInfo schema.
-message MigrationNotification {
+message Notification {
     // Origin indicates which side of the live migration this notification
     // pertains to.
-    MigrationOrigin origin = 1;
-    // Event is the type of live migration event being reported.
-    MigrationEvent event = 2;
-    // Result is an optional outcome accompanying the event. Typically
-    // populated for terminal events.
-    MigrationResult result = 3;
-    // AdditionalDetails carries extra event-specific information whose
-    // schema depends on the event being reported.
+    Origin origin = 1;
+    // Phase is the live migration phase being reported.
+    Phase phase = 2;
+    // State is an optional outcome accompanying the phase. Typically
+    // populated for terminal phases.
+    PhaseState state = 3;
+    // AdditionalDetails carries extra phase-specific information whose
+    // schema depends on the phase being reported.
     google.protobuf.Any additional_details = 4;
 }

--- a/pkg/migration/migration_options.proto
+++ b/pkg/migration/migration_options.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 option go_package = "github.com/Microsoft/hcsshim/pkg/migration;migration";
 
-import "google/protobuf/any.proto";
+import "google/protobuf/timestamp.proto";
 
 // MemoryTransport is the transport protocol used for memory transfer during migration.
 enum MemoryTransport {
@@ -175,6 +175,16 @@ enum PhaseState {
     PHASE_STATE_RECOVERY_FAILED = 6;
 }
 
+// BlackoutExitedEventDetails carries additional details reported alongside
+// PHASE_BLACKOUT_EXITED, describing the blackout that just ended. Mirrors
+// the HCS MigrationBlackoutExitedEventDetails schema.
+message BlackoutExitedEventDetails {
+    // Duration of the blackout phase, in milliseconds.
+    uint64 blackout_duration_milliseconds = 1;
+    // Timestamp at which the blackout phase ended.
+    google.protobuf.Timestamp blackout_stop_timestamp = 2;
+}
+
 // Notification is a notification payload describing the current
 // state of an in-progress live migration operation. It mirrors the HCS
 // OperationSystemMigrationNotificationInfo schema.
@@ -187,7 +197,10 @@ message Notification {
     // State is an optional outcome accompanying the phase. Typically
     // populated for terminal phases.
     PhaseState state = 3;
-    // AdditionalDetails carries extra phase-specific information whose
-    // schema depends on the phase being reported.
-    google.protobuf.Any additional_details = 4;
+    // PhaseDetails carries extra phase-specific information whose concrete
+    // type depends on the phase being reported.
+    oneof phase_details {
+        // Details reported with PHASE_BLACKOUT_EXITED.
+        BlackoutExitedEventDetails blackout_exited = 4;
+    }
 }

--- a/pkg/migration/migration_options.proto
+++ b/pkg/migration/migration_options.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 option go_package = "github.com/Microsoft/hcsshim/pkg/migration;migration";
 
+import "google/protobuf/any.proto";
+
 // MigrationMemoryTransport is the transport protocol used for memory transfer during migration.
 enum MigrationMemoryTransport {
     MIGRATION_MEMORY_TRANSPORT_UNSPECIFIED = 0;
@@ -57,4 +59,66 @@ message MigrationCompressionSettings {
     // Number of worker threads used for [de]compression. Values higher than what the host
     // and VM configuration can support will be adjusted. The value should be non-zero.
     optional uint32 throttle_worker_count = 1;
+}
+
+// MigrationOrigin indicates which side of a live migration an operation or
+// notification pertains to.
+enum MigrationOrigin {
+    MIGRATION_ORIGIN_UNSPECIFIED = 0;
+    // Source side of the live migration.
+    MIGRATION_ORIGIN_SOURCE = 1;
+    // Destination side of the live migration.
+    MIGRATION_ORIGIN_DESTINATION = 2;
+}
+
+// MigrationEvent describes a live migration event reported by HCS during the
+// transfer phase of a live migration.
+enum MigrationEvent {
+    MIGRATION_EVENT_UNSPECIFIED = 0;
+    // Migration has completed.
+    MIGRATION_EVENT_MIGRATION_DONE = 1;
+    // The VM has entered the blackout phase.
+    MIGRATION_EVENT_BLACKOUT_STARTED = 2;
+    // Taking the VM offline has completed.
+    MIGRATION_EVENT_OFFLINE_DONE = 3;
+    // The VM has successfully started again after the blackout phase.
+    MIGRATION_EVENT_BLACKOUT_EXITED = 4;
+    // The live migration setup has completed.
+    MIGRATION_EVENT_SETUP_DONE = 5;
+    // The VM is still transferring memory and other necessary state.
+    MIGRATION_EVENT_TRANSFER_IN_PROGRESS = 6;
+    // Migration recovery has been performed.
+    MIGRATION_EVENT_MIGRATION_RECOVERY_DONE = 7;
+    // Migration failed.
+    MIGRATION_EVENT_MIGRATION_FAILED = 8;
+}
+
+// MigrationResult describes the possible result of a migration operation,
+// typically populated for terminal events such as MIGRATION_EVENT_MIGRATION_DONE
+// or MIGRATION_EVENT_MIGRATION_FAILED.
+enum MigrationResult {
+    MIGRATION_RESULT_UNSPECIFIED = 0;
+    MIGRATION_RESULT_SUCCESS = 1;
+    MIGRATION_RESULT_MIGRATION_CANCELLED = 2;
+    MIGRATION_RESULT_GUEST_INITIATED_CANCELLATION = 3;
+    MIGRATION_RESULT_SOURCE_MIGRATION_FAILED = 4;
+    MIGRATION_RESULT_DESTINATION_MIGRATION_FAILED = 5;
+    MIGRATION_RESULT_MIGRATION_RECOVERY_FAILED = 6;
+}
+
+// MigrationNotification is a notification payload describing the current
+// state of an in-progress live migration operation. It mirrors the HCS
+// OperationSystemMigrationNotificationInfo schema.
+message MigrationNotification {
+    // Origin indicates which side of the live migration this notification
+    // pertains to.
+    MigrationOrigin origin = 1;
+    // Event is the type of live migration event being reported.
+    MigrationEvent event = 2;
+    // Result is an optional outcome accompanying the event. Typically
+    // populated for terminal events.
+    MigrationResult result = 3;
+    // AdditionalDetails carries extra event-specific information whose
+    // schema depends on the event being reported.
+    google.protobuf.Any additional_details = 4;
 }

--- a/pkg/migration/migration_ttrpc.pb.go
+++ b/pkg/migration/migration_ttrpc.pb.go
@@ -11,21 +11,22 @@ type MigrationService interface {
 	PrepareAndExportSandbox(context.Context, *PrepareAndExportSandboxRequest) (*PrepareAndExportSandboxResponse, error)
 	ImportSandbox(context.Context, *ImportSandboxRequest) (*ImportSandboxResponse, error)
 	PrepareSandbox(context.Context, *PrepareSandboxRequest) (*PrepareSandboxResponse, error)
-	TransferSandbox(context.Context, *TransferSandboxRequest, Migration_TransferSandboxServer) error
+	TransferSandbox(context.Context, *TransferSandboxRequest) (*TransferSandboxResponse, error)
 	FinalizeSandbox(context.Context, *FinalizeSandboxRequest) (*FinalizeSandboxResponse, error)
+	Notifications(context.Context, *NotificationsRequest, Migration_NotificationsServer) error
 	CreateDuplicateSocket(context.Context, *CreateDuplicateSocketRequest) (*CreateDuplicateSocketResponse, error)
 }
 
-type Migration_TransferSandboxServer interface {
-	Send(*TransferSandboxResponse) error
+type Migration_NotificationsServer interface {
+	Send(*NotificationsResponse) error
 	ttrpc.StreamServer
 }
 
-type migrationTransferSandboxServer struct {
+type migrationNotificationsServer struct {
 	ttrpc.StreamServer
 }
 
-func (x *migrationTransferSandboxServer) Send(m *TransferSandboxResponse) error {
+func (x *migrationNotificationsServer) Send(m *NotificationsResponse) error {
 	return x.StreamServer.SendMsg(m)
 }
 
@@ -53,6 +54,13 @@ func RegisterMigrationService(srv *ttrpc.Server, svc MigrationService) {
 				}
 				return svc.PrepareSandbox(ctx, &req)
 			},
+			"TransferSandbox": func(ctx context.Context, unmarshal func(interface{}) error) (interface{}, error) {
+				var req TransferSandboxRequest
+				if err := unmarshal(&req); err != nil {
+					return nil, err
+				}
+				return svc.TransferSandbox(ctx, &req)
+			},
 			"FinalizeSandbox": func(ctx context.Context, unmarshal func(interface{}) error) (interface{}, error) {
 				var req FinalizeSandboxRequest
 				if err := unmarshal(&req); err != nil {
@@ -69,13 +77,13 @@ func RegisterMigrationService(srv *ttrpc.Server, svc MigrationService) {
 			},
 		},
 		Streams: map[string]ttrpc.Stream{
-			"TransferSandbox": {
+			"Notifications": {
 				Handler: func(ctx context.Context, stream ttrpc.StreamServer) (interface{}, error) {
-					m := new(TransferSandboxRequest)
+					m := new(NotificationsRequest)
 					if err := stream.RecvMsg(m); err != nil {
 						return nil, err
 					}
-					return nil, svc.TransferSandbox(ctx, m, &migrationTransferSandboxServer{stream})
+					return nil, svc.Notifications(ctx, m, &migrationNotificationsServer{stream})
 				},
 				StreamingClient: false,
 				StreamingServer: true,
@@ -88,8 +96,9 @@ type MigrationClient interface {
 	PrepareAndExportSandbox(context.Context, *PrepareAndExportSandboxRequest) (*PrepareAndExportSandboxResponse, error)
 	ImportSandbox(context.Context, *ImportSandboxRequest) (*ImportSandboxResponse, error)
 	PrepareSandbox(context.Context, *PrepareSandboxRequest) (*PrepareSandboxResponse, error)
-	TransferSandbox(context.Context, *TransferSandboxRequest) (Migration_TransferSandboxClient, error)
+	TransferSandbox(context.Context, *TransferSandboxRequest) (*TransferSandboxResponse, error)
 	FinalizeSandbox(context.Context, *FinalizeSandboxRequest) (*FinalizeSandboxResponse, error)
+	Notifications(context.Context, *NotificationsRequest) (Migration_NotificationsClient, error)
 	CreateDuplicateSocket(context.Context, *CreateDuplicateSocketRequest) (*CreateDuplicateSocketResponse, error)
 }
 
@@ -127,33 +136,12 @@ func (c *migrationClient) PrepareSandbox(ctx context.Context, req *PrepareSandbo
 	return &resp, nil
 }
 
-func (c *migrationClient) TransferSandbox(ctx context.Context, req *TransferSandboxRequest) (Migration_TransferSandboxClient, error) {
-	stream, err := c.client.NewStream(ctx, &ttrpc.StreamDesc{
-		StreamingClient: false,
-		StreamingServer: true,
-	}, "Migration", "TransferSandbox", req)
-	if err != nil {
+func (c *migrationClient) TransferSandbox(ctx context.Context, req *TransferSandboxRequest) (*TransferSandboxResponse, error) {
+	var resp TransferSandboxResponse
+	if err := c.client.Call(ctx, "Migration", "TransferSandbox", req, &resp); err != nil {
 		return nil, err
 	}
-	x := &migrationTransferSandboxClient{stream}
-	return x, nil
-}
-
-type Migration_TransferSandboxClient interface {
-	Recv() (*TransferSandboxResponse, error)
-	ttrpc.ClientStream
-}
-
-type migrationTransferSandboxClient struct {
-	ttrpc.ClientStream
-}
-
-func (x *migrationTransferSandboxClient) Recv() (*TransferSandboxResponse, error) {
-	m := new(TransferSandboxResponse)
-	if err := x.ClientStream.RecvMsg(m); err != nil {
-		return nil, err
-	}
-	return m, nil
+	return &resp, nil
 }
 
 func (c *migrationClient) FinalizeSandbox(ctx context.Context, req *FinalizeSandboxRequest) (*FinalizeSandboxResponse, error) {
@@ -162,6 +150,35 @@ func (c *migrationClient) FinalizeSandbox(ctx context.Context, req *FinalizeSand
 		return nil, err
 	}
 	return &resp, nil
+}
+
+func (c *migrationClient) Notifications(ctx context.Context, req *NotificationsRequest) (Migration_NotificationsClient, error) {
+	stream, err := c.client.NewStream(ctx, &ttrpc.StreamDesc{
+		StreamingClient: false,
+		StreamingServer: true,
+	}, "Migration", "Notifications", req)
+	if err != nil {
+		return nil, err
+	}
+	x := &migrationNotificationsClient{stream}
+	return x, nil
+}
+
+type Migration_NotificationsClient interface {
+	Recv() (*NotificationsResponse, error)
+	ttrpc.ClientStream
+}
+
+type migrationNotificationsClient struct {
+	ttrpc.ClientStream
+}
+
+func (x *migrationNotificationsClient) Recv() (*NotificationsResponse, error) {
+	m := new(NotificationsResponse)
+	if err := x.ClientStream.RecvMsg(m); err != nil {
+		return nil, err
+	}
+	return m, nil
 }
 
 func (c *migrationClient) CreateDuplicateSocket(ctx context.Context, req *CreateDuplicateSocketRequest) (*CreateDuplicateSocketResponse, error) {


### PR DESCRIPTION
### Summary

Drop the free-form `event` and `error` string fields on TransferSandboxResponse in favor of a structured `MigrationNotification` message that mirrors the HCS OperationSystemMigrationNotificationInfo payload.

The new MigrationNotification carries:
  - MigrationOrigin: source vs. destination side of the migration
  - MigrationEvent: lifecycle event (setup done, blackout started/exited, transfer in progress, migration done/failed, recovery done, etc)
  - MigrationResult: terminal outcome (success, cancelled, guest-initiated cancellation, source/destination failure, recovery failure)
  - AdditionalDetails: google.protobuf.Any for event-specific data