### PR TITLE
guest: unify pod model for V1, virtual pod, and V2 shim support

### DIFF
--- a/cmd/gcs/main.go
+++ b/cmd/gcs/main.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strings"
 	"syscall"
 	"time"
 
@@ -80,12 +79,7 @@ func readMemoryEvents(startTime time.Time, efdFile *os.File, cgName string, thre
 		}
 
 		count++
-		var msg string
-		if strings.HasPrefix(cgName, "/virtual-pods") {
-			msg = "memory usage for virtual pods cgroup exceeded threshold"
-		} else {
-			msg = "memory usage for cgroup exceeded threshold"
-		}
+		msg := "memory usage for cgroup exceeded threshold"
 
 		cgVersion := "v2"
 		if isV1 {
@@ -328,7 +322,7 @@ func main() {
 
 	// Setup the UVM cgroups to protect against a workload taking all available
 	// memory and causing the GCS to malfunction we create cgroups: gcs,
-	// containers, and virtual-pods for multi-pod support.
+	// containers, and pods for pod support.
 	//
 
 	// Write 1 to memory.use_hierarchy on the root cgroup to enable hierarchy
@@ -340,8 +334,7 @@ func main() {
 		}
 	}
 
-	// The containers cgroup is limited only by {Totalram - 75 MB
-	// (reservation)}.
+	// The pods cgroup is limited only by {Totalram - 75 MB (reservation)}.
 	//
 	// The gcs cgroup is not limited but an event will get logged if memory
 	// usage exceeds 50 MB.
@@ -349,28 +342,16 @@ func main() {
 	if err := syscall.Sysinfo(&sinfo); err != nil {
 		logrus.WithError(err).Fatal("failed to get sys info")
 	}
-	containersLimit := int64(sinfo.Totalram - *rootMemReserveBytes)
-	containersControl, err := cgroup.NewManager("/containers", &oci.LinuxResources{
+	podsLimit := int64(sinfo.Totalram - *rootMemReserveBytes)
+	podsControl, err := cgroup.NewManager("/pods", &oci.LinuxResources{
 		Memory: &oci.LinuxMemory{
-			Limit: &containersLimit,
+			Limit: &podsLimit,
 		},
 	})
 	if err != nil {
-		logrus.WithError(err).Fatal("failed to create containers cgroup")
+		logrus.WithError(err).Fatal("failed to create pods cgroup")
 	}
-	defer containersControl.Delete() //nolint:errcheck
-
-	// Create virtual-pods cgroup hierarchy for multi-pod support
-	// This will be the parent for all virtual pod cgroups: /containers/virtual-pods/{virtualSandboxID}
-	virtualPodsControl, err := cgroup.NewManager("/containers/virtual-pods", &oci.LinuxResources{
-		Memory: &oci.LinuxMemory{
-			Limit: &containersLimit, // Share the same limit as containers
-		},
-	})
-	if err != nil {
-		logrus.WithError(err).Fatal("failed to create containers/virtual-pods cgroup")
-	}
-	defer virtualPodsControl.Delete() //nolint:errcheck
+	defer podsControl.Delete() //nolint:errcheck
 
 	gcsControl, err := cgroup.NewManager("/gcs", &oci.LinuxResources{})
 	if err != nil {
@@ -388,10 +369,6 @@ func main() {
 	}
 
 	h := hcsv2.NewHost(rtime, tport, initialEnforcer, logWriter)
-	// Initialize virtual pod support in the host
-	if err := h.InitializeVirtualPodSupport(virtualPodsControl); err != nil {
-		logrus.WithError(err).Warn("Virtual pod support initialization failed")
-	}
 
 	// During live migration the VM is frozen and only wakes up when the host
 	// shim is ready, so the vsock port should be immediately available. We
@@ -406,20 +383,13 @@ func main() {
 	gefdFile := os.NewFile(gefd, "gefd")
 	defer gefdFile.Close()
 
-	oom, err := containersControl.OOMEventFD()
+	// Setup OOM monitoring for pods cgroup
+	podsOom, err := podsControl.OOMEventFD()
 	if err != nil {
-		logrus.WithError(err).Fatal("failed to retrieve the container cgroups oom eventfd")
+		logrus.WithError(err).Fatal("failed to retrieve the pods cgroups oom eventfd")
 	}
-	oomFile := os.NewFile(oom, "cefd")
-	defer oomFile.Close()
-
-	// Setup OOM monitoring for virtual-pods cgroup
-	virtualPodsOom, err := virtualPodsControl.OOMEventFD()
-	if err != nil {
-		logrus.WithError(err).Fatal("failed to retrieve the virtual-pods cgroups oom eventfd")
-	}
-	virtualPodsOomFile := os.NewFile(virtualPodsOom, "vp-oomfd")
-	defer virtualPodsOomFile.Close()
+	podsOomFile := os.NewFile(podsOom, "pods-oomfd")
+	defer podsOomFile.Close()
 
 	// time synchronization service
 	if !(*disableTimeSync) {
@@ -429,8 +399,7 @@ func main() {
 	}
 
 	go readMemoryEvents(startTime, gefdFile, "/gcs", int64(*gcsMemLimitBytes), gcsControl)
-	go readMemoryEvents(startTime, oomFile, "/containers", containersLimit, containersControl)
-	go readMemoryEvents(startTime, virtualPodsOomFile, "/containers/virtual-pods", containersLimit, virtualPodsControl)
+	go readMemoryEvents(startTime, podsOomFile, "/pods", podsLimit, podsControl)
 
 	mux := bridge.NewBridgeMux()
 	b := bridge.New(mux, *v4)

--- a/internal/guest/runtime/hcsv2/container.go
+++ b/internal/guest/runtime/hcsv2/container.go
@@ -44,7 +44,10 @@ const (
 )
 
 type Container struct {
+	// id is the unique container identifier.
 	id string
+	// sandboxID is the pod this container belongs to. For sandbox containers, sandboxID == id.
+	sandboxID string
 
 	vsock   transport.Transport
 	logPath string   // path to [logFile].

--- a/internal/guest/runtime/hcsv2/container_stats_test.go
+++ b/internal/guest/runtime/hcsv2/container_stats_test.go
@@ -494,16 +494,3 @@ func TestConvertV2StatsToV1_NilInput(t *testing.T) {
 		t.Error("ConvertV2StatsToV1(nil) should return empty metrics with all nil fields")
 	}
 }
-
-func TestHost_InitializeVirtualPodSupport_ErrorCases(t *testing.T) {
-	host := &Host{}
-
-	// Test with nil input
-	err := host.InitializeVirtualPodSupport(nil)
-	if err == nil {
-		t.Error("Expected error for nil input")
-	}
-	if err != nil && err.Error() != "no valid cgroup manager provided for virtual pod support" {
-		t.Errorf("Unexpected error message: %s", err.Error())
-	}
-}

--- a/internal/guest/runtime/hcsv2/sandbox_container.go
+++ b/internal/guest/runtime/hcsv2/sandbox_container.go
@@ -119,14 +119,12 @@ func setupSandboxContainerSpec(ctx context.Context, id, sandboxRoot string, spec
 	// also has a concept of a sandbox/shm file when the IPC NamespaceMode !=
 	// NODE.
 
-	// Set cgroup path - check if this is a virtual pod
-	if virtualSandboxID != "" {
-		// Virtual pod sandbox gets its own cgroup under /containers/virtual-pods using the virtual pod ID
-		spec.Linux.CgroupsPath = "/containers/virtual-pods/" + virtualSandboxID
-	} else {
-		// Traditional sandbox goes under /containers
-		spec.Linux.CgroupsPath = "/containers/" + id
+	// Set cgroup path under the pod.
+	sandboxID := id
+	if vpID := spec.Annotations[annotations.VirtualPodID]; vpID != "" {
+		sandboxID = vpID
 	}
+	spec.Linux.CgroupsPath = "/pods/" + sandboxID
 
 	// Clear the windows section as we dont want to forward to runc
 	spec.Windows = nil

--- a/internal/guest/runtime/hcsv2/sandbox_container.go
+++ b/internal/guest/runtime/hcsv2/sandbox_container.go
@@ -5,6 +5,7 @@ package hcsv2
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -119,12 +120,13 @@ func setupSandboxContainerSpec(ctx context.Context, id, sandboxRoot string, spec
 	// also has a concept of a sandbox/shm file when the IPC NamespaceMode !=
 	// NODE.
 
-	// Set cgroup path under the pod.
+	// Set cgroup path under the pod. For virtual pods, the pod cgroup is keyed
+	// by the virtual pod ID rather than the sandbox container ID.
 	sandboxID := id
-	if vpID := spec.Annotations[annotations.VirtualPodID]; vpID != "" {
-		sandboxID = vpID
+	if virtualSandboxID != "" {
+		sandboxID = virtualSandboxID
 	}
-	spec.Linux.CgroupsPath = "/pods/" + sandboxID
+	spec.Linux.CgroupsPath = fmt.Sprintf(podCgroupPathFmt, sandboxID)
 
 	// Clear the windows section as we dont want to forward to runc
 	spec.Windows = nil

--- a/internal/guest/runtime/hcsv2/standalone_container.go
+++ b/internal/guest/runtime/hcsv2/standalone_container.go
@@ -15,7 +15,6 @@ import (
 	"github.com/Microsoft/hcsshim/internal/guest/network"
 	specGuest "github.com/Microsoft/hcsshim/internal/guest/spec"
 	"github.com/Microsoft/hcsshim/internal/oc"
-	"github.com/Microsoft/hcsshim/pkg/annotations"
 )
 
 func getStandaloneHostnamePath(rootDir string) string {
@@ -119,12 +118,7 @@ func setupStandaloneContainerSpec(ctx context.Context, id, rootDir string, spec 
 	}
 
 	// Set cgroup path
-	virtualSandboxID := spec.Annotations[annotations.VirtualPodID]
-	if virtualSandboxID != "" {
-		spec.Linux.CgroupsPath = "/containers/virtual-pods/" + virtualSandboxID + "/" + id
-	} else {
-		spec.Linux.CgroupsPath = "/containers/" + id
-	}
+	spec.Linux.CgroupsPath = "/pods/" + id
 
 	// Clear the windows section as we dont want to forward to runc
 	spec.Windows = nil

--- a/internal/guest/runtime/hcsv2/standalone_container.go
+++ b/internal/guest/runtime/hcsv2/standalone_container.go
@@ -5,6 +5,7 @@ package hcsv2
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -118,7 +119,7 @@ func setupStandaloneContainerSpec(ctx context.Context, id, rootDir string, spec 
 	}
 
 	// Set cgroup path
-	spec.Linux.CgroupsPath = "/pods/" + id
+	spec.Linux.CgroupsPath = fmt.Sprintf(podCgroupPathFmt, id)
 
 	// Clear the windows section as we dont want to forward to runc
 	spec.Windows = nil

--- a/internal/guest/runtime/hcsv2/uvm.go
+++ b/internal/guest/runtime/hcsv2/uvm.go
@@ -73,31 +73,25 @@ func checkValidContainerID(id string, idType string) error {
 	return errors.Errorf("invalid %s id: %s (must match %s)", idType, id, validContainerIDRegex.String())
 }
 
-// VirtualPod represents a virtual pod that shares a UVM/Sandbox with other pods
-type VirtualPod struct {
-	VirtualSandboxID string
-	MasterSandboxID  string
-	NetworkNamespace string
-	CgroupPath       string
-	CgroupControl    cgroup.Manager  // Unified cgroup manager (v1 or v2)
-	Containers       map[string]bool // containerID -> exists
-	CreatedAt        time.Time
+// uvmPod tracks pod-level state within the UVM.
+type uvmPod struct {
+	sandboxID        string
+	networkNamespace string
+	cgroupPath       string
+	cgroupControl    cgroup.Manager
+	containers       map[string]bool
 }
 
 // Host is the structure tracking all UVM host state including all containers
 // and processes.
 type Host struct {
+	// containersMutex guards both containers and pods maps.
 	containersMutex sync.Mutex
 	containers      map[string]*Container
+	pods            map[string]*uvmPod
 
 	externalProcessesMutex sync.Mutex
 	externalProcesses      map[int]*externalProcess
-
-	// Virtual pod support for multi-pod scenarios
-	virtualPodsMutex         sync.Mutex
-	virtualPods              map[string]*VirtualPod // virtualSandboxID -> VirtualPod
-	containerToVirtualPod    map[string]string      // containerID -> virtualSandboxID
-	virtualPodsCgroupManager cgroup.Manager         // Parent cgroup for all virtual pods
 
 	// sandboxRoots maps sandboxID to the resolved sandbox root directory.
 	// Populated via registerSandboxRoot during sandbox creation using
@@ -126,16 +120,15 @@ func NewHost(rtime runtime.Runtime, vsock transport.Transport, initialEnforcer s
 		logWriter,
 	)
 	return &Host{
-		containers:            make(map[string]*Container),
-		externalProcesses:     make(map[int]*externalProcess),
-		virtualPods:           make(map[string]*VirtualPod),
-		containerToVirtualPod: make(map[string]string),
-		sandboxRoots:          make(map[string]string),
-		rtime:                 rtime,
-		vsock:                 vsock,
-		devNullTransport:      &transport.DevNullTransport{},
-		hostMounts:            newHostMounts(),
-		securityOptions:       securityPolicyOptions,
+		containers:        make(map[string]*Container),
+		externalProcesses: make(map[int]*externalProcess),
+		pods:              make(map[string]*uvmPod),
+		sandboxRoots:      make(map[string]string),
+		rtime:             rtime,
+		vsock:             vsock,
+		devNullTransport:  &transport.DevNullTransport{},
+		hostMounts:        newHostMounts(),
+		securityOptions:   securityPolicyOptions,
 	}
 }
 
@@ -214,25 +207,39 @@ func (h *Host) RemoveContainer(id string) {
 		return
 	}
 
-	// Check if this container is part of a virtual pod
-	virtualPodID, isVirtualPod := c.spec.Annotations[annotations.VirtualPodID]
-	if isVirtualPod {
-		// Remove from virtual pod tracking
-		h.RemoveContainerFromVirtualPod(id)
-		// Network namespace cleanup is handled in virtual pod cleanup when last container is removed.
-		logrus.WithFields(logrus.Fields{
-			logfields.ContainerID:      id,
-			logfields.VirtualSandboxID: virtualPodID,
-		}).Info("Container removed from virtual pod")
-	} else {
-		// delete the network namespace for standalone and sandbox containers
-		criType, isCRI := c.spec.Annotations[annotations.KubernetesContainerType]
-		if !isCRI || criType == "sandbox" {
-			_ = RemoveNetworkNamespace(context.Background(), id)
+	criType, isCRI := c.spec.Annotations[annotations.KubernetesContainerType]
+
+	// Do NOT call RemoveNetworkNamespace for virtual pod sandbox containers.
+	// The host-driven teardown path (TearDownNetworking → RemoveNetNS → removeNIC)
+	// removes adapters first and then the namespace. Calling it here would fail
+	// with "contains adapters" because the host hasn't removed them yet.
+	virtualPodID := c.spec.Annotations[annotations.VirtualPodID]
+	isVirtualPodSandbox := virtualPodID != "" && id == virtualPodID
+	if !isVirtualPodSandbox && (!isCRI || criType == "sandbox") {
+		if err := RemoveNetworkNamespace(context.Background(), id); err != nil {
+			logrus.WithError(err).WithField(logfields.ContainerID, id).Warn("failed to remove network namespace")
 		}
 	}
 
 	delete(h.containers, id)
+
+	// Clean up pod tracking. For standalone containers, sandboxID == id but
+	// no pod entry exists (createPodInUVM is only called for CRI sandboxes),
+	// so the lookup returns false and the block is skipped.
+	if pod, exists := h.pods[c.sandboxID]; exists {
+		delete(pod.containers, id)
+		// When the sandbox container itself is removed, tear down the pod.
+		if id == c.sandboxID {
+			if pod.cgroupControl != nil {
+				if err := pod.cgroupControl.Delete(); err != nil {
+					logrus.WithFields(logrus.Fields{
+						"sandboxID": c.sandboxID,
+					}).WithError(err).Warn("failed to delete pod cgroup")
+				}
+			}
+			delete(h.pods, c.sandboxID)
+		}
+	}
 
 	// Clean up the sandbox root mapping for sandbox containers.
 	if c.isSandbox {
@@ -377,7 +384,8 @@ func (h *Host) CreateContainer(ctx context.Context, id string, settings *prot.VM
 	criType, isCRI := settings.OCISpecification.Annotations[annotations.KubernetesContainerType]
 
 	// Check for virtual pod annotation
-	virtualPodID, isVirtualPod := settings.OCISpecification.Annotations[annotations.VirtualPodID]
+	virtualPodID := settings.OCISpecification.Annotations[annotations.VirtualPodID]
+	isVirtualPod := virtualPodID != ""
 
 	if h.HasSecurityPolicy() {
 		if err = checkValidContainerID(id, "container"); err != nil {
@@ -415,6 +423,21 @@ func (h *Host) CreateContainer(ctx context.Context, id string, settings *prot.VM
 	}
 	c.setStatus(containerCreating)
 
+	// Resolve sandboxID early so all downstream code uses the correct value.
+	// For sandbox containers, sandboxID == id (or virtualPodID for virtual pods).
+	// For workload containers, sandboxID comes from the KubernetesSandboxID annotation.
+	// For standalone containers, sandboxID == id.
+	sandboxID := id
+	if isVirtualPod {
+		sandboxID = virtualPodID
+	} else if criType == "container" {
+		sid := settings.OCISpecification.Annotations[annotations.KubernetesSandboxID]
+		if sid != "" {
+			sandboxID = sid
+		}
+	}
+	c.sandboxID = sandboxID
+
 	if err := h.AddContainer(id, c); err != nil {
 		return nil, err
 	}
@@ -424,50 +447,10 @@ func (h *Host) CreateContainer(ctx context.Context, id string, settings *prot.VM
 		}
 	}()
 
-	// Handle virtual pod logic
-	if isVirtualPod && isCRI {
-		logrus.WithFields(logrus.Fields{
-			logfields.ContainerID:      id,
-			logfields.VirtualSandboxID: virtualPodID,
-			"criType":                  criType,
-		}).Info("Processing container for virtual pod")
-
-		if criType == "sandbox" {
-			// This is a virtual pod sandbox - create the virtual pod if it doesn't exist
-			if _, exists := h.GetVirtualPod(virtualPodID); !exists {
-				// Use the network namespace ID from the current container spec
-				// Virtual pods share the same network namespace
-				networkNamespace := specGuest.GetNetworkNamespaceID(settings.OCISpecification)
-				if networkNamespace == "" {
-					networkNamespace = fmt.Sprintf("virtual-pod-%s", virtualPodID)
-				}
-
-				if err := h.CreateVirtualPod(ctx, virtualPodID, virtualPodID, networkNamespace, settings.OCISpecification); err != nil {
-					return nil, errors.Wrapf(err, "failed to create virtual pod %s", virtualPodID)
-				}
-			}
-		}
-
-		// Add this container to the virtual pod
-		if err := h.AddContainerToVirtualPod(id, virtualPodID); err != nil {
-			return nil, errors.Wrapf(err, "failed to add container %s to virtual pod %s", id, virtualPodID)
-		}
-	}
-
-	// Normally we would be doing policy checking here at the start of our
-	// "policy gated function". However, we can't for create container as we
-	// need a properly correct sandboxID which might be changed by the code
-	// below that determines the sandboxID. This is a bit of future proofing
-	// as currently for our single use case, the sandboxID is the same as the
-	// container id
-
 	var namespaceID string
-	// for sandbox container sandboxID is same as container id
-	sandboxID := id
 	if isCRI {
 		switch criType {
 		case "sandbox":
-			// Capture namespaceID if any because setupSandboxContainerSpec clears the Windows section.
 			namespaceID = specGuest.GetNetworkNamespaceID(settings.OCISpecification)
 
 			// Resolve the sandbox root from OCIBundlePath.
@@ -503,20 +486,23 @@ func (h *Host) CreateContainer(ctx context.Context, id string, settings *prot.VM
 			if err := securitypolicy.ExtendPolicyWithNetworkingMounts(id, h.securityOptions.PolicyEnforcer, settings.OCISpecification); err != nil {
 				return nil, err
 			}
+
+			if err := h.createPodInUVM(sandboxID, settings.OCISpecification, namespaceID); err != nil {
+				return nil, err
+			}
 		case "container":
-			sid, ok := settings.OCISpecification.Annotations[annotations.KubernetesSandboxID]
-			sandboxID = sid
+			sid := settings.OCISpecification.Annotations[annotations.KubernetesSandboxID]
 			if h.HasSecurityPolicy() {
 				if err = checkValidContainerID(sid, "sandbox"); err != nil {
 					return nil, err
 				}
 			}
-			if !ok || sid == "" {
+			if sid == "" {
 				return nil, errors.Errorf("unsupported 'io.kubernetes.cri.sandbox-id': '%s'", sid)
 			}
-			sandboxRoot := h.resolveSandboxRoot(sid)
+			sandboxRoot := h.resolveSandboxRoot(sandboxID)
 			c.sandboxRoot = sandboxRoot
-			if err = setupWorkloadContainerSpec(ctx, sid, id, sandboxRoot, settings.OCISpecification, settings.OCIBundlePath); err != nil {
+			if err = setupWorkloadContainerSpec(ctx, sandboxID, id, sandboxRoot, settings.OCISpecification, settings.OCIBundlePath); err != nil {
 				return nil, err
 			}
 
@@ -540,8 +526,15 @@ func (h *Host) CreateContainer(ctx context.Context, id string, settings *prot.VM
 		default:
 			return nil, errors.Errorf("unsupported 'io.kubernetes.cri.container-type': '%s'", criType)
 		}
+
+		// Register container with its pod.
+		h.containersMutex.Lock()
+		if pod, exists := h.pods[sandboxID]; exists {
+			pod.containers[id] = true
+		}
+		h.containersMutex.Unlock()
 	} else {
-		// Capture namespaceID if any because setupStandaloneContainerSpec clears the Windows section.
+		// Standalone container: no pod entry is created.
 		namespaceID = specGuest.GetNetworkNamespaceID(settings.OCISpecification)
 		// Standalone uses OCIBundlePath directly as its root.
 		c.sandboxRoot = settings.OCIBundlePath
@@ -1489,194 +1482,41 @@ func isPrivilegedContainerCreationRequest(ctx context.Context, spec *specs.Spec)
 	return oci.ParseAnnotationsBool(ctx, spec.Annotations, annotations.LCOWPrivileged, false)
 }
 
-// Virtual Pod Management Methods
-
-// InitializeVirtualPodSupport sets up the parent cgroup for virtual pods
-func (h *Host) InitializeVirtualPodSupport(mgr cgroup.Manager) error {
-	h.virtualPodsMutex.Lock()
-	defer h.virtualPodsMutex.Unlock()
-
-	if mgr == nil {
-		return errors.New("no valid cgroup manager provided for virtual pod support")
+// createPodInUVM allocates a cgroup for a pod and registers it in the host.
+func (h *Host) createPodInUVM(sid string, pSpec *specs.Spec, nsID string) error {
+	h.containersMutex.Lock()
+	if _, exists := h.pods[sid]; exists {
+		h.containersMutex.Unlock()
+		return fmt.Errorf("pod %s already exists", sid)
 	}
+	h.containersMutex.Unlock()
 
-	h.virtualPodsCgroupManager = mgr
-	logrus.Info("Virtual pod support initialized")
-	return nil
-}
-
-// CreateVirtualPod creates a new virtual pod with its own cgroup and network namespace
-func (h *Host) CreateVirtualPod(ctx context.Context, virtualSandboxID, masterSandboxID, networkNamespace string, pSpec *specs.Spec) error {
-	h.virtualPodsMutex.Lock()
-	defer h.virtualPodsMutex.Unlock()
-
-	// Check if virtual pod already exists
-	if _, exists := h.virtualPods[virtualSandboxID]; exists {
-		return fmt.Errorf("virtual pod %s already exists", virtualSandboxID)
-	}
-
-	// Extract resource limits if provided
+	cgroupPath := path.Join("/pods", sid)
 	resources := &specs.LinuxResources{}
 	if pSpec != nil && pSpec.Linux != nil && pSpec.Linux.Resources != nil {
 		resources = pSpec.Linux.Resources
-		logrus.WithFields(logrus.Fields{
-			logfields.VirtualSandboxID: virtualSandboxID,
-		}).Info("Creating virtual pod with specified resources")
-	} else {
-		logrus.WithField(logfields.VirtualSandboxID, virtualSandboxID).Info("Creating pod cgroup with default resources as none were specified")
 	}
-
-	if h.virtualPodsCgroupManager == nil {
-		return fmt.Errorf("no virtual pod cgroup manager available")
-	}
-
-	cgroupPath := path.Join("/containers/virtual-pods", virtualSandboxID)
 	cgroupControl, err := cgroup.NewManager(cgroupPath, resources)
 	if err != nil {
-		return errors.Wrapf(err, "failed to create cgroup for virtual pod %s", virtualSandboxID)
+		return fmt.Errorf("failed to create cgroup for pod %s: %w", sid, err)
 	}
-	logrus.WithField("cgroupPath", cgroupPath).Info("Created virtual pod cgroup")
-
-	// Create virtual pod structure
-	virtualPod := &VirtualPod{
-		VirtualSandboxID: virtualSandboxID,
-		MasterSandboxID:  masterSandboxID,
-		NetworkNamespace: networkNamespace,
-		CgroupPath:       cgroupPath,
-		CgroupControl:    cgroupControl,
-		Containers:       make(map[string]bool),
-		CreatedAt:        time.Now(),
+	h.containersMutex.Lock()
+	defer h.containersMutex.Unlock()
+	// Double-check after cgroup creation in case of a race.
+	if _, exists := h.pods[sid]; exists {
+		_ = cgroupControl.Delete()
+		return fmt.Errorf("pod %s already exists", sid)
 	}
-
-	h.virtualPods[virtualSandboxID] = virtualPod
-
+	h.pods[sid] = &uvmPod{
+		sandboxID:        sid,
+		networkNamespace: nsID,
+		cgroupPath:       cgroupPath,
+		cgroupControl:    cgroupControl,
+		containers:       make(map[string]bool),
+	}
 	logrus.WithFields(logrus.Fields{
-		logfields.VirtualSandboxID: virtualSandboxID,
-		"masterSandboxID":          masterSandboxID,
-		"cgroupPath":               cgroupPath,
-		"networkNamespace":         networkNamespace,
-	}).Info("Virtual pod created successfully")
-
+		"sandboxID":  sid,
+		"cgroupPath": cgroupPath,
+	}).Info("pod created in UVM")
 	return nil
-}
-
-// CreateVirtualPodWithoutMemoryLimit creates a virtual pod without memory limits (backward compatibility)
-func (h *Host) CreateVirtualPodWithoutMemoryLimit(ctx context.Context, virtualSandboxID, masterSandboxID, networkNamespace string) error {
-	return h.CreateVirtualPod(ctx, virtualSandboxID, masterSandboxID, networkNamespace, nil)
-}
-
-// GetVirtualPod retrieves a virtual pod by its virtualSandboxID
-func (h *Host) GetVirtualPod(virtualSandboxID string) (*VirtualPod, bool) {
-	h.virtualPodsMutex.Lock()
-	defer h.virtualPodsMutex.Unlock()
-
-	vp, exists := h.virtualPods[virtualSandboxID]
-	return vp, exists
-}
-
-// AddContainerToVirtualPod associates a container with a virtual pod
-func (h *Host) AddContainerToVirtualPod(containerID, virtualSandboxID string) error {
-	h.virtualPodsMutex.Lock()
-	defer h.virtualPodsMutex.Unlock()
-
-	// Check if virtual pod exists
-	vp, exists := h.virtualPods[virtualSandboxID]
-	if !exists {
-		return fmt.Errorf("virtual pod %s does not exist", virtualSandboxID)
-	}
-
-	// Add container to virtual pod
-	vp.Containers[containerID] = true
-	h.containerToVirtualPod[containerID] = virtualSandboxID
-
-	logrus.WithFields(logrus.Fields{
-		logfields.ContainerID:      containerID,
-		logfields.VirtualSandboxID: virtualSandboxID,
-	}).Info("Container added to virtual pod")
-
-	return nil
-}
-
-// RemoveContainerFromVirtualPod removes a container from a virtual pod
-func (h *Host) RemoveContainerFromVirtualPod(containerID string) {
-	h.virtualPodsMutex.Lock()
-	defer h.virtualPodsMutex.Unlock()
-
-	virtualSandboxID, exists := h.containerToVirtualPod[containerID]
-	if !exists {
-		return // Container not in any virtual pod
-	}
-
-	ctx, entry := log.SetEntry(context.Background(), logrus.Fields{
-		logfields.VirtualSandboxID: virtualSandboxID,
-		logfields.ContainerID:      containerID,
-	})
-
-	// Remove from virtual pod
-	if vp, vpExists := h.virtualPods[virtualSandboxID]; vpExists {
-		delete(vp.Containers, containerID)
-
-		// If this is the sandbox container, clean up the network namespace adapters first,
-		// then remove the namespace.
-
-		// Do NOT call [RemoveNetworkNamespace] here.
-		// When cleaning up the virtual pod's sandbox container on the host,
-		// [UtilityVM.TearDownNetworking] calls [UtilityVM.RemoveNetNS],
-		// which, via [UtilityVM.removeNIC], removes the NICs from the uVM and
-		// sends [guestresource.ResourceTypeNetwork] RPCs that ultimately cal [modifyNetwork]
-		// to remove adapters from guest tracking.
-		// However, that happens AFTER this function runs.
-		// Calling [RemoveNetworkNamespace] here would
-		// fail with "contains adapters" since the host hasn't removed them yet.
-		//
-		// The host-driven path handles cleanup in the correct order.
-		if containerID == virtualSandboxID && vp.NetworkNamespace != "" {
-			entry.WithField(logfields.NamespaceID, vp.NetworkNamespace).Debug("skipping virtual pod network namespace removal")
-		}
-
-		// If this was the last container, cleanup the virtual pod
-		if len(vp.Containers) == 0 {
-			h.cleanupVirtualPod(ctx, virtualSandboxID)
-		}
-	}
-
-	delete(h.containerToVirtualPod, containerID)
-
-	entry.Info("Container removed from virtual pod")
-}
-
-func (h *Host) cleanupVirtualPod(ctx context.Context, virtualSandboxID string) {
-	// logfields set on [Host.RemoveContainerFromVirtualPod]
-	entry := log.G(ctx)
-
-	vp, exists := h.virtualPods[virtualSandboxID]
-	if !exists {
-		entry.Warn("attempted to cleanup non-existent virtual sandbox pod")
-		return // virtual pod does not exist
-	}
-
-	// Delete the cgroup
-	if vp.CgroupControl != nil {
-		if err := vp.CgroupControl.Delete(); err != nil {
-			entry.WithError(err).Warn("failed to delete virtual pod cgroup")
-		}
-	}
-
-	// NOTE: Do NOT call [RemoveNetworkNamespace] here.
-	// See comment in [Host.RemoveContainerFromVirtualPod] for more info.
-
-	// Clean up the virtual pod root directory which contains hostname, hosts,
-	// resolv.conf, and logs/. These are NOT cleaned by Container.Delete() because
-	// they live under /run/gcs/c/virtual-pods/<id>/ which is separate from the
-	// container's ociBundlePath (/run/gcs/c/<id>/).
-	if vpRootDir := specGuest.VirtualPodRootDir(virtualSandboxID); vpRootDir != "" {
-		if err := os.RemoveAll(vpRootDir); err != nil {
-			entry.WithField("path", vpRootDir).WithError(err).Warn("Failed to remove virtual pod root directory")
-		} else {
-			entry.WithField("path", vpRootDir).Debug("Removed virtual pod root directory")
-		}
-	}
-
-	delete(h.virtualPods, virtualSandboxID)
-	entry.Info("Virtual pod cleaned up")
 }

--- a/internal/guest/runtime/hcsv2/uvm.go
+++ b/internal/guest/runtime/hcsv2/uvm.go
@@ -431,10 +431,7 @@ func (h *Host) CreateContainer(ctx context.Context, id string, settings *prot.VM
 	if isVirtualPod {
 		sandboxID = virtualPodID
 	} else if criType == "container" {
-		sid := settings.OCISpecification.Annotations[annotations.KubernetesSandboxID]
-		if sid != "" {
-			sandboxID = sid
-		}
+		sandboxID = settings.OCISpecification.Annotations[annotations.KubernetesSandboxID]
 	}
 	c.sandboxID = sandboxID
 
@@ -1484,28 +1481,22 @@ func isPrivilegedContainerCreationRequest(ctx context.Context, spec *specs.Spec)
 
 // createPodInUVM allocates a cgroup for a pod and registers it in the host.
 func (h *Host) createPodInUVM(sid string, pSpec *specs.Spec, nsID string) error {
-	h.containersMutex.Lock()
-	if _, exists := h.pods[sid]; exists {
-		h.containersMutex.Unlock()
-		return fmt.Errorf("pod %s already exists", sid)
-	}
-	h.containersMutex.Unlock()
-
 	cgroupPath := path.Join("/pods", sid)
 	resources := &specs.LinuxResources{}
 	if pSpec != nil && pSpec.Linux != nil && pSpec.Linux.Resources != nil {
 		resources = pSpec.Linux.Resources
 	}
+
+	h.containersMutex.Lock()
+	defer h.containersMutex.Unlock()
+
+	if _, exists := h.pods[sid]; exists {
+		return fmt.Errorf("pod %s already exists", sid)
+	}
+
 	cgroupControl, err := cgroup.NewManager(cgroupPath, resources)
 	if err != nil {
 		return fmt.Errorf("failed to create cgroup for pod %s: %w", sid, err)
-	}
-	h.containersMutex.Lock()
-	defer h.containersMutex.Unlock()
-	// Double-check after cgroup creation in case of a race.
-	if _, exists := h.pods[sid]; exists {
-		_ = cgroupControl.Delete()
-		return fmt.Errorf("pod %s already exists", sid)
 	}
 	h.pods[sid] = &uvmPod{
 		sandboxID:        sid,

--- a/internal/guest/runtime/hcsv2/uvm.go
+++ b/internal/guest/runtime/hcsv2/uvm.go
@@ -81,8 +81,8 @@ const (
 	containerCgroupPathFmt = "/pods/%s/%s"
 )
 
-// uvmPod tracks pod-level state within the UVM.
-type uvmPod struct {
+// pod tracks pod-level state within the UVM.
+type pod struct {
 	sandboxID     string
 	cgroupControl cgroup.Manager
 	containers    map[string]bool
@@ -94,7 +94,7 @@ type Host struct {
 	// containersMutex guards both containers and pods maps.
 	containersMutex sync.Mutex
 	containers      map[string]*Container
-	pods            map[string]*uvmPod
+	pods            map[string]*pod
 
 	externalProcessesMutex sync.Mutex
 	externalProcesses      map[int]*externalProcess
@@ -128,7 +128,7 @@ func NewHost(rtime runtime.Runtime, vsock transport.Transport, initialEnforcer s
 	return &Host{
 		containers:        make(map[string]*Container),
 		externalProcesses: make(map[int]*externalProcess),
-		pods:              make(map[string]*uvmPod),
+		pods:              make(map[string]*pod),
 		sandboxRoots:      make(map[string]string),
 		rtime:             rtime,
 		vsock:             vsock,
@@ -1502,7 +1502,7 @@ func (h *Host) createPodInUVM(sid string, pSpec *specs.Spec) error {
 	if err != nil {
 		return fmt.Errorf("failed to create cgroup for pod %s: %w", sid, err)
 	}
-	h.pods[sid] = &uvmPod{
+	h.pods[sid] = &pod{
 		sandboxID:     sid,
 		cgroupControl: cgroupControl,
 		// Register the sandbox container with its pod.

--- a/internal/guest/runtime/hcsv2/uvm.go
+++ b/internal/guest/runtime/hcsv2/uvm.go
@@ -73,13 +73,19 @@ func checkValidContainerID(id string, idType string) error {
 	return errors.Errorf("invalid %s id: %s (must match %s)", idType, id, validContainerIDRegex.String())
 }
 
+// Cgroup path formats for pod and container cgroups within the UVM.
+const (
+	// podCgroupPathFmt is the cgroup path for a pod (sandbox or standalone): /pods/{sandboxID}.
+	podCgroupPathFmt = "/pods/%s"
+	// containerCgroupPathFmt is the cgroup path for a workload container nested under its pod: /pods/{sandboxID}/{containerID}.
+	containerCgroupPathFmt = "/pods/%s/%s"
+)
+
 // uvmPod tracks pod-level state within the UVM.
 type uvmPod struct {
-	sandboxID        string
-	networkNamespace string
-	cgroupPath       string
-	cgroupControl    cgroup.Manager
-	containers       map[string]bool
+	sandboxID     string
+	cgroupControl cgroup.Manager
+	containers    map[string]bool
 }
 
 // Host is the structure tracking all UVM host state including all containers
@@ -444,6 +450,23 @@ func (h *Host) CreateContainer(ctx context.Context, id string, settings *prot.VM
 		}
 	}()
 
+	// For workload containers, verify the pod exists and register the container.
+	// Sandbox containers register themselves after createPodInUVM creates the pod.
+	if isCRI && criType == "container" {
+		h.containersMutex.Lock()
+		pod, podExists := h.pods[sandboxID]
+		if !podExists {
+			h.containersMutex.Unlock()
+			return nil, fmt.Errorf("pod %s does not exist for workload container %s", sandboxID, id)
+		}
+		if _, exists := pod.containers[id]; exists {
+			h.containersMutex.Unlock()
+			return nil, fmt.Errorf("container %s already registered with pod %s", id, sandboxID)
+		}
+		pod.containers[id] = true
+		h.containersMutex.Unlock()
+	}
+
 	var namespaceID string
 	if isCRI {
 		switch criType {
@@ -484,9 +507,15 @@ func (h *Host) CreateContainer(ctx context.Context, id string, settings *prot.VM
 				return nil, err
 			}
 
-			if err := h.createPodInUVM(sandboxID, settings.OCISpecification, namespaceID); err != nil {
+			if err := h.createPodInUVM(sandboxID, settings.OCISpecification); err != nil {
 				return nil, err
 			}
+			// Register the sandbox container with its pod.
+			h.containersMutex.Lock()
+			if pod, exists := h.pods[sandboxID]; exists {
+				pod.containers[id] = true
+			}
+			h.containersMutex.Unlock()
 		case "container":
 			sid := settings.OCISpecification.Annotations[annotations.KubernetesSandboxID]
 			if h.HasSecurityPolicy() {
@@ -523,13 +552,6 @@ func (h *Host) CreateContainer(ctx context.Context, id string, settings *prot.VM
 		default:
 			return nil, errors.Errorf("unsupported 'io.kubernetes.cri.container-type': '%s'", criType)
 		}
-
-		// Register container with its pod.
-		h.containersMutex.Lock()
-		if pod, exists := h.pods[sandboxID]; exists {
-			pod.containers[id] = true
-		}
-		h.containersMutex.Unlock()
 	} else {
 		// Standalone container: no pod entry is created.
 		namespaceID = specGuest.GetNetworkNamespaceID(settings.OCISpecification)
@@ -1480,8 +1502,8 @@ func isPrivilegedContainerCreationRequest(ctx context.Context, spec *specs.Spec)
 }
 
 // createPodInUVM allocates a cgroup for a pod and registers it in the host.
-func (h *Host) createPodInUVM(sid string, pSpec *specs.Spec, nsID string) error {
-	cgroupPath := path.Join("/pods", sid)
+func (h *Host) createPodInUVM(sid string, pSpec *specs.Spec) error {
+	cgroupPath := fmt.Sprintf(podCgroupPathFmt, sid)
 	resources := &specs.LinuxResources{}
 	if pSpec != nil && pSpec.Linux != nil && pSpec.Linux.Resources != nil {
 		resources = pSpec.Linux.Resources
@@ -1499,11 +1521,9 @@ func (h *Host) createPodInUVM(sid string, pSpec *specs.Spec, nsID string) error 
 		return fmt.Errorf("failed to create cgroup for pod %s: %w", sid, err)
 	}
 	h.pods[sid] = &uvmPod{
-		sandboxID:        sid,
-		networkNamespace: nsID,
-		cgroupPath:       cgroupPath,
-		cgroupControl:    cgroupControl,
-		containers:       make(map[string]bool),
+		sandboxID:     sid,
+		cgroupControl: cgroupControl,
+		containers:    make(map[string]bool),
 	}
 	logrus.WithFields(logrus.Fields{
 		"sandboxID":  sid,

--- a/internal/guest/runtime/hcsv2/uvm.go
+++ b/internal/guest/runtime/hcsv2/uvm.go
@@ -450,23 +450,6 @@ func (h *Host) CreateContainer(ctx context.Context, id string, settings *prot.VM
 		}
 	}()
 
-	// For workload containers, verify the pod exists and register the container.
-	// Sandbox containers register themselves after createPodInUVM creates the pod.
-	if isCRI && criType == "container" {
-		h.containersMutex.Lock()
-		pod, podExists := h.pods[sandboxID]
-		if !podExists {
-			h.containersMutex.Unlock()
-			return nil, fmt.Errorf("pod %s does not exist for workload container %s", sandboxID, id)
-		}
-		if _, exists := pod.containers[id]; exists {
-			h.containersMutex.Unlock()
-			return nil, fmt.Errorf("container %s already registered with pod %s", id, sandboxID)
-		}
-		pod.containers[id] = true
-		h.containersMutex.Unlock()
-	}
-
 	var namespaceID string
 	if isCRI {
 		switch criType {
@@ -510,22 +493,21 @@ func (h *Host) CreateContainer(ctx context.Context, id string, settings *prot.VM
 			if err := h.createPodInUVM(sandboxID, settings.OCISpecification); err != nil {
 				return nil, err
 			}
-			// Register the sandbox container with its pod.
-			h.containersMutex.Lock()
-			if pod, exists := h.pods[sandboxID]; exists {
-				pod.containers[id] = true
-			}
-			h.containersMutex.Unlock()
 		case "container":
-			sid := settings.OCISpecification.Annotations[annotations.KubernetesSandboxID]
 			if h.HasSecurityPolicy() {
-				if err = checkValidContainerID(sid, "sandbox"); err != nil {
+				if err = checkValidContainerID(sandboxID, "sandbox"); err != nil {
 					return nil, err
 				}
 			}
-			if sid == "" {
-				return nil, errors.Errorf("unsupported 'io.kubernetes.cri.sandbox-id': '%s'", sid)
+
+			if sandboxID == "" {
+				return nil, errors.Errorf("unsupported 'io.kubernetes.cri.sandbox-id': '%s'", sandboxID)
 			}
+
+			if err = h.createContainerInPod(sandboxID, id); err != nil {
+				return nil, err
+			}
+
 			sandboxRoot := h.resolveSandboxRoot(sandboxID)
 			c.sandboxRoot = sandboxRoot
 			if err = setupWorkloadContainerSpec(ctx, sandboxID, id, sandboxRoot, settings.OCISpecification, settings.OCIBundlePath); err != nil {
@@ -1523,11 +1505,33 @@ func (h *Host) createPodInUVM(sid string, pSpec *specs.Spec) error {
 	h.pods[sid] = &uvmPod{
 		sandboxID:     sid,
 		cgroupControl: cgroupControl,
-		containers:    make(map[string]bool),
+		// Register the sandbox container with its pod.
+		containers: map[string]bool{sid: true},
 	}
 	logrus.WithFields(logrus.Fields{
 		"sandboxID":  sid,
 		"cgroupPath": cgroupPath,
 	}).Info("pod created in UVM")
+	return nil
+}
+
+func (h *Host) createContainerInPod(sandboxID string, containerID string) error {
+	h.containersMutex.Lock()
+	defer h.containersMutex.Unlock()
+
+	// Find the pod corresponding to the sandboxID.
+	pod, podExists := h.pods[sandboxID]
+	if !podExists {
+		return fmt.Errorf("pod %s does not exist for workload container %s", sandboxID, containerID)
+	}
+
+	// Validate that the container was not already registered.
+	if _, exists := pod.containers[containerID]; exists {
+		return fmt.Errorf("container %s already registered with pod %s", containerID, sandboxID)
+	}
+
+	// Register container with the pod.
+	pod.containers[containerID] = true
+
 	return nil
 }

--- a/internal/guest/runtime/hcsv2/workload_container.go
+++ b/internal/guest/runtime/hcsv2/workload_container.go
@@ -225,7 +225,7 @@ func setupWorkloadContainerSpec(ctx context.Context, sbid, id, sandboxRoot strin
 	}
 
 	// Set cgroup path under the sandbox's pod cgroup.
-	spec.Linux.CgroupsPath = "/pods/" + sbid + "/" + id
+	spec.Linux.CgroupsPath = fmt.Sprintf(containerCgroupPathFmt, sbid, id)
 
 	if spec.Windows != nil {
 		// we only support Nvidia gpus right now

--- a/internal/guest/runtime/hcsv2/workload_container.go
+++ b/internal/guest/runtime/hcsv2/workload_container.go
@@ -224,17 +224,8 @@ func setupWorkloadContainerSpec(ctx context.Context, sbid, id, sandboxRoot strin
 		}
 	}
 
-	// Check if this is a virtual pod container
-	virtualPodID := spec.Annotations[annotations.VirtualPodID]
-
-	// Set cgroup path - check if this is a virtual pod container
-	if virtualPodID != "" {
-		// Virtual pod containers go under /containers/virtual-pods/virtualPodID/containerID
-		spec.Linux.CgroupsPath = "/containers/virtual-pods/" + virtualPodID + "/" + id
-	} else {
-		// Regular containers go under /containers
-		spec.Linux.CgroupsPath = "/containers/" + id
-	}
+	// Set cgroup path under the sandbox's pod cgroup.
+	spec.Linux.CgroupsPath = "/pods/" + sbid + "/" + id
 
 	if spec.Windows != nil {
 		// we only support Nvidia gpus right now

--- a/test/gcs/cgroup_test.go
+++ b/test/gcs/cgroup_test.go
@@ -435,8 +435,8 @@ func TestOOMEventFD_ContainerKill(t *testing.T) {
 
 	// --- Set up OOMEventFD on the container's cgroup ---
 	//
-	// Standalone containers get cgroup path "/containers/<id>".
-	cgroupPath := "/containers/" + id
+	// Standalone containers get cgroup path "/pods/<id>".
+	cgroupPath := "/pods/" + id
 
 	// LoadManager works for both v1 and v2 — the cgroup already exists (created by runc).
 	mgr, err := cgroup.LoadManager(cgroupPath)


### PR DESCRIPTION
The GCS guest runtime (`internal/guest/runtime/hcsv2/uvm.go`) tracks virtual pods separately from V1 sandbox containers — a dedicated `VirtualPod` type, seven exported methods, a parent cgroup manager, and a reverse-lookup map. V1 sandboxes have no pod-level tracking at all. Adding V2 shim support would need a third path.

This collapses all three into one: a private `uvmPod` type and a single `pods` map on `Host`. Every sandbox — V1, virtual pod, or V2 shim — goes through `createPodInUVM`, which allocates a cgroup under `/pods/{sandboxID}`. Workload containers nest at `/pods/{sandboxID}/{containerID}`. Container-to-pod membership is tracked via `addContainerToPod`. Cleanup in `RemoveContainer` is a single code path: remove the container from the pod, and when the sandbox container itself is removed, delete the pod's cgroup.

Cgroup hierarchy changes from:
```
/containers/{id}                         (V1 sandbox)
/containers/virtual-pods/{virtualPodID}  (virtual pod)
```
to:
```
/pods/{sandboxID}                        (all pod types)
/pods/{sandboxID}/{containerID}          (workload containers)
```

Standalone (non-CRI) containers keep their own cgroup at `/pods/{id}` with no pod entry — same isolation as before, just under the new prefix.

Network namespace teardown for virtual pod sandboxes is preserved: `RemoveContainer` skips `RemoveNetworkNamespace` for virtual pod sandbox containers since the host-driven path (`TearDownNetworking` → `RemoveNetNS` → `removeNIC`) handles adapter removal first.

`cmd/gcs/main.go` replaces the `/containers/virtual-pods` parent cgroup with `/pods` and drops the `InitializeVirtualPodSupport` call.

Tested E2E with both shims:

| | V1 shim (`io.containerd.runhcs.v1`) | V2 shim (`io.containerd.lcow.v2`) |
|---|---|---|
| OCIBundlePath | `/run/gcs/c/<podId>` | `/run/gcs/pods/<podId>/<podId>` |
| Pod cgroup | `/sys/fs/cgroup/memory/pods/<podId>` | `/sys/fs/cgroup/memory/pods/<podId>` |
| `/containers/virtual-pods/` | absent | absent |