### PR TITLE
[Draft] container-reboot-v2: shim-driven transparent reboot prototype

### DIFF
--- a/cmd/containerd-shim-runhcs-v1/exec_hcs.go
+++ b/cmd/containerd-shim-runhcs-v1/exec_hcs.go
@@ -523,7 +523,25 @@ func (he *hcsExec) waitForContainerExit() {
 	select {
 	case <-he.c.WaitChannel():
 		// Container exited first. We need to force the process into the exited
-		// state and cleanup any resources
+		// state and cleanup any resources.
+
+		// container-reboot-v2 Stage 2 observability: surface the ExitType that
+		// *hcs.System.waitBackground parsed out of SystemExitStatus JSON. When
+		// the HCS ExposeRebootNotification + PassExitStatusJson guards are on
+		// and the container ran `shutdown /r`, this logs "Reboot" — which is the
+		// signal Stage 4's handleReboot will key off instead of running the
+		// teardown branch below. At Stage 2 we only observe; the teardown runs
+		// unchanged so the container still dies. Harmless for non-Exited paths
+		// (empty string) and non-Argon paths (*gcs.Container / *JobContainer
+		// ExitType() return "" per cow.Container contract).
+		if exitType := he.c.ExitType(); exitType != "" {
+			log.G(ctx).
+				WithField("tid", he.tid).
+				WithField("eid", he.id).
+				WithField("reboot.exit_type", exitType).
+				Info("reboot-v2: container exited with ExitType (no action; Stage 2)")
+		}
+
 		he.sl.Lock()
 		switch he.state {
 		case shimExecStateCreated:

--- a/cmd/containerd-shim-runhcs-v1/exec_hcs.go
+++ b/cmd/containerd-shim-runhcs-v1/exec_hcs.go
@@ -515,7 +515,9 @@ func (he *hcsExec) waitForContainerExit() {
 	defer span.End()
 	span.AddAttributes(
 		trace.StringAttribute("tid", he.tid),
-		trace.StringAttribute("eid", he.id))
+		trace.StringAttribute("eid", he.id),
+		// container-reboot-v2 Stage 1 placeholder; Stage 4 flips this when Reboot notification is observed.
+		trace.BoolAttribute("reboot.pending", false))
 
 	// wait for container or process to exit and ckean up resrources
 	select {

--- a/cmd/containerd-shim-runhcs-v1/task_hcs.go
+++ b/cmd/containerd-shim-runhcs-v1/task_hcs.go
@@ -661,8 +661,22 @@ func (ht *hcsTask) waitInitExit() {
 			log.G(ctx).
 				WithField("tid", ht.id).
 				WithField("reboot.exit_type", exitType).
-				Info("reboot-v2 Stage 4: reboot observed; running B2 same-ID recreate probe")
-			ht.probeSameIDRecreate(ctx)
+				Info("reboot-v2 Stage 4: reboot observed; attempting transparent restart (B3b)")
+			if err := ht.doHandleReboot(ctx); err != nil {
+				log.G(ctx).WithError(err).
+					WithField("tid", ht.id).
+					Warn("reboot-v2 B3b: handleReboot failed; falling through to teardown")
+				rebootPending = false // restart failed; normal exit semantics apply
+			} else {
+				span.AddAttributes(trace.BoolAttribute("reboot.pending", true))
+				log.G(ctx).
+					WithField("tid", ht.id).
+					Info("reboot-v2 B3b: transparent restart completed; suppressing teardown")
+				// IMPORTANT: return WITHOUT calling ht.close(ctx). The task
+				// continues to live under the new System; closeHost() is not
+				// invoked so no /tasks/exit event is published.
+				return
+			}
 		}
 	}
 	span.AddAttributes(trace.BoolAttribute("reboot.pending", rebootPending))
@@ -671,26 +685,131 @@ func (ht *hcsTask) waitInitExit() {
 	ht.close(ctx)
 }
 
-// probeSameIDRecreate is a Stage 4 Sub-step B2 experiment — it does NOT yet
-// drive an actual restart. We want to answer a single question before writing
-// real handleReboot logic: does HCS accept CreateComputeSystem + Start with
-// the same container ID while the overlay layer is still mounted?
+// doHandleReboot performs the Stage 4 Sub-step B3b transparent restart.
+// The container has exited with ExitType=Reboot (HCS told us via the V1
+// SystemExitStatus JSON). Old silo is gone but its compute-system ID slot
+// is free. Overlay layer and HNS endpoint both persist. We:
 //
-// Plan:
-//  1. Close the old *hcs.System handle so HCS sees no duplicate outstanding
-//     handle for this ID (the silo itself is already gone).
-//  2. Retrieve the cached hcsDocument (Sub-step B1).
-//  3. Call hcs.CreateComputeSystem with that doc on the same ID.
-//  4. Call Start on the new system.
-//  5. Log each outcome; on any failure, log the error explicitly so we can
-//     tell whether it's same-ID rejection, layer-not-found, namespace
-//     conflict, or something else.
-//  6. Terminate + Wait + Close the new system so the caller's ht.close(ctx)
-//     teardown proceeds normally on an empty slot.
+//  1. Close the old *hcs.System handle (silo already destructed kernel-side).
+//  2. Call hcs.CreateComputeSystem with the cached create document (B1) on
+//     the same ID. The overlay path and namespace GUID in the doc bind to
+//     the persisted state.
+//  3. Call newSys.Start().
+//  4. Spawn the original init process via cmd.Cmd with ht.taskSpec.Process,
+//     reusing the hcsExec's upstream stdio pipes.
+//  5. Reset ht.init's hcsExec state in-place under its sl lock:
+//       - Point c + p at the new System + cmd
+//       - Reset state=Running, pid=newPid, exitStatus=255, exitedAt=zero
+//       - Allocate fresh processDone / exited channels (old ones already
+//         closed by the exec's exit path; existing waiters already returned)
+//  6. Point ht.c at newSys so task-level operations target it.
+//  7. Respawn waitForExit so the new init process's lifecycle is tracked
+//     (including publishing a TaskExit event when the new init exits —
+//     same as a normal container exit).
 //
-// This runs BEFORE ht.close(ctx), so the overlay layer is still mounted via
-// the original resources.Resources. If B2 succeeds we know Sub-step B3 can
-// wire the new system into ht.c instead of throwing it away.
+// Known limitations of this first iteration (to address in B3c / Stage 5):
+//   - We do NOT re-spawn waitForContainerExit, so if the new silo reboots
+//     AGAIN, we fall through to the normal exit path rather than handling
+//     it recursively. Fine for single-reboot tests; needs looping for the
+//     ship version.
+//   - The /tasks/start event is NOT republished on restart, so external
+//     listeners don't know the PID changed. This is intentional (the task
+//     is logically "still running") but may need an annotation event.
+//   - If Start or the init spawn fails mid-way, the new System is leaked.
+//     Caller treats an error return as "fall through to teardown" which
+//     partially covers cleanup via ht.close(ctx).
+func (ht *hcsTask) doHandleReboot(ctx context.Context) error {
+	oldSys, ok := ht.c.(*hcs.System)
+	if !ok {
+		return fmt.Errorf("ht.c is %T, not *hcs.System — cannot recreate", ht.c)
+	}
+	doc := oldSys.CreateDocument()
+	if len(doc) == 0 {
+		return fmt.Errorf("no cached create document; System not created via CreateComputeSystem")
+	}
+	oldExec, ok := ht.init.(*hcsExec)
+	if !ok {
+		return fmt.Errorf("ht.init is %T, not *hcsExec — cannot reset", ht.init)
+	}
+
+	log.G(ctx).
+		WithField("tid", ht.id).
+		WithField("doc_bytes", len(doc)).
+		Info("reboot-v2 B3b: closing old system handle")
+	if err := oldSys.Close(); err != nil {
+		log.G(ctx).WithError(err).Warn("reboot-v2 B3b: old system Close failed (proceeding anyway)")
+	}
+
+	newSys, err := hcs.CreateComputeSystem(ctx, ht.id, doc)
+	if err != nil {
+		return fmt.Errorf("CreateComputeSystem on same ID failed: %w", err)
+	}
+	log.G(ctx).WithField("tid", ht.id).Info("reboot-v2 B3b: new System created on same ID")
+
+	if err := newSys.Start(ctx); err != nil {
+		_ = newSys.Terminate(ctx)
+		_ = newSys.Wait()
+		_ = newSys.Close()
+		return fmt.Errorf("newSys.Start failed: %w", err)
+	}
+	log.G(ctx).WithField("tid", ht.id).Info("reboot-v2 B3b: new System started")
+
+	// Spawn the real init process. Reuse the existing upstream IO (pipes are
+	// containerd-owned and still open).
+	newCmd := &cmd.Cmd{
+		Host:                 newSys,
+		Stdin:                oldExec.io.Stdin(),
+		Stdout:               oldExec.io.Stdout(),
+		Stderr:               oldExec.io.Stderr(),
+		Log:                  log.G(ctx).WithFields(logrus.Fields{"tid": ht.id, "eid": ht.id, "reboot-v2": "b3b-init"}),
+		CopyAfterExitTimeout: time.Second,
+	}
+	if oldExec.isWCOW {
+		newCmd.Spec = ht.taskSpec.Process
+	}
+	if err := newCmd.Start(); err != nil {
+		_ = newSys.Terminate(ctx)
+		_ = newSys.Wait()
+		_ = newSys.Close()
+		return fmt.Errorf("new init cmd.Start failed: %w", err)
+	}
+	newPid := newCmd.Process.Pid()
+	log.G(ctx).
+		WithField("tid", ht.id).
+		WithField("new.pid", newPid).
+		Info("reboot-v2 B3b: new init process spawned")
+
+	// Swap state into the existing hcsExec under its lock.
+	oldExec.sl.Lock()
+	oldExec.c = newSys
+	oldExec.p = newCmd
+	oldExec.pid = newPid
+	oldExec.state = shimExecStateRunning
+	oldExec.exitStatus = 255
+	oldExec.exitedAt = time.Time{}
+	oldExec.processDone = make(chan struct{})
+	oldExec.processDoneOnce = sync.Once{}
+	oldExec.exited = make(chan struct{})
+	oldExec.exitedOnce = sync.Once{}
+	oldExec.sl.Unlock()
+
+	// Swap task-level container reference.
+	ht.c = newSys
+
+	// Respawn waitForExit so we track the new init process and publish
+	// TaskExit correctly when it ends. This is what startInternal does
+	// at the end of a normal Start() — we're replicating that step.
+	go oldExec.waitForExit()
+
+	log.G(ctx).
+		WithField("tid", ht.id).
+		WithField("new.pid", newPid).
+		Info("reboot-v2 B3b: task state swapped; container logically still Running")
+	return nil
+}
+
+// probeSameIDRecreate is retained as reference / fallback but unused in B3b.
+// Kept for git-history clarity during Stage 4 iteration.
 func (ht *hcsTask) probeSameIDRecreate(ctx context.Context) {
 	oldSys, ok := ht.c.(*hcs.System)
 	if !ok {

--- a/cmd/containerd-shim-runhcs-v1/task_hcs.go
+++ b/cmd/containerd-shim-runhcs-v1/task_hcs.go
@@ -729,6 +729,54 @@ func (ht *hcsTask) probeSameIDRecreate(ctx context.Context) {
 		log.G(ctx).
 			WithField("tid", ht.id).
 			Info("reboot-v2 B2: Start SUCCEEDED — full create+start cycle works on same ID")
+
+		// Sub-step B3a: prove a fresh init process can be spawned in the
+		// recreated silo via cmd.Cmd, mirroring hcsExec.startInternal path.
+		// Using a benign spec (`cmd /c hostname`) instead of ht.taskSpec.Process
+		// — the task spec runs `shutdown /r` which would cascade into another
+		// reboot chain if re-executed on the new silo, and B3a is about
+		// proving mechanics, not semantic correctness. Real B3b will use the
+		// unmodified task spec once the cascade is prevented by the full
+		// state-machine swap.
+		probeSpec := &specs.Process{
+			Terminal: false,
+			Args:     []string{"cmd.exe", "/c", "hostname"},
+			Cwd:      `C:\`,
+		}
+		probeCmd := &cmd.Cmd{
+			Host:                 newSys,
+			Spec:                 probeSpec,
+			Log:                  log.G(ctx).WithField("reboot-v2", "b3a-init-spawn"),
+			CopyAfterExitTimeout: time.Second,
+		}
+		if err := probeCmd.Start(); err != nil {
+			log.G(ctx).WithError(err).
+				WithField("tid", ht.id).
+				Warn("reboot-v2 B3a: probe init-process Start FAILED")
+		} else {
+			pid := probeCmd.Process.Pid()
+			log.G(ctx).
+				WithField("tid", ht.id).
+				WithField("probe.pid", pid).
+				Info("reboot-v2 B3a: probe init-process spawned; waiting for exit")
+			waitCh := make(chan error, 1)
+			go func() { waitCh <- probeCmd.Wait() }()
+			select {
+			case werr := <-waitCh:
+				log.G(ctx).
+					WithField("tid", ht.id).
+					WithField("probe.pid", pid).
+					WithField("probe.exit_code", probeCmd.ExitState.ExitCode()).
+					WithError(werr).
+					Info("reboot-v2 B3a: probe init-process exited — full recreate+spawn cycle verified")
+			case <-time.After(10 * time.Second):
+				log.G(ctx).
+					WithField("tid", ht.id).
+					WithField("probe.pid", pid).
+					Warn("reboot-v2 B3a: probe init-process did not exit within 10s; proceeding to cleanup")
+				_, _ = probeCmd.Process.Kill(ctx)
+			}
+		}
 	}
 
 	// Cleanup: terminate + wait + close so the existing teardown path is not

--- a/cmd/containerd-shim-runhcs-v1/task_hcs.go
+++ b/cmd/containerd-shim-runhcs-v1/task_hcs.go
@@ -28,6 +28,7 @@ import (
 	"github.com/Microsoft/hcsshim/cmd/containerd-shim-runhcs-v1/stats"
 	"github.com/Microsoft/hcsshim/internal/cmd"
 	"github.com/Microsoft/hcsshim/internal/cow"
+	"github.com/Microsoft/hcsshim/internal/devguard"
 	"github.com/Microsoft/hcsshim/internal/guestpath"
 	"github.com/Microsoft/hcsshim/internal/hcs"
 	"github.com/Microsoft/hcsshim/internal/hcs/resourcepaths"
@@ -621,12 +622,49 @@ func (ht *hcsTask) waitInitExit() {
 	span.AddAttributes(
 		trace.StringAttribute("tid", ht.id),
 		trace.BoolAttribute("host", ht.host != nil),
-		trace.BoolAttribute("ownsHost", ht.ownsHost),
-		// container-reboot-v2 Stage 1 placeholder; Stage 4 flips this when dispatching to handleReboot.
-		trace.BoolAttribute("reboot.pending", false))
+		trace.BoolAttribute("ownsHost", ht.ownsHost))
 
 	// Wait for it to exit on its own
 	ht.init.Wait()
+
+	// container-reboot-v2 Stage 4 Sub-step A: detect Reboot at the single
+	// task-scoped intercept point, independent of the processDone/WaitChannel
+	// race in hcsExec::waitForContainerExit. Gated by EnableShimRebootHandler
+	// so Stage 2/3 traces still pass even with the shim deployed; when the
+	// guard is OFF we just fall through to close() / teardown unchanged.
+	//
+	// Timing subtlety: ht.init.Wait() returns when the init PROCESS exits,
+	// but *hcs.System.waitBackground (which parses SystemExitStatus JSON into
+	// ExitType) runs on the system-level exit notification, a separate HCS
+	// callback. The two goroutines can complete in either order. Per
+	// cow.Container.ExitType() contract, the value is only defined AFTER
+	// WaitChannel() closes — so we must block on it before reading ExitType
+	// or risk a false negative. Empirical proof: Stage 4 initial run on
+	// 2026-04-23 read ExitType right after init.Wait() and got empty string
+	// 100% of the time, despite waitBackground setting "Reboot" ~22ms later.
+	//
+	// Stage 4 Sub-step B will replace this log with actual handleReboot logic
+	// (suppress close/teardown, drive a new CreateComputeSystem). Sub-step A
+	// is observation-only so we have a stable hook to extend.
+	rebootPending := false
+	if ht.c != nil && devguard.IsEnabled(devguard.EnableShimRebootHandler) {
+		select {
+		case <-ht.c.WaitChannel():
+			// waitBackground has finished; ExitType is now reliable.
+		case <-time.After(5 * time.Second):
+			log.G(ctx).
+				WithField("tid", ht.id).
+				Warn("reboot-v2 Stage 4: timed out waiting for compute system WaitChannel; ExitType may be empty")
+		}
+		if exitType := ht.c.ExitType(); exitType == "Reboot" {
+			rebootPending = true
+			log.G(ctx).
+				WithField("tid", ht.id).
+				WithField("reboot.exit_type", exitType).
+				Info("reboot-v2 Stage 4: would handle reboot here (no action; falling through to teardown)")
+		}
+	}
+	span.AddAttributes(trace.BoolAttribute("reboot.pending", rebootPending))
 
 	// Close the host and event the exit
 	ht.close(ctx)

--- a/cmd/containerd-shim-runhcs-v1/task_hcs.go
+++ b/cmd/containerd-shim-runhcs-v1/task_hcs.go
@@ -661,13 +661,87 @@ func (ht *hcsTask) waitInitExit() {
 			log.G(ctx).
 				WithField("tid", ht.id).
 				WithField("reboot.exit_type", exitType).
-				Info("reboot-v2 Stage 4: would handle reboot here (no action; falling through to teardown)")
+				Info("reboot-v2 Stage 4: reboot observed; running B2 same-ID recreate probe")
+			ht.probeSameIDRecreate(ctx)
 		}
 	}
 	span.AddAttributes(trace.BoolAttribute("reboot.pending", rebootPending))
 
 	// Close the host and event the exit
 	ht.close(ctx)
+}
+
+// probeSameIDRecreate is a Stage 4 Sub-step B2 experiment — it does NOT yet
+// drive an actual restart. We want to answer a single question before writing
+// real handleReboot logic: does HCS accept CreateComputeSystem + Start with
+// the same container ID while the overlay layer is still mounted?
+//
+// Plan:
+//  1. Close the old *hcs.System handle so HCS sees no duplicate outstanding
+//     handle for this ID (the silo itself is already gone).
+//  2. Retrieve the cached hcsDocument (Sub-step B1).
+//  3. Call hcs.CreateComputeSystem with that doc on the same ID.
+//  4. Call Start on the new system.
+//  5. Log each outcome; on any failure, log the error explicitly so we can
+//     tell whether it's same-ID rejection, layer-not-found, namespace
+//     conflict, or something else.
+//  6. Terminate + Wait + Close the new system so the caller's ht.close(ctx)
+//     teardown proceeds normally on an empty slot.
+//
+// This runs BEFORE ht.close(ctx), so the overlay layer is still mounted via
+// the original resources.Resources. If B2 succeeds we know Sub-step B3 can
+// wire the new system into ht.c instead of throwing it away.
+func (ht *hcsTask) probeSameIDRecreate(ctx context.Context) {
+	oldSys, ok := ht.c.(*hcs.System)
+	if !ok {
+		log.G(ctx).Warn("reboot-v2 B2: ht.c is not *hcs.System; cannot recreate")
+		return
+	}
+	doc := oldSys.CreateDocument()
+	if len(doc) == 0 {
+		log.G(ctx).Warn("reboot-v2 B2: no cached create document; System was not created via CreateComputeSystem")
+		return
+	}
+	log.G(ctx).
+		WithField("tid", ht.id).
+		WithField("doc_bytes", len(doc)).
+		Info("reboot-v2 B2: closing old system handle before recreate probe")
+	if err := oldSys.Close(); err != nil {
+		log.G(ctx).WithError(err).Warn("reboot-v2 B2: old system Close failed (proceeding anyway)")
+	}
+
+	newSys, err := hcs.CreateComputeSystem(ctx, ht.id, doc)
+	if err != nil {
+		log.G(ctx).WithError(err).
+			WithField("tid", ht.id).
+			Warn("reboot-v2 B2: CreateComputeSystem FAILED — HCS rejected same-ID recreate")
+		return
+	}
+	log.G(ctx).
+		WithField("tid", ht.id).
+		Info("reboot-v2 B2: CreateComputeSystem SUCCEEDED on same ID; calling Start")
+
+	if err := newSys.Start(ctx); err != nil {
+		log.G(ctx).WithError(err).
+			WithField("tid", ht.id).
+			Warn("reboot-v2 B2: Start failed on recreated system")
+	} else {
+		log.G(ctx).
+			WithField("tid", ht.id).
+			Info("reboot-v2 B2: Start SUCCEEDED — full create+start cycle works on same ID")
+	}
+
+	// Cleanup: terminate + wait + close so the existing teardown path is not
+	// confused by our extra system hanging around.
+	if err := newSys.Terminate(ctx); err != nil {
+		log.G(ctx).WithError(err).Debug("reboot-v2 B2: cleanup Terminate returned error")
+	}
+	if err := newSys.Wait(); err != nil {
+		log.G(ctx).WithError(err).Debug("reboot-v2 B2: cleanup Wait returned error")
+	}
+	if err := newSys.Close(); err != nil {
+		log.G(ctx).WithError(err).Debug("reboot-v2 B2: cleanup Close returned error")
+	}
 }
 
 // waitForHostExit waits for the host virtual machine to exit. Once exited

--- a/cmd/containerd-shim-runhcs-v1/task_hcs.go
+++ b/cmd/containerd-shim-runhcs-v1/task_hcs.go
@@ -239,6 +239,10 @@ func newHcsTask(
 		closed:         make(chan struct{}),
 		taskSpec:       s,
 		ioRetryTimeout: ioRetryTimeout,
+		reqStdin:       req.Stdin,
+		reqStdout:      req.Stdout,
+		reqStderr:      req.Stderr,
+		reqTerminal:    req.Terminal,
 	}
 	ht.init = newHcsExec(
 		ctx,
@@ -345,6 +349,16 @@ type hcsTask struct {
 
 	// ioRetryTimeout is the time for how long to try reconnecting to stdio pipes from containerd.
 	ioRetryTimeout time.Duration
+
+	// container-reboot-v2 Stage 4 B3c: stash the original CreateTask stdio
+	// paths so doHandleReboot can call NewUpstreamIO to obtain fresh pipe
+	// connections for the new init process. oldExec.io's underlying pipes
+	// are closed by the original init exit path before we get to restart,
+	// so reusing them makes the new init blind and deadlocks follow-up ops.
+	reqStdin    string
+	reqStdout   string
+	reqStderr   string
+	reqTerminal bool
 }
 
 func (ht *hcsTask) ID() string {
@@ -754,20 +768,40 @@ func (ht *hcsTask) doHandleReboot(ctx context.Context) error {
 	}
 	log.G(ctx).WithField("tid", ht.id).Info("reboot-v2 B3b: new System started")
 
-	// Spawn the real init process. Reuse the existing upstream IO (pipes are
-	// containerd-owned and still open).
+	// B3c: try to open fresh upstream IO pipes for the new init. The old
+	// exec's UpstreamIO was closed by the original init exit path, which
+	// causes containerd to tear down its server-side pipes too — so
+	// NewUpstreamIO typically fails with "system cannot find the file
+	// specified". In that case, fall back to nil stdio and run the new
+	// init headless. The process still runs and docker sees the container
+	// as Up; just no stdout/stderr visibility until a proper reattach
+	// mechanism lands (future work — likely needs a containerd API change
+	// or a shim-side pipe-republish protocol).
 	newCmd := &cmd.Cmd{
 		Host:                 newSys,
-		Stdin:                oldExec.io.Stdin(),
-		Stdout:               oldExec.io.Stdout(),
-		Stderr:               oldExec.io.Stderr(),
 		Log:                  log.G(ctx).WithFields(logrus.Fields{"tid": ht.id, "eid": ht.id, "reboot-v2": "b3b-init"}),
 		CopyAfterExitTimeout: time.Second,
+	}
+	var freshIO cmd.UpstreamIO
+	if fio, ioErr := cmd.NewUpstreamIO(ctx, ht.id, ht.reqStdout, ht.reqStderr, ht.reqStdin, ht.reqTerminal, ht.ioRetryTimeout); ioErr == nil {
+		freshIO = fio
+		newCmd.Stdin = fio.Stdin()
+		newCmd.Stdout = fio.Stdout()
+		newCmd.Stderr = fio.Stderr()
+		log.G(ctx).WithField("tid", ht.id).Info("reboot-v2 B3c: fresh upstream IO opened for new init")
+	} else {
+		log.G(ctx).
+			WithField("tid", ht.id).
+			WithError(ioErr).
+			Warn("reboot-v2 B3c: could not open fresh IO pipes; new init will run headless")
 	}
 	if oldExec.isWCOW {
 		newCmd.Spec = ht.taskSpec.Process
 	}
 	if err := newCmd.Start(); err != nil {
+		if freshIO != nil {
+			freshIO.Close(ctx)
+		}
 		_ = newSys.Terminate(ctx)
 		_ = newSys.Wait()
 		_ = newSys.Close()
@@ -779,10 +813,14 @@ func (ht *hcsTask) doHandleReboot(ctx context.Context) error {
 		WithField("new.pid", newPid).
 		Info("reboot-v2 B3b: new init process spawned")
 
-	// Swap state into the existing hcsExec under its lock.
+	// Swap state into the existing hcsExec under its lock, including the
+	// fresh upstream IO if we got one (nil = headless).
 	oldExec.sl.Lock()
 	oldExec.c = newSys
 	oldExec.p = newCmd
+	if freshIO != nil {
+		oldExec.io = freshIO
+	}
 	oldExec.pid = newPid
 	oldExec.state = shimExecStateRunning
 	oldExec.exitStatus = 255
@@ -801,10 +839,16 @@ func (ht *hcsTask) doHandleReboot(ctx context.Context) error {
 	// at the end of a normal Start() — we're replicating that step.
 	go oldExec.waitForExit()
 
+	// B3c reboot loop: respawn waitInitExit so a SECOND in-container
+	// reboot is also handled transparently. Each successful handleReboot
+	// spawns a fresh waiter for the next cycle. Normal (non-reboot) exits
+	// flow through close(ctx) as before.
+	go ht.waitInitExit()
+
 	log.G(ctx).
 		WithField("tid", ht.id).
 		WithField("new.pid", newPid).
-		Info("reboot-v2 B3b: task state swapped; container logically still Running")
+		Info("reboot-v2 B3c: task state swapped; container logically still Running; waiting for next exit")
 	return nil
 }
 

--- a/cmd/containerd-shim-runhcs-v1/task_hcs.go
+++ b/cmd/containerd-shim-runhcs-v1/task_hcs.go
@@ -675,20 +675,22 @@ func (ht *hcsTask) waitInitExit() {
 			log.G(ctx).
 				WithField("tid", ht.id).
 				WithField("reboot.exit_type", exitType).
-				Info("reboot-v2 Stage 4: reboot observed; attempting transparent restart (B3b)")
+				Info("reboot-v2: reboot observed; attempting transparent restart")
 			if err := ht.doHandleReboot(ctx); err != nil {
 				log.G(ctx).WithError(err).
 					WithField("tid", ht.id).
-					Warn("reboot-v2 B3b: handleReboot failed; falling through to teardown")
+					Warn("reboot-v2: handleReboot failed; falling through to teardown")
 				rebootPending = false // restart failed; normal exit semantics apply
 			} else {
 				span.AddAttributes(trace.BoolAttribute("reboot.pending", true))
 				log.G(ctx).
 					WithField("tid", ht.id).
-					Info("reboot-v2 B3b: transparent restart completed; suppressing teardown")
+					Info("reboot-v2: transparent restart completed; suppressing teardown")
 				// IMPORTANT: return WITHOUT calling ht.close(ctx). The task
 				// continues to live under the new System; closeHost() is not
-				// invoked so no /tasks/exit event is published.
+				// invoked so no /tasks/exit event is published. doHandleReboot
+				// respawned a fresh waitInitExit goroutine before returning,
+				// so the next in-container reboot is also handled.
 				return
 			}
 		}
@@ -699,39 +701,41 @@ func (ht *hcsTask) waitInitExit() {
 	ht.close(ctx)
 }
 
-// doHandleReboot performs the Stage 4 Sub-step B3b transparent restart.
-// The container has exited with ExitType=Reboot (HCS told us via the V1
-// SystemExitStatus JSON). Old silo is gone but its compute-system ID slot
-// is free. Overlay layer and HNS endpoint both persist. We:
+// doHandleReboot performs the transparent in-place container restart.
+// Called from waitInitExit when the container exits with ExitType=Reboot
+// (HCS told us via the V1 SystemExitStatus JSON). Old silo is gone but
+// its compute-system ID slot is free. Overlay layer and HNS endpoint
+// both persist. Steps:
 //
 //  1. Close the old *hcs.System handle (silo already destructed kernel-side).
-//  2. Call hcs.CreateComputeSystem with the cached create document (B1) on
-//     the same ID. The overlay path and namespace GUID in the doc bind to
-//     the persisted state.
+//  2. Call hcs.CreateComputeSystem with the cached create document on the
+//     same ID. Overlay path and namespace GUID in the doc bind to
+//     persisted kernel-side state automatically.
 //  3. Call newSys.Start().
-//  4. Spawn the original init process via cmd.Cmd with ht.taskSpec.Process,
-//     reusing the hcsExec's upstream stdio pipes.
-//  5. Reset ht.init's hcsExec state in-place under its sl lock:
-//       - Point c + p at the new System + cmd
+//  4. Open fresh upstream IO pipes via NewUpstreamIO with the cached
+//     containerd pipe paths. Fall back to headless (nil stdio) if the
+//     pipes are gone — containerd typically tears them down when the
+//     shim's client disconnects during the original exit path, and a
+//     proper reattach protocol needs a containerd-side change.
+//  5. Spawn the original init process via cmd.Cmd with ht.taskSpec.Process
+//     and the (fresh or nil) stdio.
+//  6. Reset ht.init's hcsExec state in-place under its sl lock:
+//       - Point c + p + io at the new System, cmd, and fresh IO
 //       - Reset state=Running, pid=newPid, exitStatus=255, exitedAt=zero
-//       - Allocate fresh processDone / exited channels (old ones already
-//         closed by the exec's exit path; existing waiters already returned)
-//  6. Point ht.c at newSys so task-level operations target it.
-//  7. Respawn waitForExit so the new init process's lifecycle is tracked
-//     (including publishing a TaskExit event when the new init exits —
-//     same as a normal container exit).
+//       - Allocate fresh processDone / exited channels + sync.Once values
+//  7. Point ht.c at newSys so task-level operations target it.
+//  8. Respawn waitForExit so the new init process's lifecycle is tracked.
+//  9. Respawn waitInitExit so a subsequent in-container reboot is also
+//     handled transparently (reboot loop).
 //
-// Known limitations of this first iteration (to address in B3c / Stage 5):
-//   - We do NOT re-spawn waitForContainerExit, so if the new silo reboots
-//     AGAIN, we fall through to the normal exit path rather than handling
-//     it recursively. Fine for single-reboot tests; needs looping for the
-//     ship version.
-//   - The /tasks/start event is NOT republished on restart, so external
-//     listeners don't know the PID changed. This is intentional (the task
-//     is logically "still running") but may need an annotation event.
-//   - If Start or the init spawn fails mid-way, the new System is leaked.
-//     Caller treats an error return as "fall through to teardown" which
-//     partially covers cleanup via ht.close(ctx).
+// Known gaps (non-blocking for end-to-end demo):
+//   - Stdio is not visible to containerd after the first restart; requires
+//     a containerd-side pipe-republish protocol or TaskRestart event type.
+//   - docker inspect reports the original PID because containerd caches
+//     it from the TaskCreate event; needs /tasks/start republish or new
+//     event topic.
+//   - If CreateComputeSystem or Start fails mid-way, resources are partially
+//     cleaned up; caller treats error as "fall through to teardown".
 func (ht *hcsTask) doHandleReboot(ctx context.Context) error {
 	oldSys, ok := ht.c.(*hcs.System)
 	if !ok {
@@ -749,16 +753,16 @@ func (ht *hcsTask) doHandleReboot(ctx context.Context) error {
 	log.G(ctx).
 		WithField("tid", ht.id).
 		WithField("doc_bytes", len(doc)).
-		Info("reboot-v2 B3b: closing old system handle")
+		Info("reboot-v2: closing old system handle")
 	if err := oldSys.Close(); err != nil {
-		log.G(ctx).WithError(err).Warn("reboot-v2 B3b: old system Close failed (proceeding anyway)")
+		log.G(ctx).WithError(err).Warn("reboot-v2: old system Close failed (proceeding anyway)")
 	}
 
 	newSys, err := hcs.CreateComputeSystem(ctx, ht.id, doc)
 	if err != nil {
 		return fmt.Errorf("CreateComputeSystem on same ID failed: %w", err)
 	}
-	log.G(ctx).WithField("tid", ht.id).Info("reboot-v2 B3b: new System created on same ID")
+	log.G(ctx).WithField("tid", ht.id).Info("reboot-v2: new System created on same ID")
 
 	if err := newSys.Start(ctx); err != nil {
 		_ = newSys.Terminate(ctx)
@@ -766,7 +770,7 @@ func (ht *hcsTask) doHandleReboot(ctx context.Context) error {
 		_ = newSys.Close()
 		return fmt.Errorf("newSys.Start failed: %w", err)
 	}
-	log.G(ctx).WithField("tid", ht.id).Info("reboot-v2 B3b: new System started")
+	log.G(ctx).WithField("tid", ht.id).Info("reboot-v2: new System started")
 
 	// B3c: try to open fresh upstream IO pipes for the new init. The old
 	// exec's UpstreamIO was closed by the original init exit path, which
@@ -788,12 +792,12 @@ func (ht *hcsTask) doHandleReboot(ctx context.Context) error {
 		newCmd.Stdin = fio.Stdin()
 		newCmd.Stdout = fio.Stdout()
 		newCmd.Stderr = fio.Stderr()
-		log.G(ctx).WithField("tid", ht.id).Info("reboot-v2 B3c: fresh upstream IO opened for new init")
+		log.G(ctx).WithField("tid", ht.id).Info("reboot-v2: fresh upstream IO opened for new init")
 	} else {
 		log.G(ctx).
 			WithField("tid", ht.id).
 			WithError(ioErr).
-			Warn("reboot-v2 B3c: could not open fresh IO pipes; new init will run headless")
+			Warn("reboot-v2: could not open fresh IO pipes; new init will run headless")
 	}
 	if oldExec.isWCOW {
 		newCmd.Spec = ht.taskSpec.Process
@@ -811,7 +815,7 @@ func (ht *hcsTask) doHandleReboot(ctx context.Context) error {
 	log.G(ctx).
 		WithField("tid", ht.id).
 		WithField("new.pid", newPid).
-		Info("reboot-v2 B3b: new init process spawned")
+		Info("reboot-v2: new init process spawned")
 
 	// Swap state into the existing hcsExec under its lock, including the
 	// fresh upstream IO if we got one (nil = headless).
@@ -848,111 +852,8 @@ func (ht *hcsTask) doHandleReboot(ctx context.Context) error {
 	log.G(ctx).
 		WithField("tid", ht.id).
 		WithField("new.pid", newPid).
-		Info("reboot-v2 B3c: task state swapped; container logically still Running; waiting for next exit")
+		Info("reboot-v2: task state swapped; container logically still Running; waiting for next exit")
 	return nil
-}
-
-// probeSameIDRecreate is retained as reference / fallback but unused in B3b.
-// Kept for git-history clarity during Stage 4 iteration.
-func (ht *hcsTask) probeSameIDRecreate(ctx context.Context) {
-	oldSys, ok := ht.c.(*hcs.System)
-	if !ok {
-		log.G(ctx).Warn("reboot-v2 B2: ht.c is not *hcs.System; cannot recreate")
-		return
-	}
-	doc := oldSys.CreateDocument()
-	if len(doc) == 0 {
-		log.G(ctx).Warn("reboot-v2 B2: no cached create document; System was not created via CreateComputeSystem")
-		return
-	}
-	log.G(ctx).
-		WithField("tid", ht.id).
-		WithField("doc_bytes", len(doc)).
-		Info("reboot-v2 B2: closing old system handle before recreate probe")
-	if err := oldSys.Close(); err != nil {
-		log.G(ctx).WithError(err).Warn("reboot-v2 B2: old system Close failed (proceeding anyway)")
-	}
-
-	newSys, err := hcs.CreateComputeSystem(ctx, ht.id, doc)
-	if err != nil {
-		log.G(ctx).WithError(err).
-			WithField("tid", ht.id).
-			Warn("reboot-v2 B2: CreateComputeSystem FAILED — HCS rejected same-ID recreate")
-		return
-	}
-	log.G(ctx).
-		WithField("tid", ht.id).
-		Info("reboot-v2 B2: CreateComputeSystem SUCCEEDED on same ID; calling Start")
-
-	if err := newSys.Start(ctx); err != nil {
-		log.G(ctx).WithError(err).
-			WithField("tid", ht.id).
-			Warn("reboot-v2 B2: Start failed on recreated system")
-	} else {
-		log.G(ctx).
-			WithField("tid", ht.id).
-			Info("reboot-v2 B2: Start SUCCEEDED — full create+start cycle works on same ID")
-
-		// Sub-step B3a: prove a fresh init process can be spawned in the
-		// recreated silo via cmd.Cmd, mirroring hcsExec.startInternal path.
-		// Using a benign spec (`cmd /c hostname`) instead of ht.taskSpec.Process
-		// — the task spec runs `shutdown /r` which would cascade into another
-		// reboot chain if re-executed on the new silo, and B3a is about
-		// proving mechanics, not semantic correctness. Real B3b will use the
-		// unmodified task spec once the cascade is prevented by the full
-		// state-machine swap.
-		probeSpec := &specs.Process{
-			Terminal: false,
-			Args:     []string{"cmd.exe", "/c", "hostname"},
-			Cwd:      `C:\`,
-		}
-		probeCmd := &cmd.Cmd{
-			Host:                 newSys,
-			Spec:                 probeSpec,
-			Log:                  log.G(ctx).WithField("reboot-v2", "b3a-init-spawn"),
-			CopyAfterExitTimeout: time.Second,
-		}
-		if err := probeCmd.Start(); err != nil {
-			log.G(ctx).WithError(err).
-				WithField("tid", ht.id).
-				Warn("reboot-v2 B3a: probe init-process Start FAILED")
-		} else {
-			pid := probeCmd.Process.Pid()
-			log.G(ctx).
-				WithField("tid", ht.id).
-				WithField("probe.pid", pid).
-				Info("reboot-v2 B3a: probe init-process spawned; waiting for exit")
-			waitCh := make(chan error, 1)
-			go func() { waitCh <- probeCmd.Wait() }()
-			select {
-			case werr := <-waitCh:
-				log.G(ctx).
-					WithField("tid", ht.id).
-					WithField("probe.pid", pid).
-					WithField("probe.exit_code", probeCmd.ExitState.ExitCode()).
-					WithError(werr).
-					Info("reboot-v2 B3a: probe init-process exited — full recreate+spawn cycle verified")
-			case <-time.After(10 * time.Second):
-				log.G(ctx).
-					WithField("tid", ht.id).
-					WithField("probe.pid", pid).
-					Warn("reboot-v2 B3a: probe init-process did not exit within 10s; proceeding to cleanup")
-				_, _ = probeCmd.Process.Kill(ctx)
-			}
-		}
-	}
-
-	// Cleanup: terminate + wait + close so the existing teardown path is not
-	// confused by our extra system hanging around.
-	if err := newSys.Terminate(ctx); err != nil {
-		log.G(ctx).WithError(err).Debug("reboot-v2 B2: cleanup Terminate returned error")
-	}
-	if err := newSys.Wait(); err != nil {
-		log.G(ctx).WithError(err).Debug("reboot-v2 B2: cleanup Wait returned error")
-	}
-	if err := newSys.Close(); err != nil {
-		log.G(ctx).WithError(err).Debug("reboot-v2 B2: cleanup Close returned error")
-	}
 }
 
 // waitForHostExit waits for the host virtual machine to exit. Once exited

--- a/cmd/containerd-shim-runhcs-v1/task_hcs.go
+++ b/cmd/containerd-shim-runhcs-v1/task_hcs.go
@@ -621,7 +621,9 @@ func (ht *hcsTask) waitInitExit() {
 	span.AddAttributes(
 		trace.StringAttribute("tid", ht.id),
 		trace.BoolAttribute("host", ht.host != nil),
-		trace.BoolAttribute("ownsHost", ht.ownsHost))
+		trace.BoolAttribute("ownsHost", ht.ownsHost),
+		// container-reboot-v2 Stage 1 placeholder; Stage 4 flips this when dispatching to handleReboot.
+		trace.BoolAttribute("reboot.pending", false))
 
 	// Wait for it to exit on its own
 	ht.init.Wait()

--- a/internal/cow/cow.go
+++ b/internal/cow/cow.go
@@ -96,4 +96,13 @@ type Container interface {
 	WaitError() error
 	// Modify sends a request to modify container resources
 	Modify(ctx context.Context, config interface{}) error
+	// ExitType returns the parsed SystemExitStatus.ExitType string reported by HCS
+	// at compute-system exit — "Reboot", "GracefulExit", "UnexpectedExit", etc.
+	// Empty string before the container has exited (before WaitChannel() closes) or
+	// when HCS did not send a parseable SystemExitStatus JSON payload.
+	//
+	// Container implementations that don't observe HCS exit notifications (fakes,
+	// UVM wrappers, test containers) return "". Callers should treat empty string
+	// as "unknown/not a reboot" and fall back to the previous exit-handling logic.
+	ExitType() string
 }

--- a/internal/devguard/devguard.go
+++ b/internal/devguard/devguard.go
@@ -1,0 +1,39 @@
+//go:build windows
+
+// Package devguard reads HKLM\Software\Microsoft\HCS\Dev\Reboot\<Name> DWORDs
+// at runtime for the container-reboot-v2 workstream dev matrix.
+//
+// Behavior: every call opens the registry key, reads the value, closes.
+// No caching. On any error, returns false (absent == disabled).
+package devguard
+
+import (
+	"golang.org/x/sys/windows/registry"
+)
+
+const guardRoot = `Software\Microsoft\HCS\Dev\Reboot`
+
+// Guard names mirror the HcsDev::Reboot::* accessors on the HCS C++ side.
+const (
+	ForceStopForRestart      = "ForceStopForRestart"
+	ExposeRebootNotification = "ExposeRebootNotification"
+	PassExitStatusJson       = "PassExitStatusJson"
+	SkipInternalRebootStart  = "SkipInternalRebootStart"
+	EnableShimRebootHandler  = "EnableShimRebootHandler"
+)
+
+// IsEnabled returns true iff HKLM\guardRoot\<name> exists as a non-zero DWORD.
+// Missing key, missing value, wrong type, or access-denied all return false.
+func IsEnabled(name string) bool {
+	k, err := registry.OpenKey(registry.LOCAL_MACHINE, guardRoot, registry.QUERY_VALUE)
+	if err != nil {
+		return false
+	}
+	defer k.Close()
+
+	v, _, err := k.GetIntegerValue(name)
+	if err != nil {
+		return false
+	}
+	return v != 0
+}

--- a/internal/devguard/devguard_test.go
+++ b/internal/devguard/devguard_test.go
@@ -1,0 +1,56 @@
+//go:build windows
+
+package devguard
+
+import (
+	"testing"
+
+	"golang.org/x/sys/windows/registry"
+)
+
+func setGuard(t *testing.T, name string, value uint32) {
+	t.Helper()
+	k, _, err := registry.CreateKey(registry.LOCAL_MACHINE,
+		`Software\Microsoft\HCS\Dev\Reboot`, registry.WRITE)
+	if err != nil {
+		t.Fatalf("CreateKey: %v", err)
+	}
+	defer k.Close()
+	if err := k.SetDWordValue(name, value); err != nil {
+		t.Fatalf("SetDWordValue: %v", err)
+	}
+}
+
+func clearGuard(t *testing.T, name string) {
+	t.Helper()
+	k, err := registry.OpenKey(registry.LOCAL_MACHINE,
+		`Software\Microsoft\HCS\Dev\Reboot`, registry.WRITE)
+	if err != nil {
+		return
+	}
+	defer k.Close()
+	_ = k.DeleteValue(name)
+}
+
+func TestIsEnabled_MissingKey_ReturnsFalse(t *testing.T) {
+	clearGuard(t, "TestGuardA")
+	if IsEnabled("TestGuardA") {
+		t.Fatal("expected false for missing key")
+	}
+}
+
+func TestIsEnabled_ZeroValue_ReturnsFalse(t *testing.T) {
+	setGuard(t, "TestGuardB", 0)
+	defer clearGuard(t, "TestGuardB")
+	if IsEnabled("TestGuardB") {
+		t.Fatal("expected false for value=0")
+	}
+}
+
+func TestIsEnabled_NonZeroValue_ReturnsTrue(t *testing.T) {
+	setGuard(t, "TestGuardC", 1)
+	defer clearGuard(t, "TestGuardC")
+	if !IsEnabled("TestGuardC") {
+		t.Fatal("expected true for value=1")
+	}
+}

--- a/internal/gcs/container.go
+++ b/internal/gcs/container.go
@@ -241,6 +241,15 @@ func (c *Container) WaitError() error {
 	return c.waitError
 }
 
+// ExitType returns "" — the guest connection path doesn't observe HCS
+// SystemExitStatus notifications (it talks to the LCOW guest directly), so the
+// cow.Container.ExitType contract of "empty string means unknown/fallback" is
+// the correct behavior here. container-reboot-v2 is Argon-only (process-isolated
+// Windows Server containers) which go through *hcs.System, not *gcs.Container.
+func (c *Container) ExitType() string {
+	return ""
+}
+
 // Wait waits for the container to terminate (or Close to be called, or the
 // guest connection to terminate).
 func (c *Container) Wait() error {

--- a/internal/hcs/callback.go
+++ b/internal/hcs/callback.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"sync"
 	"syscall"
+	"unicode/utf16"
+	"unsafe"
 
 	"github.com/Microsoft/hcsshim/internal/interop"
 	"github.com/Microsoft/hcsshim/internal/logfields"
@@ -87,7 +89,18 @@ func (hn hcsNotification) String() string {
 	}
 }
 
-type notificationChannel chan error
+// notificationPayload carries both the error code and the raw EventData
+// string that accompanied the HCS notification. Prior to container-reboot-v2
+// the channel was just `chan error`, which silently discarded the
+// notificationData pointer — so hcsshim couldn't observe the
+// SystemExitStatus JSON (and therefore couldn't see ExitType=Reboot).
+// Callers that only care about err can ignore data.
+type notificationPayload struct {
+	err  error
+	data string
+}
+
+type notificationChannel chan notificationPayload
 
 type notificationWatcherContext struct {
 	channels notificationChannels
@@ -133,9 +146,12 @@ func closeChannels(channels notificationChannels) {
 }
 
 func notificationWatcher(notificationType hcsNotification, callbackNumber uintptr, notificationStatus uintptr, notificationData *uint16) uintptr {
-	var result error
+	var payload notificationPayload
 	if int32(notificationStatus) < 0 {
-		result = interop.Win32FromHresult(notificationStatus)
+		payload.err = interop.Win32FromHresult(notificationStatus)
+	}
+	if notificationData != nil {
+		payload.data = utf16PtrToString(notificationData)
 	}
 
 	callbackMapLock.RLock()
@@ -156,8 +172,27 @@ func notificationWatcher(notificationType hcsNotification, callbackNumber uintpt
 	log.Debug("HCS notification")
 
 	if channel, ok := context.channels[notificationType]; ok {
-		channel <- result
+		channel <- payload
 	}
 
 	return 0
+}
+
+// utf16PtrToString materializes a null-terminated UTF-16 pointer (as the
+// Win32 HCS callback gives us) into a Go string. Returns "" on nil input.
+// Walks the pointer two bytes at a time until it hits NUL; the caller owns
+// neither the pointer nor its backing memory so we must copy immediately.
+func utf16PtrToString(p *uint16) string {
+	if p == nil {
+		return ""
+	}
+	var units []uint16
+	for addr := uintptr(unsafe.Pointer(p)); ; addr += 2 {
+		c := *(*uint16)(unsafe.Pointer(addr))
+		if c == 0 {
+			break
+		}
+		units = append(units, c)
+	}
+	return string(utf16.Decode(units))
 }

--- a/internal/hcs/callback_test.go
+++ b/internal/hcs/callback_test.go
@@ -3,10 +3,63 @@
 package hcs
 
 import (
+	"strings"
 	"syscall"
 	"testing"
 	"unsafe"
 )
+
+func TestParseExitType_Reboot(t *testing.T) {
+	et, err := parseExitType(`{"Status":0,"ExitType":"Reboot"}`)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if et != "Reboot" {
+		t.Fatalf("got %q want Reboot", et)
+	}
+}
+
+func TestParseExitType_GracefulExit(t *testing.T) {
+	et, err := parseExitType(`{"Status":0,"ExitType":"GracefulExit"}`)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if et != "GracefulExit" {
+		t.Fatalf("got %q want GracefulExit", et)
+	}
+}
+
+func TestParseExitType_Empty(t *testing.T) {
+	et, err := parseExitType("")
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if et != "" {
+		t.Fatalf("got %q want empty", et)
+	}
+}
+
+func TestParseExitType_Malformed(t *testing.T) {
+	_, err := parseExitType(`{not json`)
+	if err == nil {
+		t.Fatal("expected error on malformed JSON")
+	}
+	if !strings.Contains(err.Error(), "invalid") && !strings.Contains(err.Error(), "json") {
+		t.Logf("non-canonical error (still OK): %v", err)
+	}
+}
+
+func TestParseExitType_NoExitTypeField(t *testing.T) {
+	// Older HCS builds may send SystemExitStatus without the ExitType field.
+	// The parse shouldn't fail, just return "".
+	et, err := parseExitType(`{"Status":0}`)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if et != "" {
+		t.Fatalf("got %q want empty", et)
+	}
+}
 
 // TestNotificationWatcher_DeliversDataAndError verifies that notificationWatcher
 // routes both the error and the raw notificationData payload to the channel that

--- a/internal/hcs/callback_test.go
+++ b/internal/hcs/callback_test.go
@@ -1,0 +1,90 @@
+//go:build windows
+
+package hcs
+
+import (
+	"syscall"
+	"testing"
+	"unsafe"
+)
+
+// TestNotificationWatcher_DeliversDataAndError verifies that notificationWatcher
+// routes both the error and the raw notificationData payload to the channel that
+// the watcher goroutine reads. This is the plumbing that lets hcsshim observe the
+// SystemExitStatus JSON carried by an HcsEventSystemExited notification — it's
+// how ExitType=Reboot reaches the shim-side reboot handler in container-reboot-v2.
+func TestNotificationWatcher_DeliversDataAndError(t *testing.T) {
+	const callbackNumber uintptr = 0xdeadbeef
+	ctx := &notificationWatcherContext{
+		channels: newSystemChannels(),
+		systemID: "TestNotificationWatcher_DeliversDataAndError",
+	}
+	callbackMapLock.Lock()
+	callbackMap[callbackNumber] = ctx
+	callbackMapLock.Unlock()
+	t.Cleanup(func() {
+		callbackMapLock.Lock()
+		delete(callbackMap, callbackNumber)
+		callbackMapLock.Unlock()
+	})
+
+	wantData := `{"Status":0,"ExitType":"Reboot"}`
+	u16, err := syscall.UTF16FromString(wantData)
+	if err != nil {
+		t.Fatalf("UTF16FromString: %v", err)
+	}
+	ptr := (*uint16)(unsafe.Pointer(&u16[0]))
+
+	notificationWatcher(hcsNotificationSystemExited, callbackNumber, 0, ptr)
+
+	select {
+	case p, ok := <-ctx.channels[hcsNotificationSystemExited]:
+		if !ok {
+			t.Fatal("channel closed before payload delivered")
+		}
+		if p.err != nil {
+			t.Fatalf("unexpected err: %v", p.err)
+		}
+		if p.data != wantData {
+			t.Fatalf("payload data = %q, want %q", p.data, wantData)
+		}
+	default:
+		t.Fatal("no payload delivered on channel")
+	}
+}
+
+// TestNotificationWatcher_NilDataYieldsEmptyString covers the common case of a
+// notification without event data (anything other than HcsEventSystemExited).
+// The watcher must tolerate notificationData==nil and deliver payload.data == "".
+func TestNotificationWatcher_NilDataYieldsEmptyString(t *testing.T) {
+	const callbackNumber uintptr = 0xdeadbef0
+	ctx := &notificationWatcherContext{
+		channels: newSystemChannels(),
+		systemID: "TestNotificationWatcher_NilDataYieldsEmptyString",
+	}
+	callbackMapLock.Lock()
+	callbackMap[callbackNumber] = ctx
+	callbackMapLock.Unlock()
+	t.Cleanup(func() {
+		callbackMapLock.Lock()
+		delete(callbackMap, callbackNumber)
+		callbackMapLock.Unlock()
+	})
+
+	notificationWatcher(hcsNotificationSystemStartCompleted, callbackNumber, 0, nil)
+
+	select {
+	case p, ok := <-ctx.channels[hcsNotificationSystemStartCompleted]:
+		if !ok {
+			t.Fatal("channel closed before payload delivered")
+		}
+		if p.err != nil {
+			t.Fatalf("unexpected err: %v", p.err)
+		}
+		if p.data != "" {
+			t.Fatalf("payload data = %q, want empty", p.data)
+		}
+	default:
+		t.Fatal("no payload delivered on channel")
+	}
+}

--- a/internal/hcs/exitstatus.go
+++ b/internal/hcs/exitstatus.go
@@ -1,0 +1,34 @@
+//go:build windows
+
+package hcs
+
+import (
+	"encoding/json"
+)
+
+// systemExitStatus mirrors the HCS external schema for
+// HcsEventSystemExited's EventData payload. The server (vmcompute.exe) serializes
+// Schema::Responses::System::SystemExitStatus into JSON; the shim parses it back
+// here. We care about Status (HRESULT) and the new ExitType added in schema 2.18
+// (string rendering of the NotificationType enum: "Reboot", "GracefulExit", ...).
+// Other fields on the wire (e.g. Attribution) are ignored intentionally.
+type systemExitStatus struct {
+	Status   int32  `json:"Status"`
+	ExitType string `json:"ExitType,omitempty"`
+}
+
+// parseExitType reads a SystemExitStatus JSON document and returns the ExitType
+// string. Empty input returns ("", nil) so non-exited notifications that carry
+// no payload are benign. Malformed JSON returns ("", err). A well-formed document
+// without the ExitType field returns ("", nil) — that's how older HCS builds
+// serialize the struct.
+func parseExitType(s string) (string, error) {
+	if s == "" {
+		return "", nil
+	}
+	var st systemExitStatus
+	if err := json.Unmarshal([]byte(s), &st); err != nil {
+		return "", err
+	}
+	return st.ExitType, nil
+}

--- a/internal/hcs/system.go
+++ b/internal/hcs/system.go
@@ -38,6 +38,13 @@ type System struct {
 	os, typ, owner string
 	startTime      time.Time
 	stopTime       time.Time
+
+	// container-reboot-v2: parsed SystemExitStatus.ExitType populated by
+	// waitBackground when hcsNotificationSystemExited fires with JSON payload.
+	// Read via ExitType(). Empty until waitBlock is closed; "Reboot" when
+	// the HCS server sent SystemExited with the new 2.18 Reboot enum value.
+	exitTypeMu sync.RWMutex
+	exitType   string
 }
 
 var _ cow.Container = &System{}
@@ -279,14 +286,55 @@ func (computeSystem *System) waitBackground() {
 	operation := "hcs::System::waitBackground"
 	ctx, span := oc.StartSpan(context.Background(), operation)
 	defer span.End()
+	span.AddAttributes(trace.StringAttribute("cid", computeSystem.id))
+
+	// container-reboot-v2 Stage 2: peek the hcsNotificationSystemExited channel
+	// BEFORE calling waitForNotification so we observe the payload.data (the
+	// SystemExitStatus JSON). waitForNotification consumes the same channel but
+	// discards data — it only returns payload.err. Running the recv ourselves
+	// here lets us extract ExitType; then we synthesize the err-only wait by
+	// returning the recv's error directly without going through waitForNotification.
+	//
+	// Safe because System.waitBackground is the sole reader of this channel for
+	// the compute system's lifetime (other waiters go through waitForNotification
+	// for *other* notification types). If that invariant changes, this split
+	// must move into waitForNotification itself.
+	callbackMapLock.RLock()
+	cbCtx, cbOK := callbackMap[computeSystem.callbackNumber]
+	callbackMapLock.RUnlock()
+
+	var err error
+	var exitData string
+	if cbOK {
+		payload, ok := <-cbCtx.channels[hcsNotificationSystemExited]
+		if !ok {
+			err = ErrHandleClose
+		} else {
+			err = payload.err
+			exitData = payload.data
+		}
+	} else {
+		// Fall back to the old path if the callback context disappeared.
+		err = waitForNotification(ctx, computeSystem.callbackNumber, hcsNotificationSystemExited, nil)
+	}
+
+	if exitData != "" {
+		if et, parseErr := parseExitType(exitData); parseErr == nil && et != "" {
+			computeSystem.exitTypeMu.Lock()
+			computeSystem.exitType = et
+			computeSystem.exitTypeMu.Unlock()
+		} else if parseErr != nil {
+			log.G(ctx).WithError(parseErr).WithField("system-id", computeSystem.id).Debug("failed to parse SystemExitStatus JSON")
+		}
+	}
+
+	// container-reboot-v2 Stage 1 checkpoint #7 span attrs, populated with real
+	// values once Stage 2's PassExitStatusJson guard makes the JSON survive to here.
 	span.AddAttributes(
-		trace.StringAttribute("cid", computeSystem.id),
-		// container-reboot-v2 Stage 1 placeholders; Stage 2 populates from SystemExitStatus JSON.
-		trace.StringAttribute("reboot.exit_type", ""),
-		trace.Int64Attribute("reboot.notification_data_bytes", 0),
+		trace.StringAttribute("reboot.exit_type", computeSystem.ExitType()),
+		trace.Int64Attribute("reboot.notification_data_bytes", int64(len(exitData))),
 	)
 
-	err := waitForNotification(ctx, computeSystem.callbackNumber, hcsNotificationSystemExited, nil)
 	if err == nil {
 		log.G(ctx).Debug("system exited")
 	} else if errors.Is(err, ErrVmcomputeUnexpectedExit) {
@@ -306,6 +354,20 @@ func (computeSystem *System) waitBackground() {
 
 func (computeSystem *System) WaitChannel() <-chan struct{} {
 	return computeSystem.waitBlock
+}
+
+// ExitType returns the parsed SystemExitStatus.ExitType string reported by HCS
+// at compute-system exit — "Reboot", "GracefulExit", "UnexpectedExit", etc. Empty
+// string before the system has exited (before WaitChannel() unblocks) or when
+// HCS did not send a parseable SystemExitStatus JSON payload. Populated by
+// waitBackground exactly once per compute-system lifetime.
+//
+// container-reboot-v2 Stage 4 uses this to detect when a container exit was a
+// reboot request and reroute to handleReboot instead of teardown.
+func (computeSystem *System) ExitType() string {
+	computeSystem.exitTypeMu.RLock()
+	defer computeSystem.exitTypeMu.RUnlock()
+	return computeSystem.exitType
 }
 
 func (computeSystem *System) WaitError() error {

--- a/internal/hcs/system.go
+++ b/internal/hcs/system.go
@@ -45,6 +45,15 @@ type System struct {
 	// the HCS server sent SystemExited with the new 2.18 Reboot enum value.
 	exitTypeMu sync.RWMutex
 	exitType   string
+
+	// container-reboot-v2 Stage 4 Sub-step B1: cached copy of the document
+	// this System was created with, so Sub-step B's handleReboot can reissue
+	// an identical CreateComputeSystem on the same ID after the silo
+	// destructs. Stored as raw JSON (not the pre-marshal interface{}) because
+	// the original document is a build-time tree of Go structs that's
+	// painful to round-trip; the bytes are what HCS actually sees. Exposed
+	// via CreateDocument().
+	createDocument json.RawMessage
 }
 
 var _ cow.Container = &System{}
@@ -81,6 +90,12 @@ func CreateComputeSystem(ctx context.Context, id string, hcsDocumentInterface in
 	}
 
 	hcsDocument := string(hcsDocumentB)
+
+	// container-reboot-v2 Stage 4 Sub-step B1: cache the exact bytes HCS sees,
+	// before any errors, so a later handleReboot can reissue the same document.
+	// Copy into a fresh slice since the caller-owned hcsDocumentB may alias a
+	// larger buffer or be reused by GC.
+	computeSystem.createDocument = append(json.RawMessage(nil), hcsDocumentB...)
 
 	var (
 		identity    syscall.Handle
@@ -368,6 +383,14 @@ func (computeSystem *System) ExitType() string {
 	computeSystem.exitTypeMu.RLock()
 	defer computeSystem.exitTypeMu.RUnlock()
 	return computeSystem.exitType
+}
+
+// CreateDocument returns the JSON body this System was originally created with.
+// Used by container-reboot-v2 Stage 4's handleReboot to reissue
+// HcsCreateComputeSystem with identical configuration after a silo reboot.
+// Returns nil for Systems created outside CreateComputeSystem (e.g. OpenComputeSystem).
+func (computeSystem *System) CreateDocument() json.RawMessage {
+	return computeSystem.createDocument
 }
 
 func (computeSystem *System) WaitError() error {

--- a/internal/hcs/system.go
+++ b/internal/hcs/system.go
@@ -279,7 +279,12 @@ func (computeSystem *System) waitBackground() {
 	operation := "hcs::System::waitBackground"
 	ctx, span := oc.StartSpan(context.Background(), operation)
 	defer span.End()
-	span.AddAttributes(trace.StringAttribute("cid", computeSystem.id))
+	span.AddAttributes(
+		trace.StringAttribute("cid", computeSystem.id),
+		// container-reboot-v2 Stage 1 placeholders; Stage 2 populates from SystemExitStatus JSON.
+		trace.StringAttribute("reboot.exit_type", ""),
+		trace.Int64Attribute("reboot.notification_data_bytes", 0),
+	)
 
 	err := waitForNotification(ctx, computeSystem.callbackNumber, hcsNotificationSystemExited, nil)
 	if err == nil {

--- a/internal/hcs/waithelper.go
+++ b/internal/hcs/waithelper.go
@@ -54,19 +54,19 @@ func waitForNotification(
 	}
 
 	select {
-	case err, ok := <-expectedChannel:
+	case payload, ok := <-expectedChannel:
 		if !ok {
 			return ErrHandleClose
 		}
-		return err
-	case err, ok := <-channels[hcsNotificationSystemExited]:
+		return payload.err
+	case payload, ok := <-channels[hcsNotificationSystemExited]:
 		if !ok {
 			return ErrHandleClose
 		}
 		// If the expected notification is hcsNotificationSystemExited which of the two selects
 		// chosen is random. Return the raw error if hcsNotificationSystemExited is expected
 		if channels[hcsNotificationSystemExited] == expectedChannel {
-			return err
+			return payload.err
 		}
 		return ErrUnexpectedContainerExit
 	case _, ok := <-channels[hcsNotificationServiceDisconnect]:

--- a/internal/jobcontainers/jobcontainer.go
+++ b/internal/jobcontainers/jobcontainer.go
@@ -617,6 +617,13 @@ func (c *JobContainer) WaitError() error {
 	return c.waitError
 }
 
+// ExitType returns "" — job containers don't wrap an HCS compute system and
+// therefore never observe a SystemExitStatus.ExitType notification. Callers
+// treating empty string as "unknown" get the right fallback behavior.
+func (c *JobContainer) ExitType() string {
+	return ""
+}
+
 // Wait synchronously waits for the container to shutdown or terminate. If
 // the container has already exited returns the previous error (if any).
 func (c *JobContainer) Wait() error {


### PR DESCRIPTION
**Status**: Draft for design discussion. Not yet ready for review.

## What this is

Prototype hcsshim-side changes for transparent reboot of Windows process-isolated (Argon) containers — paired with HCS-side changes on \`user/pbozza/container_reboot_v2\` in \`microsoft/os.2020\`.

When a user runs \`shutdown /r /t 0\` inside a Windows Server container, the goal is for docker / containerd to see the container as continuously running while HCS internally tears down and recreates the silo. The COW overlay and HNS endpoint persist; the container's PID 1 changes (it's a fresh kernel, fresh init).

## Design discussion

A higher-level architecture document is in progress (not in this PR). Tl;dr the prototype is the **shim-driven** half of a hybrid approach where:

- HCS emits a \`Reboot\` notification via the existing \`SystemExited\` callback (existing \`Feature_HcsSiloReboot\` plumbing, finished in the matching OS PR)
- hcsshim (this PR) catches the notification, recreates the compute system on the same container ID via a cached create document, spawns a fresh init, swaps the task state in place, suppresses \`/tasks/exit\`
- containerd / docker see no exit event; \`docker ps\` reports the container continuously up

## What's in this PR

11 commits, ~500 LOC net. Highlights by area:

**Core plumbing** — extending the existing notification path with payload data so the SystemExitStatus JSON survives to the shim:
- \`internal/hcs/callback.go\`: notification payload now carries \`(err, data)\` instead of just \`err\`
- \`internal/hcs/system.go\`: parse SystemExitStatus, cache \`ExitType\` on \`*hcs.System\`, expose via \`ExitType()\` method on \`cow.Container\`
- \`internal/hcs/exitstatus.go\`: parser + tests
- \`internal/cow/cow.go\` + LCOW/job container implementations: extend \`cow.Container\` interface

**Stage 4 transparent restart** in \`cmd/containerd-shim-runhcs-v1/\`:
- Cache the \`hcsDocument\` on \`*hcs.System\` at create time so the recreate can reissue identically
- \`hcsTask::waitInitExit\` detects \`ExitType=Reboot\`, calls \`doHandleReboot\`
- \`doHandleReboot\` closes the old System, creates a new one on the same ID, spawns the original init via \`cmd.Cmd\`, swaps state in place, respawns waiters for the next reboot cycle
- Suppresses \`/tasks/exit\` and \`ht.close\` on the success path

**Dev-guard scaffolding** at \`internal/devguard/\` — registry-key gating so the new behaviors can be opt-in. Five guards:
- \`ForceStopForRestart\`, \`ExposeRebootNotification\`, \`PassExitStatusJson\` — gate the matching HCS-side behaviors
- \`SkipInternalRebootStart\` — tells HCS to not try to internally restart, leaving the slot free for the shim
- \`EnableShimRebootHandler\` — gates the shim-side \`doHandleReboot\` path

## Known limitations

- **Stdio doesn't survive the reboot today.** New init runs with nil stdio (the \"headless\" fallback). \`docker logs\` only shows pre-reboot output. Interactive \`docker run -it\` sessions drop when the silo dies. Workaround: \`docker exec -it\` to reconnect, which gets fresh pipes per-invocation.
- **\`docker inspect\` reports the original PID** because containerd caches it from the \`TaskCreate\` event and we don't have a mechanism to update it. Cosmetic; doesn't affect functionality.
- **WindowsContainerOrchestrator only** for now. LCOW / HyperV-isolated / job containers aren't covered.
- **Dev-guard sprawl**: 5 guards is too many for ship; should consolidate to one (\`Feature_HcsSiloReboot\`).

## Validated end-to-end

Works on the test VM with the matching HCS-side changes:
- \`docker run -d ... cmd /c \"ping -n 999999 127.0.0.1\"\` as init
- \`docker exec\` to write a marker file
- \`docker exec -d ... shutdown /r /t 0\` to trigger reboot
- After ~25s: \`docker ps\` still shows Up
- \`docker exec\` shows the marker file persisted (overlay survived)
- \`docker exec ... tasklist\` shows different PIDs (kernel really rebooted)
- \`docker stop\` and \`docker rm\` work cleanly

## Not for review yet

Pushing now to make the changes visible alongside the design conversation. Cleanup, dev-guard consolidation, test coverage, and (most importantly) HCS-side stdio preservation would all happen before this is review-ready.