### PR TITLE
Fix builds: Remove vpmem multimapping annotation from parity tests

### DIFF
--- a/test/parity/vm/lcow_doc_permutations_test.go
+++ b/test/parity/vm/lcow_doc_permutations_test.go
@@ -542,19 +542,12 @@ func TestLCOWSandboxOptionsFieldParityNonDefault(t *testing.T) {
 			},
 		},
 		{
-			name: "VPMem no multi-mapping",
-			annotations: map[string]string{
-				shimannotations.VPMemNoMultiMapping: "true",
-			},
-		},
-		{
 			name: "all sandbox options non-default",
 			annotations: map[string]string{
 				shimannotations.LCOWEncryptedScratchDisk:  "true",
 				iannotations.NetworkingPolicyBasedRouting: "true",
 				shimannotations.FullyPhysicallyBacked:     "true",
 				shimannotations.DisableWritableFileShares: "true",
-				shimannotations.VPMemNoMultiMapping:       "true",
 				shimannotations.MemorySizeInMB:            "2048",
 			},
 		},


### PR DESCRIPTION
The v2 LCOW builder explicitly rejects the `io.microsoft.virtualmachine.lcow.vpmem.nomultimapping` annotation in `processAnnotations` (`internal/builder/vm/lcow/specs.go`) as not yet implemented, but `TestLCOWSandboxOptionsFieldParityNonDefault` set it in two cases. `buildV2LCOWDocument` therefore always failed with `"...vpmem.nomultimapping annotation is not supported"`, making the parent test permanently red in CI without verifying any real parity.

Removed the standalone "VPMem no multi-mapping" case and drop the annotation from "all sandbox options non-default". The intentional v2 rejection is still covered by the unit test in `internal/builder/vm/lcow/specs_test.go`.
