### PR TITLE
update hcs.Start to use HCS V1 API

### DIFF
--- a/internal/hcs/migration.go
+++ b/internal/hcs/migration.go
@@ -198,7 +198,7 @@ func (computeSystem *System) StartWithMigrationOptions(ctx context.Context, conf
 		return makeSystemError(computeSystem, operation, err, nil)
 	}
 
-	return computeSystem.start(ctx, op, string(raw))
+	return computeSystem.startV2(ctx, op, string(raw))
 }
 
 // InitializeLiveMigrationOnSource initializes a live migration on the source side with the given options.

--- a/internal/hcs/system.go
+++ b/internal/hcs/system.go
@@ -202,31 +202,44 @@ func GetComputeSystems(ctx context.Context, q schema1.ComputeSystemQuery) ([]sch
 	return computeSystems, nil
 }
 
-// Start synchronously starts the computeSystem.
-func (computeSystem *System) Start(ctx context.Context) error {
+// Start synchronously starts the computeSystem using HCS V1 API.
+func (computeSystem *System) Start(ctx context.Context) (err error) {
+	operation := "hcs::System::Start"
+
+	// hcsStartComputeSystemContext is an async operation. Start the outer span
+	// here to measure the full start time.
+	ctx, span := oc.StartSpan(ctx, operation)
+	defer span.End()
+	defer func() { oc.SetSpanStatus(span, err) }()
+	span.AddAttributes(trace.StringAttribute("cid", computeSystem.id))
+
 	computeSystem.handleLock.RLock()
 	defer computeSystem.handleLock.RUnlock()
 
+	// prevent starting an exited system because waitblock we do not recreate waitBlock
+	// or rerun waitBackground, so we have no way to be notified of it closing again
 	if computeSystem.handle == 0 {
-		return makeSystemError(computeSystem, "hcs::System::Start", ErrAlreadyClosed, nil)
+		return makeSystemError(computeSystem, operation, ErrAlreadyClosed, nil)
 	}
 
-	op, err := computecore.HcsCreateOperation(ctx, 0, 0)
+	resultJSON, err := vmcompute.HcsStartComputeSystem(ctx, computeSystem.handle, "")
+	events, err := processAsyncHcsResult(ctx, err, resultJSON, computeSystem.callbackNumber,
+		hcsNotificationSystemStartCompleted, &timeout.SystemStart)
 	if err != nil {
-		return makeSystemError(computeSystem, "hcs::System::Start", err, nil)
+		return makeSystemError(computeSystem, operation, err, events)
 	}
-	defer computecore.HcsCloseOperation(ctx, op)
-
-	return computeSystem.start(ctx, op, "")
+	computeSystem.startTime = time.Now()
+	return nil
 }
 
-// start is the shared implementation used by Start and StartWithMigrationOptions.
+// startV2 is the implementation used by StartWithMigrationOptions to start the compute system
+// using HCS V2 APIs.
 // The caller provides a pre-created computecore operation (with any resources already
 // attached) and the JSON-encoded options string to pass to HcsStartComputeSystem.
 //
 // The caller MUST hold computeSystem.handleLock and verify the handle is valid
 // before calling this method.
-func (computeSystem *System) start(ctx context.Context, op computecore.HcsOperation, opts string) (err error) {
+func (computeSystem *System) startV2(ctx context.Context, op computecore.HcsOperation, opts string) (err error) {
 	operation := "hcs::System::Start"
 
 	// hcsStartComputeSystemContext is an async operation. Start the outer span


### PR DESCRIPTION
### Summary
Presently, the implementation of Start method used computecore i.e. HCS V2 for starting the compute system. However, the same compute system was created using HCS V1 and therefore, due to an incompatibility within HCS between V1 and V2 APIs, this was failing.

Therefore, as a stop gap, we have reverted the Start method to use the HCS V1 API. During our full scale migration to V2 APIs, this will be taken care of properly.

**Start implementation in old code using HCS V1**- https://github.com/microsoft/hcsshim/blob/2e7b58a24971afb3709ea07a0aef8fe5b04fa238/internal/hcs/system.go#L195