### PR TITLE
test/util: add arm64 to aarch64 translation in translateGOARCH

### DIFF
--- a/test/internal/util/util.go
+++ b/test/internal/util/util.go
@@ -105,6 +105,8 @@ func translateGOARCH(s string) string {
 		return "x86"
 	case "amd64":
 		return "x86_64"
+	case "arm64":
+		return "aarch64"
 	}
 	return s
 }


### PR DESCRIPTION
Add arm64 → aarch64 mapping to translateGOARCH in the test utility package, aligning Go's GOARCH value with the official architecture name used by OCI image specs and platform matching.

The translateGOARCH function converts Go architecture identifiers to their canonical names (e.g., 386 → x86, amd64 → x86_64). The arm64 case was missing, which is needed for ARM64/AArch64 platform support in tests that rely on architecture-specific image selection or platform matching.