### PR TITLE
[cherry-pick] Update CgroupsPath to include container ID for sandbox container

### DIFF
--- a/internal/guest/runtime/hcsv2/sandbox_container.go
+++ b/internal/guest/runtime/hcsv2/sandbox_container.go
@@ -126,7 +126,7 @@ func setupSandboxContainerSpec(ctx context.Context, id, sandboxRoot string, spec
 	if virtualSandboxID != "" {
 		sandboxID = virtualSandboxID
 	}
-	spec.Linux.CgroupsPath = fmt.Sprintf(podCgroupPathFmt, sandboxID)
+	spec.Linux.CgroupsPath = fmt.Sprintf(containerCgroupPathFmt, sandboxID, id)
 
 	// Clear the windows section as we dont want to forward to runc
 	spec.Windows = nil


### PR DESCRIPTION
This pull request makes a targeted change to the way cgroup paths are set for sandbox containers in the `setupSandboxContainerSpec` function. Instead of using the pod-level cgroup path format, the code now uses the container-level cgroup path format, which includes both the sandbox and container IDs. This ensures that each container is assigned its own unique cgroup path.