### PR TITLE
fix: enlighten lcow uvmboot with dm-verity boot

### DIFF
--- a/internal/tools/uvmboot/lcow.go
+++ b/internal/tools/uvmboot/lcow.go
@@ -41,6 +41,7 @@ const (
 	shareFilesArgName             = "share"
 	securityPolicyArgName         = "security-policy"
 	securityHardwareFlag          = "security-hardware"
+	noVerityBoot                  = "no-verity-boot"
 	securityPolicyEnforcerArgName = "security-policy-enforcer"
 )
 
@@ -104,6 +105,10 @@ var lcowCommand = cli.Command{
 		cli.BoolFlag{
 			Name:  securityHardwareFlag,
 			Usage: "Use VMGS file to run on secure hardware. ('root-fs-type' must be set to 'none')",
+		},
+		cli.BoolFlag{
+			Name:  noVerityBoot,
+			Usage: "Do not use verity boot. (IMPORTANT: can only be used together with --security-hardware flag)",
 		},
 		cli.StringFlag{
 			Name:  execCommandLineArgName,
@@ -276,8 +281,16 @@ func createLCOWOptions(ctx context.Context, c *cli.Context, id string) (*uvm.Opt
 	}
 	if c.IsSet(securityHardwareFlag) {
 		options.GuestStateFilePath = vmutils.DefaultGuestStateFile
+		hclEnabled := false
+		options.HclEnabled = &hclEnabled
 		options.SecurityPolicyEnabled = true
+		options.BundleDirectory = os.TempDir()
 		options.AllowOvercommit = false
+
+		if !c.IsSet(noVerityBoot) {
+			options.DmVerityRootFsVhd = vmutils.DefaultDmVerityRootfsVhd
+			options.DmVerityMode = true
+		}
 	}
 
 	return options, nil


### PR DESCRIPTION
lcow uvmboot wasn't enlightened with dm-verity boot when the feature was introduced for C-LCOW. Address the gap by by setting the necessary lcow options:
 - `HclEnabled` must be set to false on newer OS builds
 - `BundleDirectory` must be set, so the template copy can happen
 - add `-no-verity-boot` flag for backward compat with earlier versions of kernel.vmgs which had rootfs baked in.
 - `DmVerityRootFsVhd` will be set to the default value from vmutils
 - `DmVerityMode` will be set to `true`