### PR TITLE
ensure consistent error message as V1 shim

### DIFF
--- a/internal/controller/device/plan9/controller.go
+++ b/internal/controller/device/plan9/controller.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Microsoft/go-winio/pkg/guid"
 	"github.com/Microsoft/hcsshim/internal/controller/device/plan9/mount"
 	"github.com/Microsoft/hcsshim/internal/controller/device/plan9/share"
+	"github.com/Microsoft/hcsshim/internal/hcs"
 	"github.com/Microsoft/hcsshim/internal/log"
 	"github.com/Microsoft/hcsshim/internal/logfields"
 	"github.com/sirupsen/logrus"
@@ -84,7 +85,7 @@ func (c *Controller) Reserve(ctx context.Context, shareConfig share.Config, moun
 
 	// Validate write-share policy before touching shared state.
 	if !shareConfig.ReadOnly && c.noWritableFileShares {
-		return guid.GUID{}, fmt.Errorf("adding writable Plan9 shares is denied")
+		return guid.GUID{}, fmt.Errorf("adding writable shares is denied: %w", hcs.ErrOperationDenied)
 	}
 
 	ctx, _ = log.WithContext(ctx, logrus.WithField(logfields.HostPath, shareConfig.HostPath))


### PR DESCRIPTION
This change ensures that the error message is consistent and wrapped similarly for V1 and V2 which simplifies the functional tests.