### PR TITLE
gcs-sidecar/bridge: Do not enforce MaxMsgSize on incoming messages

### DIFF
--- a/internal/gcs-sidecar/bridge.go
+++ b/internal/gcs-sidecar/bridge.go
@@ -191,7 +191,9 @@ func readMessage(r io.Reader) (messageHeader, []byte, error) {
 	}
 
 	n := header.Size
-	if n < prot.HdrSize || n > prot.MaxMsgSize {
+	// Deliberately don't enforce MaxMsgSize here. This follows what the LCOW
+	// gcs does, and allows us to inject long fragments.
+	if n < prot.HdrSize {
 		logrus.Errorf("invalid message size %d", n)
 		return messageHeader{}, nil, fmt.Errorf("invalid message size %d: %w", n, err)
 	}


### PR DESCRIPTION
This was discovered as causing the UVM to crash when we try to load a long fragment.  Currently, the LCOW gcs does not enforce this limit, and so we never hit this in LCOW.  I think it should be fine to also not enforce it for WCOW, since DoS attack from the host is outside the scope of the confidential threat model, and this avoid arbitrary length limits on policy and fragments.