### PR TITLE
[internal/wclayer]: harden reset dir-state cleanup

### DIFF
--- a/internal/wclayer/legacy.go
+++ b/internal/wclayer/legacy.go
@@ -453,15 +453,15 @@ func (w *legacyLayerWriter) reset() (err error) {
 			w.currentFile = nil
 			w.currentFileName = ""
 			w.currentFileRoot = nil
-			w.currentIsDir = false
 		}
+		w.currentIsDir = false
 	}()
 
 	if err = w.bufWriter.Flush(); err != nil {
 		return err
 	}
 	w.bufWriter.Reset(io.Discard)
-	if w.currentIsDir {
+	if w.currentIsDir && w.currentFile != nil {
 		r := w.currentFile
 		br := winio.NewBackupStreamReader(r)
 		// Seek to the beginning of the backup stream, skipping the fileattrs

--- a/internal/wclayer/legacy_test.go
+++ b/internal/wclayer/legacy_test.go
@@ -114,6 +114,23 @@ func Test_legacyLayerWriter_reset_ClearsCurrentIsDirOnError(t *testing.T) {
 	}
 }
 
+// Test_legacyLayerWriter_reset_DirFlagWithoutFile verifies reset is robust when
+// currentIsDir is true but currentFile is nil (a state that can occur if an
+// earlier error path closed/cleared currentFile before currentIsDir was reset).
+func Test_legacyLayerWriter_reset_DirFlagWithoutFile(t *testing.T) {
+	w := &legacyLayerWriter{
+		currentIsDir: true,
+		bufWriter:    bufio.NewWriter(io.Discard),
+	}
+
+	if err := w.reset(); err != nil {
+		t.Fatalf("expected reset to succeed when currentFile is nil, got: %v", err)
+	}
+	if w.currentIsDir {
+		t.Error("expected currentIsDir to be false after reset")
+	}
+}
+
 // closes and clears the current file handle.
 func Test_legacyLayerWriter_reset_ClosesFileOnSuccess(t *testing.T) {
 	dir := t.TempDir()


### PR DESCRIPTION
Address follow-up review feedback by making reset robust when currentIsDir is true while currentFile is nil.

- Always clear currentIsDir in deferred cleanup (outside currentFile nil-check)
- Guard the directory stream handling path with currentFile != nil
- Add regression test for currentIsDir=true/currentFile=nil state