### PR TITLE
[live-migration] add Cancel and Cleanup RPC methods for live migration management

### DIFF
--- a/pkg/migration/migration.pb.go
+++ b/pkg/migration/migration.pb.go
@@ -790,6 +790,170 @@ func (*CreateDuplicateSocketResponse) Descriptor() ([]byte, []int) {
 	return file_github_com_Microsoft_hcsshim_pkg_migration_migration_proto_rawDescGZIP(), []int{13}
 }
 
+type CancelRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Identifier for the active LM session. Must match the session_id used
+	// for the rest of this LM on this side.
+	SessionID     string `protobuf:"bytes,1,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CancelRequest) Reset() {
+	*x = CancelRequest{}
+	mi := &file_github_com_Microsoft_hcsshim_pkg_migration_migration_proto_msgTypes[14]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CancelRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CancelRequest) ProtoMessage() {}
+
+func (x *CancelRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_github_com_Microsoft_hcsshim_pkg_migration_migration_proto_msgTypes[14]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CancelRequest.ProtoReflect.Descriptor instead.
+func (*CancelRequest) Descriptor() ([]byte, []int) {
+	return file_github_com_Microsoft_hcsshim_pkg_migration_migration_proto_rawDescGZIP(), []int{14}
+}
+
+func (x *CancelRequest) GetSessionID() string {
+	if x != nil {
+		return x.SessionID
+	}
+	return ""
+}
+
+type CancelResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CancelResponse) Reset() {
+	*x = CancelResponse{}
+	mi := &file_github_com_Microsoft_hcsshim_pkg_migration_migration_proto_msgTypes[15]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CancelResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CancelResponse) ProtoMessage() {}
+
+func (x *CancelResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_github_com_Microsoft_hcsshim_pkg_migration_migration_proto_msgTypes[15]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CancelResponse.ProtoReflect.Descriptor instead.
+func (*CancelResponse) Descriptor() ([]byte, []int) {
+	return file_github_com_Microsoft_hcsshim_pkg_migration_migration_proto_rawDescGZIP(), []int{15}
+}
+
+type CleanupRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Identifier for the active LM session. Must match the session_id used
+	// for the rest of this LM on this side.
+	SessionID     string `protobuf:"bytes,1,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CleanupRequest) Reset() {
+	*x = CleanupRequest{}
+	mi := &file_github_com_Microsoft_hcsshim_pkg_migration_migration_proto_msgTypes[16]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CleanupRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CleanupRequest) ProtoMessage() {}
+
+func (x *CleanupRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_github_com_Microsoft_hcsshim_pkg_migration_migration_proto_msgTypes[16]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CleanupRequest.ProtoReflect.Descriptor instead.
+func (*CleanupRequest) Descriptor() ([]byte, []int) {
+	return file_github_com_Microsoft_hcsshim_pkg_migration_migration_proto_rawDescGZIP(), []int{16}
+}
+
+func (x *CleanupRequest) GetSessionID() string {
+	if x != nil {
+		return x.SessionID
+	}
+	return ""
+}
+
+type CleanupResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CleanupResponse) Reset() {
+	*x = CleanupResponse{}
+	mi := &file_github_com_Microsoft_hcsshim_pkg_migration_migration_proto_msgTypes[17]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CleanupResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CleanupResponse) ProtoMessage() {}
+
+func (x *CleanupResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_github_com_Microsoft_hcsshim_pkg_migration_migration_proto_msgTypes[17]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CleanupResponse.ProtoReflect.Descriptor instead.
+func (*CleanupResponse) Descriptor() ([]byte, []int) {
+	return file_github_com_Microsoft_hcsshim_pkg_migration_migration_proto_rawDescGZIP(), []int{17}
+}
+
 var File_github_com_Microsoft_hcsshim_pkg_migration_migration_proto protoreflect.FileDescriptor
 
 const file_github_com_Microsoft_hcsshim_pkg_migration_migration_proto_rawDesc = "" +
@@ -838,11 +1002,19 @@ const file_github_com_Microsoft_hcsshim_pkg_migration_migration_proto_rawDesc = 
 	"\n" +
 	"session_id\x18\x01 \x01(\tR\tsessionId\x12#\n" +
 	"\rprotocol_info\x18\x02 \x01(\fR\fprotocolInfo\"\x1f\n" +
-	"\x1dCreateDuplicateSocketResponse*g\n" +
+	"\x1dCreateDuplicateSocketResponse\".\n" +
+	"\rCancelRequest\x12\x1d\n" +
+	"\n" +
+	"session_id\x18\x01 \x01(\tR\tsessionId\"\x10\n" +
+	"\x0eCancelResponse\"/\n" +
+	"\x0eCleanupRequest\x12\x1d\n" +
+	"\n" +
+	"session_id\x18\x01 \x01(\tR\tsessionId\"\x11\n" +
+	"\x0fCleanupResponse*g\n" +
 	"\x0eFinalizeAction\x12\x1f\n" +
 	"\x1bFINALIZE_ACTION_UNSPECIFIED\x10\x00\x12\x18\n" +
 	"\x14FINALIZE_ACTION_STOP\x10\x01\x12\x1a\n" +
-	"\x16FINALIZE_ACTION_RESUME\x10\x022\x92\x04\n" +
+	"\x16FINALIZE_ACTION_RESUME\x10\x022\xeb\x04\n" +
 	"\tMigration\x12\\\n" +
 	"\x17PrepareAndExportSandbox\x12\x1f.PrepareAndExportSandboxRequest\x1a .PrepareAndExportSandboxResponse\x12>\n" +
 	"\rImportSandbox\x12\x15.ImportSandboxRequest\x1a\x16.ImportSandboxResponse\x12A\n" +
@@ -850,7 +1022,9 @@ const file_github_com_Microsoft_hcsshim_pkg_migration_migration_proto_rawDesc = 
 	"\x0fTransferSandbox\x12\x17.TransferSandboxRequest\x1a\x18.TransferSandboxResponse\x12D\n" +
 	"\x0fFinalizeSandbox\x12\x17.FinalizeSandboxRequest\x1a\x18.FinalizeSandboxResponse\x12@\n" +
 	"\rNotifications\x12\x15.NotificationsRequest\x1a\x16.NotificationsResponse0\x01\x12V\n" +
-	"\x15CreateDuplicateSocket\x12\x1d.CreateDuplicateSocketRequest\x1a\x1e.CreateDuplicateSocketResponseB6Z4github.com/Microsoft/hcsshim/pkg/migration;migrationb\x06proto3"
+	"\x15CreateDuplicateSocket\x12\x1d.CreateDuplicateSocketRequest\x1a\x1e.CreateDuplicateSocketResponse\x12)\n" +
+	"\x06Cancel\x12\x0e.CancelRequest\x1a\x0f.CancelResponse\x12,\n" +
+	"\aCleanup\x12\x0f.CleanupRequest\x1a\x10.CleanupResponseB6Z4github.com/Microsoft/hcsshim/pkg/migration;migrationb\x06proto3"
 
 var (
 	file_github_com_Microsoft_hcsshim_pkg_migration_migration_proto_rawDescOnce sync.Once
@@ -865,7 +1039,7 @@ func file_github_com_Microsoft_hcsshim_pkg_migration_migration_proto_rawDescGZIP
 }
 
 var file_github_com_Microsoft_hcsshim_pkg_migration_migration_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_github_com_Microsoft_hcsshim_pkg_migration_migration_proto_msgTypes = make([]protoimpl.MessageInfo, 14)
+var file_github_com_Microsoft_hcsshim_pkg_migration_migration_proto_msgTypes = make([]protoimpl.MessageInfo, 18)
 var file_github_com_Microsoft_hcsshim_pkg_migration_migration_proto_goTypes = []any{
 	(FinalizeAction)(0),                     // 0: FinalizeAction
 	(*PrepareAndExportSandboxRequest)(nil),  // 1: PrepareAndExportSandboxRequest
@@ -882,22 +1056,26 @@ var file_github_com_Microsoft_hcsshim_pkg_migration_migration_proto_goTypes = []
 	(*NotificationsResponse)(nil),           // 12: NotificationsResponse
 	(*CreateDuplicateSocketRequest)(nil),    // 13: CreateDuplicateSocketRequest
 	(*CreateDuplicateSocketResponse)(nil),   // 14: CreateDuplicateSocketResponse
-	(*InitializeOptions)(nil),               // 15: InitializeOptions
-	(*anypb.Any)(nil),                       // 16: google.protobuf.Any
-	(*durationpb.Duration)(nil),             // 17: google.protobuf.Duration
-	(*Notification)(nil),                    // 18: Notification
-	(*timestamppb.Timestamp)(nil),           // 19: google.protobuf.Timestamp
+	(*CancelRequest)(nil),                   // 15: CancelRequest
+	(*CancelResponse)(nil),                  // 16: CancelResponse
+	(*CleanupRequest)(nil),                  // 17: CleanupRequest
+	(*CleanupResponse)(nil),                 // 18: CleanupResponse
+	(*InitializeOptions)(nil),               // 19: InitializeOptions
+	(*anypb.Any)(nil),                       // 20: google.protobuf.Any
+	(*durationpb.Duration)(nil),             // 21: google.protobuf.Duration
+	(*Notification)(nil),                    // 22: Notification
+	(*timestamppb.Timestamp)(nil),           // 23: google.protobuf.Timestamp
 }
 var file_github_com_Microsoft_hcsshim_pkg_migration_migration_proto_depIdxs = []int32{
-	15, // 0: PrepareAndExportSandboxRequest.init_options:type_name -> InitializeOptions
-	16, // 1: PrepareAndExportSandboxResponse.config:type_name -> google.protobuf.Any
-	16, // 2: ImportSandboxRequest.config:type_name -> google.protobuf.Any
-	15, // 3: PrepareSandboxRequest.init_options:type_name -> InitializeOptions
-	17, // 4: TransferSandboxRequest.timeout:type_name -> google.protobuf.Duration
+	19, // 0: PrepareAndExportSandboxRequest.init_options:type_name -> InitializeOptions
+	20, // 1: PrepareAndExportSandboxResponse.config:type_name -> google.protobuf.Any
+	20, // 2: ImportSandboxRequest.config:type_name -> google.protobuf.Any
+	19, // 3: PrepareSandboxRequest.init_options:type_name -> InitializeOptions
+	21, // 4: TransferSandboxRequest.timeout:type_name -> google.protobuf.Duration
 	0,  // 5: FinalizeSandboxRequest.action:type_name -> FinalizeAction
-	18, // 6: NotificationsResponse.notification:type_name -> Notification
-	19, // 7: NotificationsResponse.start_time:type_name -> google.protobuf.Timestamp
-	19, // 8: NotificationsResponse.update_time:type_name -> google.protobuf.Timestamp
+	22, // 6: NotificationsResponse.notification:type_name -> Notification
+	23, // 7: NotificationsResponse.start_time:type_name -> google.protobuf.Timestamp
+	23, // 8: NotificationsResponse.update_time:type_name -> google.protobuf.Timestamp
 	1,  // 9: Migration.PrepareAndExportSandbox:input_type -> PrepareAndExportSandboxRequest
 	3,  // 10: Migration.ImportSandbox:input_type -> ImportSandboxRequest
 	5,  // 11: Migration.PrepareSandbox:input_type -> PrepareSandboxRequest
@@ -905,15 +1083,19 @@ var file_github_com_Microsoft_hcsshim_pkg_migration_migration_proto_depIdxs = []
 	9,  // 13: Migration.FinalizeSandbox:input_type -> FinalizeSandboxRequest
 	11, // 14: Migration.Notifications:input_type -> NotificationsRequest
 	13, // 15: Migration.CreateDuplicateSocket:input_type -> CreateDuplicateSocketRequest
-	2,  // 16: Migration.PrepareAndExportSandbox:output_type -> PrepareAndExportSandboxResponse
-	4,  // 17: Migration.ImportSandbox:output_type -> ImportSandboxResponse
-	6,  // 18: Migration.PrepareSandbox:output_type -> PrepareSandboxResponse
-	8,  // 19: Migration.TransferSandbox:output_type -> TransferSandboxResponse
-	10, // 20: Migration.FinalizeSandbox:output_type -> FinalizeSandboxResponse
-	12, // 21: Migration.Notifications:output_type -> NotificationsResponse
-	14, // 22: Migration.CreateDuplicateSocket:output_type -> CreateDuplicateSocketResponse
-	16, // [16:23] is the sub-list for method output_type
-	9,  // [9:16] is the sub-list for method input_type
+	15, // 16: Migration.Cancel:input_type -> CancelRequest
+	17, // 17: Migration.Cleanup:input_type -> CleanupRequest
+	2,  // 18: Migration.PrepareAndExportSandbox:output_type -> PrepareAndExportSandboxResponse
+	4,  // 19: Migration.ImportSandbox:output_type -> ImportSandboxResponse
+	6,  // 20: Migration.PrepareSandbox:output_type -> PrepareSandboxResponse
+	8,  // 21: Migration.TransferSandbox:output_type -> TransferSandboxResponse
+	10, // 22: Migration.FinalizeSandbox:output_type -> FinalizeSandboxResponse
+	12, // 23: Migration.Notifications:output_type -> NotificationsResponse
+	14, // 24: Migration.CreateDuplicateSocket:output_type -> CreateDuplicateSocketResponse
+	16, // 25: Migration.Cancel:output_type -> CancelResponse
+	18, // 26: Migration.Cleanup:output_type -> CleanupResponse
+	18, // [18:27] is the sub-list for method output_type
+	9,  // [9:18] is the sub-list for method input_type
 	9,  // [9:9] is the sub-list for extension type_name
 	9,  // [9:9] is the sub-list for extension extendee
 	0,  // [0:9] is the sub-list for field type_name
@@ -931,7 +1113,7 @@ func file_github_com_Microsoft_hcsshim_pkg_migration_migration_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_github_com_Microsoft_hcsshim_pkg_migration_migration_proto_rawDesc), len(file_github_com_Microsoft_hcsshim_pkg_migration_migration_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   14,
+			NumMessages:   18,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/pkg/migration/migration.proto
+++ b/pkg/migration/migration.proto
@@ -11,7 +11,7 @@ import "github.com/Microsoft/hcsshim/pkg/migration/migration_options.proto";
 // migration (LM) of a sandbox (utility VM and its containers) from a SOURCE
 // host to a DESTINATION host.
 //
-// High-level flow (in order):
+// High-level success flow (in order):
 //
 //   SOURCE                                  DESTINATION
 //   ------                                  -----------
@@ -22,6 +22,13 @@ import "github.com/Microsoft/hcsshim/pkg/migration/migration_options.proto";
 //   6. Notifications (stream)               6. Notifications (stream)
 //   7. TransferSandbox          ◄────────►  7. TransferSandbox
 //   8. FinalizeSandbox                      8. FinalizeSandbox
+//   9. Cleanup                              9. Cleanup
+//
+// Cancel is invoked on BOTH sides whenever a migration is aborted, to stop
+// the in-flight transfer. Cleanup is the terminal call on BOTH sides and is
+// always issued last to revert the shim state machine, regardless of
+// whether the migration succeeded, failed, or was cancelled. Both Cancel
+// and Cleanup are mandatory on both sides when cancelling a migration.
 //
 // NewTask is part of the existing task service (not this service) and is what
 // the destination uses to attach updated resource paths to the rehydrated
@@ -122,6 +129,30 @@ service Migration {
     // the duplicated sockets in the shim continue to work and the shim can
     // finish the live migration on its own.
     rpc CreateDuplicateSocket(CreateDuplicateSocketRequest) returns (CreateDuplicateSocketResponse);
+
+    // Cancel aborts an in-flight live migration. It is mandatory on BOTH
+    // the source and the destination to cancel a migration that is already
+    // underway, and is the only way to do so.
+    //
+    // Cancel calls into HCS to cancel the migration on the underlying
+    // compute system and closes the migration socket. It does NOT revert
+    // the shim's migration state machine back to the normal state; that is
+    // done exclusively by Cleanup. Consequently, after Cancel returns, the
+    // sandbox is still considered to be migrating and the regular task APIs
+    // remain unavailable until Cleanup is called.
+    rpc Cancel(CancelRequest) returns (CancelResponse);
+
+    // Cleanup is the LAST, terminal call of a live migration and is invoked
+    // in ALL cases — whether the migration completed successfully, failed,
+    // or was cancelled. It is called on BOTH the source and the destination.
+    //
+    // Cleanup reverts the migration controller's state machine, along with
+    // all other controllers, back to the normal state. The migration
+    // controller tracks the current state of the migration; based on that
+    // state Cleanup either resumes or aborts the controllers as appropriate.
+    // On resume, the regular task APIs become available again once Cleanup
+    // completes.
+    rpc Cleanup(CleanupRequest) returns (CleanupResponse);
 }
 
 message PrepareAndExportSandboxRequest {
@@ -246,3 +277,20 @@ message CreateDuplicateSocketRequest {
 }
 
 message CreateDuplicateSocketResponse {}
+
+message CancelRequest {
+    // Identifier for the active LM session. Must match the session_id used
+    // for the rest of this LM on this side.
+    string session_id = 1;
+}
+
+message CancelResponse {}
+
+message CleanupRequest {
+    // Identifier for the active LM session. Must match the session_id used
+    // for the rest of this LM on this side.
+    string session_id = 1;
+}
+
+message CleanupResponse {}
+

--- a/pkg/migration/migration_ttrpc.pb.go
+++ b/pkg/migration/migration_ttrpc.pb.go
@@ -15,6 +15,8 @@ type MigrationService interface {
 	FinalizeSandbox(context.Context, *FinalizeSandboxRequest) (*FinalizeSandboxResponse, error)
 	Notifications(context.Context, *NotificationsRequest, Migration_NotificationsServer) error
 	CreateDuplicateSocket(context.Context, *CreateDuplicateSocketRequest) (*CreateDuplicateSocketResponse, error)
+	Cancel(context.Context, *CancelRequest) (*CancelResponse, error)
+	Cleanup(context.Context, *CleanupRequest) (*CleanupResponse, error)
 }
 
 type Migration_NotificationsServer interface {
@@ -75,6 +77,20 @@ func RegisterMigrationService(srv *ttrpc.Server, svc MigrationService) {
 				}
 				return svc.CreateDuplicateSocket(ctx, &req)
 			},
+			"Cancel": func(ctx context.Context, unmarshal func(interface{}) error) (interface{}, error) {
+				var req CancelRequest
+				if err := unmarshal(&req); err != nil {
+					return nil, err
+				}
+				return svc.Cancel(ctx, &req)
+			},
+			"Cleanup": func(ctx context.Context, unmarshal func(interface{}) error) (interface{}, error) {
+				var req CleanupRequest
+				if err := unmarshal(&req); err != nil {
+					return nil, err
+				}
+				return svc.Cleanup(ctx, &req)
+			},
 		},
 		Streams: map[string]ttrpc.Stream{
 			"Notifications": {
@@ -100,6 +116,8 @@ type MigrationClient interface {
 	FinalizeSandbox(context.Context, *FinalizeSandboxRequest) (*FinalizeSandboxResponse, error)
 	Notifications(context.Context, *NotificationsRequest) (Migration_NotificationsClient, error)
 	CreateDuplicateSocket(context.Context, *CreateDuplicateSocketRequest) (*CreateDuplicateSocketResponse, error)
+	Cancel(context.Context, *CancelRequest) (*CancelResponse, error)
+	Cleanup(context.Context, *CleanupRequest) (*CleanupResponse, error)
 }
 
 type migrationClient struct {
@@ -184,6 +202,22 @@ func (x *migrationNotificationsClient) Recv() (*NotificationsResponse, error) {
 func (c *migrationClient) CreateDuplicateSocket(ctx context.Context, req *CreateDuplicateSocketRequest) (*CreateDuplicateSocketResponse, error) {
 	var resp CreateDuplicateSocketResponse
 	if err := c.client.Call(ctx, "Migration", "CreateDuplicateSocket", req, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+func (c *migrationClient) Cancel(ctx context.Context, req *CancelRequest) (*CancelResponse, error) {
+	var resp CancelResponse
+	if err := c.client.Call(ctx, "Migration", "Cancel", req, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+func (c *migrationClient) Cleanup(ctx context.Context, req *CleanupRequest) (*CleanupResponse, error) {
+	var resp CleanupResponse
+	if err := c.client.Call(ctx, "Migration", "Cleanup", req, &resp); err != nil {
 		return nil, err
 	}
 	return &resp, nil


### PR DESCRIPTION
This pull request introduces two new RPC methods, `Cancel` and `Cleanup`, to the migration protocol, along with their associated request and response messages. These methods provide a standardized way to abort and clean up live migration sessions, ensuring that both the source and destination properly handle migration cancellation and state reversion.

**Migration protocol enhancements:**

* Added `Cancel` and `Cleanup` RPC methods to the `Migration` service in `migration.proto`, including detailed documentation on their roles in aborting and finalizing migration sessions.
* 
**Protobuf message additions:**

* Introduced new messages: `CancelRequest`, `CancelResponse`, `CleanupRequest`, and `CleanupResponse`, each with appropriate fields and documentation, in `migration.proto` and generated code.

These changes ensure that live migration sessions can be reliably cancelled and cleaned up, improving the robustness and correctness of the migration workflow.