### PR TITLE
fix(hns): preserve HRESULT in typed HNSError for downstream unwrapping

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -12,6 +12,10 @@ import (
 	"github.com/Microsoft/hcsshim/internal/hcserror"
 )
 
+// HNSError is a typed error for HNS failures that preserves the HRESULT (ErrorCode)
+// It is re-exported from internal/hns to allow downstream consumers to use errors.As()
+type HNSError = hns.HNSError
+
 var (
 	// ErrComputeSystemDoesNotExist is an error encountered when the container being operated on no longer exists = hcs.exist
 	ErrComputeSystemDoesNotExist = hcs.ErrComputeSystemDoesNotExist

--- a/internal/hns/hnsfuncs.go
+++ b/internal/hns/hnsfuncs.go
@@ -28,13 +28,27 @@ func hnsCallRawResponse(method, path, request string) (*hnsResponse, error) {
 	return hnsresponse, nil
 }
 
+type HNSError struct {
+	ErrorString string
+	ErrorCode   uint32
+}
+
+func (e *HNSError) Error() string {
+	return fmt.Sprintf("hns failed with error : %s", e.ErrorString)
+}
+
+var hnsCallRawResponseMock = hnsCallRawResponse
+
 func hnsCall(method, path, request string, returnResponse interface{}) error {
-	hnsresponse, err := hnsCallRawResponse(method, path, request)
+	hnsresponse, err := hnsCallRawResponseMock(method, path, request)
 	if err != nil {
 		return fmt.Errorf("failed during hnsCallRawResponse: %w", err)
 	}
 	if !hnsresponse.Success {
-		return fmt.Errorf("hns failed with error : %s", hnsresponse.Error)
+		return &HNSError{
+			ErrorString: hnsresponse.Error,
+			ErrorCode:   uint32(hnsresponse.ErrorCode),
+		}
 	}
 
 	if len(hnsresponse.Output) == 0 {

--- a/internal/hns/hnsfuncs_test.go
+++ b/internal/hns/hnsfuncs_test.go
@@ -1,0 +1,43 @@
+//go:build windows
+
+package hns
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+)
+
+func TestHNSErrorPreservation(t *testing.T) {
+	// Mock the raw response
+	originalMock := hnsCallRawResponseMock
+	defer func() { hnsCallRawResponseMock = originalMock }()
+
+	hnsCallRawResponseMock = func(method, path, request string) (*hnsResponse, error) {
+		var resp hnsResponse
+		if err := json.Unmarshal([]byte(`{"Success":false,"Error":"vSwitch in transient state","ErrorCode":-2143617005}`), &resp); err != nil {
+			return nil, err
+		}
+		return &resp, nil
+	}
+
+	// Execute hnsCall
+	err := hnsCall("POST", "/endpoints", "{}", nil)
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+
+	// Assert errors.As
+	var hnsErr *HNSError
+	if !errors.As(err, &hnsErr) {
+		t.Fatalf("expected error to be of type *HNSError, got %T: %v", err, err)
+	}
+
+	if hnsErr.ErrorCode != 0x803b0013 {
+		t.Errorf("expected ErrorCode 0x803b0013, got %#x", hnsErr.ErrorCode)
+	}
+
+	if hnsErr.ErrorString != "vSwitch in transient state" {
+		t.Errorf("expected ErrorString 'vSwitch in transient state', got %s", hnsErr.ErrorString)
+	}
+}

--- a/internal/hns/hnsnetwork.go
+++ b/internal/hns/hnsnetwork.go
@@ -43,9 +43,10 @@ type HNSNetwork struct {
 }
 
 type hnsResponse struct {
-	Success bool
-	Error   string
-	Output  json.RawMessage
+	Success   bool
+	Error     string
+	ErrorCode int32 `json:"ErrorCode,omitempty"`
+	Output    json.RawMessage
 }
 
 // HNSNetworkRequest makes a call into HNS to update/query a single network


### PR DESCRIPTION
### Problem
Currently, `hnsCall` collapses the JSON failure response from the Host Networking Service into a flat string (`fmt.Errorf("hns failed with error : %s", hnsresponse.Error)`). This strips the underlying `ErrorCode` (HRESULT) returned by the API. Because of this, downstream consumers (specifically the containerd CRI plugin) cannot use `errors.As()` to inspect the error type. This leads to severe downstream bugs—such as containerd hanging indefinitely during transient vSwitch states, because it cannot identify the specific HRESULT that should trigger its retry/backoff logic.

### Fix
* Introduced a strongly-typed `HNSError` struct that implements the error interface and maps the `ErrorCode` field from the HNS JSON payload.
* Modified `hnsCall` to return this typed error, ensuring the HRESULT is preserved and bubbled up the stack.

### Verification
* Added `TestHNSErrorPreservation` to mock a failed HNS JSON response containing a transient `ErrorCode` (e.g., `0x803b0013`).
* Verified that downstream callers can successfully use standard `errors.As()` to unwrap the error and evaluate the specific `ErrorCode`.
