### PR TITLE
gcs-sidecar, resource_wcow: Don't use UVM exec to create sandbox mount sources

### DIFF
--- a/internal/gcs-sidecar/handlers.go
+++ b/internal/gcs-sidecar/handlers.go
@@ -19,6 +19,7 @@ import (
 	"github.com/Microsoft/hcsshim/internal/copyfile"
 	"github.com/Microsoft/hcsshim/internal/fsformatter"
 	"github.com/Microsoft/hcsshim/internal/gcs/prot"
+	"github.com/Microsoft/hcsshim/internal/guestpath"
 	hcsschema "github.com/Microsoft/hcsshim/internal/hcs/schema2"
 	"github.com/Microsoft/hcsshim/internal/log"
 	oci "github.com/Microsoft/hcsshim/internal/oci"
@@ -142,7 +143,7 @@ func (b *Bridge) createContainer(req *request) (err error) {
 		// sandbox:// mounts by exec'ing `cmd /c mkdir ... & dir ...` inside the
 		// UVM (see resources_wcow.go:setupMounts), but for confidential, we
 		// handle this here in the sidecar GCS.
-		if err := createMappedDirectorySourceDirs(ctx, container.MappedDirectories); err != nil {
+		if err := createSandboxMountSourceDirs(ctx, container.MappedDirectories); err != nil {
 			return fmt.Errorf("failed to create mapped directory source directories: %w", err)
 		}
 
@@ -271,24 +272,28 @@ func stageDLL(ctx context.Context, srcPath, dstDir string) (bool, error) {
 	return true, nil
 }
 
-// createMappedDirectorySourceDirs creates the host-side source directory for
-// every mapped directory (i.e. "mounts") in the container document, if it does
-// not already exist.
-func createMappedDirectorySourceDirs(ctx context.Context, mappedDirectories []hcsschema.MappedDirectory) error {
+// createSandboxMountSourceDirs creates source directories for sandbox
+// mounts if they do not already exist.
+func createSandboxMountSourceDirs(ctx context.Context, mappedDirectories []hcsschema.MappedDirectory) error {
 	for _, md := range mappedDirectories {
 		source := md.HostPath
+		if strings.EqualFold(source, guestpath.WCOWSandboxMountPath) ||
+			strings.HasPrefix(strings.ToLower(source), strings.ToLower(guestpath.WCOWSandboxMountPath+`\`)) {
 
-		if _, err := os.Stat(source); err == nil {
-			// exists
-			continue
-		} else if !os.IsNotExist(err) {
-			return fmt.Errorf("failed to stat mapped directory source %q: %w", source, err)
-		}
+			// do this stat rather than call MkdirAll unconditionally,
+			// since the latter will fail with a source file (not dir)
+			if _, err := os.Stat(source); err == nil {
+				log.G(ctx).WithField("source", source).Debug("source of mapped directory mount exists, not creating directories")
+				continue
+			} else if !os.IsNotExist(err) {
+				return fmt.Errorf("failed to stat mapped directory source %q: %w", source, err)
+			}
 
-		if err := os.MkdirAll(source, 0755); err != nil {
-			return fmt.Errorf("failed to create mapped directory source %q: %w", source, err)
+			if err := os.MkdirAll(source, 0755); err != nil {
+				return fmt.Errorf("failed to create mapped directory source %q: %w", source, err)
+			}
+			log.G(ctx).WithField("source", source).Debug("created mapped directory source directory")
 		}
-		log.G(ctx).WithField("source", source).Debug("created mapped directory source directory")
 	}
 	return nil
 }

--- a/internal/gcs-sidecar/handlers.go
+++ b/internal/gcs-sidecar/handlers.go
@@ -137,6 +137,15 @@ func (b *Bridge) createContainer(req *request) (err error) {
 			return fmt.Errorf("CreateContainer operation is denied by policy: %w", err)
 		}
 
+		// Create the source directory for each mapped directory if it does not
+		// already exist. In non-confidential WCOW the host does this for
+		// sandbox:// mounts by exec'ing `cmd /c mkdir ... & dir ...` inside the
+		// UVM (see resources_wcow.go:setupMounts), but for confidential, we
+		// handle this here in the sidecar GCS.
+		if err := createMappedDirectorySourceDirs(ctx, container.MappedDirectories); err != nil {
+			return fmt.Errorf("failed to create mapped directory source directories: %w", err)
+		}
+
 		commandLine := len(spec.Process.Args) > 0
 		c := &Container{
 			id:              containerID,
@@ -260,6 +269,28 @@ func stageDLL(ctx context.Context, srcPath, dstDir string) (bool, error) {
 	}
 
 	return true, nil
+}
+
+// createMappedDirectorySourceDirs creates the host-side source directory for
+// every mapped directory (i.e. "mounts") in the container document, if it does
+// not already exist.
+func createMappedDirectorySourceDirs(ctx context.Context, mappedDirectories []hcsschema.MappedDirectory) error {
+	for _, md := range mappedDirectories {
+		source := md.HostPath
+
+		if _, err := os.Stat(source); err == nil {
+			// exists
+			continue
+		} else if !os.IsNotExist(err) {
+			return fmt.Errorf("failed to stat mapped directory source %q: %w", source, err)
+		}
+
+		if err := os.MkdirAll(source, 0755); err != nil {
+			return fmt.Errorf("failed to create mapped directory source %q: %w", source, err)
+		}
+		log.G(ctx).WithField("source", source).Debug("created mapped directory source directory")
+	}
+	return nil
 }
 
 // processParamEnvToOCIEnv converts an Environment field from ProcessParameters

--- a/internal/gcs-sidecar/handlers_test.go
+++ b/internal/gcs-sidecar/handlers_test.go
@@ -7,15 +7,59 @@ import (
 	"context"
 	"encoding/json"
 	"io"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/Microsoft/go-winio/pkg/guid"
 	"github.com/Microsoft/hcsshim/internal/gcs/prot"
+	"github.com/Microsoft/hcsshim/internal/guestpath"
+	hcsschema "github.com/Microsoft/hcsshim/internal/hcs/schema2"
 	"github.com/Microsoft/hcsshim/internal/protocol/guestrequest"
 	"github.com/Microsoft/hcsshim/internal/protocol/guestresource"
 	"github.com/Microsoft/hcsshim/pkg/securitypolicy"
 )
+
+func TestCreateSandboxMountSourceDirs(t *testing.T) {
+	testRoot := filepath.Join(guestpath.WCOWSandboxMountPath, filepath.Base(t.TempDir()))
+	if err := os.MkdirAll(testRoot, 0755); err != nil {
+		t.Fatalf("failed to create test root: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(testRoot) })
+
+	existingFile := filepath.Join(testRoot, "existing-file")
+	if err := os.WriteFile(existingFile, nil, 0644); err != nil {
+		t.Fatalf("failed to create existing source file: %v", err)
+	}
+
+	createdDir := filepath.Join(strings.ToLower(testRoot), "created", "nested")
+	outsideDir := filepath.Join(t.TempDir(), "outside")
+	mappedDirectories := []hcsschema.MappedDirectory{
+		{HostPath: createdDir},
+		{HostPath: existingFile},
+		{HostPath: outsideDir},
+	}
+
+	if err := createSandboxMountSourceDirs(context.Background(), mappedDirectories); err != nil {
+		t.Fatalf("createSandboxMountSourceDirs returned error: %v", err)
+	}
+
+	if info, err := os.Stat(createdDir); err != nil {
+		t.Fatalf("failed to stat created sandbox directory: %v", err)
+	} else if !info.IsDir() {
+		t.Fatalf("sandbox source %q is not a directory", createdDir)
+	}
+	if info, err := os.Stat(existingFile); err != nil {
+		t.Fatalf("failed to stat existing sandbox source file: %v", err)
+	} else if info.IsDir() {
+		t.Fatalf("existing sandbox source file %q was replaced by a directory", existingFile)
+	}
+	if _, err := os.Stat(outsideDir); !os.IsNotExist(err) {
+		t.Fatalf("outside source %q was created or returned unexpected error: %v", outsideDir, err)
+	}
+}
 
 // buildModifySettingsRequest creates a serialized ModifySettings request message
 // for the given resource type and settings.

--- a/internal/guestpath/paths.go
+++ b/internal/guestpath/paths.go
@@ -11,6 +11,9 @@ const (
 	// WCOWRootPrefixInUVM is the path inside UVM where WCOW container's root
 	// file system will be mounted
 	WCOWRootPrefixInUVM = `C:\c`
+	// WCOWSandboxMountPath is the path inside the UVM where WCOW sandbox mounts
+	// are created.
+	WCOWSandboxMountPath = `C:\SandboxMounts`
 	// SandboxMountPrefix is mount prefix used in container spec to mark a
 	// sandbox-mount
 	SandboxMountPrefix = "sandbox://"

--- a/internal/hcsoci/resources_wcow.go
+++ b/internal/hcsoci/resources_wcow.go
@@ -27,8 +27,6 @@ import (
 	"github.com/Microsoft/hcsshim/internal/uvm/scsi"
 )
 
-const wcowSandboxMountPath = "C:\\SandboxMounts"
-
 func allocateWindowsResources(ctx context.Context, coi *createOptionsInternal, r *resources.Resources, isSandbox bool) error {
 	if coi.Spec.Root == nil {
 		coi.Spec.Root = &specs.Root{}
@@ -255,5 +253,5 @@ func setupMounts(ctx context.Context, coi *createOptionsInternal, r *resources.R
 
 func convertToWCOWSandboxMountPath(source string) string {
 	subPath := strings.TrimPrefix(source, guestpath.SandboxMountPrefix)
-	return filepath.Join(wcowSandboxMountPath, subPath)
+	return filepath.Join(guestpath.WCOWSandboxMountPath, subPath)
 }

--- a/internal/hcsoci/resources_wcow.go
+++ b/internal/hcsoci/resources_wcow.go
@@ -203,23 +203,30 @@ func setupMounts(ctx context.Context, coi *createOptionsInternal, r *resources.R
 			// so first convert to a path in the sandboxmounts path itself.
 			sandboxPath := convertToWCOWSandboxMountPath(mount.Source)
 
-			// Now we need to exec a process in the vm that will make these directories as theres
+			// Now we need to exec a process in the vm that will make these directories as there's
 			// no functionality in the Windows gcs to create an arbitrary directory.
 			//
-			// Create the directory, but also run dir afterwards regardless of if mkdir succeeded to handle the case where the directory already exists
-			// e.g. from a previous container specifying the same mount (and thus creating the same directory).
-			b := &bytes.Buffer{}
-			stderr, err := cmd.CreatePipeAndListen(b, false)
-			if err != nil {
-				return err
-			}
-			req := &cmd.CmdProcessRequest{
-				Args:   []string{"cmd", "/c", "mkdir", sandboxPath, "&", "dir", sandboxPath},
-				Stderr: stderr,
-			}
-			exitCode, err := coi.HostingSystem.ExecInUVM(ctx, req)
-			if err != nil {
-				return errors.Wrapf(err, "failed to create sandbox mount directory in utility VM with exit code %d %q", exitCode, b.String())
+			// We do not need to do this for Confidential WCOW, because in that case the gcs-sidecar
+			// handles the create container request and will do this for us.  This way the policy
+			// does not have to have exceptions for allowing such mkdir commands.
+			//
+			// Create the directory, but also run dir afterwards regardless of if mkdir succeeded to
+			// handle the case where the directory already exists e.g. from a previous container
+			// specifying the same mount (and thus creating the same directory).
+			if !coi.HostingSystem.HasConfidentialPolicy() {
+				b := &bytes.Buffer{}
+				stderr, err := cmd.CreatePipeAndListen(b, false)
+				if err != nil {
+					return err
+				}
+				req := &cmd.CmdProcessRequest{
+					Args:   []string{"cmd", "/c", "mkdir", sandboxPath, "&", "dir", sandboxPath},
+					Stderr: stderr,
+				}
+				exitCode, err := coi.HostingSystem.ExecInUVM(ctx, req)
+				if err != nil {
+					return errors.Wrapf(err, "failed to create sandbox mount directory in utility VM with exit code %d %q", exitCode, b.String())
+				}
 			}
 		} else if np, ok := uvm.ParseNamedPipe(coi.HostingSystem, mount); ok {
 			if !np.UVMPipe {


### PR DESCRIPTION
gcs-sidecar, resource_wcow: Don't use UVM exec to create sandbox mount sources

In confidential WCOW this will not work due to the policy not allowing exec, and
we don't want to add an exception for this.  Instead, we make the gcs-sidecar
handle this job, and make the host skip this for confidential containers.

To test, use a container json that has a mount:

	{
	  "metadata": {
	    "name": "wcow_emptydir_info_cwcow_primary"
	  },
	  "image": {
	    "image": "mcr.microsoft.com/windows/servercore@sha256:f5f92ece3c213cec075d4abbcf6263eb69c1b94daf17b777da239b909d2862a6"
	  },
	  "command": [
	    "ping",
	    "-t",
	    "127.0.0.1"
	  ],
	  "mounts": [
	    {
	      "container_path": "/volumemountscratch",
	      "host_path": "sandbox:///tmp/atlas/emptydir/vol1",
	      "propagation": 2
	    }
	  ]
	}

along with a policy that denies arbitrary execs:

	package policy

	import future.keywords.every
	import future.keywords.in

	api_version := "0.12.0"
	framework_version := "0.5.0"

	transparency_trust_lists := [
	]

	fragments := [
	]

	containers := [
	  {
	    "allow_stdio_access": true,
	    "command": [
	      "ping",
	      "-t",
	      "127.0.0.1"
	    ],
	    "env_rules": [
	      {
	        "pattern": ".+",
	        "required": false,
	        "strategy": "re2"
	      }
	    ],
	    "exec_processes": [
	      {
	        "command": [
	          "cmd"
	        ],
	        "signals": []
	      }
	    ],
	    "id": "mcr.microsoft.com/windows/servercore@sha256:f5f92ece3c213cec075d4abbcf6263eb69c1b94daf17b777da239b909d2862a6",
	    "layers": [
	      "1aba71bb6a4b4c6df1dee7c37607c8e1da4eb6b93de103b6509daf8efd663a7d",
	      "8f05ecc2618a5410c5f5360d1bfe5f4b413dd18e3d7ba0bbc724d77e8d6e4628"
	    ],
	    "mounted_cim": [
	      "0b1bdf3036da10b119eb0f656d67f59a87e54bdaa932c3f9dbd1ace1a1738743"
	    ],
	    "mounts": [
	      {
	        "destination": "/volumemountscratch",
	        "options": [
	            "rbind",
	            "rshared",
	            "rw"
	        ],
	        "source": "sandbox:///tmp/atlas/emptydir/.+",
	        "type": "bind"
	      },
	    ],
	    "name": "mcr.microsoft.com/windows/servercore@sha256:f5f92ece3c213cec075d4abbcf6263eb69c1b94daf17b777da239b909d2862a6",
	    "signals": [],
	    "user": "",
	    "working_dir": "C:\\"
	  }
	]

	external_processes := [
	  {
	    "command": [
	      "cmd"
	    ],
	    "env_rules": [
	      {
	        "pattern": ".+",
	        "required": false,
	        "strategy": "re2"
	      }
	    ],
	    "working_dir": "C:\\",
	    "allow_stdio_access": true
	  }
	]

	allow_properties_access := true
	allow_dump_stacks := true
	allow_runtime_logging := true
	allow_environment_variable_dropping := true

	mount_device := data.framework.mount_device
	mount_overlay := data.framework.mount_overlay
	create_container := data.framework.create_container
	mount_cims := data.framework.mount_cims
	unmount_device := data.framework.unmount_device
	unmount_overlay := data.framework.unmount_overlay
	# exec_in_container := {"allowed": true, "env_list": null}
	exec_in_container := data.framework.exec_in_container
	# exec_external := {"allowed": true, "env_list": null, "allow_stdio_access": true}
	exec_external := data.framework.exec_external
	shutdown_container := data.framework.shutdown_container
	signal_container_process := data.framework.signal_container_process
	plan9_mount := data.framework.plan9_mount
	plan9_unmount := data.framework.plan9_unmount
	get_properties := data.framework.get_properties
	dump_stacks := data.framework.dump_stacks
	runtime_logging := data.framework.runtime_logging
	load_fragment := data.framework.load_fragment
	scratch_mount := data.framework.scratch_mount
	scratch_unmount := data.framework.scratch_unmount
	registry_changes := data.framework.registry_changes
	log_provider := data.framework.log_provider
	load_transparency_trust_list := data.framework.load_transparency_trust_list

	reason := {"errors": data.framework.errors, "candidate_containers": data.framework.candidate_containers}

Reported-by: Adrian Cotolan @ManalahBT
Assisted-by: GitHub-Copilot copilot-review
Signed-off-by: Tingmao Wang <tingmaowang@microsoft.com>

