### PR TITLE
Add Dependabot Tidy workflow for managing Go module dependencies

### DIFF
--- a/.github/workflows/dependabot-tidy.yml
+++ b/.github/workflows/dependabot-tidy.yml
@@ -1,6 +1,7 @@
 # Dependabot bumps `/` and `/test` as independent modules, but `/test` inherits the
 # root's dependencies via `replace ... => ../`, so a root bump leaves test/go.{mod,sum}
-# (and vendoring) stale. This re-tidies both and pushes the fix back to the PR branch.
+# stale. This re-tidies both modules and re-vendors the root (the only vendored module),
+# then pushes the fix back to the PR branch.
 name: Dependabot Tidy
 
 on: pull_request
@@ -29,7 +30,7 @@ jobs:
         with:
           fill-module-cache: true
 
-      - name: Run go mod tidy and vendor
+      - name: Tidy both modules and vendor the root
         run: |
           go mod tidy -e
           go mod vendor -e

--- a/.github/workflows/dependabot-tidy.yml
+++ b/.github/workflows/dependabot-tidy.yml
@@ -43,7 +43,7 @@ jobs:
             echo 'modules already tidy, nothing to push'
             exit 0
           fi
-          git config user.name 'dependabot[bot]'
-          git config user.email '49699333+dependabot[bot]@users.noreply.github.com'
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
           git commit -s -m 'go mod tidy && go mod vendor'
           git push origin HEAD:"${{ github.head_ref }}"

--- a/.github/workflows/dependabot-tidy.yml
+++ b/.github/workflows/dependabot-tidy.yml
@@ -1,0 +1,48 @@
+# Dependabot bumps `/` and `/test` as independent modules, but `/test` inherits the
+# root's dependencies via `replace ... => ../`, so a root bump leaves test/go.{mod,sum}
+# (and vendoring) stale. This re-tidies both and pushes the fix back to the PR branch.
+name: Dependabot Tidy
+
+on: pull_request
+
+# contents:write lets the built-in GITHUB_TOKEN push the fix; no PAT/App token needed.
+permissions:
+  contents: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
+jobs:
+  tidy:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.head_ref }}
+          show-progress: false
+
+      - name: Install Go
+        uses: ./.github/actions/setup-go
+        with:
+          fill-module-cache: true
+
+      - name: Run go mod tidy and vendor
+        run: |
+          go mod tidy -e
+          go mod vendor -e
+          (cd test && go mod tidy -e)
+
+      - name: Commit and push if changed
+        run: |
+          git add -A go.mod go.sum vendor test/go.mod test/go.sum
+          if git diff --cached --quiet; then
+            echo 'modules already tidy, nothing to push'
+            exit 0
+          fi
+          git config user.name 'dependabot[bot]'
+          git config user.email '49699333+dependabot[bot]@users.noreply.github.com'
+          git commit -s -m 'go mod tidy && go mod vendor'
+          git push origin HEAD:"${{ github.head_ref }}"


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automatically tidy and vendor Go modules for both the root and `/test` modules when Dependabot opens a pull request. This ensures that module dependencies remain consistent and up-to-date, especially since `/test` inherits dependencies from the root, which can otherwise become stale after root bumps.

**Automation for dependency management:**

* Added `.github/workflows/dependabot-tidy.yml` to automatically run `go mod tidy` and `go mod vendor` on both the root and `/test` modules when Dependabot opens a PR, and pushes any resulting changes back to the PR branch.
* Ensures that `/test` module dependencies and vendoring stay in sync with the root after dependency updates, preventing stale or inconsistent dependency files.