### PR TITLE
fix: set padding bits at end of inode bitmap in compactext4

### DIFF
--- a/ext4/internal/compactext4/compact.go
+++ b/ext4/internal/compactext4/compact.go
@@ -1276,6 +1276,13 @@ func (w *Writer) Close() error {
 				dirCount++
 			}
 		}
+		// Bits beyond inodesPerGroup don't correspond to real inodes; e2fsck
+		// expects this padding to be set so allocators never consider them
+		// free. Don't count them in usedInodeCount: free-inode accounting is
+		// based on inodesPerGroup real inodes.
+		for j := inodesPerGroup; j < BlockSize*8; j++ {
+			b[BlockSize+j/8] |= 1 << (j % 8)
+		}
 		_, err := w.write(b[:])
 		if err != nil {
 			return err

--- a/ext4/internal/compactext4/compact_test.go
+++ b/ext4/internal/compactext4/compact_test.go
@@ -221,6 +221,73 @@ func TestBasic(t *testing.T) {
 	runTestsOnFiles(t, testFiles)
 }
 
+// TestInodeBitmapPadding verifies that inode bitmap bits beyond
+// inodesPerGroup are set in every group. e2fsck (1.47.x and later) reports
+// "Padding at end of inode bitmap is not set" otherwise, and allocators
+// could treat nonexistent inodes as free.
+func TestInodeBitmapPadding(t *testing.T) {
+	image := "testfs.img"
+	imagef, err := os.Create(image)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(image)
+	defer imagef.Close()
+
+	w := NewWriter(imagef)
+	testFiles := []testFile{
+		{Path: "dir", File: &File{Mode: format.S_IFDIR | 0755}},
+		{Path: "dir/file", File: &File{Mode: 0644}, Data: data[:40]},
+	}
+	for _, tf := range testFiles {
+		createTestFile(t, w, tf)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	var sb format.SuperBlock
+	if _, err := imagef.Seek(1024, io.SeekStart); err != nil {
+		t.Fatal(err)
+	}
+	if err := binary.Read(imagef, binary.LittleEndian, &sb); err != nil {
+		t.Fatal(err)
+	}
+	if sb.Magic != format.SuperBlockMagic {
+		t.Fatalf("bad superblock magic %#x", sb.Magic)
+	}
+	if sb.InodesPerGroup >= BlockSize*8 {
+		t.Fatalf("test image has no inode bitmap padding (inodesPerGroup=%d)", sb.InodesPerGroup)
+	}
+	groups := sb.InodesCount / sb.InodesPerGroup
+
+	gds := make([]format.GroupDescriptor, groups)
+	if _, err := imagef.Seek(BlockSize, io.SeekStart); err != nil {
+		t.Fatal(err)
+	}
+	if err := binary.Read(imagef, binary.LittleEndian, gds); err != nil {
+		t.Fatal(err)
+	}
+
+	var bitmap [BlockSize]byte
+	for g, gd := range gds {
+		if _, err := imagef.ReadAt(bitmap[:], int64(gd.InodeBitmapLow)*BlockSize); err != nil {
+			t.Fatal(err)
+		}
+		for j := sb.InodesPerGroup; j < BlockSize*8; j++ {
+			if bitmap[j/8]&(1<<(j%8)) == 0 {
+				t.Fatalf("group %d: inode bitmap padding bit %d is not set", g, j)
+			}
+		}
+		// Padding bits must not be counted as used inodes.
+		if uint32(gd.FreeInodesCountLow) > sb.InodesPerGroup {
+			t.Errorf("group %d: free inode count %d exceeds inodesPerGroup %d", g, gd.FreeInodesCountLow, sb.InodesPerGroup)
+		}
+	}
+
+	fsck(t, image)
+}
+
 func TestLargeDirectory(t *testing.T) {
 	testFiles := []testFile{
 		{Path: "bigdir", File: &File{Mode: format.S_IFDIR | 0755}},


### PR DESCRIPTION
## Description

`compactext4` leaves the tail bits of each group's inode bitmap clear. ext4
convention (enforced by e2fsck) is that bitmap bits beyond the last real inode
in the block are set to 1 so allocators never treat nonexistent inodes as
free. As a result, e2fsck 1.47.x reports on any tar2ext4 output:

    Padding at end of inode bitmap is not set. Fix? no

and exits 4 ("filesystem still has errors"). The image is otherwise clean.

Since `bestGroupCount` commonly picks an `inodesPerGroup` well below
`maxInodesPerGroup` (32768), the unset padding affects every group, not just
the last. The block bitmap already handles its analogous case (blocks absent
from the disk in the last group are marked allocated); this adds the
inode-bitmap equivalent.

Padding bits are deliberately not counted in `usedInodeCount`: free-inode
accounting in the group descriptors and superblock is based on
`inodesPerGroup` real inodes. e2fsck reports identical file counts before and
after this change.

Found by running `e2fsck -f -n` against tar2ext4 output while benchmarking it
against another ext4 writer implementation (e2fsck 1.47.3). Existing tests
didn't catch this because the `fsck()` verification helper is Linux-only and
the per-block inode-bitmap padding check only appears in recent e2fsprogs.

## Repro

    go build ./cmd/tar2ext4
    ./tar2ext4 -i rootfs.tar -o rootfs.ext4
    e2fsck -f -n rootfs.ext4   # exits 4 before this change, 0 after

## Changes

- Set inode bitmap bits from `inodesPerGroup` to `BlockSize*8` in every group
  in `Writer.Close()`
- Add `TestInodeBitmapPadding`, which parses the superblock and group
  descriptors from the emitted image and asserts the padding bits directly
  (platform-independent, doesn't depend on the host's e2fsck version), then
  runs the existing `fsck()` helper

## Compatibility note

This changes the emitted image bytes. Images remain deterministic (the
existing tar2ext4 determinism test passes), but dm-verity root hashes
computed over newly generated images will differ from those of images
generated before this change.