### PR TITLE
test: use k8s.io/cri-client util for GetAddressAndDialer

### DIFF
--- a/test/cri-containerd/main_test.go
+++ b/test/cri-containerd/main_test.go
@@ -10,10 +10,10 @@ import (
 	"testing"
 	"time"
 
-	kubeutil "github.com/containerd/containerd/v2/integration/remote/util"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+	kubeutil "k8s.io/cri-client/pkg/util"
 
 	"github.com/Microsoft/hcsshim/osversion"
 	testflag "github.com/Microsoft/hcsshim/test/pkg/flag"

--- a/test/go.mod
+++ b/test/go.mod
@@ -27,6 +27,7 @@ require (
 	google.golang.org/grpc v1.82.0
 	google.golang.org/protobuf v1.36.11
 	k8s.io/cri-api v0.34.1
+	k8s.io/cri-client v0.34.1
 )
 
 require (

--- a/test/go.sum
+++ b/test/go.sum
@@ -395,5 +395,7 @@ honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 k8s.io/cri-api v0.34.1 h1:n2bU++FqqJq0CNjP/5pkOs0nIx7aNpb1Xa053TecQkM=
 k8s.io/cri-api v0.34.1/go.mod h1:4qVUjidMg7/Z9YGZpqIDygbkPWkg3mkS1PvOx/kpHTE=
+k8s.io/cri-client v0.34.1 h1:eq6FcEPDDL379w0WhPnItj2egsMZqOtU7nv1JaJmwP0=
+k8s.io/cri-client v0.34.1/go.mod h1:Dq6mKWV2ugO5tMv4xqVgcQ8vD7csP//e4KkzcFi2Pio=
 sigs.k8s.io/yaml v1.6.0 h1:G8fkbMSAFqgEFgh4b1wmtzDnioxFCUgTZhlbj5P9QYs=
 sigs.k8s.io/yaml v1.6.0/go.mod h1:796bPqUfzR/0jLAl6XjHl3Ck7MiyVv8dbTdyT3/pMf4=

--- a/test/internal/containerd/containerd.go
+++ b/test/internal/containerd/containerd.go
@@ -14,12 +14,12 @@ import (
 	"github.com/containerd/containerd/v2/core/remotes/docker"
 	"github.com/containerd/containerd/v2/core/remotes/docker/config"
 	"github.com/containerd/containerd/v2/core/snapshots"
-	kubeutil "github.com/containerd/containerd/v2/integration/remote/util"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/platforms"
 	"github.com/opencontainers/image-spec/identity"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+	kubeutil "k8s.io/cri-client/pkg/util"
 
 	imagesutil "github.com/Microsoft/hcsshim/test/pkg/images"
 	"github.com/Microsoft/hcsshim/test/pkg/timeout"


### PR DESCRIPTION
containerd removed integration/remote/util in v2.3 (CRI migrated to the upstream Kubernetes modules). Switch hcsshim/test to k8s.io/cri-client/pkg/util so the test module builds against containerd/v2 v2.3+.