### PR TITLE
test: fix race in TestBridge_FullReconnectCycle

### DIFF
--- a/internal/guest/bridge/bridge_reconnect_test.go
+++ b/internal/guest/bridge/bridge_reconnect_test.go
@@ -120,8 +120,13 @@ func TestBridge_FullReconnectCycle(t *testing.T) {
 	b.responseChan = make(chan bridgeResponse, 4)
 	b.quitChan = make(chan bool)
 
+	// Bind the writer goroutine to this iteration's channel explicitly.
+	// Ranging over b.responseChan directly reads the field lazily when the
+	// goroutine is scheduled, which can race with the reassignment in
+	// iteration 2 and let this goroutine steal the drained notification.
+	rc1 := b.responseChan
 	go func() {
-		for range b.responseChan {
+		for range rc1 {
 		}
 	}() // drain writer
 


### PR DESCRIPTION
The iteration-1 writer goroutine ranged over b.responseChan directly, so the field was read lazily when the goroutine was scheduled. If that happened after iteration 2 reassigned b.responseChan, the leftover goroutine bound to the new channel and consumed the drained "between" notification, making the test's receive time out.

Capture the channel in a local variable so the goroutine is bound to iteration 1's channel regardless of later reassignment.