### PR TITLE
Write enhanced fragment loading diagnostics and expose to container in the security context

### DIFF
--- a/internal/gcs-sidecar/handlers.go
+++ b/internal/gcs-sidecar/handlers.go
@@ -22,6 +22,7 @@ import (
 	"github.com/Microsoft/hcsshim/internal/guestpath"
 	hcsschema "github.com/Microsoft/hcsshim/internal/hcs/schema2"
 	"github.com/Microsoft/hcsshim/internal/log"
+	"github.com/Microsoft/hcsshim/internal/logfields"
 	oci "github.com/Microsoft/hcsshim/internal/oci"
 	"github.com/Microsoft/hcsshim/internal/ot"
 	"github.com/Microsoft/hcsshim/internal/protocol/guestrequest"
@@ -163,8 +164,10 @@ func (b *Bridge) createContainer(req *request) (err error) {
 			}
 		}()
 
+		var securityContextDir string
+
 		if oci.ParseAnnotationsBool(ctx, spec.Annotations, annotations.WCOWSecurityPolicyEnv, true) {
-			securityContextDir, err := b.hostState.securityOptions.WriteSecurityContextDir(&spec)
+			securityContextDir, err = b.hostState.securityOptions.WriteSecurityContextDir(&spec)
 			if err != nil {
 				return fmt.Errorf("failed to write security context dir: %w", err)
 			}
@@ -179,6 +182,21 @@ func (b *Bridge) createContainer(req *request) (err error) {
 				}
 			}
 			cwcowHostedSystemConfig.Spec = spec
+		}
+
+		// Add this fragments.debug mount after policy enforcement and
+		// reconcile checks so the policy does not have to explicitly
+		// allow it.
+		if securityContextDir != "" {
+			if err := os.MkdirAll(guestpath.WCOWFragmentsPath, 0755); err != nil {
+				log.G(ctx).WithError(err).WithField(logfields.Path, guestpath.WCOWFragmentsPath).Warn("failed to create fragments debug mount path in uVM")
+			} else {
+				container.MappedDirectories = append(container.MappedDirectories, hcsschema.MappedDirectory{
+					HostPath:      guestpath.WCOWFragmentsPath,
+					ContainerPath: filepath.Join(`C:\`, filepath.Base(securityContextDir), "fragments.debug"),
+					ReadOnly:      true,
+				})
+			}
 		}
 
 		// Strip the spec field

--- a/internal/gcs-sidecar/handlers.go
+++ b/internal/gcs-sidecar/handlers.go
@@ -181,16 +181,16 @@ func (b *Bridge) createContainer(req *request) (err error) {
 			cwcowHostedSystemConfig.Spec = spec
 		}
 
-		// Add this fragments.debug mount after policy enforcement and
+		// Add this fragments.info mount after policy enforcement and
 		// reconcile checks so the policy does not have to explicitly
 		// allow it.
 		if securityContextDir != "" {
-			if err := os.MkdirAll(guestpath.WCOWFragmentsPath, 0755); err != nil {
-				log.G(ctx).WithError(err).WithField(logfields.Path, guestpath.WCOWFragmentsPath).Warn("failed to create fragments debug mount path in uVM")
+			if err := b.hostState.securityOptions.EnsureFragmentDiagnosticsDir(); err != nil {
+				log.G(ctx).WithError(err).WithField(logfields.Path, guestpath.WCOWFragmentsPath).Warn("failed to prepare fragments.info mount path in uVM")
 			} else {
 				container.MappedDirectories = append(container.MappedDirectories, hcsschema.MappedDirectory{
 					HostPath:      guestpath.WCOWFragmentsPath,
-					ContainerPath: filepath.Join(`C:\`, filepath.Base(securityContextDir), "fragments.debug"),
+					ContainerPath: filepath.Join(`C:\`, filepath.Base(securityContextDir), "fragments.info"),
 					ReadOnly:      true,
 				})
 			}

--- a/internal/gcs-sidecar/handlers.go
+++ b/internal/gcs-sidecar/handlers.go
@@ -19,8 +19,10 @@ import (
 	"github.com/Microsoft/hcsshim/internal/copyfile"
 	"github.com/Microsoft/hcsshim/internal/fsformatter"
 	"github.com/Microsoft/hcsshim/internal/gcs/prot"
+	"github.com/Microsoft/hcsshim/internal/guestpath"
 	hcsschema "github.com/Microsoft/hcsshim/internal/hcs/schema2"
 	"github.com/Microsoft/hcsshim/internal/log"
+	"github.com/Microsoft/hcsshim/internal/logfields"
 	oci "github.com/Microsoft/hcsshim/internal/oci"
 	"github.com/Microsoft/hcsshim/internal/ot"
 	"github.com/Microsoft/hcsshim/internal/protocol/guestrequest"
@@ -159,8 +161,10 @@ func (b *Bridge) createContainer(req *request) (err error) {
 			}
 		}()
 
+		var securityContextDir string
+
 		if oci.ParseAnnotationsBool(ctx, spec.Annotations, annotations.WCOWSecurityPolicyEnv, true) {
-			securityContextDir, err := b.hostState.securityOptions.WriteSecurityContextDir(&spec)
+			securityContextDir, err = b.hostState.securityOptions.WriteSecurityContextDir(&spec)
 			if err != nil {
 				return fmt.Errorf("failed to write security context dir: %w", err)
 			}
@@ -175,6 +179,21 @@ func (b *Bridge) createContainer(req *request) (err error) {
 				}
 			}
 			cwcowHostedSystemConfig.Spec = spec
+		}
+
+		// Add this fragments.debug mount after policy enforcement and
+		// reconcile checks so the policy does not have to explicitly
+		// allow it.
+		if securityContextDir != "" {
+			if err := os.MkdirAll(guestpath.WCOWFragmentsPath, 0755); err != nil {
+				log.G(ctx).WithError(err).WithField(logfields.Path, guestpath.WCOWFragmentsPath).Warn("failed to create fragments debug mount path in uVM")
+			} else {
+				container.MappedDirectories = append(container.MappedDirectories, hcsschema.MappedDirectory{
+					HostPath:      guestpath.WCOWFragmentsPath,
+					ContainerPath: filepath.Join(`C:\`, filepath.Base(securityContextDir), "fragments.debug"),
+					ReadOnly:      true,
+				})
+			}
 		}
 
 		// Strip the spec field

--- a/internal/gcs-sidecar/handlers.go
+++ b/internal/gcs-sidecar/handlers.go
@@ -184,16 +184,16 @@ func (b *Bridge) createContainer(req *request) (err error) {
 			cwcowHostedSystemConfig.Spec = spec
 		}
 
-		// Add this fragments.debug mount after policy enforcement and
+		// Add this fragments.info mount after policy enforcement and
 		// reconcile checks so the policy does not have to explicitly
 		// allow it.
 		if securityContextDir != "" {
-			if err := os.MkdirAll(guestpath.WCOWFragmentsPath, 0755); err != nil {
-				log.G(ctx).WithError(err).WithField(logfields.Path, guestpath.WCOWFragmentsPath).Warn("failed to create fragments debug mount path in uVM")
+			if err := b.hostState.securityOptions.EnsureFragmentDiagnosticsDir(); err != nil {
+				log.G(ctx).WithError(err).WithField(logfields.Path, guestpath.WCOWFragmentsPath).Warn("failed to prepare fragments.info mount path in uVM")
 			} else {
 				container.MappedDirectories = append(container.MappedDirectories, hcsschema.MappedDirectory{
 					HostPath:      guestpath.WCOWFragmentsPath,
-					ContainerPath: filepath.Join(`C:\`, filepath.Base(securityContextDir), "fragments.debug"),
+					ContainerPath: filepath.Join(`C:\`, filepath.Base(securityContextDir), "fragments.info"),
 					ReadOnly:      true,
 				})
 			}

--- a/internal/guest/runtime/hcsv2/uvm.go
+++ b/internal/guest/runtime/hcsv2/uvm.go
@@ -826,8 +826,23 @@ func (h *Host) CreateContainer(ctx context.Context, id string, settings *prot.VM
 	}
 
 	if oci.ParseAnnotationsBool(ctx, settings.OCISpecification.Annotations, annotations.LCOWSecurityPolicyEnv, true) {
-		if _, err := h.securityOptions.WriteSecurityContextDir(settings.OCISpecification); err != nil {
+		securityContextDir, err := h.securityOptions.WriteSecurityContextDir(settings.OCISpecification)
+		if err != nil {
 			return nil, fmt.Errorf("failed to write security context dir: %w", err)
+		}
+		// Add this special fragments debug mount after policy enforcement
+		// so the policy does not have to explicitly allow it.
+		if securityContextDir != "" {
+			if err := os.MkdirAll(guestpath.LCOWFragmentsPath, 0755); err != nil {
+				log.G(ctx).WithError(err).WithField(logfields.Path, guestpath.LCOWFragmentsPath).Warn("failed to create fragments debug mount path in uVM")
+			} else {
+				settings.OCISpecification.Mounts = append(settings.OCISpecification.Mounts, specs.Mount{
+					Destination: path.Join("/", filepath.Base(securityContextDir), "fragments.debug"),
+					Type:        "bind",
+					Source:      guestpath.LCOWFragmentsPath,
+					Options:     []string{"bind", "ro"},
+				})
+			}
 		}
 	}
 

--- a/internal/guest/runtime/hcsv2/uvm.go
+++ b/internal/guest/runtime/hcsv2/uvm.go
@@ -739,8 +739,23 @@ func (h *Host) CreateContainer(ctx context.Context, id string, settings *prot.VM
 	}
 
 	if oci.ParseAnnotationsBool(ctx, settings.OCISpecification.Annotations, annotations.LCOWSecurityPolicyEnv, true) {
-		if _, err := h.securityOptions.WriteSecurityContextDir(settings.OCISpecification); err != nil {
+		securityContextDir, err := h.securityOptions.WriteSecurityContextDir(settings.OCISpecification)
+		if err != nil {
 			return nil, fmt.Errorf("failed to write security context dir: %w", err)
+		}
+		// Add this special fragments debug mount after policy enforcement
+		// so the policy does not have to explicitly allow it.
+		if securityContextDir != "" {
+			if err := os.MkdirAll(guestpath.LCOWFragmentsPath, 0755); err != nil {
+				log.G(ctx).WithError(err).WithField(logfields.Path, guestpath.LCOWFragmentsPath).Warn("failed to create fragments debug mount path in uVM")
+			} else {
+				settings.OCISpecification.Mounts = append(settings.OCISpecification.Mounts, specs.Mount{
+					Destination: path.Join("/", filepath.Base(securityContextDir), "fragments.debug"),
+					Type:        "bind",
+					Source:      guestpath.LCOWFragmentsPath,
+					Options:     []string{"bind", "ro"},
+				})
+			}
 		}
 	}
 

--- a/internal/guest/runtime/hcsv2/uvm.go
+++ b/internal/guest/runtime/hcsv2/uvm.go
@@ -743,14 +743,14 @@ func (h *Host) CreateContainer(ctx context.Context, id string, settings *prot.VM
 		if err != nil {
 			return nil, fmt.Errorf("failed to write security context dir: %w", err)
 		}
-		// Add this special fragments debug mount after policy enforcement
+		// Add this special fragments.info mount after policy enforcement
 		// so the policy does not have to explicitly allow it.
 		if securityContextDir != "" {
-			if err := os.MkdirAll(guestpath.LCOWFragmentsPath, 0755); err != nil {
-				log.G(ctx).WithError(err).WithField(logfields.Path, guestpath.LCOWFragmentsPath).Warn("failed to create fragments debug mount path in uVM")
+			if err := h.securityOptions.EnsureFragmentDiagnosticsDir(); err != nil {
+				log.G(ctx).WithError(err).WithField(logfields.Path, guestpath.LCOWFragmentsPath).Warn("failed to prepare fragments.info mount path in uVM")
 			} else {
 				settings.OCISpecification.Mounts = append(settings.OCISpecification.Mounts, specs.Mount{
-					Destination: path.Join("/", filepath.Base(securityContextDir), "fragments.debug"),
+					Destination: path.Join("/", filepath.Base(securityContextDir), "fragments.info"),
 					Type:        "bind",
 					Source:      guestpath.LCOWFragmentsPath,
 					Options:     []string{"bind", "ro"},

--- a/internal/guest/runtime/hcsv2/uvm.go
+++ b/internal/guest/runtime/hcsv2/uvm.go
@@ -830,14 +830,14 @@ func (h *Host) CreateContainer(ctx context.Context, id string, settings *prot.VM
 		if err != nil {
 			return nil, fmt.Errorf("failed to write security context dir: %w", err)
 		}
-		// Add this special fragments debug mount after policy enforcement
+		// Add this special fragments.info mount after policy enforcement
 		// so the policy does not have to explicitly allow it.
 		if securityContextDir != "" {
-			if err := os.MkdirAll(guestpath.LCOWFragmentsPath, 0755); err != nil {
-				log.G(ctx).WithError(err).WithField(logfields.Path, guestpath.LCOWFragmentsPath).Warn("failed to create fragments debug mount path in uVM")
+			if err := h.securityOptions.EnsureFragmentDiagnosticsDir(); err != nil {
+				log.G(ctx).WithError(err).WithField(logfields.Path, guestpath.LCOWFragmentsPath).Warn("failed to prepare fragments.info mount path in uVM")
 			} else {
 				settings.OCISpecification.Mounts = append(settings.OCISpecification.Mounts, specs.Mount{
-					Destination: path.Join("/", filepath.Base(securityContextDir), "fragments.debug"),
+					Destination: path.Join("/", filepath.Base(securityContextDir), "fragments.info"),
 					Type:        "bind",
 					Source:      guestpath.LCOWFragmentsPath,
 					Options:     []string{"bind", "ro"},

--- a/internal/guestpath/paths.go
+++ b/internal/guestpath/paths.go
@@ -11,6 +11,12 @@ const (
 	// WCOWRootPrefixInUVM is the path inside UVM where WCOW container's root
 	// file system will be mounted
 	WCOWRootPrefixInUVM = `C:\c`
+	// LCOWFragmentsPath is the path inside the UVM where injected security
+	// policy fragments are stored.
+	LCOWFragmentsPath = "/tmp/fragments"
+	// WCOWFragmentsPath is the path inside the UVM where injected security
+	// policy fragments are stored.
+	WCOWFragmentsPath = `C:\InjectedFragments`
 	// SandboxMountPrefix is mount prefix used in container spec to mark a
 	// sandbox-mount
 	SandboxMountPrefix = "sandbox://"

--- a/internal/guestpath/paths.go
+++ b/internal/guestpath/paths.go
@@ -14,6 +14,12 @@ const (
 	// WCOWSandboxMountPath is the path inside the UVM where WCOW sandbox mounts
 	// are created.
 	WCOWSandboxMountPath = `C:\SandboxMounts`
+	// LCOWFragmentsPath is the path inside the UVM where injected security
+	// policy fragments are stored.
+	LCOWFragmentsPath = "/tmp/fragments"
+	// WCOWFragmentsPath is the path inside the UVM where injected security
+	// policy fragments are stored.
+	WCOWFragmentsPath = `C:\InjectedFragments`
 	// SandboxMountPrefix is mount prefix used in container spec to mark a
 	// sandbox-mount
 	SandboxMountPrefix = "sandbox://"

--- a/pkg/securitypolicy/fragments_info_README
+++ b/pkg/securitypolicy/fragments_info_README
@@ -1,1 +1,1 @@
-The content of this directory is for informational purpose and should not be relied upon for security.
+The content of this directory is for informational purposes and should not be relied upon for security.

--- a/pkg/securitypolicy/fragments_info_README
+++ b/pkg/securitypolicy/fragments_info_README
@@ -1,0 +1,1 @@
+The content of this directory is for informational purpose and should not be relied upon for security.

--- a/pkg/securitypolicy/securitypolicy_linux.go
+++ b/pkg/securitypolicy/securitypolicy_linux.go
@@ -15,7 +15,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-//nolint:unused
 const osType = "linux"
 
 func ExtendPolicyWithNetworkingMounts(sandboxRoot string, enforcer SecurityPolicyEnforcer, spec *oci.Spec) error {

--- a/pkg/securitypolicy/securitypolicy_options.go
+++ b/pkg/securitypolicy/securitypolicy_options.go
@@ -4,16 +4,19 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"io"
 	"math"
 	"os"
 	"path/filepath"
 	"sync"
-	"time"
+	"sync/atomic"
 
 	"github.com/Microsoft/cosesign1go/pkg/cosesign1"
 	didx509resolver "github.com/Microsoft/didx509go/pkg/did-x509-resolver"
+	"github.com/Microsoft/hcsshim/internal/guestpath"
 	"github.com/Microsoft/hcsshim/internal/log"
 	"github.com/Microsoft/hcsshim/internal/ot"
 	"github.com/Microsoft/hcsshim/internal/protocol/guestresource"
@@ -33,6 +36,18 @@ type SecurityOptions struct {
 	UvmHashEnvelopeReferenceInfo string
 	policyMutex                  sync.Mutex
 	logWriter                    io.Writer
+}
+
+// Global counter for fragment injection requests, used to create unique
+// error / success marker files even when the same fragment is injected
+// multiple times.
+var FragmentRequestId atomic.Uint64
+
+func fragmentsPath() string {
+	if osType == "windows" {
+		return guestpath.WCOWFragmentsPath
+	}
+	return guestpath.LCOWFragmentsPath
 }
 
 func NewSecurityOptions(enforcer SecurityPolicyEnforcer, enforcerSet bool, uvmReferenceInfo string, uvmHashEnvelopeReferenceInfo string, logWriter io.Writer) *SecurityOptions {
@@ -57,6 +72,14 @@ func (s *SecurityOptions) SetConfidentialOptions(ctx context.Context, enforcerTy
 
 	if s.PolicyEnforcerSet {
 		return errors.New("security policy has already been set")
+	}
+
+	// Pre-create this directory so that we can mount this dir into
+	// containers even if no fragments have been injected yet when the
+	// container starts.
+	if err := os.MkdirAll(fragmentsPath(), 0755); err != nil {
+		// This is not fatal, don't fail here.
+		log.G(ctx).WithError(err).Error("failed to create injected fragments directory")
 	}
 
 	hostData, err := NewSecurityPolicyDigest(encodedSecurityPolicy)
@@ -140,6 +163,42 @@ func asInt64(v interface{}) (int64, error) {
 	}
 }
 
+func writeFileIfNotExists(filename string, data []byte, perm os.FileMode) error {
+	file, err := os.OpenFile(filename, os.O_WRONLY|os.O_CREATE|os.O_EXCL, perm)
+	if os.IsExist(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	if _, err := file.Write(data); err != nil {
+		_ = file.Close()
+		return err
+	}
+	return file.Close()
+}
+
+func writeFragmentMetadata(ctx context.Context, filename, issuer, feed string, headerSVN *int64) {
+	metadata := struct {
+		Issuer    string `json:"issuer"`
+		Feed      string `json:"feed"`
+		HeaderSVN *int64 `json:"headerSvn"`
+	}{
+		Issuer:    issuer,
+		Feed:      feed,
+		HeaderSVN: headerSVN,
+	}
+	contents, err := json.Marshal(metadata)
+	if err != nil {
+		log.G(ctx).WithError(err).Warn("failed to marshal injected fragment metadata")
+		return
+	}
+	if err := writeFileIfNotExists(filename, contents, 0644); err != nil {
+		log.G(ctx).WithError(err).Warn("failed to write injected fragment metadata")
+	}
+}
+
 // Fragment extends current security policy with additional constraints
 // from the incoming fragment. Note that it is base64 encoded over the bridge/
 //
@@ -155,12 +214,39 @@ func (s *SecurityOptions) InjectFragment(ctx context.Context, fragment *guestres
 	defer span.End()
 	defer func() { ot.SetSpanStatus(span, err) }()
 	span.SetAttributes(attribute.String("fragment", fmt.Sprintf("%+v", fragment)))
+	currReqId := FragmentRequestId.Add(1)
 
 	// An empty media type defaults to a Rego policy fragment, for backward
 	// compatibility with older hosts that do not set the field.
 	mediaType := fragment.MediaType
 	if mediaType == "" {
 		mediaType = mediaTypeFragment
+	}
+
+	raw, err := base64.StdEncoding.DecodeString(fragment.Fragment)
+	if err != nil {
+		return fmt.Errorf("failed to decode fragment: %w", err)
+	}
+	sha := sha256.Sum256(raw)
+	shaHex := hex.EncodeToString(sha[:])
+	thisFragmentDir := filepath.Join(fragmentsPath(), shaHex)
+	defer func() {
+		markerName := fmt.Sprintf("%d.succeed", currReqId)
+		var markerContents []byte
+		if err != nil {
+			markerName = fmt.Sprintf("%d.fail", currReqId)
+			markerContents = []byte(err.Error())
+		}
+		if markerErr := os.WriteFile(filepath.Join(thisFragmentDir, markerName), markerContents, 0644); markerErr != nil {
+			log.G(ctx).WithError(markerErr).Warnf("failed to write injected fragment outcome marker %s", markerName)
+		}
+	}()
+
+	if err := os.MkdirAll(thisFragmentDir, 0755); err != nil {
+		return fmt.Errorf("failed to create injected fragment directory: %w", err)
+	}
+	if err := writeFileIfNotExists(filepath.Join(thisFragmentDir, "fragment.cose"), raw, 0644); err != nil {
+		return fmt.Errorf("failed to write fragment.cose: %w", err)
 	}
 	switch mediaType {
 	case mediaTypeFragment, mediaTypeTransparencyTrustList:
@@ -172,23 +258,12 @@ func (s *SecurityOptions) InjectFragment(ctx context.Context, fragment *guestres
 		return fmt.Errorf("cannot inject fragment blob with unsupported media type %q", mediaType)
 	}
 
-	raw, err := base64.StdEncoding.DecodeString(fragment.Fragment)
-	if err != nil {
-		return fmt.Errorf("failed to decode fragment: %w", err)
-	}
-	blob := []byte(fragment.Fragment)
-	// keep a copy of the fragment, so we can manually figure out what went wrong
-	// will be removed eventually. Give it a unique name to avoid any potential
-	// race conditions.
-	sha := sha256.New()
-	sha.Write(blob)
-	timestamp := time.Now()
-	fragmentPath := fmt.Sprintf("fragment-%x-%d.blob", sha.Sum(nil), timestamp.UnixMilli())
-	_ = os.WriteFile(filepath.Join(os.TempDir(), fragmentPath), blob, 0644)
-
 	unpacked, err := cosesign1.UnpackAndValidateCOSE1CertChain(raw)
 	if err != nil {
 		return fmt.Errorf("InjectFragment failed COSE validation: %w", err)
+	}
+	if err := writeFileIfNotExists(filepath.Join(thisFragmentDir, "fragment"), unpacked.Payload, 0644); err != nil {
+		return fmt.Errorf("failed to write injected fragment payload: %w", err)
 	}
 
 	cwtClaimsRaw, hasCwtClaims := unpacked.Protected[cosesign1.COSE_Header_CWTClaims]
@@ -241,6 +316,7 @@ func (s *SecurityOptions) InjectFragment(ctx context.Context, fragment *guestres
 			svnFromCwt = &svn
 		}
 	}
+	writeFragmentMetadata(ctx, filepath.Join(thisFragmentDir, "metadata.json"), issuer, feed, svnFromCwt)
 
 	switch mediaType {
 	case mediaTypeTransparencyTrustList:

--- a/pkg/securitypolicy/securitypolicy_options.go
+++ b/pkg/securitypolicy/securitypolicy_options.go
@@ -48,7 +48,7 @@ type SecurityOptions struct {
 // Global counter for fragment injection requests, used to create unique
 // deny / success marker files even when the same fragment is injected
 // multiple times.
-var FragmentRequestId atomic.Uint64
+var FragmentRequestID atomic.Uint64
 
 //go:embed fragments_info_README
 var fragmentsInfoREADME []byte
@@ -240,7 +240,7 @@ func (s *SecurityOptions) InjectFragment(ctx context.Context, fragment *guestres
 	defer span.End()
 	defer func() { ot.SetSpanStatus(span, err) }()
 	span.SetAttributes(attribute.String("fragment", fmt.Sprintf("%+v", fragment)))
-	currReqId := FragmentRequestId.Add(1)
+	currReqID := FragmentRequestID.Add(1)
 
 	// An empty media type defaults to a Rego policy fragment, for backward
 	// compatibility with older hosts that do not set the field.
@@ -257,10 +257,10 @@ func (s *SecurityOptions) InjectFragment(ctx context.Context, fragment *guestres
 	shaHex := hex.EncodeToString(sha[:])
 	thisFragmentDir := filepath.Join(fragmentsPath(), shaHex)
 	defer func() {
-		markerName := fmt.Sprintf("%d.succeed", currReqId)
+		markerName := fmt.Sprintf("%d.succeed", currReqID)
 		var markerContents []byte
 		if err != nil {
-			markerName = fmt.Sprintf("%d.deny", currReqId)
+			markerName = fmt.Sprintf("%d.deny", currReqID)
 			markerContents = []byte(err.Error())
 		}
 		if markerErr := os.WriteFile(filepath.Join(thisFragmentDir, markerName), markerContents, 0644); markerErr != nil {

--- a/pkg/securitypolicy/securitypolicy_options.go
+++ b/pkg/securitypolicy/securitypolicy_options.go
@@ -3,6 +3,7 @@ package securitypolicy
 import (
 	"context"
 	"crypto/sha256"
+	_ "embed"
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
@@ -45,15 +46,28 @@ type SecurityOptions struct {
 }
 
 // Global counter for fragment injection requests, used to create unique
-// error / success marker files even when the same fragment is injected
+// deny / success marker files even when the same fragment is injected
 // multiple times.
 var FragmentRequestId atomic.Uint64
+
+//go:embed fragments_info_README
+var fragmentsInfoREADME []byte
 
 func fragmentsPath() string {
 	if osType == "windows" {
 		return guestpath.WCOWFragmentsPath
 	}
 	return guestpath.LCOWFragmentsPath
+}
+
+// EnsureFragmentDiagnosticsDir creates the fragment diagnostics directory and
+// its informational README.
+func (s *SecurityOptions) EnsureFragmentDiagnosticsDir() error {
+	dir := fragmentsPath()
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(dir, "README"), fragmentsInfoREADME, 0644)
 }
 
 func NewSecurityOptions(enforcer SecurityPolicyEnforcer, enforcerSet bool, uvmReferenceInfo string, uvmHashEnvelopeReferenceInfo string, logWriter io.Writer) *SecurityOptions {
@@ -83,9 +97,9 @@ func (s *SecurityOptions) SetConfidentialOptions(ctx context.Context, enforcerTy
 	// Pre-create this directory so that we can mount this dir into
 	// containers even if no fragments have been injected yet when the
 	// container starts.
-	if err := os.MkdirAll(fragmentsPath(), 0755); err != nil {
+	if err := s.EnsureFragmentDiagnosticsDir(); err != nil {
 		// This is not fatal, don't fail here.
-		log.G(ctx).WithError(err).Error("failed to create injected fragments directory")
+		log.G(ctx).WithError(err).Error("failed to prepare injected fragments directory")
 	}
 
 	hostData, err := NewSecurityPolicyDigest(encodedSecurityPolicy)
@@ -246,7 +260,7 @@ func (s *SecurityOptions) InjectFragment(ctx context.Context, fragment *guestres
 		markerName := fmt.Sprintf("%d.succeed", currReqId)
 		var markerContents []byte
 		if err != nil {
-			markerName = fmt.Sprintf("%d.fail", currReqId)
+			markerName = fmt.Sprintf("%d.deny", currReqId)
 			markerContents = []byte(err.Error())
 		}
 		if markerErr := os.WriteFile(filepath.Join(thisFragmentDir, markerName), markerContents, 0644); markerErr != nil {

--- a/pkg/securitypolicy/securitypolicy_options.go
+++ b/pkg/securitypolicy/securitypolicy_options.go
@@ -67,7 +67,7 @@ func (s *SecurityOptions) EnsureFragmentDiagnosticsDir() error {
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return err
 	}
-	return os.WriteFile(filepath.Join(dir, "README"), fragmentsInfoREADME, 0644)
+	return writeFileIfNotExists(filepath.Join(dir, "README"), fragmentsInfoREADME, 0644)
 }
 
 func NewSecurityOptions(enforcer SecurityPolicyEnforcer, enforcerSet bool, uvmReferenceInfo string, uvmHashEnvelopeReferenceInfo string, logWriter io.Writer) *SecurityOptions {

--- a/pkg/securitypolicy/securitypolicy_options.go
+++ b/pkg/securitypolicy/securitypolicy_options.go
@@ -3,6 +3,7 @@ package securitypolicy
 import (
 	"context"
 	"crypto/sha256"
+	_ "embed"
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
@@ -39,15 +40,28 @@ type SecurityOptions struct {
 }
 
 // Global counter for fragment injection requests, used to create unique
-// error / success marker files even when the same fragment is injected
+// deny / success marker files even when the same fragment is injected
 // multiple times.
 var FragmentRequestId atomic.Uint64
+
+//go:embed fragments_info_README
+var fragmentsInfoREADME []byte
 
 func fragmentsPath() string {
 	if osType == "windows" {
 		return guestpath.WCOWFragmentsPath
 	}
 	return guestpath.LCOWFragmentsPath
+}
+
+// EnsureFragmentDiagnosticsDir creates the fragment diagnostics directory and
+// its informational README.
+func (s *SecurityOptions) EnsureFragmentDiagnosticsDir() error {
+	dir := fragmentsPath()
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(dir, "README"), fragmentsInfoREADME, 0644)
 }
 
 func NewSecurityOptions(enforcer SecurityPolicyEnforcer, enforcerSet bool, uvmReferenceInfo string, uvmHashEnvelopeReferenceInfo string, logWriter io.Writer) *SecurityOptions {
@@ -77,9 +91,9 @@ func (s *SecurityOptions) SetConfidentialOptions(ctx context.Context, enforcerTy
 	// Pre-create this directory so that we can mount this dir into
 	// containers even if no fragments have been injected yet when the
 	// container starts.
-	if err := os.MkdirAll(fragmentsPath(), 0755); err != nil {
+	if err := s.EnsureFragmentDiagnosticsDir(); err != nil {
 		// This is not fatal, don't fail here.
-		log.G(ctx).WithError(err).Error("failed to create injected fragments directory")
+		log.G(ctx).WithError(err).Error("failed to prepare injected fragments directory")
 	}
 
 	hostData, err := NewSecurityPolicyDigest(encodedSecurityPolicy)
@@ -234,7 +248,7 @@ func (s *SecurityOptions) InjectFragment(ctx context.Context, fragment *guestres
 		markerName := fmt.Sprintf("%d.succeed", currReqId)
 		var markerContents []byte
 		if err != nil {
-			markerName = fmt.Sprintf("%d.fail", currReqId)
+			markerName = fmt.Sprintf("%d.deny", currReqId)
 			markerContents = []byte(err.Error())
 		}
 		if markerErr := os.WriteFile(filepath.Join(thisFragmentDir, markerName), markerContents, 0644); markerErr != nil {

--- a/pkg/securitypolicy/securitypolicy_options.go
+++ b/pkg/securitypolicy/securitypolicy_options.go
@@ -4,16 +4,19 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"io"
 	"math"
 	"os"
 	"path/filepath"
 	"sync"
-	"time"
+	"sync/atomic"
 
 	"github.com/Microsoft/cosesign1go/pkg/cosesign1"
 	didx509resolver "github.com/Microsoft/didx509go/pkg/did-x509-resolver"
+	"github.com/Microsoft/hcsshim/internal/guestpath"
 	"github.com/Microsoft/hcsshim/internal/log"
 	"github.com/Microsoft/hcsshim/internal/ot"
 	"github.com/Microsoft/hcsshim/internal/protocol/guestresource"
@@ -41,6 +44,18 @@ type SecurityOptions struct {
 	logWriter io.Writer
 }
 
+// Global counter for fragment injection requests, used to create unique
+// error / success marker files even when the same fragment is injected
+// multiple times.
+var FragmentRequestId atomic.Uint64
+
+func fragmentsPath() string {
+	if osType == "windows" {
+		return guestpath.WCOWFragmentsPath
+	}
+	return guestpath.LCOWFragmentsPath
+}
+
 func NewSecurityOptions(enforcer SecurityPolicyEnforcer, enforcerSet bool, uvmReferenceInfo string, uvmHashEnvelopeReferenceInfo string, logWriter io.Writer) *SecurityOptions {
 	return &SecurityOptions{
 		PolicyEnforcer:               enforcer,
@@ -63,6 +78,14 @@ func (s *SecurityOptions) SetConfidentialOptions(ctx context.Context, enforcerTy
 
 	if s.PolicyEnforcerSet {
 		return errors.New("security policy has already been set")
+	}
+
+	// Pre-create this directory so that we can mount this dir into
+	// containers even if no fragments have been injected yet when the
+	// container starts.
+	if err := os.MkdirAll(fragmentsPath(), 0755); err != nil {
+		// This is not fatal, don't fail here.
+		log.G(ctx).WithError(err).Error("failed to create injected fragments directory")
 	}
 
 	hostData, err := NewSecurityPolicyDigest(encodedSecurityPolicy)
@@ -152,6 +175,42 @@ func asInt64(v interface{}) (int64, error) {
 	}
 }
 
+func writeFileIfNotExists(filename string, data []byte, perm os.FileMode) error {
+	file, err := os.OpenFile(filename, os.O_WRONLY|os.O_CREATE|os.O_EXCL, perm)
+	if os.IsExist(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	if _, err := file.Write(data); err != nil {
+		_ = file.Close()
+		return err
+	}
+	return file.Close()
+}
+
+func writeFragmentMetadata(ctx context.Context, filename, issuer, feed string, headerSVN *int64) {
+	metadata := struct {
+		Issuer    string `json:"issuer"`
+		Feed      string `json:"feed"`
+		HeaderSVN *int64 `json:"headerSvn"`
+	}{
+		Issuer:    issuer,
+		Feed:      feed,
+		HeaderSVN: headerSVN,
+	}
+	contents, err := json.Marshal(metadata)
+	if err != nil {
+		log.G(ctx).WithError(err).Warn("failed to marshal injected fragment metadata")
+		return
+	}
+	if err := writeFileIfNotExists(filename, contents, 0644); err != nil {
+		log.G(ctx).WithError(err).Warn("failed to write injected fragment metadata")
+	}
+}
+
 // Fragment extends current security policy with additional constraints
 // from the incoming fragment. Note that it is base64 encoded over the bridge/
 //
@@ -167,12 +226,39 @@ func (s *SecurityOptions) InjectFragment(ctx context.Context, fragment *guestres
 	defer span.End()
 	defer func() { ot.SetSpanStatus(span, err) }()
 	span.SetAttributes(attribute.String("fragment", fmt.Sprintf("%+v", fragment)))
+	currReqId := FragmentRequestId.Add(1)
 
 	// An empty media type defaults to a Rego policy fragment, for backward
 	// compatibility with older hosts that do not set the field.
 	mediaType := fragment.MediaType
 	if mediaType == "" {
 		mediaType = mediaTypeFragment
+	}
+
+	raw, err := base64.StdEncoding.DecodeString(fragment.Fragment)
+	if err != nil {
+		return fmt.Errorf("failed to decode fragment: %w", err)
+	}
+	sha := sha256.Sum256(raw)
+	shaHex := hex.EncodeToString(sha[:])
+	thisFragmentDir := filepath.Join(fragmentsPath(), shaHex)
+	defer func() {
+		markerName := fmt.Sprintf("%d.succeed", currReqId)
+		var markerContents []byte
+		if err != nil {
+			markerName = fmt.Sprintf("%d.fail", currReqId)
+			markerContents = []byte(err.Error())
+		}
+		if markerErr := os.WriteFile(filepath.Join(thisFragmentDir, markerName), markerContents, 0644); markerErr != nil {
+			log.G(ctx).WithError(markerErr).Warnf("failed to write injected fragment outcome marker %s", markerName)
+		}
+	}()
+
+	if err := os.MkdirAll(thisFragmentDir, 0755); err != nil {
+		return fmt.Errorf("failed to create injected fragment directory: %w", err)
+	}
+	if err := writeFileIfNotExists(filepath.Join(thisFragmentDir, "fragment.cose"), raw, 0644); err != nil {
+		return fmt.Errorf("failed to write fragment.cose: %w", err)
 	}
 	switch mediaType {
 	case mediaTypeFragment, mediaTypeTransparencyTrustList, mediaTypeTCBReferenceInfo, mediaTypePlatformReferenceInfo:
@@ -184,24 +270,14 @@ func (s *SecurityOptions) InjectFragment(ctx context.Context, fragment *guestres
 		return fmt.Errorf("cannot inject fragment blob with unsupported media type %q", mediaType)
 	}
 
-	raw, err := base64.StdEncoding.DecodeString(fragment.Fragment)
-	if err != nil {
-		return fmt.Errorf("failed to decode fragment: %w", err)
-	}
-	blob := []byte(fragment.Fragment)
-	// keep a copy of the fragment, so we can manually figure out what went wrong
-	// will be removed eventually. Give it a unique name to avoid any potential
-	// race conditions.
-	sha := sha256.New()
-	sha.Write(blob)
-	timestamp := time.Now()
-	fragmentPath := fmt.Sprintf("fragment-%x-%d.blob", sha.Sum(nil), timestamp.UnixMilli())
-	_ = os.WriteFile(filepath.Join(os.TempDir(), fragmentPath), blob, 0644)
-
 	unpacked, err := cosesign1.UnpackAndValidateCOSE1CertChain(raw)
 	if err != nil {
 		return fmt.Errorf("InjectFragment failed COSE validation: %w", err)
 	}
+	if err := writeFileIfNotExists(filepath.Join(thisFragmentDir, "fragment"), unpacked.Payload, 0644); err != nil {
+		return fmt.Errorf("failed to write injected fragment payload: %w", err)
+	}
+
 	// We do not need to validate this.
 	if mediaType == mediaTypeTCBReferenceInfo || mediaType == mediaTypePlatformReferenceInfo {
 		s.platformReferenceInfoMutex.Lock()
@@ -264,6 +340,7 @@ func (s *SecurityOptions) InjectFragment(ctx context.Context, fragment *guestres
 			svnFromCwt = &svn
 		}
 	}
+	writeFragmentMetadata(ctx, filepath.Join(thisFragmentDir, "metadata.json"), issuer, feed, svnFromCwt)
 
 	switch mediaType {
 	case mediaTypeTransparencyTrustList:

--- a/pkg/securitypolicy/securitypolicy_options.go
+++ b/pkg/securitypolicy/securitypolicy_options.go
@@ -48,7 +48,7 @@ type SecurityOptions struct {
 // Global counter for fragment injection requests, used to create unique
 // deny / success marker files even when the same fragment is injected
 // multiple times.
-var FragmentRequestID atomic.Uint64
+var fragmentRequestID atomic.Uint64
 
 //go:embed fragments_info_README
 var fragmentsInfoREADME []byte
@@ -240,7 +240,7 @@ func (s *SecurityOptions) InjectFragment(ctx context.Context, fragment *guestres
 	defer span.End()
 	defer func() { ot.SetSpanStatus(span, err) }()
 	span.SetAttributes(attribute.String("fragment", fmt.Sprintf("%+v", fragment)))
-	currReqID := FragmentRequestID.Add(1)
+	currReqID := fragmentRequestID.Add(1)
 
 	// An empty media type defaults to a Rego policy fragment, for backward
 	// compatibility with older hosts that do not set the field.

--- a/pkg/securitypolicy/securitypolicy_windows.go
+++ b/pkg/securitypolicy/securitypolicy_windows.go
@@ -7,7 +7,6 @@ import (
 	oci "github.com/opencontainers/runtime-spec/specs-go"
 )
 
-//nolint:unused
 const osType = "windows"
 
 // SandboxMountsDir returns sandbox mounts directory inside UVM/host.


### PR DESCRIPTION
This is useful as a debugging aid and **not a security feature**.

Enhance the existing fragment dumping code to also write the error string or a success marker, the decoded fragment content, and metadata, and place them in a findable place on Windows and Linux.


Example:
```
PS C:\Users\azureuser\wcow_skr_fragment> .\runp.ps1
Started pod wcow_skr_fragment with ID:
3150bc51b63c583689503d1c26fe1d08a6cdddc217ff5087f9875bcd09a4f231
PS C:\Users\azureuser\wcow_skr_fragment> $env:podId=azcrictl pods -q
PS C:\Users\azureuser\wcow_skr_fragment> azcrictl inject-fragment $env:podId 'acidevacr.azurecr.io/internal/aci/aci-cc-infra-fragment:transparent-fragment-signing-0-20260615.3'
time="2026-07-19T23:37:53Z" level=fatal msg="injecting policy fragment: rpc error: code = Unknown desc = failed to inject any fragment: guest modify: guest RPC failure: error loading security policy fragment: policyDecision< eyJkZWNpc2lvbiI6ImRlbnkiLCJpbnB1dCI6eyJmZWVkIjoiYWNpZGV2YWNyLmF6dXJlY3IuaW8vaW50ZXJuYWwvYWNpL2FjaS1jYy1pbmZyYS1mcmFnbWVudCIsImZyYWdtZW50X2xvYWRlZCI6ZmFsc2UsImhhc19oZWFkZXJfc3ZuIjpmYWxzZSwiaGVhZGVyX3N2biI6bnVsbCwiaXNzdWVyIjoiZGlkOng1MDk6MDpzaGEyNTY6d1ZrU000NlNEcHc0THV5RVlvSDZyNXltMDd3aEw1bFd4TmxHTi1VUHRmNDo6ZWt1OjEuMy42LjEuNC4xLjMxMS4xMC4zLjEzIiwibmFtZXNwYWNlIjoiYXp1cmVjb250YWluZXJpbnN0YW5jZSIsInJlY2VpcHRzIjpbXSwicnVsZSI6ImxvYWRfZnJhZ21lbnQifSwicmVhc29uIjp7ImVycm9ycyI6WyJtaXNzaW5nIHJlY2VpcHQgZnJvbSBlc3JwLWN0cy1kZXYuY29uZmlkZW50aWFsLWxlZGdlci5henVyZS5jb20iXX19 >policyDecision\nguest modify: guest RPC failure: error loading security policy fragment: policyDecision< eyJkZWNpc2lvbiI6ImRlbnkiLCJpbnB1dCI6eyJmZWVkIjoiYWNpZGV2YWNyLmF6dXJlY3IuaW8vaW50ZXJuYWwvYWNpL2FjaS1jYy1pbmZyYS1mcmFnbWVudCIsImZyYWdtZW50X2xvYWRlZCI6ZmFsc2UsImhhc19oZWFkZXJfc3ZuIjp0cnVlLCJoZWFkZXJfc3ZuIjowLCJpc3N1ZXIiOiJkaWQ6eDUwOTowOnNoYTI1Njp3VmtTTTQ2U0RwdzRMdXlFWW9INnI1eW0wN3doTDVsV3hObEdOLVVQdGY0Ojpla3U6MS4zLjYuMS40LjEuMzExLjEwLjMuMTMiLCJuYW1lc3BhY2UiOiJhenVyZWNvbnRhaW5lcmluc3RhbmNlIiwicmVjZWlwdHMiOltdLCJydWxlIjoibG9hZF9mcmFnbWVudCJ9LCJyZWFzb24iOnsiZXJyb3JzIjpbIm1pc3NpbmcgcmVjZWlwdCBmcm9tIGVzcnAtY3RzLWRldi5jb25maWRlbnRpYWwtbGVkZ2VyLmF6dXJlLmNvbSJdfX0= >policyDecision"
PS C:\Users\azureuser\wcow_skr_fragment> .\createc.ps1
a261dd550c2868f26bce5013edf96b9ae4f2040296c4ad74ee96b36479298f52
PS C:\Users\azureuser\wcow_skr_fragment> .\startc.ps1
a261dd550c2868f26bce5013edf96b9ae4f2040296c4ad74ee96b36479298f52
Started container wcow_skr_fragment_skr_cwcow_fragment_skr with ID:
a261dd550c2868f26bce5013edf96b9ae4f2040296c4ad74ee96b36479298f52
PS C:\Users\azureuser\wcow_skr_fragment> .\container.ps1 powershell

PS C:\app> dir C:\security-context-2340068210\


    Directory: C:\security-context-2340068210


Mode                 LastWriteTime         Length Name
----                 -------------         ------ ----
d-----         7/19/2026  11:37 PM                fragments.debug
-a----          7/1/2026   7:47 AM          45056 amdsnppspapi.dll
-a----         7/19/2026  11:38 PM          13956 reference-info-base64
-a----         7/19/2026  11:38 PM           6412 security-policy-base64

PS C:\app> dir C:\security-context-2340068210\fragments.debug\b59e1ac5ea85d58a515d1369b05f21245f76627858803ccbdb543e0b3b64362c


    Directory: C:\security-context-2340068210\fragments.debug\b59e1ac5ea85d58a515d1369b05f21245f76627858803ccbdb543e0b3b64362c


Mode                 LastWriteTime         Length Name
----                 -------------         ------ ----
-a----         7/19/2026  11:37 PM            632 2.fail
-a----         7/19/2026  11:37 PM          83742 fragment
-a----         7/19/2026  11:37 PM          87785 fragment.cose
-a----         7/19/2026  11:37 PM            182 metadata.json

PS C:\app> cat C:\security-context-2340068210\fragments.debug\b59e1ac5ea85d58a515d1369b05f21245f76627858803ccbdb543e0b3b64362c\2.fail
error loading security policy fragment: policyDecision< ... >policyDecision
> base64 -d | jq
...
{
  "decision": "deny",
  "input": {
    "feed": "acidevacr.azurecr.io/internal/aci/aci-cc-infra-fragment",
    "fragment_loaded": false,
    "has_header_svn": true,
    "header_svn": 0,
    "issuer": "did:x509:0:sha256:wVkSM46SDpw4LuyEYoH6r5ym07whL5lWxNlGN-UPtf4::eku:1.3.6.1.4.1.311.10.3.13",
    "namespace": "azurecontainerinstance",
    "receipts": [],
    "rule": "load_fragment"
  },
  "reason": {
    "errors": [
      "missing receipt from esrp-cts-dev.confidential-ledger.azure.com"
    ]
  }
}
PS C:\app> exit
PS C:\Users\azureuser\wcow_skr_fragment> azcrictl inject-fragment $env:podId 'acidevacr.azurecr.io/internal/aci/aci-cc-ttl:transparent-fragment-signing-0-20260615.1'
sha256:2cacf5a79d1d6f28eeeb8ff5e30bb634a6caffb6afd85b9e4549a90556cd45f3
PS C:\Users\azureuser\wcow_skr_fragment> azcrictl inject-fragment $env:podId 'acidevacr.azurecr.io/internal/aci/aci-cc-infra-fragment:transparent-fragment-signing-0-20260615.3'
sha256:b59e1ac5ea85d58a515d1369b05f21245f76627858803ccbdb543e0b3b64362c

PS C:\app> dir C:\security-context-2340068210\fragments.debug\b59e1ac5ea85d58a515d1369b05f21245f76627858803ccbdb543e0b3b64362c


    Directory: C:\security-context-2340068210\fragments.debug\b59e1ac5ea85d58a515d1369b05f21245f76627858803ccbdb543e0b3b64362c


Mode                 LastWriteTime         Length Name
----                 -------------         ------ ----
-a----         7/19/2026  11:37 PM            632 2.fail
-a----         7/19/2026  11:41 PM              0 6.succeed
-a----         7/19/2026  11:37 PM          83742 fragment
-a----         7/19/2026  11:37 PM          87785 fragment.cose
-a----         7/19/2026  11:37 PM            182 metadata.json
```