### PR TITLE
fix(lcow/v2): report physically backed VM stats

### DIFF
--- a/internal/builder/vm/lcow/sandbox_options.go
+++ b/internal/builder/vm/lcow/sandbox_options.go
@@ -19,7 +19,10 @@ type SandboxOptions struct {
 	// Architecture is the processor architecture (e.g., "amd64", "arm64").
 	Architecture string
 
-	// FullyPhysicallyBacked indicates all memory allocations are backed by physical memory.
+	// FullyPhysicallyBacked reports whether the VM's own memory is physically
+	// backed (equal to !AllowOvercommit). It does not cover additional devices
+	// added to the running VM (e.g. file shares or mounted layer disks), whose
+	// physical backing is determined directly by the FullyPhysicallyBacked annotation.
 	FullyPhysicallyBacked bool
 
 	// ConfidentialConfig carries confidential computing fields that are not

--- a/internal/builder/vm/lcow/specs.go
+++ b/internal/builder/vm/lcow/specs.go
@@ -72,6 +72,9 @@ func BuildSandboxConfig(
 	// When no-security-hardware is set, we still plumb the policy but use the standard HCS doc.
 	isConfidentialSNP := sandboxOptions.ConfidentialConfig != nil && !noSecurityHardware
 
+	// The FullyPhysicallyBacked annotation forces memory overcommit off.
+	fullyPhysicallyBacked := oci.ParseAnnotationsBool(ctx, spec.Annotations, shimannotations.FullyPhysicallyBacked, false)
+
 	// ================== Parse Topology (CPU, Memory, NUMA) options =================
 	// ===============================================================================
 
@@ -88,7 +91,7 @@ func BuildSandboxConfig(
 	}
 
 	// Parse memory configuration.
-	memoryConfig, err := parseMemoryOptions(ctx, opts, spec.Annotations, sandboxOptions.FullyPhysicallyBacked)
+	memoryConfig, err := parseMemoryOptions(ctx, opts, spec.Annotations, fullyPhysicallyBacked)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to parse memory parameters: %w", err)
 	}
@@ -149,7 +152,7 @@ func BuildSandboxConfig(
 		spec.Devices,
 		rootFsFullPath,
 		numa != nil && numaProcessors != nil, // isNumaEnabled
-		sandboxOptions.FullyPhysicallyBacked, // isFullyPhysicallyBacked
+		fullyPhysicallyBacked,                // isFullyPhysicallyBacked
 		isConfidentialSNP,                    // isConfidential
 	)
 	if err != nil {
@@ -206,6 +209,10 @@ func BuildSandboxConfig(
 		log.G(ctx).Debug("disabling memory overcommit for confidential VM")
 		memoryConfig.AllowOvercommit = false
 	}
+
+	// Record whether the VM's own memory is physically backed (!AllowOvercommit).
+	// This is VM memory backing only, not additional-device backing.
+	sandboxOptions.FullyPhysicallyBacked = !memoryConfig.AllowOvercommit
 
 	// ================== Parse and set Kernel Args ==================================
 	// ===============================================================================
@@ -332,7 +339,6 @@ func parseSandboxOptions(ctx context.Context, platform string, annotations map[s
 	sandboxOptions := &SandboxOptions{
 		// Extract architecture from platform string (e.g., "linux/amd64" -> "amd64")
 		Architecture:                platform[strings.IndexByte(platform, '/')+1:],
-		FullyPhysicallyBacked:       oci.ParseAnnotationsBool(ctx, annotations, shimannotations.FullyPhysicallyBacked, false),
 		PolicyBasedRouting:          oci.ParseAnnotationsBool(ctx, annotations, iannotations.NetworkingPolicyBasedRouting, false),
 		NoWritableFileShares:        oci.ParseAnnotationsBool(ctx, annotations, shimannotations.DisableWritableFileShares, false),
 		LiveMigrationSupportEnabled: oci.ParseAnnotationsBool(ctx, annotations, shimannotations.LiveMigrationSupportEnabled, false),

--- a/internal/builder/vm/lcow/specs_test.go
+++ b/internal/builder/vm/lcow/specs_test.go
@@ -268,6 +268,29 @@ func TestBuildSandboxConfig(t *testing.T) {
 			},
 		},
 		{
+			// FullyPhysicallyBacked tracks the VM's memory backing (!AllowOvercommit),
+			// so disabling overcommit alone (without the annotation) marks it true.
+			name: "overcommit off alone marks VM physically backed",
+			opts: &runhcsoptions.Options{
+				SandboxPlatform:   "linux/amd64",
+				BootFilesRootPath: validBootFilesPath,
+			},
+			spec: &vm.Spec{
+				Annotations: map[string]string{
+					shimannotations.AllowOvercommit: "false",
+				},
+			},
+			validate: func(t *testing.T, doc *hcsschema.ComputeSystem, sandboxOpts *SandboxOptions) {
+				t.Helper()
+				if doc.VirtualMachine.ComputeTopology.Memory.AllowOvercommit != false {
+					t.Errorf("expected allow overcommit false, got %v", doc.VirtualMachine.ComputeTopology.Memory.AllowOvercommit)
+				}
+				if sandboxOpts.FullyPhysicallyBacked != true {
+					t.Errorf("expected fully physically backed true when overcommit off, got %v", sandboxOpts.FullyPhysicallyBacked)
+				}
+			},
+		},
+		{
 			name: "memory MMIO configuration",
 			opts: &runhcsoptions.Options{
 				SandboxPlatform:   "linux/amd64",

--- a/internal/controller/vm/vm.go
+++ b/internal/controller/vm/vm.go
@@ -530,15 +530,6 @@ func (c *Controller) Stats(ctx context.Context) (*stats.VirtualMachineStatistics
 		return nil, fmt.Errorf("cannot get stats: VM is in incorrect state %s", c.vmState)
 	}
 
-	// Initialization of vmmemProcess to calculate stats properly for VA-backed UVMs.
-	if c.vmmemProcess == 0 {
-		vmmemHandle, err := vmutils.LookupVMMEM(ctx, c.uvm.RuntimeID(), &iwin.WinAPI{})
-		if err != nil {
-			return nil, fmt.Errorf("cannot get stats: %w", err)
-		}
-		c.vmmemProcess = vmmemHandle
-	}
-
 	s := &stats.VirtualMachineStatistics{}
 	props, err := c.uvm.PropertiesV2(ctx, hcsschema.PTStatistics, hcsschema.PTMemory)
 	if err != nil {
@@ -553,6 +544,13 @@ func (c *Controller) Stats(ctx context.Context) (*stats.VirtualMachineStatistics
 		// working set size for a VA-backed UVM. To work around this, we instead
 		// locate the vmmem process for the VM, and query that process's working set
 		// instead, which will be the working set for the VM.
+		if c.vmmemProcess == 0 {
+			vmmemHandle, err := vmutils.LookupVMMEM(ctx, c.uvm.RuntimeID(), &iwin.WinAPI{})
+			if err != nil {
+				return nil, fmt.Errorf("cannot get stats: %w", err)
+			}
+			c.vmmemProcess = vmmemHandle
+		}
 		memCounters, err := process.GetProcessMemoryInfo(c.vmmemProcess)
 		if err != nil {
 			return nil, err

--- a/test/parity/vm/lcow_doc_test.go
+++ b/test/parity/vm/lcow_doc_test.go
@@ -204,7 +204,7 @@ func checkSandboxOptionsParity(t *testing.T, legacyOpts *uvm.OptionsLCOW, sandbo
 		{"NoWritableFileShares", legacyOpts.NoWritableFileShares, sandboxOpts.NoWritableFileShares},
 		{"EnableScratchEncryption", legacyOpts.EnableScratchEncryption, sandboxOpts.EnableScratchEncryption},
 		{"PolicyBasedRouting", legacyOpts.PolicyBasedRouting, sandboxOpts.PolicyBasedRouting},
-		{"FullyPhysicallyBacked", legacyOpts.FullyPhysicallyBacked, sandboxOpts.FullyPhysicallyBacked},
+		{"PhysicallyBacked", !legacyOpts.AllowOvercommit, sandboxOpts.FullyPhysicallyBacked},
 	}
 
 	for _, c := range checks {


### PR DESCRIPTION
## Summary
- derive LCOW V2 `SandboxOptions.FullyPhysicallyBacked` from the final VM memory configuration (`!Memory.AllowOvercommit`)
- avoid looking up a vmmem process for physically backed UVMs; their working set comes from HCS `AssignedMemory`
- add focused builder and parity coverage for the memory-backing decision

This includes Harsh's [`47c5b143`](https://github.com/microsoft/hcsshim/commit/47c5b1432ad3af1d22cec2db2168f362ee41f9a6) patch, cherry-picked as `e3e4cfb6`, together with the complementary `vm.go` lookup gating.

## Problem
LCOW V2 physically backed sandbox stats had two related failure modes:

1. setting `AllowOvercommit=false` without the stronger `FullyPhysicallyBacked` annotation left `SandboxOptions.FullyPhysicallyBacked` false, so the controller selected the VA-backed stats path for physically backed VM memory;
2. `Stats()` looked up vmmem before checking the backing mode, even though physically backed UVMs use HCS `AssignedMemory`. A failed lookup therefore prevented metrics that do not require vmmem.

## Implementation
- parse the `FullyPhysicallyBacked` annotation separately for device-backing behavior and its existing overcommit override
- set `SandboxOptions.FullyPhysicallyBacked` from the finalized memory configuration
- move `LookupVMMEM` and process working-set collection inside the VA-backed branch
- update parity expectations and cover `AllowOvercommit=false` without the annotation

## Validation
- `go test -tags lcow ./internal/builder/vm/lcow/... ./internal/controller/vm/... -count=1`
- `go vet -tags lcow ./internal/builder/vm/lcow/... ./internal/controller/vm/...`
- rebuilt `containerd-shim-lcow-v2.exe` with both changes and ran `Test_SandboxStats_WorkingSet_PhysicallyBacked/LCOW` against a local build 26200 host: PASS
- restored the original deployed shim after the functional run and verified its SHA-256 and the running containerd service