### PR TITLE
[guest] back container bundle with scratch so sandbox mounts are on disk

### DIFF
--- a/internal/controller/linuxcontainer/container.go
+++ b/internal/controller/linuxcontainer/container.go
@@ -255,6 +255,26 @@ func (c *Controller) releaseResources(ctx context.Context) error {
 		c.layers.layersCombined = false
 	}
 
+	// DeleteContainerState performs the guest-side container delete: it unmounts
+	// the pod's sandbox mounts and the scratch-backed bundle bind, deletes the
+	// runtime state, and removes the bundle and scratch directories. We run it
+	// before removing the overlay layer devices and detaching the scratch disk,
+	// so the guest releases everything backed by those disks while they are still
+	// attached (the overlay mount itself has already been removed above).
+	// Short-circuit on isContainerStateDeleted so retries don't re-issue Capabilities.
+	if !c.isContainerStateDeleted {
+		if caps := c.guest.Capabilities(); caps != nil && caps.IsDeleteContainerStateSupported() {
+			// GCS bridge evicts the container from its host-state map even if the inner Delete fails,
+			// so retries will always return not-found.
+			if err := c.guest.DeleteContainerState(ctx, c.gcsContainerID); err != nil && !isResourceAlreadyReleased(err) {
+				return fmt.Errorf("delete container state: %w", err)
+			}
+
+			// Set isContainerStateDeleted to true so that we do not retry this post successful delete.
+			c.isContainerStateDeleted = true
+		}
+	}
+
 	// Unmap the scratch layer. A zero ID indicates it has already been
 	// unmapped on a prior call.
 	var zeroGUID guid.GUID
@@ -297,23 +317,6 @@ func (c *Controller) releaseResources(ctx context.Context) error {
 		if err := c.vpci.RemoveFromVM(ctx, id); err != nil && !isResourceAlreadyReleased(err) {
 			c.devices = c.devices[i:]
 			return fmt.Errorf("remove vpci device: %w", err)
-		}
-	}
-
-	// After layer overlay has been removed, we can safely delete the
-	// bundle path inside the UVM for the container. Therefore, delete
-	// the guest-side container state if supported. Short-circuit on
-	// isContainerStateDeleted so retries don't re-issue Capabilities.
-	if !c.isContainerStateDeleted {
-		if caps := c.guest.Capabilities(); caps != nil && caps.IsDeleteContainerStateSupported() {
-			// GCS bridge evicts the container from its host-state map even if the inner Delete fails,
-			// so retries will always return not-found.
-			if err := c.guest.DeleteContainerState(ctx, c.gcsContainerID); err != nil && !isResourceAlreadyReleased(err) {
-				return fmt.Errorf("delete container state: %w", err)
-			}
-
-			// Set isContainerStateDeleted to true so that we do not retry this post successful delete.
-			c.isContainerStateDeleted = true
 		}
 	}
 

--- a/internal/controller/linuxcontainer/container_test.go
+++ b/internal/controller/linuxcontainer/container_test.go
@@ -675,12 +675,15 @@ func TestReleaseResources_StopsOnFirstError(t *testing.T) {
 
 			scsiCtrl.EXPECT().UnmapFromGuest(gomock.Any(), scsiGUID).Return(tc.scsiErr)
 
+			// The DeleteContainerState capability gate now runs early (after
+			// RemoveCombinedLayers, before the unmaps), so Capabilities is always
+			// queried regardless of whether a later unmap fails.
+			guestCtrl.EXPECT().Capabilities().Return(&gcs.LCOWGuestDefinedCapabilities{})
+
 			if !tc.wantStops {
-				// Tolerated error: the chain must proceed through plan9, vpci,
-				// and the DeleteContainerState capability gate.
+				// Tolerated error: the chain must proceed through plan9 and vpci.
 				plan9Ctrl.EXPECT().UnmapFromGuest(gomock.Any(), plan9GUID).Return(nil)
 				vpciCtrl.EXPECT().RemoveFromVM(gomock.Any(), deviceGUID).Return(nil)
-				guestCtrl.EXPECT().Capabilities().Return(&gcs.LCOWGuestDefinedCapabilities{})
 			}
 
 			err := c.releaseResources(t.Context())
@@ -777,12 +780,15 @@ func TestReleaseResources_RemoveCombinedLayersFails(t *testing.T) {
 // failure leaves the scratch reservation intact for retry.
 func TestReleaseResources_ScratchUnmapFails(t *testing.T) {
 	t.Parallel()
-	c, scsiCtrl, _, _, _ := newContainerTestController(t)
+	c, scsiCtrl, _, _, guestCtrl := newContainerTestController(t)
 
 	scratchGUID, _ := guid.NewV4()
 	c.layers = &scsiLayers{
 		scratch: scsiReservation{id: scratchGUID, guestPath: "/dev/scratch"},
 	}
+
+	// DeleteContainerState's capability gate runs before the scratch unmap.
+	guestCtrl.EXPECT().Capabilities().Return(&gcs.LCOWGuestDefinedCapabilities{})
 
 	wantErr := errors.New("scratch unmap failed")
 	scsiCtrl.EXPECT().UnmapFromGuest(gomock.Any(), scratchGUID).Return(wantErr)
@@ -801,7 +807,7 @@ func TestReleaseResources_ScratchUnmapFails(t *testing.T) {
 // retained while already-unmapped entries are dropped.
 func TestReleaseResources_ROLayerUnmapMidwayFails(t *testing.T) {
 	t.Parallel()
-	c, scsiCtrl, _, _, _ := newContainerTestController(t)
+	c, scsiCtrl, _, _, guestCtrl := newContainerTestController(t)
 
 	roGUIDs := [3]guid.GUID{}
 	for i := range roGUIDs {
@@ -815,6 +821,9 @@ func TestReleaseResources_ROLayerUnmapMidwayFails(t *testing.T) {
 			{id: roGUIDs[2]},
 		},
 	}
+
+	// DeleteContainerState's capability gate runs before the RO layer unmaps.
+	guestCtrl.EXPECT().Capabilities().Return(&gcs.LCOWGuestDefinedCapabilities{})
 
 	wantErr := errors.New("ro layer unmap failed")
 	gomock.InOrder(

--- a/internal/guest/runtime/hcsv2/bundle_bind_test.go
+++ b/internal/guest/runtime/hcsv2/bundle_bind_test.go
@@ -1,0 +1,67 @@
+//go:build linux
+// +build linux
+
+package hcsv2
+
+import "testing"
+
+// TestBundleNeedsScratchBind covers the path-based rule that decides whether a
+// container bundle must be bind-mounted onto its scratch disk. The cases mirror
+// the layouts observed for both shims:
+//   - V1 non-shared: the shim mounts the scratch disk at the bundle path, so the
+//     scratch dir is nested under the bundle and no bind is needed.
+//   - V1 shared-scratch: the scratch lives under the sandbox's bundle, so a
+//     workload's own bundle is not disk-backed and needs a bind.
+//   - V2: the scratch is mounted at a global path unrelated to the bundle, so
+//     the bundle needs a bind.
+func TestBundleNeedsScratchBind(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		bundleDir  string
+		scratchDir string
+		want       bool
+	}{
+		{
+			name:       "no scratch",
+			bundleDir:  "/run/gcs/c/abc",
+			scratchDir: "",
+			want:       false,
+		},
+		{
+			name:       "v1 non-shared scratch under bundle",
+			bundleDir:  "/run/gcs/c/abc",
+			scratchDir: "/run/gcs/c/abc/scratch/abc",
+			want:       false,
+		},
+		{
+			name:       "v1 shared scratch under sandbox bundle",
+			bundleDir:  "/run/gcs/c/workload",
+			scratchDir: "/run/gcs/c/sandbox/scratch/workload",
+			want:       true,
+		},
+		{
+			name:       "v2 scratch on global scsi mount",
+			bundleDir:  "/run/gcs/pods/pod/ctr",
+			scratchDir: "/run/mounts/scsi/0_2_0/scratch/pod/ctr",
+			want:       true,
+		},
+		{
+			name:       "scratch equals bundle",
+			bundleDir:  "/run/gcs/c/abc",
+			scratchDir: "/run/gcs/c/abc",
+			want:       false,
+		},
+		{
+			name:       "sibling dir with shared prefix is not under bundle",
+			bundleDir:  "/run/gcs/c/abc",
+			scratchDir: "/run/gcs/c/abcdef/scratch/abcdef",
+			want:       true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := bundleNeedsScratchBind(tc.bundleDir, tc.scratchDir); got != tc.want {
+				t.Errorf("bundleNeedsScratchBind(%q, %q) = %v, want %v", tc.bundleDir, tc.scratchDir, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/guest/runtime/hcsv2/container.go
+++ b/internal/guest/runtime/hcsv2/container.go
@@ -266,6 +266,21 @@ func (c *Container) Delete(ctx context.Context) error {
 		retErr = err
 	}
 
+	// If the bundle was bind-mounted onto the scratch disk during create
+	// (modifyCombinedLayers), undo that bind. The same path-based rule is used
+	// here as at create time, so both shims are handled identically. Order
+	// matters: this runs before removing the scratch/bundle dirs below (the
+	// bind's source lives under scratchDirPath) and before the host unmaps the
+	// scratch disk, so no mount still references that disk. removeTarget=false
+	// detaches the bind only - the ociBundlePath directory itself remains and is
+	// deleted by RemoveAll below.
+	if bundleNeedsScratchBind(c.ociBundlePath, c.scratchDirPath) {
+		if err := storage.UnmountPath(ctx, c.ociBundlePath, false); err != nil {
+			entity.WithError(err).WithField("bundle", c.ociBundlePath).
+				Warn("failed to unmount scratch-backed bundle bind")
+		}
+	}
+
 	if err := os.RemoveAll(c.scratchDirPath); err != nil {
 		if retErr != nil {
 			retErr = fmt.Errorf("errors deleting container state: %w; %w", retErr, err)

--- a/internal/guest/runtime/hcsv2/uvm.go
+++ b/internal/guest/runtime/hcsv2/uvm.go
@@ -1811,9 +1811,9 @@ func bundleNeedsScratchBind(bundleDir, scratchDir string) bool {
 		// Unrelated paths: the scratch is not under the bundle, so it needs a bind.
 		return true
 	}
-	// scratchDir is under bundleDir when the relative path does not escape it.
-	underBundle := rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
-	return !underBundle
+	// A bind is needed only when scratchDir is not nested under bundleDir, i.e.
+	// when the relative path escapes the bundle (is ".." or starts with "../").
+	return rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator))
 }
 
 // bindBundleToScratch backs a container bundle directory with a directory on the

--- a/internal/guest/runtime/hcsv2/uvm.go
+++ b/internal/guest/runtime/hcsv2/uvm.go
@@ -1731,11 +1731,31 @@ func (h *Host) modifyCombinedLayers(
 				}()
 			}
 
+			// The sandbox root (the bundle dir) must be disk-backed so that
+			// everything created under it - sandbox:// mounts, logs, etc. - lives
+			// on disk rather than the UVM tmpfs. When the shim already mounts the
+			// scratch disk at the bundle path, the scratch dir is nested under the
+			// bundle and there is nothing to do. Otherwise (the scratch is mounted
+			// elsewhere and the bundle would be tmpfs) bind a scratch directory
+			// onto the bundle. This is decided purely from the paths, so V1 and V2
+			// are handled by the same rule.
+			bundleDir := filepath.Dir(cl.ContainerRootPath)
+			bindBundle := bundleNeedsScratchBind(bundleDir, cl.ScratchPath)
+			if bindBundle {
+				if bindErr := bindBundleToScratch(cl.ScratchPath, bundleDir); bindErr != nil {
+					return bindErr
+				}
+			}
+
 			// Correctness for policy transaction rollback:
 			// MountLayer does two things - mkdir, then mount. On mount failure, the
 			// target directory is cleaned up.  Therefore we're clean in terms of
 			// side effects.
-			return overlay.MountLayer(ctx, layerPaths, upperdirPath, workdirPath, cl.ContainerRootPath, readonly)
+			mountErr := overlay.MountLayer(ctx, layerPaths, upperdirPath, workdirPath, cl.ContainerRootPath, readonly)
+			if mountErr != nil && bindBundle {
+				_ = storage.UnmountPath(ctx, bundleDir, false)
+			}
+			return mountErr
 		case guestrequest.RequestTypeRemove:
 			// cl.ContainerID is not set on remove requests, but rego checks that we can
 			// only umount previously mounted targets anyway
@@ -1773,6 +1793,46 @@ func (h *Host) modifyCombinedLayers(
 			return newInvalidRequestTypeError(rt)
 		}
 	})
+}
+
+// bundleNeedsScratchBind reports whether the container's bundle directory needs
+// to be bind-mounted onto its scratch disk to be disk-backed. It returns false
+// when there is no scratch, or when the scratch dir is already nested under the
+// bundle dir (i.e. the shim mounted the scratch disk at the bundle path, so the
+// bundle is already on disk). It returns true when the scratch is mounted
+// elsewhere and the bundle would otherwise live on the UVM tmpfs. The decision
+// is derived only from the paths, so it applies identically to both shims.
+func bundleNeedsScratchBind(bundleDir, scratchDir string) bool {
+	if scratchDir == "" {
+		return false
+	}
+	rel, err := filepath.Rel(bundleDir, scratchDir)
+	if err != nil {
+		// Unrelated paths: the scratch is not under the bundle, so it needs a bind.
+		return true
+	}
+	// scratchDir is under bundleDir when the relative path does not escape it.
+	underBundle := rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+	return !underBundle
+}
+
+// bindBundleToScratch backs a container bundle directory with a directory on the
+// container's scratch disk, so the sandbox root - and everything created under
+// it (sandbox:// mounts, logs, etc.) - is disk-backed rather than tmpfs-backed.
+// The bind is removed during container delete, before the scratch disk is
+// unmapped.
+func bindBundleToScratch(scratchPath, bundleDir string) error {
+	src := filepath.Join(scratchPath, "bundle")
+	if err := os.MkdirAll(src, 0755); err != nil {
+		return fmt.Errorf("create bundle backing dir %s: %w", src, err)
+	}
+	if err := os.MkdirAll(bundleDir, 0755); err != nil {
+		return fmt.Errorf("create bundle dir %s: %w", bundleDir, err)
+	}
+	if err := unix.Mount(src, bundleDir, "", unix.MS_BIND, ""); err != nil {
+		return fmt.Errorf("bind bundle dir %s to %s: %w", src, bundleDir, err)
+	}
+	return nil
 }
 
 func modifyNetwork(ctx context.Context, rt guestrequest.RequestType, na *guestresource.LCOWNetworkAdapter) (err error) {


### PR DESCRIPTION
A `sandbox://` mount is served from a directory under the container bundle, so the bundle must live on the pod scratch disk for the mount to be disk-backed. The v1 shim mounts the scratch disk at the bundle path, so this holds. The v2 shim keeps the bundle on the `UVM tmpfs` and mounts the scratch elsewhere, so `sandbox://` mounts end up on `tmpfs` instead of disk.

In the guest, when the scratch dir is not already nested under the bundle, bind a scratch directory onto the bundle before mounting the overlay. The choice is path-based (`bundleNeedsScratchBind`), so both shims share one rule. Unmount the bind in `Container.Delete`, and reorder `releaseResources` so the guest releases the disk-backed mounts before the host detaches the scratch.

## Manual validation

All of the following were run manually against a live host (v1 = `runhcs-lcow`, v2 = `runhcs-lcow-v2`), verifying the `sandbox://` mount filesystem via `df /sandboxmount` and confirming clean teardown (mounts, dirs, and scratch disk released; no `EBUSY`).

| Scenario | Runtime | `sandbox://` backing | Teardown | What it exercises |
| --- | --- | --- | --- | --- |
| Single pod, standard scratch | v1 | `/dev/sd*` (no regression) | clean | Container with its own scratch mounted at its bundle; scratch is already nested under the bundle, so `bundleNeedsScratchBind` skips the bind — confirms the path rule leaves working v1 layouts untouched. |
| Single pod, standard scratch | v2 | `/dev/sd*` (fixed) | clean + state cleanup | The core bug: v2 keeps the bundle on UVM `tmpfs` with scratch mounted elsewhere, so `sandbox://` previously landed on `tmpfs`. The new bind puts the bundle (and thus the mount) on the scratch disk; teardown also verifies bundle/scratch dirs are removed. |
| Shared scratch workload | v1 | `/dev/sd*` (new bind) | clean | Container with `reuse-scratch` reuses the sandbox's scratch, so its own bundle sits on `tmpfs`. The path rule detects the non-nested scratch and binds — the case where v1 newly needs the bind, proving the rule is layout-based rather than shim-based. |
| Shared scratch workload | v2 | `/dev/sd*` (fixed) | clean | Same `reuse-scratch` container on v2; confirms the fix holds when scratch is shared and the bundle is on `tmpfs`. |
| Multi-pod, single UVM (`tenant-sandbox-id`) | v2 | `/dev/sd*` on every tenant | clean partial + full teardown | Multiple pods packed into one UVM via `tenant-sandbox-id`; each tenant gets its own pod namespace whose bundle is bound to that tenant's scratch, so every tenant's `sandbox://` is disk-backed, and removing one tenant leaves the others (and the UVM) intact. |

Additional cases:

- Multiple `sandbox://` mounts on one container — all disk-backed.
- `sandbox-tmp://` mount — remains `tmpfs` as intended (unchanged).
- Container with no `sandbox://` mount — starts and stops normally.
- Exec from a `sandbox://` mount — succeeds (not `noexec`).
- `bundleNeedsScratchBind` unit test — passes (Linux/WSL).
- Controller unit tests and `GOOS=linux` guest build — pass.
- Shim + guest logs (via LogMonitor / ETW) — no bind or `EBUSY` errors across the full run.
