### PR TITLE
securitypolicy_options: Add {tcb,platform}-reference-info to security-context, populated from a special fragment

### DIFF
--- a/pkg/securitypolicy/securitypolicy.go
+++ b/pkg/securitypolicy/securitypolicy.go
@@ -52,6 +52,7 @@ const (
 	HostAMDCertFilename               = "host-amd-cert-base64"
 	ReferenceInfoFilename             = "reference-info-base64"
 	HashEnvelopeReferenceInfoFilename = "transparent-reference-info-base64"
+	TCBReferenceInfoFilename          = "tcb-reference-info"
 )
 
 // PolicyConfig contains toml or JSON config for security policy.

--- a/pkg/securitypolicy/securitypolicy.go
+++ b/pkg/securitypolicy/securitypolicy.go
@@ -52,7 +52,7 @@ const (
 	HostAMDCertFilename               = "host-amd-cert-base64"
 	ReferenceInfoFilename             = "reference-info-base64"
 	HashEnvelopeReferenceInfoFilename = "transparent-reference-info-base64"
-	TCBReferenceInfoFilename          = "tcb-reference-info"
+	TCBReferenceInfoFilename          = "tcb-reference-info-base64"
 )
 
 // PolicyConfig contains toml or JSON config for security policy.

--- a/pkg/securitypolicy/securitypolicy.go
+++ b/pkg/securitypolicy/securitypolicy.go
@@ -53,6 +53,7 @@ const (
 	ReferenceInfoFilename             = "reference-info-base64"
 	HashEnvelopeReferenceInfoFilename = "transparent-reference-info-base64"
 	TCBReferenceInfoFilename          = "tcb-reference-info-base64"
+	PlatformReferenceInfoFilename     = "platform-reference-info-base64"
 )
 
 // PolicyConfig contains toml or JSON config for security policy.

--- a/pkg/securitypolicy/securitypolicy_options.go
+++ b/pkg/securitypolicy/securitypolicy_options.go
@@ -32,6 +32,8 @@ type SecurityOptions struct {
 	UvmReferenceInfo             string
 	UvmHashEnvelopeReferenceInfo string
 	policyMutex                  sync.Mutex
+	tcbReferenceInfoMutex        sync.RWMutex
+	tcbReferenceInfo             []byte
 	logWriter                    io.Writer
 }
 
@@ -114,6 +116,9 @@ const (
 	mediaTypeFragment = "application/cose-x509+rego"
 	// mediaTypeTransparencyTrustList is a signed Transparency Trust List (TTL).
 	mediaTypeTransparencyTrustList = "application/vnd.transparency-trust-list.v1+cose"
+	// mediaTypeTCBReferenceInfo is a TCB reference information COSE blob made
+	// available to subsequently created containers.
+	mediaTypeTCBReferenceInfo = "application/vnd.tcb-reference-info.v1+cose"
 )
 
 // asInt64 coerces a CBOR-decoded integer value (which may be returned as
@@ -163,7 +168,7 @@ func (s *SecurityOptions) InjectFragment(ctx context.Context, fragment *guestres
 		mediaType = mediaTypeFragment
 	}
 	switch mediaType {
-	case mediaTypeFragment, mediaTypeTransparencyTrustList:
+	case mediaTypeFragment, mediaTypeTransparencyTrustList, mediaTypeTCBReferenceInfo:
 	default:
 		// The host (azcri) only ever injects blobs whose media type it knows
 		// we handle, so receiving an unrecognized one means either a host bug
@@ -189,6 +194,13 @@ func (s *SecurityOptions) InjectFragment(ctx context.Context, fragment *guestres
 	unpacked, err := cosesign1.UnpackAndValidateCOSE1CertChain(raw)
 	if err != nil {
 		return fmt.Errorf("InjectFragment failed COSE validation: %w", err)
+	}
+	// We do not need to validate this.
+	if mediaType == mediaTypeTCBReferenceInfo {
+		s.tcbReferenceInfoMutex.Lock()
+		s.tcbReferenceInfo = append(s.tcbReferenceInfo[:0], raw...)
+		s.tcbReferenceInfoMutex.Unlock()
+		return nil
 	}
 
 	cwtClaimsRaw, hasCwtClaims := unpacked.Protected[cosesign1.COSE_Header_CWTClaims]
@@ -338,8 +350,11 @@ func writeFileInDir(dir string, filename string, data []byte, perm os.FileMode) 
 // because there was nothing to write.
 func (s *SecurityOptions) WriteSecurityContextDir(spec *specs.Spec) (string, error) {
 	encodedPolicy := s.PolicyEnforcer.EncodedSecurityPolicy()
+	s.tcbReferenceInfoMutex.RLock()
+	tcbReferenceInfo := append([]byte(nil), s.tcbReferenceInfo...)
+	s.tcbReferenceInfoMutex.RUnlock()
 	hostAMDCert := spec.Annotations[annotations.WCOWHostAMDCertificate]
-	if len(encodedPolicy) > 0 || len(hostAMDCert) > 0 || len(s.UvmReferenceInfo) > 0 || len(s.UvmHashEnvelopeReferenceInfo) > 0 {
+	if len(encodedPolicy) > 0 || len(hostAMDCert) > 0 || len(s.UvmReferenceInfo) > 0 || len(s.UvmHashEnvelopeReferenceInfo) > 0 || len(tcbReferenceInfo) > 0 {
 		// Use os.MkdirTemp to make sure that the directory is unique.
 		securityContextDir, err := os.MkdirTemp(spec.Root.Path, SecurityContextDirTemplate)
 		if err != nil {
@@ -363,6 +378,11 @@ func (s *SecurityOptions) WriteSecurityContextDir(spec *specs.Spec) (string, err
 		if len(s.UvmHashEnvelopeReferenceInfo) > 0 {
 			if err := writeFileInDir(securityContextDir, HashEnvelopeReferenceInfoFilename, []byte(s.UvmHashEnvelopeReferenceInfo), 0777); err != nil {
 				return "", fmt.Errorf("failed to write UVM hash envelope reference info: %w", err)
+			}
+		}
+		if len(tcbReferenceInfo) > 0 {
+			if err := writeFileInDir(securityContextDir, TCBReferenceInfoFilename, tcbReferenceInfo, 0777); err != nil {
+				return "", fmt.Errorf("failed to write TCB reference info: %w", err)
 			}
 		}
 

--- a/pkg/securitypolicy/securitypolicy_options.go
+++ b/pkg/securitypolicy/securitypolicy_options.go
@@ -351,10 +351,13 @@ func writeFileInDir(dir string, filename string, data []byte, perm os.FileMode) 
 func (s *SecurityOptions) WriteSecurityContextDir(spec *specs.Spec) (string, error) {
 	encodedPolicy := s.PolicyEnforcer.EncodedSecurityPolicy()
 	s.tcbReferenceInfoMutex.RLock()
-	tcbReferenceInfo := append([]byte(nil), s.tcbReferenceInfo...)
+	var tcbReferenceInfoBase64 string
+	if len(s.tcbReferenceInfo) > 0 {
+		tcbReferenceInfoBase64 = base64.StdEncoding.EncodeToString(s.tcbReferenceInfo)
+	}
 	s.tcbReferenceInfoMutex.RUnlock()
 	hostAMDCert := spec.Annotations[annotations.WCOWHostAMDCertificate]
-	if len(encodedPolicy) > 0 || len(hostAMDCert) > 0 || len(s.UvmReferenceInfo) > 0 || len(s.UvmHashEnvelopeReferenceInfo) > 0 || len(tcbReferenceInfo) > 0 {
+	if len(encodedPolicy) > 0 || len(hostAMDCert) > 0 || len(s.UvmReferenceInfo) > 0 || len(s.UvmHashEnvelopeReferenceInfo) > 0 || len(tcbReferenceInfoBase64) > 0 {
 		// Use os.MkdirTemp to make sure that the directory is unique.
 		securityContextDir, err := os.MkdirTemp(spec.Root.Path, SecurityContextDirTemplate)
 		if err != nil {
@@ -380,8 +383,8 @@ func (s *SecurityOptions) WriteSecurityContextDir(spec *specs.Spec) (string, err
 				return "", fmt.Errorf("failed to write UVM hash envelope reference info: %w", err)
 			}
 		}
-		if len(tcbReferenceInfo) > 0 {
-			if err := writeFileInDir(securityContextDir, TCBReferenceInfoFilename, tcbReferenceInfo, 0777); err != nil {
+		if len(tcbReferenceInfoBase64) > 0 {
+			if err := writeFileInDir(securityContextDir, TCBReferenceInfoFilename, []byte(tcbReferenceInfoBase64), 0777); err != nil {
 				return "", fmt.Errorf("failed to write TCB reference info: %w", err)
 			}
 		}

--- a/pkg/securitypolicy/securitypolicy_options.go
+++ b/pkg/securitypolicy/securitypolicy_options.go
@@ -32,9 +32,13 @@ type SecurityOptions struct {
 	UvmReferenceInfo             string
 	UvmHashEnvelopeReferenceInfo string
 	policyMutex                  sync.Mutex
-	tcbReferenceInfoMutex        sync.RWMutex
-	tcbReferenceInfo             []byte
-	logWriter                    io.Writer
+
+	// Used for both tcbReferenceInfo and platformReferenceInfo
+	platformReferenceInfoMutex sync.RWMutex
+	tcbReferenceInfo           []byte
+	platformReferenceInfo      []byte
+
+	logWriter io.Writer
 }
 
 func NewSecurityOptions(enforcer SecurityPolicyEnforcer, enforcerSet bool, uvmReferenceInfo string, uvmHashEnvelopeReferenceInfo string, logWriter io.Writer) *SecurityOptions {
@@ -119,6 +123,9 @@ const (
 	// mediaTypeTCBReferenceInfo is a TCB reference information COSE blob made
 	// available to subsequently created containers.
 	mediaTypeTCBReferenceInfo = "application/vnd.tcb-reference-info.v1+cose"
+	// mediaTypePlatformReferenceInfo is a platform reference information COSE
+	// blob made available to subsequently created containers.
+	mediaTypePlatformReferenceInfo = "application/vnd.platform-reference-info.v1+cose"
 )
 
 // asInt64 coerces a CBOR-decoded integer value (which may be returned as
@@ -168,7 +175,7 @@ func (s *SecurityOptions) InjectFragment(ctx context.Context, fragment *guestres
 		mediaType = mediaTypeFragment
 	}
 	switch mediaType {
-	case mediaTypeFragment, mediaTypeTransparencyTrustList, mediaTypeTCBReferenceInfo:
+	case mediaTypeFragment, mediaTypeTransparencyTrustList, mediaTypeTCBReferenceInfo, mediaTypePlatformReferenceInfo:
 	default:
 		// The host (azcri) only ever injects blobs whose media type it knows
 		// we handle, so receiving an unrecognized one means either a host bug
@@ -196,10 +203,14 @@ func (s *SecurityOptions) InjectFragment(ctx context.Context, fragment *guestres
 		return fmt.Errorf("InjectFragment failed COSE validation: %w", err)
 	}
 	// We do not need to validate this.
-	if mediaType == mediaTypeTCBReferenceInfo {
-		s.tcbReferenceInfoMutex.Lock()
-		s.tcbReferenceInfo = append(s.tcbReferenceInfo[:0], raw...)
-		s.tcbReferenceInfoMutex.Unlock()
+	if mediaType == mediaTypeTCBReferenceInfo || mediaType == mediaTypePlatformReferenceInfo {
+		s.platformReferenceInfoMutex.Lock()
+		if mediaType == mediaTypeTCBReferenceInfo {
+			s.tcbReferenceInfo = append(s.tcbReferenceInfo[:0], raw...)
+		} else {
+			s.platformReferenceInfo = append(s.platformReferenceInfo[:0], raw...)
+		}
+		s.platformReferenceInfoMutex.Unlock()
 		return nil
 	}
 
@@ -350,14 +361,17 @@ func writeFileInDir(dir string, filename string, data []byte, perm os.FileMode) 
 // because there was nothing to write.
 func (s *SecurityOptions) WriteSecurityContextDir(spec *specs.Spec) (string, error) {
 	encodedPolicy := s.PolicyEnforcer.EncodedSecurityPolicy()
-	s.tcbReferenceInfoMutex.RLock()
-	var tcbReferenceInfoBase64 string
+	s.platformReferenceInfoMutex.RLock()
+	var tcbReferenceInfoBase64, platformReferenceInfoBase64 string
 	if len(s.tcbReferenceInfo) > 0 {
 		tcbReferenceInfoBase64 = base64.StdEncoding.EncodeToString(s.tcbReferenceInfo)
 	}
-	s.tcbReferenceInfoMutex.RUnlock()
+	if len(s.platformReferenceInfo) > 0 {
+		platformReferenceInfoBase64 = base64.StdEncoding.EncodeToString(s.platformReferenceInfo)
+	}
+	s.platformReferenceInfoMutex.RUnlock()
 	hostAMDCert := spec.Annotations[annotations.WCOWHostAMDCertificate]
-	if len(encodedPolicy) > 0 || len(hostAMDCert) > 0 || len(s.UvmReferenceInfo) > 0 || len(s.UvmHashEnvelopeReferenceInfo) > 0 || len(tcbReferenceInfoBase64) > 0 {
+	if len(encodedPolicy) > 0 || len(hostAMDCert) > 0 || len(s.UvmReferenceInfo) > 0 || len(s.UvmHashEnvelopeReferenceInfo) > 0 || len(tcbReferenceInfoBase64) > 0 || len(platformReferenceInfoBase64) > 0 {
 		// Use os.MkdirTemp to make sure that the directory is unique.
 		securityContextDir, err := os.MkdirTemp(spec.Root.Path, SecurityContextDirTemplate)
 		if err != nil {
@@ -386,6 +400,11 @@ func (s *SecurityOptions) WriteSecurityContextDir(spec *specs.Spec) (string, err
 		if len(tcbReferenceInfoBase64) > 0 {
 			if err := writeFileInDir(securityContextDir, TCBReferenceInfoFilename, []byte(tcbReferenceInfoBase64), 0777); err != nil {
 				return "", fmt.Errorf("failed to write TCB reference info: %w", err)
+			}
+		}
+		if len(platformReferenceInfoBase64) > 0 {
+			if err := writeFileInDir(securityContextDir, PlatformReferenceInfoFilename, []byte(platformReferenceInfoBase64), 0777); err != nil {
+				return "", fmt.Errorf("failed to write platform reference info: %w", err)
 			}
 		}
 


### PR DESCRIPTION
We will probably only use platform-reference-info in the end, but this PR implements both in case we change our mind (or in case the tcb reference info starts being signed by someone other than ACI)

demo:
```
PS C:\Users\azureuser\wcow_skr_fragment> azcrictl inject-fragment $env:podId 'cacidashboardaci.azurecr.io/fake-platform-reference-info:latest'
sha256:ff71a46d997fe3a041e35d03286ff37fe476a4b451e7c8ec0249b079025e31db
PS C:\Users\azureuser\wcow_skr_fragment> .\createc.ps1
4b2f935505a0e71aa296b0f322a167a6bbd395a318ac46ce84d3afe3a421194f
PS C:\Users\azureuser\wcow_skr_fragment> .\startc.ps1
4b2f935505a0e71aa296b0f322a167a6bbd395a318ac46ce84d3afe3a421194f
Started container wcow_skr_fragment_skr_cwcow_fragment_skr with ID:
4b2f935505a0e71aa296b0f322a167a6bbd395a318ac46ce84d3afe3a421194f
PS C:\Users\azureuser\wcow_skr_fragment> .\container.ps1 powershell
Windows PowerShell
Copyright (C) Microsoft Corporation. All rights reserved.

Install the latest PowerShell for new features and improvements! https://aka.ms/PSWindows

PS C:\app> ls C:\security-context-2599697702\


    Directory: C:\security-context-2599697702


Mode                 LastWriteTime         Length Name
----                 -------------         ------ ----
d-----          8/2/2026  10:36 PM                fragments.info
-a----          7/1/2026   7:47 AM          45056 amdsnppspapi.dll
-a----          8/2/2026  10:36 PM           5696 platform-reference-info-base64
-a----          8/2/2026  10:36 PM          13956 reference-info-base64
-a----          8/2/2026  10:36 PM           6412 security-policy-base64


PS C:\app> cat C:\security-context-2599697702\platform-reference-info-base64
0oRZEDClATgiA3BhcHBsaWNhdGlvbi9qc29uGCGDWQQnMIIEIzCCAgugAwIBAgICEAAwDQYJKoZIhvcNAQEMBQAwXTELMAkGA1UEBhM...
```

```
> sign1util print -in (base64 -d ~/a | psub)
checkCoseSign1 passed
iss: did:x509:0:sha256:I__iuL25oXEVFdTP_aBLx_eT1RPHbCQ_ECBQfYZpt9s::eku:1.3.6.1.4.1.311.76.59.1.2
feed: ContainerPlat-AMD-UVM
cty: application/json
pubkey: MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEBJflwND8g2MWD2kZW/jyiAAMEmzBycme2hOHe6ot+JgTHrANQIr5+YKStXoIgN7Vg6z8kABMw0KqfGDh1Gx1QwfYD+IZEf7RTsex1lUPGFuUZeZDIAMDbTdhvFvgoFCQ
pubcert: MIIEIzCCA...
all protected headers:
  iss: "did:x509:0:sha256:I__iuL25oXEVFdTP_aBLx_eT1RPHbCQ_ECBQfYZpt9s::eku:1.3.6.1.4.1.311.76.59.1.2"
  feed: "ContainerPlat-AMD-UVM"
  1: ES384
  3: "application/json"
  33: ...
all unprotected headers:
payload:
{
  "version": "1"
}
```

Assisted-by: GitHub-Copilot copilot-review