### PR TITLE
[live-migration] wire cancel to the HcsCancelLiveMigration API

### DIFF
--- a/cmd/containerd-shim-lcow-v2/service/mocks/mock_service.go
+++ b/cmd/containerd-shim-lcow-v2/service/mocks/mock_service.go
@@ -63,17 +63,17 @@ func (m *MockvmController) EXPECT() *MockvmControllerMockRecorder {
 }
 
 // CancelLiveMigration mocks base method.
-func (m *MockvmController) CancelLiveMigration(ctx context.Context) error {
+func (m *MockvmController) CancelLiveMigration(ctx context.Context, options *schema2.MigrationCancelOptions) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CancelLiveMigration", ctx)
+	ret := m.ctrl.Call(m, "CancelLiveMigration", ctx, options)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // CancelLiveMigration indicates an expected call of CancelLiveMigration.
-func (mr *MockvmControllerMockRecorder) CancelLiveMigration(ctx any) *gomock.Call {
+func (mr *MockvmControllerMockRecorder) CancelLiveMigration(ctx, options any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CancelLiveMigration", reflect.TypeOf((*MockvmController)(nil).CancelLiveMigration), ctx)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CancelLiveMigration", reflect.TypeOf((*MockvmController)(nil).CancelLiveMigration), ctx, options)
 }
 
 // CreateVM mocks base method.

--- a/cmd/containerd-shim-lcow-v2/service/types.go
+++ b/cmd/containerd-shim-lcow-v2/service/types.go
@@ -127,7 +127,7 @@ type vmController interface {
 	StartLiveMigrationTransfer(ctx context.Context, options *hcsschema.MigrationTransferOptions) error
 
 	// CancelLiveMigration aborts an in-flight migration on the VM.
-	CancelLiveMigration(ctx context.Context) error
+	CancelLiveMigration(ctx context.Context, options *hcsschema.MigrationCancelOptions) error
 
 	// FinalizeLiveMigration applies the migration's final operation to the VM.
 	FinalizeLiveMigration(ctx context.Context, options *hcsschema.MigrationFinalizedOptions) error

--- a/internal/computecore/computecore.go
+++ b/internal/computecore/computecore.go
@@ -64,6 +64,7 @@ import (
 //sys hcsStartLiveMigrationOnSource(computeSystem HcsSystem, operation HcsOperation, options string) (hr error) = computecore.HcsStartLiveMigrationOnSource?
 //sys hcsStartLiveMigrationTransfer(computeSystem HcsSystem, operation HcsOperation, options string) (hr error) = computecore.HcsStartLiveMigrationTransfer?
 //sys hcsFinalizeLiveMigration(computeSystem HcsSystem, operation HcsOperation, options string) (hr error) = computecore.HcsFinalizeLiveMigration?
+//sys hcsCancelLiveMigration(computeSystem HcsSystem, operation HcsOperation, options string) (hr error) = computecore.HcsCancelLiveMigration?
 
 // Process lifecycle
 //sys hcsCreateProcess(computeSystem HcsSystem, processParameters string, operation HcsOperation, securityDescriptor unsafe.Pointer, process *HcsProcess) (hr error) = computecore.HcsCreateProcess?
@@ -640,6 +641,17 @@ func HcsFinalizeLiveMigration(ctx gcontext.Context, computeSystem HcsSystem, ope
 
 	return execute(ctx, timeout.SyscallWatcher, func() error {
 		return hcsFinalizeLiveMigration(computeSystem, operation, options)
+	})
+}
+
+func HcsCancelLiveMigration(ctx gcontext.Context, computeSystem HcsSystem, operation HcsOperation, options string) (hr error) {
+	ctx, span := ot.StartSpan(ctx, "HcsCancelLiveMigration")
+	defer span.End()
+	defer func() { ot.SetSpanStatus(span, hr) }()
+	span.SetAttributes(attribute.String("options", options))
+
+	return execute(ctx, timeout.SyscallWatcher, func() error {
+		return hcsCancelLiveMigration(computeSystem, operation, options)
 	})
 }
 

--- a/internal/computecore/zsyscall_windows.go
+++ b/internal/computecore/zsyscall_windows.go
@@ -40,6 +40,7 @@ var (
 	modcomputecore = windows.NewLazySystemDLL("computecore.dll")
 
 	procHcsAddResourceToOperation                  = modcomputecore.NewProc("HcsAddResourceToOperation")
+	procHcsCancelLiveMigration                     = modcomputecore.NewProc("HcsCancelLiveMigration")
 	procHcsCancelOperation                         = modcomputecore.NewProc("HcsCancelOperation")
 	procHcsCloseComputeSystem                      = modcomputecore.NewProc("HcsCloseComputeSystem")
 	procHcsCloseOperation                          = modcomputecore.NewProc("HcsCloseOperation")
@@ -115,6 +116,30 @@ func _hcsAddResourceToOperation(operation HcsOperation, resourceType uint32, uri
 		return
 	}
 	r0, _, _ := syscall.SyscallN(procHcsAddResourceToOperation.Addr(), uintptr(operation), uintptr(resourceType), uintptr(unsafe.Pointer(uri)), uintptr(handle))
+	if int32(r0) < 0 {
+		if r0&0x1fff0000 == 0x00070000 {
+			r0 &= 0xffff
+		}
+		hr = syscall.Errno(r0)
+	}
+	return
+}
+
+func hcsCancelLiveMigration(computeSystem HcsSystem, operation HcsOperation, options string) (hr error) {
+	var _p0 *uint16
+	_p0, hr = syscall.UTF16PtrFromString(options)
+	if hr != nil {
+		return
+	}
+	return _hcsCancelLiveMigration(computeSystem, operation, _p0)
+}
+
+func _hcsCancelLiveMigration(computeSystem HcsSystem, operation HcsOperation, options *uint16) (hr error) {
+	hr = procHcsCancelLiveMigration.Find()
+	if hr != nil {
+		return
+	}
+	r0, _, _ := syscall.SyscallN(procHcsCancelLiveMigration.Addr(), uintptr(computeSystem), uintptr(operation), uintptr(unsafe.Pointer(options)))
 	if int32(r0) < 0 {
 		if r0&0x1fff0000 == 0x00070000 {
 			r0 &= 0xffff

--- a/internal/controller/migration/controller.go
+++ b/internal/controller/migration/controller.go
@@ -438,7 +438,7 @@ func (c *Controller) Cancel(ctx context.Context, sessionID string) error {
 func (c *Controller) cancelLiveMigration(ctx context.Context) error {
 	c.mu.Unlock()
 	defer c.mu.Lock()
-	return c.vmController.CancelLiveMigration(ctx)
+	return c.vmController.CancelLiveMigration(ctx, &hcsschema.MigrationCancelOptions{Origin: c.origin})
 }
 
 // Cleanup is the terminal call of a migration session on either side. It

--- a/internal/controller/migration/controller_test.go
+++ b/internal/controller/migration/controller_test.go
@@ -179,7 +179,7 @@ func TestTransfer_CompletionDoesNotClobberCancel(t *testing.T) {
 	vm.EXPECT().StartLiveMigrationOnSource(gomock.Any(), gomock.Any()).Return(nil)
 	// Simulate a concurrent Cancel arriving mid-transfer, once the goroutine has
 	// released the lock to run the transfer.
-	vm.EXPECT().CancelLiveMigration(gomock.Any()).Return(nil)
+	vm.EXPECT().CancelLiveMigration(gomock.Any(), gomock.Any()).Return(nil)
 	vm.EXPECT().StartLiveMigrationTransfer(gomock.Any(), gomock.Any()).DoAndReturn(
 		func(context.Context, *hcsschema.MigrationTransferOptions) error {
 			return c.Cancel(context.Background(), "sess-1")
@@ -485,7 +485,7 @@ func TestCancel_Idempotent(t *testing.T) {
 func TestCancel_Success(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	vm := mocks.NewMockvmController(ctrl)
-	vm.EXPECT().CancelLiveMigration(gomock.Any()).Return(nil)
+	vm.EXPECT().CancelLiveMigration(gomock.Any(), gomock.Any()).Return(nil)
 
 	c := New()
 	c.sessionID = "sess-1"
@@ -505,7 +505,7 @@ func TestCancel_Success(t *testing.T) {
 func TestCancel_VMError(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	vm := mocks.NewMockvmController(ctrl)
-	vm.EXPECT().CancelLiveMigration(gomock.Any()).Return(errors.New("boom"))
+	vm.EXPECT().CancelLiveMigration(gomock.Any(), gomock.Any()).Return(errors.New("boom"))
 
 	c := New()
 	c.sessionID = "sess-1"
@@ -527,7 +527,7 @@ func TestCancel_VMError(t *testing.T) {
 func TestCancel_SocketReadyAlreadyClosed(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	vm := mocks.NewMockvmController(ctrl)
-	vm.EXPECT().CancelLiveMigration(gomock.Any()).Return(nil)
+	vm.EXPECT().CancelLiveMigration(gomock.Any(), gomock.Any()).Return(nil)
 
 	c := New()
 	c.sessionID = "sess-1"

--- a/internal/controller/migration/mocks/mock_lcow_migration.go
+++ b/internal/controller/migration/mocks/mock_lcow_migration.go
@@ -54,17 +54,17 @@ func (m *MockvmController) EXPECT() *MockvmControllerMockRecorder {
 }
 
 // CancelLiveMigration mocks base method.
-func (m *MockvmController) CancelLiveMigration(ctx context.Context) error {
+func (m *MockvmController) CancelLiveMigration(ctx context.Context, options *schema2.MigrationCancelOptions) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CancelLiveMigration", ctx)
+	ret := m.ctrl.Call(m, "CancelLiveMigration", ctx, options)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // CancelLiveMigration indicates an expected call of CancelLiveMigration.
-func (mr *MockvmControllerMockRecorder) CancelLiveMigration(ctx any) *gomock.Call {
+func (mr *MockvmControllerMockRecorder) CancelLiveMigration(ctx, options any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CancelLiveMigration", reflect.TypeOf((*MockvmController)(nil).CancelLiveMigration), ctx)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CancelLiveMigration", reflect.TypeOf((*MockvmController)(nil).CancelLiveMigration), ctx, options)
 }
 
 // CreateVM mocks base method.

--- a/internal/controller/migration/types.go
+++ b/internal/controller/migration/types.go
@@ -35,7 +35,7 @@ type vmController interface {
 	StartWithMigrationOptions(ctx context.Context, config *hcs.MigrationConfig) error
 	StartLiveMigrationTransfer(ctx context.Context, options *hcsschema.MigrationTransferOptions) error
 	FinalizeLiveMigration(ctx context.Context, options *hcsschema.MigrationFinalizedOptions) error
-	CancelLiveMigration(ctx context.Context) error
+	CancelLiveMigration(ctx context.Context, options *hcsschema.MigrationCancelOptions) error
 	TerminateVM(ctx context.Context) error
 	Resume(ctx context.Context, rebuildBridge bool) error
 	MigrationNotifications() (<-chan hcsschema.OperationSystemMigrationNotificationInfo, error)

--- a/internal/controller/vm/vm_migration.go
+++ b/internal/controller/vm/vm_migration.go
@@ -253,12 +253,12 @@ func (c *Controller) FinalizeLiveMigration(ctx context.Context, options *hcssche
 // safe because uvm is written once in CreateVM and the migration controller
 // serializes Cancel behind its own lock, so that write is already published here.
 // A nil uvm means the VM was never created.
-func (c *Controller) CancelLiveMigration(ctx context.Context) error {
+func (c *Controller) CancelLiveMigration(ctx context.Context, options *hcsschema.MigrationCancelOptions) error {
 	if c.uvm == nil {
 		return fmt.Errorf("cannot cancel live migration: VM not created")
 	}
 
-	if err := c.uvm.CancelLiveMigration(ctx); err != nil {
+	if err := c.uvm.CancelLiveMigration(ctx, options); err != nil {
 		return fmt.Errorf("failed to cancel live migration: %w", err)
 	}
 

--- a/internal/hcs/schema2/migration.go
+++ b/internal/hcs/schema2/migration.go
@@ -49,6 +49,12 @@ type MigrationTransferOptions struct {
 	Origin MigrationOrigin `json:"Origin,omitempty"`
 }
 
+// MigrationCancelOptions is a set of options used to cancel a live migration.
+type MigrationCancelOptions struct {
+	// Origin is the side of migration the workflow is performed on.
+	Origin MigrationOrigin `json:"Origin,omitempty"`
+}
+
 // StartOptions specifies options for starting a compute system.
 type StartOptions struct {
 	// DestinationMigrationOptions specifies settings to use when starting a migration on the destination side.

--- a/internal/hcs/v2/migration.go
+++ b/internal/hcs/v2/migration.go
@@ -241,16 +241,12 @@ func (computeSystem *System) FinalizeLiveMigration(ctx context.Context, opts *hc
 	return nil
 }
 
-// CancelLiveMigration is currently a stub: it verifies the compute system is
-// still open and returns success without contacting HCS or interrupting any
-// migration (pending the compute-core cancel API).
-//
-// It deliberately takes no handleLock so that, once implemented, it can interrupt
-// an in-flight transfer that holds it.
-func (computeSystem *System) CancelLiveMigration(ctx context.Context) (err error) {
+// CancelLiveMigration requests cancellation of an in-flight live migration.
+// It deliberately takes no handleLock so it can interrupt an in-flight transfer that holds it.
+func (computeSystem *System) CancelLiveMigration(ctx context.Context, options *hcsschema.MigrationCancelOptions) (err error) {
 	operation := "hcs::System::CancelLiveMigration"
 
-	_, span := ot.StartSpan(ctx, operation)
+	ctx, span := ot.StartSpan(ctx, operation)
 	defer span.End()
 	defer func() { ot.SetSpanStatus(span, err) }()
 	span.SetAttributes(attribute.String("cid", computeSystem.id))
@@ -259,9 +255,27 @@ func (computeSystem *System) CancelLiveMigration(ctx context.Context) (err error
 		return makeSystemError(computeSystem, operation, ErrAlreadyClosed)
 	}
 
-	// TODO: wire this to the HcsCancelLiveMigration compute-core API once it is
-	//  available. Until then this is a stub that reports success without contacting HCS.
+	if options == nil {
+		options = &hcsschema.MigrationCancelOptions{}
+	}
+	optionsJSON, err := json.Marshal(options)
+	if err != nil {
+		return makeSystemError(computeSystem, operation, err)
+	}
 
+	op, err := computecore.HcsCreateOperation(ctx, 0, 0)
+	if err != nil {
+		return makeSystemError(computeSystem, operation, err)
+	}
+	defer computecore.HcsCloseOperation(ctx, op)
+
+	// Issue the cancel and wait for completion.
+	if err := computecore.HcsCancelLiveMigration(ctx, computeSystem.handle, op, string(optionsJSON)); err != nil {
+		return makeSystemError(computeSystem, operation, err)
+	}
+	if _, err := computecore.HcsWaitForOperationResult(ctx, op, 0xFFFFFFFF); err != nil {
+		return makeSystemError(computeSystem, operation, err)
+	}
 	return nil
 }
 

--- a/internal/vm/vmmanager/migration.go
+++ b/internal/vm/vmmanager/migration.go
@@ -46,8 +46,8 @@ func (uvm *UtilityVM) StartLiveMigrationTransfer(ctx context.Context, options *h
 }
 
 // CancelLiveMigration aborts an in-flight live migration on the utility VM.
-func (uvm *UtilityVM) CancelLiveMigration(ctx context.Context) error {
-	if err := uvm.cs.CancelLiveMigration(ctx); err != nil {
+func (uvm *UtilityVM) CancelLiveMigration(ctx context.Context, options *hcsschema.MigrationCancelOptions) error {
+	if err := uvm.cs.CancelLiveMigration(ctx, options); err != nil {
 		return fmt.Errorf("failed to cancel live migration: %w", err)
 	}
 	return nil


### PR DESCRIPTION
CancelLiveMigration was a stub: it only checked the compute system was open and returned success, so a cancel never reached HCS and an in-flight migration kept running.

Bind the computecore.dll HcsCancelLiveMigration export and issue it from System.CancelLiveMigration, waiting on the async operation for the result (a pending status is expected, as with the sibling LM APIs). The call still takes no handle lock so it can interrupt an in-flight transfer that holds it, and it now surfaces a real error on failure instead of always succeeding.

Thread a MigrationCancelOptions through the cancel call chain (vmmanager, vm and migration controllers, service interface) so the request carries the originating side; the migration session stamps its own Origin (source or destination), matching the documented cancel sequence.

Regenerate the computecore syscall bindings and the vmController mocks.