### PR TITLE
[bug]Message fields incorrectly deleted from GCS logs

### DIFF
--- a/init/init.c
+++ b/init/init.c
@@ -875,7 +875,7 @@ void start_services() {
     char* persistenced_name = "/bin/nvidia-persistenced";
     struct stat persistenced_stat;
     if (stat(persistenced_name, &persistenced_stat) == -1) {
-        dmesgWarn("nvidia-persistenced not present, skipping ");
+        dmesgWarn("nvidia-persistenced not present, skipping");
     } else {
         dmesgInfo("start nvidia-persistenced daemon");
         pid_t persistenced_pid = launch(1, &persistenced_name);
@@ -889,7 +889,7 @@ void start_services() {
     char* fm_name = "/bin/nv-fabricmanager";
     struct stat fabric_stat;
     if (stat(fm_name, &fabric_stat) == -1) {
-        dmesgWarn("nv-fabricmanager not present, skipping ");
+        dmesgWarn("nv-fabricmanager not present, skipping");
     } else {
         dmesgInfo("start nv-fabricmanager daemon");
         char* command[] = {fm_name, "-c", "/usr/share/nvidia/nvswitch/fabricmanager.cfg"};

--- a/internal/guest/kmsg/kmsg.go
+++ b/internal/guest/kmsg/kmsg.go
@@ -93,28 +93,49 @@ func parse(s string) (*Entry, error) {
 	if err != nil {
 		return nil, ErrInvalidFormat
 	}
+
+	// TODO: validate that the message ends in with a \n and parse key/value pairs:
+	//  - "The human readable text string starts directly after the ';' and is terminated by a '\n'"
+	//  - "A line starting with ' ', is a continuation line, adding key/value pairs to the log message"
+	//
+	// See: https://docs.kernel.org/admin-guide/abi-testing.html#abi-dev-kmsg
+	msg := strings.TrimSpace(fields[1])
+
 	return &Entry{
 		Priority:           LogLevel(syslog & 0x7),
 		Facility:           uint8(syslog >> 3),
 		Seq:                seq,
 		TimeSinceBootMicro: timestamp,
 		Flags:              prefixFields[3],
-		Message:            fields[1],
+		Message:            msg,
 	}, nil
 }
 
 // ReadForever reads from /dev/kmsg forever unless /dev/kmsg cannot be opened.
 // Every entry with priority <= 'logLevel' will be logged.
 func ReadForever(logLevel LogLevel) {
+	// TODO:
+	//  - handle continuation fragments:
+	//    "/dev/kmsg users are recommended to implement fragment handling."
+	//    See: https://docs.kernel.org/admin-guide/abi-testing.html#abi-dev-kmsg
+	//  - use `dmesg --follow --json` to avoid string parsing, buffer allocation, and fragment handling
+	//  - check entry sequence numbers are sequential and warn if messages were skipped
 	file, err := os.Open("/dev/kmsg")
 	if err != nil {
 		logrus.WithError(err).Error("failed to open /dev/kmsg")
 		return
 	}
 	defer file.Close()
+	// Buffer size is controlled by LOG_BUF_SHIFT (and LOG_CPU_MAX_BUF_SHIFT) kernel parameters.
+	// Use the default shift value of 17, since records larger than 128 KiB should be unlikely and
+	// allocating the maximum (LOG_BUF_LEN_MAX) 2 GiB is overkill.
+	//
+	// See:
+	//  - https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/init/Kconfig?id=11028ab62899e4191e074ee364c712b77823a9c4#n807
+	//  - https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/kernel/printk/printk.c?id=11028ab62899e4191e074ee364c712b77823a9c4#n503
+	const bufSize = 1 << 17
 	// Reuse buffer for entries
-	// Buffer size from: https://elixir.bootlin.com/linux/latest/source/include/linux/printk.h#L44
-	buf := make([]byte, 8192)
+	buf := make([]byte, bufSize)
 	for {
 		n, err := file.Read(buf)
 		if err != nil {

--- a/internal/vm/vmutils/gcs_logs.go
+++ b/internal/vm/vmutils/gcs_logs.go
@@ -5,6 +5,7 @@ package vmutils
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"io"
 	"time"
 
@@ -12,7 +13,6 @@ import (
 	"github.com/Microsoft/hcsshim/internal/log"
 	"github.com/Microsoft/hcsshim/internal/logfields"
 
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/windows"
 )
@@ -141,22 +141,22 @@ func (e *GCSLogEntry) UnmarshalJSON(b []byte) error {
 		e.Level = logrus.ErrorLevel
 	}
 
+	// Delete standard fields to avoid duplication
+	for _, f := range []string{"time", "level", "msg"} {
+		delete(e.Fields, f)
+	}
+
 	// Handle ETW (Event Tracing for Windows) log entries that may have
 	// alternate message field names ("message" or "Message" instead of "msg")
 	if e.Fields["Source"] == "ETW" {
 		// Check for alternate message fields and use the first one found
-		if msg, ok := e.Fields["message"].(string); ok {
-			e.Message = msg
-		} else if msg, ok := e.Fields["Message"].(string); ok {
-			e.Message = msg
+		for _, f := range []string{"message", "Message"} {
+			if msg, ok := e.Fields[f].(string); ok {
+				e.Message = msg
+				delete(e.Fields, f)
+				break
+			}
 		}
-	}
-
-	// Batch delete standard and alternate fields to avoid duplication
-	// This is more efficient than multiple individual delete calls
-	fieldsToDelete := []string{"time", "level", "msg", "message", "Message"}
-	for _, field := range fieldsToDelete {
-		delete(e.Fields, field)
 	}
 
 	// Normalize floating-point values that represent whole numbers to int64.


### PR DESCRIPTION
Fix bug in `(*GCSLogEntry).UnmarshalJSON` where `[mM]essage` fields where always deleted, even in non-ETW cases.
This prevented the actual `kmsg` logs (where are added as `message` in log entries) from being correctly logged by the shim.

Also:
 - remove trailing spaces in `init` dmesg logs.
 - increase `/dev/kmsg` read buffer and add comments about size.
 - trim trailing spaces (and newline) from parsed kmsg messages.