### PR TITLE
[live-migration] Renegotiate GCS version on restore and drop Plan9 from HCS Document

### DIFF
--- a/internal/builder/vm/lcow/kernel_args.go
+++ b/internal/builder/vm/lcow/kernel_args.go
@@ -27,6 +27,7 @@ func buildKernelArgs(
 	kernelDirect bool,
 	hasConsole bool,
 	rootFsFile string,
+	liveMigrationSupported bool,
 ) (string, error) {
 
 	log.G(ctx).WithField("rootFsFile", rootFsFile).Debug("buildKernelArgs: starting kernel arguments construction")
@@ -82,7 +83,7 @@ func buildKernelArgs(
 
 	// 8. Init arguments (passed after "--" separator)
 	initArgs := buildInitArgs(ctx, opts, annotations,
-		writableOverlayDirs, disableTimeSyncService, processDumpLocation, rootFsFile, hasConsole)
+		writableOverlayDirs, disableTimeSyncService, processDumpLocation, rootFsFile, hasConsole, liveMigrationSupported)
 	args = append(args, "--", initArgs)
 
 	result := strings.Join(args, " ")
@@ -152,6 +153,7 @@ func buildInitArgs(
 	processDumpLocation string,
 	rootFsFile string,
 	hasConsole bool,
+	liveMigrationSupported bool,
 ) string {
 	log.G(ctx).WithFields(logrus.Fields{
 		"rootFsFile": rootFsFile,
@@ -161,7 +163,7 @@ func buildInitArgs(
 	entropyArgs := fmt.Sprintf("-e %d", vmutils.LinuxEntropyVsockPort)
 
 	// Build GCS execution command
-	gcsCmd := buildGCSCommand(ctx, opts, annotations, disableTimeSyncService, processDumpLocation)
+	gcsCmd := buildGCSCommand(ctx, opts, annotations, disableTimeSyncService, processDumpLocation, liveMigrationSupported)
 
 	// Construct init arguments
 	var initArgsList []string
@@ -197,6 +199,7 @@ func buildGCSCommand(
 	annotations map[string]string,
 	disableTimeSyncService bool,
 	processDumpLocation string,
+	liveMigrationSupported bool,
 ) string {
 	var cmdParts []string
 
@@ -204,8 +207,7 @@ func buildGCSCommand(
 	// When live migration is enabled, run vsockexec in reconnect mode (-r) so
 	// guest logging tolerates the host log listener being absent at boot and
 	// reconnects to the destination host's listener after a migration.
-	reconnect := oci.ParseAnnotationsBool(ctx, annotations, shimannotations.LiveMigrationSupportEnabled, false)
-	cmdParts = append(cmdParts, vmutils.LinuxLogForwarderCommand(reconnect))
+	cmdParts = append(cmdParts, vmutils.LinuxLogForwarderCommand(liveMigrationSupported))
 
 	// Determine log level
 	logLevel := "info"

--- a/internal/builder/vm/lcow/specs.go
+++ b/internal/builder/vm/lcow/specs.go
@@ -75,6 +75,11 @@ func BuildSandboxConfig(
 	// The FullyPhysicallyBacked annotation forces memory overcommit off.
 	fullyPhysicallyBacked := oci.ParseAnnotationsBool(ctx, spec.Annotations, shimannotations.FullyPhysicallyBacked, false)
 
+	// liveMigrationSupported constrains the sandbox to the feature subset that is
+	// compatible with live migration. Notably, Plan9 file shares cannot be saved
+	// or migrated, so the Plan9 device is omitted when this is set.
+	liveMigrationSupported := oci.ParseAnnotationsBool(ctx, spec.Annotations, shimannotations.LiveMigrationSupportEnabled, false)
+
 	// ================== Parse Topology (CPU, Memory, NUMA) options =================
 	// ===============================================================================
 
@@ -229,6 +234,7 @@ func BuildSandboxConfig(
 			bootOptions.LinuxKernelDirect != nil, // isKernelDirectBoot
 			comPorts != nil,                      // hasConsole
 			filepath.Base(rootFsFullPath),
+			liveMigrationSupported,
 		)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to build kernel args: %w", err)
@@ -256,6 +262,23 @@ func BuildSandboxConfig(
 		schema = schemaversion.SchemaV25()
 	}
 
+	// HCS treats the presence of the Plan9 field (even an empty one) as a request
+	// to give the VM file-sharing support. For a normal sandbox we set an empty
+	// Plan9 here so that Plan9/9P file shares can be added to the VM later at
+	// runtime: HCS keys off the field being set, not off whether any shares
+	// currently exist.
+	//
+	// The trade-off is that enabling file sharing attaches an extra virtual device
+	// to the VM. Once the VM powers on, that device becomes part of the VM's saved
+	// device state even when nothing is actually being shared, and that state
+	// cannot be saved and restored cleanly. Live migration relies on save/restore,
+	// so a live-migratable sandbox must omit Plan9 (giving up runtime file sharing)
+	// to keep the VM migratable.
+	var plan9 *hcsschema.Plan9
+	if !liveMigrationSupported {
+		plan9 = &hcsschema.Plan9{}
+	}
+
 	// Build the document.
 	doc := &hcsschema.ComputeSystem{
 		Owner:         owner,
@@ -280,7 +303,7 @@ func BuildSandboxConfig(
 					HvSocketConfig: hvSocketConfig,
 				},
 				ComPorts: comPorts,
-				Plan9:    &hcsschema.Plan9{},
+				Plan9:    plan9,
 			},
 			GuestState:       guestState,
 			SecuritySettings: securitySettings,

--- a/internal/builder/vm/lcow/specs_test.go
+++ b/internal/builder/vm/lcow/specs_test.go
@@ -2157,6 +2157,8 @@ func TestBuildSandboxConfig_CPUClamping(t *testing.T) {
 // the /bin/vsockexec wrapper in reconnect mode (-r) so guest logging tolerates a
 // missing host log listener and reconnects after a migration, while non-LM
 // sandboxes use the plain wrapper to forward GCS stderr over LinuxLogVsockPort.
+// It also gates the Plan9 device: live-migratable sandboxes omit Plan9 (its
+// share state cannot be saved or migrated) while non-LM sandboxes keep it.
 func TestBuildSandboxConfig_LiveMigration(t *testing.T) {
 	ctx := context.Background()
 
@@ -2184,6 +2186,10 @@ func TestBuildSandboxConfig_LiveMigration(t *testing.T) {
 				if !strings.Contains(kernelArgs, "/bin/gcs") {
 					t.Errorf("expected /bin/gcs in kernel args, got %q", kernelArgs)
 				}
+				// A non-migratable sandbox keeps the Plan9 device.
+				if doc.VirtualMachine.Devices.Plan9 == nil {
+					t.Errorf("expected Plan9 device to be enabled for non-migratable sandbox, got nil")
+				}
 			},
 		},
 		{
@@ -2201,6 +2207,10 @@ func TestBuildSandboxConfig_LiveMigration(t *testing.T) {
 				}
 				if strings.Contains(kernelArgs, vsockexecReconnectPrefix) {
 					t.Errorf("expected no vsockexec reconnect mode when LM disabled, got %q", kernelArgs)
+				}
+				// A non-migratable sandbox keeps the Plan9 device.
+				if doc.VirtualMachine.Devices.Plan9 == nil {
+					t.Errorf("expected Plan9 device to be enabled for non-migratable sandbox, got nil")
 				}
 			},
 		},
@@ -2221,6 +2231,10 @@ func TestBuildSandboxConfig_LiveMigration(t *testing.T) {
 				}
 				if !strings.Contains(kernelArgs, "/bin/gcs") {
 					t.Errorf("expected /bin/gcs in kernel args when LM enabled, got %q", kernelArgs)
+				}
+				// A live-migratable sandbox omits the Plan9 device.
+				if plan9 := doc.VirtualMachine.Devices.Plan9; plan9 != nil {
+					t.Errorf("expected Plan9 device to be omitted for live-migratable sandbox, got %+v", plan9)
 				}
 			},
 		},
@@ -2247,6 +2261,10 @@ func TestBuildSandboxConfig_LiveMigration(t *testing.T) {
 				if !strings.Contains(kernelArgs, vsockexecReconnectPrefix) {
 					t.Errorf("expected vsockexec reconnect wrapper %q when LM enabled, got %q", vsockexecReconnectPrefix, kernelArgs)
 				}
+				// A live-migratable sandbox omits the Plan9 device.
+				if plan9 := doc.VirtualMachine.Devices.Plan9; plan9 != nil {
+					t.Errorf("expected Plan9 device to be omitted for live-migratable sandbox, got %+v", plan9)
+				}
 			},
 		},
 		{
@@ -2265,6 +2283,10 @@ func TestBuildSandboxConfig_LiveMigration(t *testing.T) {
 				}
 				if !strings.Contains(kernelArgs, vsockexecReconnectPrefix) {
 					t.Errorf("expected vsockexec reconnect wrapper %q when LM enabled, got %q", vsockexecReconnectPrefix, kernelArgs)
+				}
+				// A live-migratable sandbox omits the Plan9 device.
+				if plan9 := doc.VirtualMachine.Devices.Plan9; plan9 != nil {
+					t.Errorf("expected Plan9 device to be omitted for live-migratable sandbox, got %+v", plan9)
 				}
 			},
 		},
@@ -2286,6 +2308,10 @@ func TestBuildSandboxConfig_LiveMigration(t *testing.T) {
 				}
 				if strings.Contains(kernelArgs, vsockexecReconnectPrefix) {
 					t.Errorf("expected no vsockexec reconnect mode on invalid LM annotation, got %q", kernelArgs)
+				}
+				// Invalid annotation falls back to false, so Plan9 stays enabled.
+				if doc.VirtualMachine.Devices.Plan9 == nil {
+					t.Errorf("expected Plan9 device to be enabled for non-migratable sandbox, got nil")
 				}
 			},
 		},

--- a/internal/controller/vm/save_lcow.go
+++ b/internal/controller/vm/save_lcow.go
@@ -249,12 +249,12 @@ func (c *Controller) Resume(ctx context.Context, rebuildBridge bool) error {
 			return fmt.Errorf("prepare source resume listener: %w", err)
 		}
 		if err := c.guest.ResumeConnection(ctx); err != nil {
-			return fmt.Errorf("resume guest connection: %w", err)
+			return fmt.Errorf("resume source guest connection: %w", err)
 		}
 	} else {
 		// Destination: reuse the connection already armed at start.
 		if err := c.guest.CreateConnection(ctx, false); err != nil {
-			return fmt.Errorf("resume guest connection: %w", err)
+			return fmt.Errorf("resume destination guest connection: %w", err)
 		}
 	}
 

--- a/internal/controller/vm/save_lcow.go
+++ b/internal/controller/vm/save_lcow.go
@@ -242,8 +242,7 @@ func (c *Controller) Resume(ctx context.Context, rebuildBridge bool) error {
 		return fmt.Errorf("arm logging listener on resume: %w", err)
 	}
 
-	switch {
-	case rebuildBridge:
+	if rebuildBridge {
 		// Source rollback: arm the host GCS listener now, then accept the guest's
 		// post-blackout re-dial and swap it into the running bridge.
 		if err := c.guest.PrepareConnection(winio.VsockServiceID(prot.LinuxGcsVsockPort)); err != nil {
@@ -252,7 +251,7 @@ func (c *Controller) Resume(ctx context.Context, rebuildBridge bool) error {
 		if err := c.guest.ResumeConnection(ctx); err != nil {
 			return fmt.Errorf("resume guest connection: %w", err)
 		}
-	default:
+	} else {
 		// Destination: reuse the connection already armed at start.
 		if err := c.guest.CreateConnection(ctx, false); err != nil {
 			return fmt.Errorf("resume guest connection: %w", err)

--- a/internal/controller/vm/save_lcow.go
+++ b/internal/controller/vm/save_lcow.go
@@ -239,15 +239,15 @@ func (c *Controller) Resume(ctx context.Context, rebuildBridge bool) error {
 	defer cancel()
 
 	if err := c.setupLoggingListener(gctx, g); err != nil {
-		return fmt.Errorf("re-arm logging listener on resume: %w", err)
+		return fmt.Errorf("arm logging listener on resume: %w", err)
 	}
 
 	switch {
 	case rebuildBridge:
-		// Source rollback: re-arm the listener and swap the bridge transport
-		// onto the fresh hvsock so outstanding RPCs (e.g. WaitForProcess) survive.
+		// Source rollback: arm the host GCS listener now, then accept the guest's
+		// post-blackout re-dial and swap it into the running bridge.
 		if err := c.guest.PrepareConnection(winio.VsockServiceID(prot.LinuxGcsVsockPort)); err != nil {
-			return fmt.Errorf("prepare guest connection on resume: %w", err)
+			return fmt.Errorf("prepare source resume listener: %w", err)
 		}
 		if err := c.guest.ResumeConnection(ctx); err != nil {
 			return fmt.Errorf("resume guest connection: %w", err)

--- a/internal/gcs/guestconnection.go
+++ b/internal/gcs/guestconnection.go
@@ -114,7 +114,9 @@ func (gc *GuestConnection) Protocol() uint32 {
 	return protocolVersion
 }
 
-// connect establishes a GCS connection. It must not be called more than once.
+// connect establishes the GCS connection: it negotiates the protocol version,
+// records the guest OS and capabilities, and on a cold start sends the host
+// create/start messages. This method must not be called more than once per active connection.
 // isColdStart should be true when the UVM is being connected to for the first time post-boot.
 // It should be false for subsequent connections (e.g. if reconnecting to an existing UVM).
 func (gc *GuestConnection) connect(ctx context.Context, isColdStart bool, initGuestState *InitialGuestState) (err error) {

--- a/internal/gcs/guestconnection.go
+++ b/internal/gcs/guestconnection.go
@@ -244,13 +244,19 @@ func (gc *GuestConnection) SetMigrating(migrating bool) {
 
 // ResumeOnConn resumes the bridge after swaping the bridge
 // transport without dropping outstanding RPCs.
-func (gc *GuestConnection) ResumeOnConn(conn io.ReadWriteCloser) error {
+func (gc *GuestConnection) ResumeOnConn(ctx context.Context, conn io.ReadWriteCloser) error {
 	if gc.brdg == nil {
 		// Not adopting conn; close it so the accepted socket does not leak.
 		_ = conn.Close()
 		return ErrBridgeClosed
 	}
-	return gc.brdg.ResumeOnConn(conn)
+	if err := gc.brdg.ResumeOnConn(conn); err != nil {
+		return err
+	}
+
+	// The guest resets its protocol version when it re-dials after the blackout,
+	// so renegotiate before any version-gated RPC (e.g. exec) is issued.
+	return gc.connect(ctx, false, nil)
 }
 
 // CreateProcess creates a process in the container host.

--- a/internal/gcs/guestconnection_test.go
+++ b/internal/gcs/guestconnection_test.go
@@ -36,16 +36,19 @@ func dialPort(port uint32) (net.Conn, error) {
 	return winio.DialPipe(fmt.Sprintf(pipePortFmt, port), nil)
 }
 
-func simpleGcs(t *testing.T, rwc io.ReadWriteCloser) {
+func simpleGcs(t *testing.T, rwc io.ReadWriteCloser, negotiated chan<- struct{}) {
 	t.Helper()
 	defer rwc.Close()
-	err := simpleGcsLoop(t, rwc)
+	err := simpleGcsLoop(t, rwc, negotiated)
 	if err != nil {
 		t.Error(err)
 	}
 }
 
-func simpleGcsLoop(t *testing.T, rw io.ReadWriter) error {
+// simpleGcsLoop answers the RPCs a fake guest needs. If negotiated is non-nil it
+// receives a value whenever a protocol handshake is answered, letting a test
+// observe a (re)negotiation such as the one ResumeOnConn drives after a redial.
+func simpleGcsLoop(t *testing.T, rw io.ReadWriter, negotiated chan<- struct{}) error {
 	t.Helper()
 	for {
 		id, typ, b, err := readMessage(rw)
@@ -68,6 +71,12 @@ func simpleGcsLoop(t *testing.T, rw io.ReadWriter) error {
 			})
 			if err != nil {
 				return err
+			}
+			// Report the handshake to any observer; non-blocking so the guest
+			// never stalls, and a buffered channel catches it before the test reads.
+			select {
+			case negotiated <- struct{}{}:
+			default:
 			}
 		case prot.RPCCreate:
 			err := sendJSON(t, rw, prot.MsgTypeResponse|prot.MsgType(proc), id, &prot.ContainerCreateResponse{})
@@ -162,7 +171,7 @@ func connectGcs(ctx context.Context, t *testing.T) *GuestConnection {
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		simpleGcs(t, c)
+		simpleGcs(t, c, nil)
 	}()
 	t.Cleanup(func() { <-done })
 	gcc := &GuestConnectionConfig{
@@ -181,6 +190,42 @@ func connectGcs(ctx context.Context, t *testing.T) *GuestConnection {
 func TestGcsConnect(t *testing.T) {
 	gc := connectGcs(context.Background(), t)
 	defer gc.Close()
+}
+
+// TestGcsResumeOnConnRenegotiates verifies that ResumeOnConn re-runs the
+// protocol handshake on the swapped-in transport. The guest resets its GCS
+// protocol version when it re-dials after a migration blackout, so a resume
+// that adopts the new connection without renegotiating would leave
+// version-gated RPCs (e.g. exec) broken on source rollback. Nothing in CI
+// exercises live migration, so this unit test is the guard against that
+// regression.
+func TestGcsResumeOnConnRenegotiates(t *testing.T) {
+	gc := connectGcs(t.Context(), t)
+	defer gc.Close()
+
+	// Enter the migration window so the bridge tolerates swapping transports.
+	gc.SetMigrating(true)
+
+	// Emulate the guest re-dialing after the blackout: a fresh transport served
+	// by the same fake guest, signalling when it answers the re-handshake.
+	s, c := pipeConn()
+	negotiated := make(chan struct{}, 1)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		simpleGcs(t, c, negotiated)
+	}()
+	t.Cleanup(func() { <-done })
+
+	if err := gc.ResumeOnConn(t.Context(), s); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case <-negotiated:
+	case <-time.After(5 * time.Second):
+		t.Fatal("resume did not renegotiate protocol on the new connection")
+	}
 }
 
 func TestGcsCreateContainer(t *testing.T) {

--- a/internal/vm/guestmanager/guest.go
+++ b/internal/vm/guestmanager/guest.go
@@ -77,8 +77,8 @@ func (gm *Guest) PrepareConnection(GCSServiceID guid.GUID) error {
 	gm.mu.Lock()
 	defer gm.mu.Unlock()
 
-	// Idempotent if already prepared/connected with the same service ID.
-	if gm.gcListener != nil || gm.gc != nil {
+	// Idempotent if a listener is already armed for the same service ID.
+	if gm.gcListener != nil {
 		if gm.gcsServiceID != GCSServiceID {
 			return fmt.Errorf("gcs service id mismatch: expected %s, got %s", gm.gcsServiceID, GCSServiceID)
 		}
@@ -245,5 +245,5 @@ func (gm *Guest) ResumeConnection(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to accept resumed guest connection: %w", err)
 	}
-	return gm.gc.ResumeOnConn(conn)
+	return gm.gc.ResumeOnConn(ctx, conn)
 }


### PR DESCRIPTION
After a migration blackout the guest re-dials and resets its GCS protocol version, so version-gated RPCs (e.g. exec) failed on source resume. Renegotiate via connect() in ResumeOnConn before adopting the new connection.

- GuestConnection.ResumeOnConn now takes a ctx and re-runs the version handshake after swapping the bridge transport.
- Fix PrepareConnection idempotency to key only on the armed listener (gcListener) so the log/GCS listener can be re-armed on resume even when a GuestConnection already exists about to be discarded.
- Clarify resume comments and error messages.

An empty Plan9 element makes HCS attach a file-sharing device that becomes part of the VM's saved device state and fails the save/restore path, breaking migration even when nothing is shared. Omit Plan9 for live-migratable sandboxes.

- Gate the Plan9 device in BuildSandboxConfig on LiveMigrationSupportEnabled (nil when set, otherwise &Plan9{}).
- Thread the migration-support flag through the kernel-arg builders instead of re-parsing the annotation.
