### PR TITLE
gcs: zero-extend HRESULT codes in rpcError.Unwrap

### DIFF
--- a/internal/gcs/bridge.go
+++ b/internal/gcs/bridge.go
@@ -235,7 +235,13 @@ func (err *rpcError) Error() string {
 }
 
 func (err *rpcError) Unwrap() error {
-	return windows.Errno(err.result)
+	// result is an int32 HRESULT. HCS error codes have the high bit set
+	// (e.g. 0xc037010e), so a direct conversion to Errno (uintptr) would
+	// sign-extend the negative int32 to 0xFFFFFFFF_C037010E and no longer
+	// match the canonical syscall.Errno constants used with errors.Is
+	// (e.g. hcs.ErrComputeSystemDoesNotExist). Convert via uint32 to keep
+	// the code zero-extended.
+	return windows.Errno(uint32(err.result))
 }
 
 // Err returns the RPC's result. This may be a transport error or an error from

--- a/internal/gcs/bridge_test.go
+++ b/internal/gcs/bridge_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/Microsoft/hcsshim/internal/gcs/prot"
+	"github.com/Microsoft/hcsshim/internal/hcs"
 	"github.com/sirupsen/logrus"
 )
 
@@ -228,5 +229,30 @@ func TestBridgeNotifyFailure(t *testing.T) {
 	})
 	if err == nil || !strings.Contains(err.Error(), errMsg) {
 		t.Error("unexpected result: ", err)
+	}
+}
+
+// TestRPCErrorUnwrapHCSCode verifies that an rpcError carrying an HCS HRESULT
+// with the high bit set (a negative int32, e.g. 0xc037010e) unwraps to an errno
+// that errors.Is matches against the canonical syscall.Errno-based HCS
+// constants. Regression test: a naive windows.Errno(int32) conversion
+// sign-extends the value to 0xFFFFFFFF_C037010E, which fails to match
+// hcs.ErrComputeSystemDoesNotExist.
+func TestRPCErrorUnwrapHCSCode(t *testing.T) {
+	// 0xc037010e == hcs.ErrComputeSystemDoesNotExist, stored as an int32 in the
+	// bridge response Result field (decimal -1070137074).
+	err := error(&rpcError{result: -1070137074}) // int32 form of 0xc037010e
+
+	if !errors.Is(err, hcs.ErrComputeSystemDoesNotExist) {
+		t.Fatalf("errors.Is(err, ErrComputeSystemDoesNotExist) = false; want true (err=%v)", err)
+	}
+	if !hcs.IsNotExist(err) {
+		t.Fatalf("hcs.IsNotExist(err) = false; want true (err=%v)", err)
+	}
+
+	// A wrapped rpcError (as produced along real call chains) must still match.
+	wrapped := errors.Join(errors.New("delete container state"), err)
+	if !hcs.IsNotExist(wrapped) {
+		t.Fatalf("hcs.IsNotExist(wrapped) = false; want true (err=%v)", wrapped)
 	}
 }


### PR DESCRIPTION
### Summary
Guest RPC failures carry their `HRESULT` in an `int32` field. `rpcError.Unwrap` converted this directly to a `windows.Errno (uintptr)`, which sign-extends any code with the high bit set (`HRESULT` failure codes, `0x8xxxxxxx` and above) into `0xFFFFFFFF_xxxxxxxx`. That value no longer equals the canonical `syscall.Errno` constants, so `errors.Is` comparisons against them - and every helper built on top (e.g. `hcs.IsNotExist`) silently failed to match.

Convert the result through uint32 before widening so the code stays zero-extended and matches the canonical constants for any HRESULT.

```
For example, with result = 0xc037010e (negative as an int32):

  before: windows.Errno(err.result)         => 0xFFFFFFFF_C037010E
  after:  windows.Errno(uint32(err.result)) => 0x00000000_C037010E

  errors.Is(err, syscall.Errno(0xc037010e))  // false before, true after
```

Add a regression test covering an errors.Is match on an unwrapped rpcError.