### PR TITLE
update Go version to 1.26.0

### DIFF
--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -8,7 +8,7 @@ branding:
 inputs:
   go-version:
     description: The Go version to download.
-    default: oldstable
+    default: stable
   cache:
     description: Enable caching Go modules and build outputs,
     default: "true"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Microsoft/hcsshim
 
-go 1.25.0
+go 1.26.0
 
 // protobuf/gRPC/ttrpc generation
 tool (

--- a/test/go.mod
+++ b/test/go.mod
@@ -1,6 +1,6 @@
 module github.com/Microsoft/hcsshim/test
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/Microsoft/go-winio v0.6.3-0.20251027160822-ad3df93bed29


### PR DESCRIPTION
This pull request updates the Go version used in the project to 1.26.0 and ensures the GitHub Actions workflow defaults to the latest stable Go version. These changes help keep the codebase up-to-date with the latest Go features and improvements.

Go version updates:

* Updated the Go version in `go.mod` and `test/go.mod` from 1.25.0 to 1.26.0 to ensure the project and its tests use the latest Go release.)

CI/CD workflow improvement:

* Changed the default Go version in the GitHub Actions workflow (`.github/actions/setup-go/action.yml`) from `oldstable` to `stable` to always use the latest stable Go version during CI runs.