### PR TITLE
fix leaked layer reader which results in deadlock

### DIFF
--- a/internal/tools/securitypolicy/helpers/helpers.go
+++ b/internal/tools/securitypolicy/helpers/helpers.go
@@ -47,8 +47,8 @@ func ComputeLayerHashes(img v1.Image) ([]string, error) {
 		if err != nil {
 			return nil, err
 		}
-
 		hashString, err := tar2ext4.ConvertAndComputeRootDigest(r)
+		_ = r.Close() // release the go-containerregistry pullLimiter
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
go-containerregistry has a pull limiter and
uncompressed layer reader has to be closed.