### PR TITLE
ext4/dmverity: use io.ReadFull when reading the super block and root hash

### DIFF
--- a/ext4/dmverity/dmverity.go
+++ b/ext4/dmverity/dmverity.go
@@ -183,11 +183,14 @@ func ReadDMVerityInfo(vhdPath string, offsetInBytes int64) (*VerityInfo, error) 
 
 func ReadDMVerityInfoReader(r io.Reader) (*VerityInfo, error) {
 	block := make([]byte, blockSize)
-	if s, err := r.Read(block); err != nil || s != blockSize {
-		if err != nil {
-			return nil, fmt.Errorf("%w: %w", ErrSuperBlockReadFailure, err)
+	// io.Reader is allowed to return fewer bytes than requested without that
+	// being an error, so read the whole block rather than relying on a single
+	// Read filling it.
+	if s, err := io.ReadFull(r, block); err != nil {
+		if errors.Is(err, io.ErrUnexpectedEOF) {
+			return nil, fmt.Errorf("unexpected bytes read expected=%d actual=%d: %w", blockSize, s, ErrSuperBlockReadFailure)
 		}
-		return nil, fmt.Errorf("unexpected bytes read expected=%d actual=%d: %w", blockSize, s, ErrSuperBlockReadFailure)
+		return nil, fmt.Errorf("%w: %w", ErrSuperBlockReadFailure, err)
 	}
 
 	dmvSB := &dmveritySuperblock{}
@@ -200,11 +203,11 @@ func ReadDMVerityInfoReader(r io.Reader) (*VerityInfo, error) {
 		return nil, ErrNotVeritySuperBlock
 	}
 
-	if s, err := r.Read(block); err != nil || s != blockSize {
-		if err != nil {
-			return nil, fmt.Errorf("%w: %w", ErrRootHashReadFailure, err)
+	if s, err := io.ReadFull(r, block); err != nil {
+		if errors.Is(err, io.ErrUnexpectedEOF) {
+			return nil, fmt.Errorf("unexpected bytes read expected=%d, actual=%d: %w", blockSize, s, ErrRootHashReadFailure)
 		}
-		return nil, fmt.Errorf("unexpected bytes read expected=%d, actual=%d: %w", blockSize, s, ErrRootHashReadFailure)
+		return nil, fmt.Errorf("%w: %w", ErrRootHashReadFailure, err)
 	}
 
 	rootHash := hash2(dmvSB.Salt[:dmvSB.SaltSize], block)

--- a/ext4/dmverity/dmverity_test.go
+++ b/ext4/dmverity/dmverity_test.go
@@ -72,6 +72,47 @@ func TestInvalidReadNotEnoughBytes(t *testing.T) {
 	}
 }
 
+// shortReader returns at most n bytes per Read, which io.Reader explicitly
+// permits. A reader like this still delivers the whole hash device.
+type shortReader struct {
+	r io.Reader
+	n int
+}
+
+func (s *shortReader) Read(p []byte) (int, error) {
+	if len(p) > s.n {
+		p = p[:s.n]
+	}
+	return s.r.Read(p)
+}
+
+func TestReadDMVerityInfoReaderShortReads(t *testing.T) {
+	tmpFile := tempFileWithContentLength(t, blockSize)
+	targetFile, err := writeDMVeritySuperBlock(tmpFile.Name())
+	if err != nil {
+		t.Fatalf("failed to write dm-verity super-block: %s", err)
+	}
+	content, err := os.ReadFile(targetFile.Name())
+	if err != nil {
+		t.Fatalf("failed to read temp file: %s", err)
+	}
+	// super block plus one block of root hash data
+	content = append(content[blockSize:], bytes.Repeat([]byte{1}, blockSize)...)
+
+	want, err := ReadDMVerityInfoReader(bytes.NewReader(content))
+	if err != nil {
+		t.Fatalf("failed to read verity info from a whole-block reader: %s", err)
+	}
+
+	got, err := ReadDMVerityInfoReader(&shortReader{r: bytes.NewReader(content), n: 1})
+	if err != nil {
+		t.Fatalf("failed to read verity info from a short reader: %s", err)
+	}
+	if got.RootDigest != want.RootDigest {
+		t.Fatalf("root digest mismatch: short reader got %q, want %q", got.RootDigest, want.RootDigest)
+	}
+}
+
 func TestNotVeritySuperBlock(t *testing.T) {
 	tmpFile := tempFileWithContentLength(t, 2*blockSize)
 	_, err := ReadDMVerityInfo(tmpFile.Name(), blockSize)


### PR DESCRIPTION
### The bug

`ReadDMVerityInfoReader` accepts an `io.Reader` but reads each block with a single `Read` call and treats a short return as a failure:

```go
block := make([]byte, blockSize)
if s, err := r.Read(block); err != nil || s != blockSize {
	...
	return nil, fmt.Errorf("unexpected bytes read expected=%d actual=%d: %w", blockSize, s, ErrSuperBlockReadFailure)
}
```

The same pattern is repeated for the root hash block.

`io.Reader` explicitly allows a `Read` to return fewer bytes than requested without that being an error:

> Read reads up to len(p) bytes into p. It returns the number of bytes read (0 <= n <= len(p)) and any error encountered. Even if Read returns n < len(p), it may use all of p as scratch space during the call. ... Callers should always process the n > 0 bytes returned before considering the error err.

So a hash device that is completely valid fails to parse whenever it arrives through a reader that returns short reads. It happens to work today only because the exported `ReadDMVerityInfo` path hands it an `*os.File`. Any other reader, for example one wrapping a network stream or a tar entry, can fail:

```
unexpected bytes read expected=4096 actual=1: failed to read dm-verity super block
```

`ext4/dmverity` is imported by `ext4/tar2ext4`, `internal/verity`, `internal/guest/storage/devicemapper` and `test/internal/layers`, and `ReadDMVerityInfoReader` is exported, so external callers can pass any reader they like.

### The change

Use `io.ReadFull` for both blocks.

Error behaviour for genuinely truncated input is preserved: `io.ReadFull` returns `io.EOF` when nothing could be read and `io.ErrUnexpectedEOF` on a partial block, so the existing `unexpected bytes read` message and the `ErrSuperBlockReadFailure` / `ErrRootHashReadFailure` wrapping still apply. The existing `TestInvalidReadEOF` and `TestInvalidReadNotEnoughBytes` pass unchanged.

### Testing

Added `TestReadDMVerityInfoReaderShortReads`, which feeds identical bytes through a reader returning one byte per `Read` and compares the root digest against a whole-block read.

Without the change:

```
--- FAIL: TestReadDMVerityInfoReaderShortReads (0.02s)
    dmverity_test.go:109: failed to read verity info from a short reader:
        unexpected bytes read expected=4096 actual=1: failed to read dm-verity super block
FAIL
```

With it, the whole package passes:

```
--- PASS: TestInvalidReadEOF
--- PASS: TestInvalidReadNotEnoughBytes
--- PASS: TestReadDMVerityInfoReaderShortReads
--- PASS: TestNotVeritySuperBlock
--- PASS: TestNoMerkleTree
ok  	github.com/Microsoft/hcsshim/ext4/dmverity
```

`gofmt -l ext4/dmverity/` and `go vet ./ext4/dmverity/` are both clean. Commit is signed off per the DCO requirement.

### Separate issue in the same file, not fixed here

While testing this I also found that `MerkleTree(r io.Reader)` never terminates on an empty reader: the inner loop breaks with `nextLevel.Len() == 0`, `0 % blockSize == 0` so no padding is appended, and the only loop exit is `nextLevel.Len() == blockSize`, which is never reached. Each pass allocates a fresh 1 MiB `bufio.NewReaderSize`, so it grows memory until the process dies rather than spinning harmlessly. No in-repo caller can currently pass zero bytes, since `ConvertTarToExt4` always emits a non-empty superblock, so this only affects external callers of the exported API. Happy to send that as a separate PR if you would like it fixed.
