### PR TITLE
add dependabot golang base image updates and pin lint to the go.mod Go version

### DIFF
--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -9,6 +9,9 @@ inputs:
   go-version:
     description: The Go version to download.
     default: stable
+  go-version-file:
+    description: go.mod/go.work file to read the Go version from (takes precedence over go-version when set).
+    default: ""
   cache:
     description: Enable caching Go modules and build outputs,
     default: "true"
@@ -35,6 +38,7 @@ runs:
       uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
       with:
         go-version: ${{ inputs.go-version }}
+        go-version-file: ${{ inputs.go-version-file }}
         check-latest: true
         cache: ${{ inputs.cache }}
         cache-dependency-path: |

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -45,8 +45,8 @@ updates:
     cooldown:
       default-days: 7
       
-  # Keep the Windows base images (nanoserver/servercore) on their latest digest: scans
-  # every Dockerfile (except vendored), bumps the digest only (tag kept), one grouped PR.
+  # Keep the test base images (nanoserver/servercore + golang) current: scans every
+  # Dockerfile (except vendored), digest/patch bumps only (major/minor ignored), one grouped PR.
   - package-ecosystem: "docker"
     directories:
       - "/**/*"
@@ -57,6 +57,8 @@ updates:
       # image names exactly as they appear in the PR (e.g. "Updates windows/nanoserver ...").
       - dependency-name: "windows/nanoserver"
       - dependency-name: "windows/servercore"
+      # golang toolchain base image used by the test images (Docker Hub official image)
+      - dependency-name: "golang"
     ignore:
       # keep the tag stable and only bump the digest / patch level.
       - dependency-name: "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,10 @@ jobs:
         with:
           # sometimes go cache causes issues when linting
           cache: false
+          # Lint with the module's target Go (go.mod), not the newest "stable" Go: a new
+          # Go release otherwise outpaces the pinned golangci-lint and breaks linting.
+          go-version: ""
+          go-version-file: go.mod
 
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0


### PR DESCRIPTION
## Summary
- Extend `.github/dependabot.yml` to also keep the `golang` Docker base image in the test Dockerfiles current (digest/patch bumps only; major/minor ignored), matching the existing `windows/nanoserver` and `windows/servercore` handling.
- Run `golangci-lint` against the Go version from `go.mod` instead of the newest stable Go, so a new Go release can't outpace the pinned linter and break CI. Build/test jobs still use the latest Go.

## Testing
Ran Dependabot locally against the updated config; it proposes the expected `golang` update.