### PR TITLE
cmd: fix limitedRead returning nil error when Stat fails

### DIFF
--- a/cmd/containerd-shim-lcow-v2/manager.go
+++ b/cmd/containerd-shim-lcow-v2/manager.go
@@ -260,11 +260,11 @@ func limitedRead(filePath string, readLimitBytes int64) ([]byte, error) {
 		readLimitBytes = fi.Size()
 	}
 	buf := make([]byte, readLimitBytes)
-	_, err = f.Read(buf)
-	if err != nil {
+	n, err := io.ReadFull(f, buf)
+	if err != nil && !errors.Is(err, io.ErrUnexpectedEOF) {
 		return []byte{}, fmt.Errorf("read file %s: %w", filePath, err)
 	}
-	return buf, nil
+	return buf[:n], nil
 }
 
 // Info returns runtime information about this shim including its name, version,

--- a/cmd/containerd-shim-runhcs-v1/delete.go
+++ b/cmd/containerd-shim-runhcs-v1/delete.go
@@ -5,6 +5,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"time"
@@ -30,18 +31,19 @@ func limitedRead(filePath string, readLimitBytes int64) ([]byte, error) {
 		return nil, errors.Wrapf(err, "limited read failed to open file: %s", filePath)
 	}
 	defer f.Close()
-	if fi, err := f.Stat(); err == nil {
-		if fi.Size() < readLimitBytes {
-			readLimitBytes = fi.Size()
-		}
-		buf := make([]byte, readLimitBytes)
-		_, err := f.Read(buf)
-		if err != nil {
-			return []byte{}, errors.Wrapf(err, "limited read failed during file read: %s", filePath)
-		}
-		return buf, nil
+	fi, err := f.Stat()
+	if err != nil {
+		return []byte{}, errors.Wrapf(err, "limited read failed during file stat: %s", filePath)
 	}
-	return []byte{}, errors.Wrapf(err, "limited read failed during file stat: %s", filePath)
+	if fi.Size() < readLimitBytes {
+		readLimitBytes = fi.Size()
+	}
+	buf := make([]byte, readLimitBytes)
+	n, err := io.ReadFull(f, buf)
+	if err != nil && err != io.ErrUnexpectedEOF {
+		return []byte{}, errors.Wrapf(err, "limited read failed during file read: %s", filePath)
+	}
+	return buf[:n], nil
 }
 
 var deleteCommand = cli.Command{

--- a/cmd/containerd-shim-runhcs-v1/delete_test.go
+++ b/cmd/containerd-shim-runhcs-v1/delete_test.go
@@ -1,0 +1,44 @@
+//go:build windows
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestLimitedRead verifies that limitedRead enforces the byte limit when the
+// file is larger than the limit and reads the full content when the file is
+// smaller than the limit.
+func TestLimitedRead(t *testing.T) {
+	filePath := filepath.Join(t.TempDir(), "panic.log")
+	if err := os.WriteFile(filePath, []byte("hello"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	buf, err := limitedRead(filePath, 2)
+	if err != nil {
+		t.Fatalf("limitedRead: %v", err)
+	}
+	if string(buf) != "he" {
+		t.Fatalf("expected 'he', got %q", string(buf))
+	}
+
+	buf, err = limitedRead(filePath, 10)
+	if err != nil {
+		t.Fatalf("limitedRead: %v", err)
+	}
+	if string(buf) != "hello" {
+		t.Fatalf("expected 'hello', got %q", string(buf))
+	}
+}
+
+// TestLimitedReadMissingFile verifies that limitedRead returns an error when
+// the target file does not exist.
+func TestLimitedReadMissingFile(t *testing.T) {
+	_, err := limitedRead(filepath.Join(t.TempDir(), "missing.log"), 10)
+	if err == nil {
+		t.Fatalf("expected error for missing file")
+	}
+}


### PR DESCRIPTION
## Summary

`limitedRead` in `cmd/containerd-shim-runhcs-v1/delete.go` can return a nil error on failure. The `Stat` result is checked inside an `if` statement, so its `err` is scoped to that statement, and the `err` in the final return refers to the outer variable from `os.Open`, which is always nil once execution gets there:

```go
f, err := os.Open(filePath)            // err == nil past this check
...
if fi, err := f.Stat(); err == nil {   // shadows err
    ...
}
return []byte{}, errors.Wrapf(err, "limited read failed during file stat: %s", filePath)
```

`errors.Wrapf` returns nil for a nil error, so a `Stat` failure produces `([]byte{}, nil)`. The caller in the delete handler then takes neither branch: `err == nil && len(logBytes) > 0` is false, and `err != nil` is false, so the shim panic log is silently skipped without even the "failed to open shim panic log" warning.

## Change

- Restructure the function the way the `containerd-shim-lcow-v2` copy (`cmd/containerd-shim-lcow-v2/manager.go`) already does, so the `Stat` error is actually returned.
- Switch both copies from `f.Read(buf)` to `io.ReadFull` with the read count sliced off. `f.Read` may return fewer bytes than requested without an error, and the old code returned the full buffer regardless, so a short read handed back NUL padding that was never in the file. Same reasoning as #2888.
- Add the same `limitedRead` unit tests the lcow shim already has, since the runhcs-v1 copy had none.

## Verification

```
go build ./cmd/containerd-shim-runhcs-v1/          ok
go vet   ./cmd/containerd-shim-runhcs-v1/          ok
go test  ./cmd/containerd-shim-runhcs-v1/ -run TestLimitedRead   PASS
go build -tags lcow ./cmd/containerd-shim-lcow-v2/ ok
go test  -tags lcow ./cmd/containerd-shim-lcow-v2/ -run TestLimitedRead   ok
```

on Windows 11.
