### PR TITLE
dmverity: validate salt size

### DIFF
--- a/ext4/dmverity/dmverity.go
+++ b/ext4/dmverity/dmverity.go
@@ -199,6 +199,9 @@ func ReadDMVerityInfoReader(r io.Reader) (*VerityInfo, error) {
 	if string(bytes.Trim(dmvSB.Signature[:], "\x00")[:]) != VeritySignature {
 		return nil, ErrNotVeritySuperBlock
 	}
+	if int(dmvSB.SaltSize) > len(dmvSB.Salt) {
+		return nil, fmt.Errorf("%w: salt size %d exceeds salt capacity %d", ErrSuperBlockParseFailure, dmvSB.SaltSize, len(dmvSB.Salt))
+	}
 
 	if s, err := r.Read(block); err != nil || s != blockSize {
 		if err != nil {

--- a/ext4/dmverity/dmverity_test.go
+++ b/ext4/dmverity/dmverity_test.go
@@ -83,6 +83,25 @@ func TestNotVeritySuperBlock(t *testing.T) {
 	}
 }
 
+func TestReadDMVerityInfoReader_InvalidSaltSize(t *testing.T) {
+	superblock := NewDMVeritySuperblock(blockSize)
+	superblock.SaltSize = uint16(len(superblock.Salt) + 1)
+
+	input := bytes.NewBuffer(make([]byte, 0, 2*blockSize))
+	if err := binary.Write(input, binary.LittleEndian, superblock); err != nil {
+		t.Fatalf("failed to write dm-verity super-block: %v", err)
+	}
+	input.Write(make([]byte, 2*blockSize-input.Len()))
+
+	_, err := ReadDMVerityInfoReader(input)
+	if err == nil {
+		t.Fatal("expected invalid salt size error")
+	}
+	if !errors.Is(err, ErrSuperBlockParseFailure) || !strings.Contains(err.Error(), "salt size") {
+		t.Fatalf("expected salt size parse error, got: %v", err)
+	}
+}
+
 func TestNoMerkleTree(t *testing.T) {
 	tmpFile := tempFileWithContentLength(t, blockSize)
 	targetFile, err := writeDMVeritySuperBlock(tmpFile.Name())


### PR DESCRIPTION
Reject superblocks whose declared salt length exceeds the
fixed salt buffer before computing the root hash.

Add regression coverage for malformed salt lengths.