### PR TITLE
containerd-shim-lcow-v2: Fix shimManager.Stop not correctly getting the context

### DIFF
--- a/cmd/containerd-shim-lcow-v2/manager.go
+++ b/cmd/containerd-shim-lcow-v2/manager.go
@@ -183,8 +183,8 @@ func (m *shimManager) Start(ctx context.Context, id string, opts shim.StartOpts)
 // It reads and logs any panic messages written to panic.log, then tries to
 // terminate the associated HCS compute system and waits up to 30 seconds for
 // it to exit.
-func (m *shimManager) Stop(_ context.Context, id string) (resp shim.StopStatus, err error) {
-	ctx, span := ot.StartSpan(context.Background(), "delete")
+func (m *shimManager) Stop(ctx context.Context, id string) (resp shim.StopStatus, err error) {
+	ctx, span := ot.StartSpan(ctx, "delete")
 	defer span.End()
 	defer func() { ot.SetSpanStatus(span, err) }()
 

--- a/cmd/containerd-shim-lcow-v2/manager_test.go
+++ b/cmd/containerd-shim-lcow-v2/manager_test.go
@@ -3,10 +3,28 @@
 package main
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/Microsoft/hcsshim/internal/shim"
 )
+
+func TestStopPreservesShimOptionsContext(t *testing.T) {
+	ctx := context.WithValue(t.Context(), shim.OptsKey{}, shim.Opts{BundlePath: t.TempDir()})
+
+	status, err := newShimManager("test").Stop(ctx, "nonexistent-stop-context-test")
+	if err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+	if status.ExitStatus != 255 {
+		t.Fatalf("ExitStatus = %d, want 255", status.ExitStatus)
+	}
+	if status.ExitedAt.IsZero() {
+		t.Fatal("ExitedAt is zero")
+	}
+}
 
 // TestLimitedRead verifies that limitedRead correctly enforces the byte limit
 // when the file is larger than the limit, and reads the full content when the


### PR DESCRIPTION
0f25a0125 ("Replace OpenCensus with OpenTelemetry (#2828)") turned this
```
    ctx, span := oc.StartSpan(ctx, "delete")
```
into a
```
    ctx, span := ot.StartSpan(context.Background(), "delete")
```

because we later get a value from the context:

    if opts, ok := ctx.Value(shim.OptsKey{}).(shim.Opts); ok {
    	bundlePath = opts.BundlePath
    }

    if bundlePath == "" {
    	return resp, fmt.Errorf("bundle path not found in context")
    }

this change probably broke it

Assisted-by: GitHub-Copilot