### PR TITLE
wclayer: fix sparse file logical size

### DIFF
--- a/internal/wclayer/legacy.go
+++ b/internal/wclayer/legacy.go
@@ -194,16 +194,30 @@ func (r *legacyLayerReader) reset() {
 
 func findBackupStreamSize(r io.Reader) (int64, error) {
 	br := winio.NewBackupStreamReader(r)
+	var size int64
 	for {
 		hdr, err := br.Next()
 		if err != nil {
 			if errors.Is(err, io.EOF) {
-				err = nil
+				// With no inline data, sparse blocks provide the logical size.
+				return size, nil
 			}
 			return 0, err
 		}
-		if hdr.Id == winio.BackupData {
-			return hdr.Size, nil
+		switch hdr.Id {
+		case winio.BackupData:
+			// Non-sparse files and sparse files with inline data carry their
+			// logical size in BackupData.
+			if hdr.Size > 0 || hdr.Attributes&winio.StreamSparseAttributes == 0 {
+				return hdr.Size, nil
+			}
+			// A sparse BackupData stream without inline data is followed by
+			// sparse blocks that describe its logical size.
+		case winio.BackupSparseBlock:
+			// The terminal zero-length block has an offset at logical EOF.
+			if end := hdr.Offset + hdr.Size; end > size {
+				size = end
+			}
 		}
 	}
 }

--- a/internal/wclayer/legacy_test.go
+++ b/internal/wclayer/legacy_test.go
@@ -9,6 +9,9 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	winio "github.com/Microsoft/go-winio"
+	"golang.org/x/sys/windows"
 )
 
 // errWriter always fails writes, used to simulate a full disk (ENOSPC) when the
@@ -159,5 +162,120 @@ func Test_legacyLayerWriter_reset_ClosesFileOnSuccess(t *testing.T) {
 
 	if err := os.Remove(fpath); err != nil {
 		t.Errorf("expected temp file to be removable after reset (handle closed), got: %v", err)
+	}
+}
+
+func setSparse(t *testing.T, f *os.File) {
+	t.Helper()
+	if err := windows.DeviceIoControl(windows.Handle(f.Fd()), windows.FSCTL_SET_SPARSE, nil, 0, nil, 0, nil, nil); err != nil {
+		t.Fatalf("set sparse: %v", err)
+	}
+}
+
+func TestFindBackupStreamSizeSparse(t *testing.T) {
+	//nolint:gosec // G306: test files do not need restrictive permissions
+	for name, setup := range map[string]func(*testing.T) string{
+		"normalFile": func(t *testing.T) string {
+			t.Helper()
+			path := filepath.Join(t.TempDir(), "foo")
+			if err := os.WriteFile(path, []byte("testing 1 2 3\n"), 0644); err != nil {
+				t.Fatal(err)
+			}
+			return path
+		},
+		"normalFileEmpty": func(t *testing.T) string {
+			t.Helper()
+			path := filepath.Join(t.TempDir(), "foo")
+			f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY, 0644)
+			if err != nil {
+				t.Fatal(err)
+			}
+			f.Close()
+			return path
+		},
+		"sparseEmpty": func(t *testing.T) string {
+			t.Helper()
+			path := filepath.Join(t.TempDir(), "foo")
+			f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY, 0644)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer f.Close()
+			setSparse(t, f)
+			return path
+		},
+		"sparseAllHoles": func(t *testing.T) string {
+			t.Helper()
+			path := filepath.Join(t.TempDir(), "foo")
+			f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY, 0644)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer f.Close()
+			setSparse(t, f)
+			if err := f.Truncate(1048576); err != nil {
+				t.Fatal(err)
+			}
+			return path
+		},
+		"sparseOneRange": func(t *testing.T) string {
+			t.Helper()
+			path := filepath.Join(t.TempDir(), "foo")
+			f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY, 0644)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer f.Close()
+			setSparse(t, f)
+			if _, err := f.WriteString("test sparse data"); err != nil {
+				t.Fatal(err)
+			}
+			return path
+		},
+		"sparseMultipleRanges": func(t *testing.T) string {
+			t.Helper()
+			path := filepath.Join(t.TempDir(), "foo")
+			f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY, 0644)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer f.Close()
+			setSparse(t, f)
+			if _, err = f.Write([]byte("leading data\n")); err != nil {
+				t.Fatal(err)
+			}
+			if _, err = f.Seek(1048576, 0); err != nil {
+				t.Fatal(err)
+			}
+			if _, err = f.Write([]byte("trailing data\n")); err != nil {
+				t.Fatal(err)
+			}
+			return path
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			path := setup(t)
+			f, err := os.Open(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer f.Close()
+
+			fi, err := f.Stat()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			br := winio.NewBackupFileReader(f, true)
+			defer br.Close()
+
+			size, err := findBackupStreamSize(br)
+			if err != nil {
+				t.Fatalf("findBackupStreamSize: %v", err)
+			}
+			if size != fi.Size() {
+				t.Errorf("findBackupStreamSize = %d, want logical size %d", size, fi.Size())
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

Prevent Windows container layer export from writing an all-hole sparse file as a zero-byte tar entry, which truncates the file's contents on export.

A sparse file can have a nonzero logical size without allocated data—for example, a 1 MiB file containing only zeroes. In this case the first `BackupData` stream reports size zero even though the file's logical EOF is 1 MiB.

`findBackupStreamSize` previously used that `BackupData` size directly. The resulting zero size was passed to the tar writer, so the exported entry was treated as empty and the file was restored truncated.

Keep the existing fast path for non-sparse files and sparse files with inline data. For a sparse `BackupData` stream with no inline data, derive the logical size from `BackupSparseBlock` records instead: the terminal zero-length block's
offset marks logical EOF, and allocated blocks satisfy `offset+size <= logical size`, so the maximum end position is the logical size.

Add regression coverage for regular files and sparse files with empty, all-hole, single-range, and multi-range layouts.

## Context

Reported downstream in Docker/Moby as [moby/moby#53464](https://github.com/moby/moby/issues/53464): building or committing a Windows image whose layer contains an NTFS sparse file fails.

That failure has two independent causes in two libraries:

- **This PR (hcsshim):** the logical size of an all-hole sparse file is computed as `0`, truncating its contents on export.
- **go-winio ([microsoft/go-winio#375](https://github.com/microsoft/go-winio/pull/375)):**  the seekable export path rejects `BackupSparseBlock` records with `unknown stream ID 9`.

The two fixes are complementary. This change touches only `findBackupStreamSize` and uses existing go-winio APIs, so it builds, tests, and merges independently of go-winio#375. Once that PR lands and is tagged, a follow-up will bump the go-winio dependency here so a tagged hcsshim release carries the complete end-to-end fix.

## Testing

- `go test ./internal/wclayer`